### PR TITLE
Solve accessions concurrence in different culture, reference #5914

### DIFF
--- a/plugins/qtAccessionPlugin/lib/model/QubitAccession.php
+++ b/plugins/qtAccessionPlugin/lib/model/QubitAccession.php
@@ -75,13 +75,13 @@ class QubitAccession extends BaseAccession
 
     if ($incrementCounter)
     {
-      $setting->value = $setting->getValue(array('sourceCulture' => true)) + 1;
+      $setting->value = $setting->getValue() + 1;
       $setting->save();
 
-      return $setting->getValue(array('sourceCulture' => true));
+      return ($setting->getCulture().$setting->getValue());
     }
 
-    return $setting->getValue(array('sourceCulture' => true)) + 1;
+    return ($setting->getCulture().(string)($setting->getValue() + 1));
   }
 
   public static function generateAccessionIdentifier($incrementCounter = false)


### PR DESCRIPTION
Use the accession_counter for the context culture incrementing and saving
it. Add the culture code into identifier to verify that it never is the
same as another culture.
