### PR TITLE
add padding-right to site-name, refs #6292

### DIFF
--- a/plugins/arDominionPlugin/css/less/header.less
+++ b/plugins/arDominionPlugin/css/less/header.less
@@ -33,6 +33,7 @@ header #logo {
   margin: 0;
   float: left;
   margin: 6px 0 0 4px;
+  padding-right: 35px;
   a {
     color: @white;
   }


### PR DESCRIPTION
This improves the spacing between the site name and the search box. It doesn't address the scenario of both site name and logo suppressed, but this seems less likely. Spacing already seems OK if there is a logo but no site name.
