### PR TITLE
Related objects titles are not being inserted

### DIFF
--- a/js/dialog.js
+++ b/js/dialog.js
@@ -347,7 +347,7 @@
                   dataSource.responseType = YAHOO.util.DataSourceBase.TYPE_TEXT;
                   dataSource.parseTextData = function (request, response)
                     {
-                      'results' : [ $(response).filter('.label').text().trim() ]
+                      return {'results' : [ $(response).filter('.label').text().trim()]};
                     }
 
                   // Set visible input field of yui-autocomplete

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -347,7 +347,7 @@
                   dataSource.responseType = YAHOO.util.DataSourceBase.TYPE_TEXT;
                   dataSource.parseTextData = function (request, response)
                     {
-                      return { 'results': [$('.label', response).text()] };
+                      'results' : [ $(response).filter('.label').text().trim() ]
                     }
 
                   // Set visible input field of yui-autocomplete


### PR DESCRIPTION
When creating releationships between authority records the title of the related authority record does not appear in the popup for editing. this is a fix for that.
