### PR TITLE
Dev/issue 3899

### DIFF
--- a/apps/qubit/modules/settings/templates/visibleElementsSuccess.php
+++ b/apps/qubit/modules/settings/templates/visibleElementsSuccess.php
@@ -15,8 +15,32 @@
     <div id="content">
 
       <fieldset class="collapsible collapsed">
+        <legend><?php echo __('ISAD template - area headings') ?></legend>
 
-        <legend><?php echo __('ISAD template') ?></legend>
+        <?php foreach (array(
+          'isad_identity_area' => __('Identity area'),
+          'isad_context_area' => __('Context area'),
+          'isad_content_and_structure_area' => __('Content and structure area'),
+          'isad_conditions_of_access_use_area' => __('Conditions of access and use area'),
+          'isad_allied_materials_area' => __('Allied materials area'),
+          'isad_notes_area' => __('Notes area'),
+          'isad_access_points_area' => __('Access points'),
+          'isad_description_control_area' => __('Description control area')) as $key => $value): ?>
+
+          <div class="form-item form-item-checkbox">
+            <?php echo $form[$key] ?>
+            <?php echo $form[$key]
+              ->label($value)
+              ->renderLabel() ?>
+          </div>
+
+        <?php endforeach; ?>
+
+      </fieldset>
+
+      <fieldset class="collapsible collapsed">
+
+        <legend><?php echo __('ISAD template - elements') ?></legend>
 
         <?php foreach (array(
           'isad_archival_history' => __('Archival history'),
@@ -46,9 +70,37 @@
 
       </fieldset>
 
+
+      <fieldset class="collapsible collapsed">
+        <legend><?php echo __('RAD template - area headings') ?></legend>
+
+        <?php foreach (array(
+          'rad_title_responsibility_area' => __('Title and statement of responsibility area'),
+          'rad_edition_area' => __('Edition area'),
+          'rad_material_specific_details_area' => __('Class of material specific details area'),
+          'rad_dates_of_creation_area' => __('Dates of creation area'),
+          'rad_physical_description_area' => __('Physical description area'),
+          'rad_publishers_series_area' => __('Publisher\'s series area'),
+          'rad_archival_description_area' => __('Archival description area'),
+          'rad_notes_area' => __('Notes area'),
+          'rad_standard_number_area' => __('Standard number area'),
+          'rad_access_points_area' => __('Access points'),
+          'rad_description_control_area' => __('Control area')) as $key => $value): ?>
+
+          <div class="form-item form-item-checkbox">
+            <?php echo $form[$key] ?>
+            <?php echo $form[$key]
+              ->label($value)
+              ->renderLabel() ?>
+          </div>
+
+        <?php endforeach; ?>
+
+      </fieldset>
+
       <fieldset class="collapsible collapsed">
 
-        <legend><?php echo __('RAD template') ?></legend>
+        <legend><?php echo __('RAD template - elements') ?></legend>
 
         <?php foreach (array(
           'rad_archival_history' => __('Custodial history'),

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 106
+    value: 107
   milestone:
     name: milestone
     editable: 0
@@ -648,5 +648,81 @@ QubitSetting:
     value: 1
   Qubit_Settings_visibleElements_physicalStorage:
     name: physical_storage
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_radTitleResponsibilityArea:
+    name: rad_title_responsibility_area
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_radEditionArea:
+    name: rad_edition_area
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_radMaterialSpecificDetailsArea:
+    name: rad_material_specific_details_area
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_radDatesOfCreationArea:
+    name: rad_dates_of_creation_area
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_radPhysicalDescriptionArea:
+    name: rad_physical_description_area
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_radPublishersSeriesArea:
+    name: rad_publishers_series_area
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_radArchivalDescriptionArea:
+    name: rad_archival_description_area
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_radNotesArea:
+    name: rad_notes_area
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_radStandardNumberArea:
+    name: rad_standard_number_area
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_radAccessPointsArea:
+    name: rad_access_points_area
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_radDescriptionControlArea:
+    name: rad_description_control_area
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_isadIdentityArea:
+    name: isad_identity_area
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_isadContextArea:
+    name: isad_context_area
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_isadContentAndStructureArea:
+    name: isad_content_and_structure_area
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_isadConditionsOfAccessAndUseArea:
+    name: isad_conditions_of_access_use_area
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_isadAlliedMaterialsArea:
+    name: isad_allied_materials_area
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_isadNotesArea:
+    name: isad_notes_area
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_isadAccessPointsArea:
+    name: isad_access_points_area
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_isadDescriptionControlArea:
+    name: isad_description_control_area
     scope: element_visibility
     value: 1

--- a/lib/task/migrate/migrations/arMigration0107.class.php
+++ b/lib/task/migrate/migrations/arMigration0107.class.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add element visibility RAD and ISAD settings for archival history field
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0105
+{
+  const
+    VERSION = 107, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  /**
+   * Upgrade
+   *
+   * @return bool True if the upgrade succeeded, False otherwise
+   */
+  public function up($configuration)
+  {
+    $elements = array(
+      'rad_title_responsibility_area',
+      'rad_edition_area',
+      'rad_material_specific_details_area',
+      'rad_dates_of_creation_area',
+      'rad_physical_description_area',
+      'rad_publishers_series_area',
+      'rad_archival_description_area',
+      'rad_notes_area',
+      'rad_standard_number_area',
+      'rad_access_points_area',
+      'rad_description_control_area',
+      'isad_identity_area',
+      'isad_context_area',
+      'isad_content_and_structure_area',
+      'isad_conditions_of_access_use_area',
+      'isad_allied_materials_area',
+      'isad_notes_area',
+      'isad_access_points_area',
+      'isad_description_control_area');
+
+    // Add visibility settings
+    foreach ($elements as $item)
+    {
+      $setting = new QubitSetting;
+      $setting->name  = $item;
+      $setting->scope = 'element_visibility';
+      $setting->value = 1;
+      $setting->culture = 'en';
+      $setting->save();
+    }
+
+    return true;
+  }
+}

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/indexSuccess.php
@@ -85,7 +85,9 @@
 
 <section id="identityArea">
 
-  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Identity area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'identityArea', 'title' => __('Edit identity area'))) ?>
+  <?php if (check_field_visibility('app_element_visibility_isad_identity_area')): ?>
+    <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Identity area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'identityArea', 'title' => __('Edit identity area'))) ?>
+  <?php endif; ?>
 
   <?php echo render_show(__('Reference code'), render_value($isad->referenceCode)) ?>
 
@@ -115,7 +117,9 @@
 
 <section id="contextArea">
 
-  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Context area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'contextArea', 'title' => __('Edit context area'))) ?>
+  <?php if (check_field_visibility('app_element_visibility_isad_context_area')): ?>
+    <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Context area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'contextArea', 'title' => __('Edit context area'))) ?>
+  <?php endif; ?>
 
   <?php echo get_component('informationobject', 'creatorDetail', array('resource' => $resource)) ?>
 
@@ -142,7 +146,9 @@
 
 <section id="contentAndStructureArea">
 
-  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Content and structure area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'contentAndStructureArea', 'title' => __('Edit content and structure area'))) ?>
+  <?php if (check_field_visibility('app_element_visibility_isad_content_and_structure_area')): ?>
+    <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Content and structure area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'contentAndStructureArea', 'title' => __('Edit content and structure area'))) ?>
+  <?php endif; ?>
 
   <?php echo render_show(__('Scope and content'), render_value($resource->getScopeAndContent(array('cultureFallback' => true)))) ?>
 
@@ -158,7 +164,9 @@
 
 <section id="conditionsOfAccessAndUseArea">
 
-  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Conditions of access and use area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'conditionsOfAccessAndUseArea', 'title' => __('Edit conditions of access and use area'))) ?>
+  <?php if (check_field_visibility('app_element_visibility_isad_conditions_of_access_use_area')): ?>
+    <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Conditions of access and use area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'conditionsOfAccessAndUseArea', 'title' => __('Edit conditions of access and use area'))) ?>
+  <?php endif; ?>
 
   <?php echo render_show(__('Conditions governing access'), render_value($resource->getAccessConditions(array('cultureFallback' => true)))) ?>
 
@@ -198,7 +206,9 @@
 
 <section id="alliedMaterialsArea">
 
-  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Allied materials area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'alliedMaterialsArea', 'title' => __('Edit alied materials area'))) ?>
+  <?php if (check_field_visibility('app_element_visibility_isad_allied_materials_area')): ?>
+    <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Allied materials area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'alliedMaterialsArea', 'title' => __('Edit alied materials area'))) ?>
+  <?php endif; ?>
 
   <?php echo render_show(__('Existence and location of originals'), render_value($resource->getLocationOfOriginals(array('cultureFallback' => true)))) ?>
 
@@ -216,7 +226,9 @@
 
 <section id="notesArea">
 
-  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Notes area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'notesArea', 'title' => __('Edit notes area'))) ?>
+  <?php if (check_field_visibility('app_element_visibility_isad_notes_area')): ?>
+    <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Notes area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'notesArea', 'title' => __('Edit notes area'))) ?>
+  <?php endif; ?>
 
   <?php if (check_field_visibility('app_element_visibility_isad_notes')): ?>
     <?php foreach ($resource->getNotesByType(array('noteTypeId' => QubitTerm::GENERAL_NOTE_ID)) as $item): ?>
@@ -230,7 +242,9 @@
 
 <section id="accessPointsArea">
 
-  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Access points').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'accessPointsArea', 'title' => __('Edit access points'))) ?>
+  <?php if (check_field_visibility('app_element_visibility_isad_access_points_area')): ?>
+    <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Access points').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'accessPointsArea', 'title' => __('Edit access points'))) ?>
+  <?php endif; ?>
 
   <?php echo get_partial('informationobject/subjectAccessPoints', array('resource' => $resource)) ?>
 
@@ -242,7 +256,9 @@
 
 <section id="descriptionControlArea">
 
-  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Description control area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'descriptionControlArea', 'title' => __('Edit description control area'))) ?>
+  <?php if (check_field_visibility('app_element_visibility_isad_description_control_area')): ?>
+    <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Description control area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'descriptionControlArea', 'title' => __('Edit description control area'))) ?>
+  <?php endif; ?>
 
   <?php if (check_field_visibility('app_element_visibility_isad_control_description_identifier')): ?>
     <?php echo render_show(__('Description identifier'), render_value($resource->getDescriptionIdentifier(array('cultureFallback' => true)))) ?>

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
@@ -85,8 +85,9 @@
 
 <section id="titleAndStatementOfResponsibilityArea">
 
-  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Title and statement of responsibility area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'titleAndStatementOfResponsibilityArea', 'title' => __('Edit title and statement of responsibility area'))) ?>
-
+  <?php if (check_field_visibility('app_element_visibility_rad_title_responsibility_area')): ?>
+    <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Title and statement of responsibility area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'titleAndStatementOfResponsibilityArea', 'title' => __('Edit title and statement of responsibility area'))) ?>
+  <?php endif; ?>
   <?php echo render_show(__('Title proper'), render_value($resource->getTitle(array('cultureFallback' => true)))) ?>
 
   <div class="field">
@@ -127,7 +128,9 @@
 
 <section id="editionArea">
 
-  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Edition area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'editionArea', 'title' => __('Edit edition area'))) ?>
+  <?php if (check_field_visibility('app_element_visibility_rad_edition_area')): ?>
+    <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Edition area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'editionArea', 'title' => __('Edit edition area'))) ?>
+  <?php endif; ?>
 
   <?php echo render_show(__('Edition statement'), render_value($resource->getEdition(array('cultureFallback' => true)))) ?>
 
@@ -137,7 +140,9 @@
 
 <section class="section" id="classOfMaterialSpecificDetailsArea">
 
-  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Class of material specific details area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'classOfMaterialSpecificDetailsArea', 'title' => __('Edit class of material specific details area'))) ?>
+  <?php if (check_field_visibility('app_element_visibility_rad_material_specific_details_area')): ?>
+    <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Class of material specific details area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'classOfMaterialSpecificDetailsArea', 'title' => __('Edit class of material specific details area'))) ?>
+  <?php endif; ?>
 
   <?php echo render_show(__('Statement of scale (cartographic)'), render_value($rad->__get('statementOfScaleCartographic', array('cultureFallback' => true)))) ?>
 
@@ -153,7 +158,9 @@
 
 <section class="section" id="datesOfCreationArea">
 
-  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Dates of creation area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'datesOfCreationArea', 'title' => __('Edit dates of creation area'))) ?>
+  <?php if (check_field_visibility('app_element_visibility_rad_dates_of_creation_area')): ?>
+    <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Dates of creation area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'datesOfCreationArea', 'title' => __('Edit dates of creation area'))) ?>
+  <?php endif; ?>
 
   <?php echo get_partial('informationobject/dates', array('resource' => $resource)) ?>
 
@@ -161,7 +168,9 @@
 
 <section id="physicalDescriptionArea">
 
-  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Physical description area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'physicalDescriptionArea', 'title' => __('Edit physical description area'))) ?>
+  <?php if (check_field_visibility('app_element_visibility_rad_physical_description_area')): ?>
+    <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Physical description area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'physicalDescriptionArea', 'title' => __('Edit physical description area'))) ?>
+  <?php endif; ?>
 
   <?php echo render_show(__('Physical description'), render_value($resource->getExtentAndMedium(array('cultureFallback' => true)))) ?>
 
@@ -169,7 +178,9 @@
 
 <section id="publishersSeriesArea">
 
-  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Publisher\'s series area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'publishersSeriesArea', 'title' => __('Edit publisher\'s series area'))) ?>
+  <?php if (check_field_visibility('app_element_visibility_rad_publishers_series_area')): ?>
+    <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Publisher\'s series area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'publishersSeriesArea', 'title' => __('Edit publisher\'s series area'))) ?>
+  <?php endif; ?>
 
   <?php echo render_show(__('Title proper of publisher\'s series'), render_value($rad->__get('titleProperOfPublishersSeries', array('cultureFallback' => true)))) ?>
 
@@ -187,7 +198,9 @@
 
 <section id="archivalDescriptionArea">
 
-  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Archival description area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'archivalDescriptionArea', 'title' => __('Edit archival description area'))) ?>
+  <?php if (check_field_visibility('app_element_visibility_rad_archival_description_area')): ?>
+    <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Archival description area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'archivalDescriptionArea', 'title' => __('Edit archival description area'))) ?>
+  <?php endif; ?>
 
   <?php echo get_component('informationobject', 'creatorDetail', array('resource' => $resource)) ?>
 
@@ -201,7 +214,9 @@
 
 <section class="section" id="notesArea">
 
-  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Notes area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'notesArea', 'title' => __('Edit notes area'))) ?>
+  <?php if (check_field_visibility('app_element_visibility_rad_notes_area')): ?>
+    <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Notes area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'notesArea', 'title' => __('Edit notes area'))) ?>
+  <?php endif; ?>
 
   <?php if (check_field_visibility('app_element_visibility_rad_physical_condition')): ?>
     <?php echo render_show(__('Physical condition'), render_value($resource->getPhysicalCharacteristics(array('cultureFallback' => true)))) ?>
@@ -284,7 +299,9 @@
 
 <section id="standardNumberArea">
 
-  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Standard number area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'standardNumberArea', 'title' => __('Edit standard number area'))) ?>
+  <?php if (check_field_visibility('app_element_visibility_rad_standard_number_area')): ?>
+    <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Standard number area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'standardNumberArea', 'title' => __('Edit standard number area'))) ?>
+  <?php endif; ?>
 
   <?php echo render_show(__('Standard number'), render_value($rad->__get('standardNumber', array('cultureFallback' => true)))) ?>
 
@@ -292,7 +309,9 @@
 
 <section id="accessPointsArea">
 
-  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Access points').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'accessPointsArea', 'title' => __('Edit access points'))) ?>
+  <?php if (check_field_visibility('app_element_visibility_rad_access_points_area')): ?>
+    <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Access points').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'accessPointsArea', 'title' => __('Edit access points'))) ?>
+  <?php endif; ?>
 
   <?php echo get_partial('informationobject/subjectAccessPoints', array('resource' => $resource)) ?>
 
@@ -304,7 +323,9 @@
 
 <section class="section" id="descriptionControlArea">
 
-  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Control area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'descriptionControlArea', 'title' => __('Edit control area'))) ?>
+  <?php if (check_field_visibility('app_element_visibility_rad_description_control_area')): ?>
+    <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Control area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'descriptionControlArea', 'title' => __('Edit control area'))) ?>
+  <?php endif; ?>
 
   <?php if (check_field_visibility('app_element_visibility_rad_control_description_identifier')): ?>
     <?php echo render_show(__('Description record identifier'), render_value($resource->descriptionIdentifier)) ?>


### PR DESCRIPTION
- provide configuration to control which area headings are displayed to un-authenticated users.
- add two collapsible tabs, "ISAD template - area headings" and "RAD template - area headings"; renamed the existing tabs to "ISAD template - elements" and "RAD template - elements".
