### PR TITLE
Add Authority description_identifier to search index and include it in the browsing - issue #6302

### DIFF
--- a/apps/qubit/modules/actor/actions/browseAction.class.php
+++ b/apps/qubit/modules/actor/actions/browseAction.class.php
@@ -94,7 +94,7 @@ class ActorBrowseAction extends DefaultBrowseAction
     }
 
     $this->query->setQuery($this->queryBool);
-    $this->query->setFields(array('slug', 'sourceCulture', 'i18n', 'entityTypeId', 'updatedAt'));
+    $this->query->setFields(array('slug', 'sourceCulture', 'i18n', 'entityTypeId', 'updatedAt', 'descriptionIdentifier'));
 
     // Set filter
     if (0 < count($this->filterBool->toArray()))

--- a/apps/qubit/modules/actor/templates/_searchResult.php
+++ b/apps/qubit/modules/actor/templates/_searchResult.php
@@ -7,6 +7,10 @@
     <p class="title"><?php echo link_to(get_search_i18n($doc, 'authorizedFormOfName'), array('module' => 'actor', 'slug' => $doc['slug'])) ?></p>
 
     <ul class="result-details">
+    
+      <?php if (isset($doc['descriptionIdentifier']) && !empty($doc['descriptionIdentifier'])): ?>
+        <li class="reference-code"><?php echo $doc['descriptionIdentifier'] ?></li>
+      <?php endif; ?>
 
       <?php if (isset($doc['entityTypeId']) && isset($types[$doc['entityTypeId']])): ?>
         <li><?php echo $types[$doc['entityTypeId']] ?></li>

--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -95,6 +95,7 @@ mapping:
     dynamic: strict
     properties:
       slug: { type: string, index: not_analyzed }
+      description_identifier: { type:string, index: not_analyzed}
       entity_type_id: { type: integer, index: not_analyzed, include_in_all: false }
 
   repository:

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchActorPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchActorPdo.class.php
@@ -136,6 +136,8 @@ class arElasticSearchActorPdo
 
     $serialized['entityTypeId'] = $this->entity_type_id;
 
+    $serialized['descriptionIdentifier'] = $this->description_identifier;
+
     $serialized['createdAt'] = arElasticSearchPluginUtil::convertDate($this->created_at);
     $serialized['updatedAt'] = arElasticSearchPluginUtil::convertDate($this->updated_at);
 


### PR DESCRIPTION
We had a use case for including the authority record description_identifier in the search index and including it in the browse results. As this matches how the archival descriptions are indexed and browsed it was straightforward to implement. Corresponding feature request:  https://projects.artefactual.com/issues/6302
