### PR TITLE
Autocomplete delay override

### DIFF
--- a/apps/qubit/modules/informationobject/templates/editPhysicalObjectsSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/editPhysicalObjectsSuccess.php
@@ -49,7 +49,7 @@
 
         <div class="form-item">
           <?php echo $form->containers->renderLabel() ?>
-          <?php echo $form->containers->render(array('class' => 'form-autocomplete')) ?>
+          <?php echo $form->containers->render(array('class' => 'form-autocomplete', 'data-autocomplete-delay' => 0.3)) ?>
           <input class="add" type="hidden" value="<?php echo url_for(array($resource, 'module' => 'informationobject', 'action' => 'editPhysicalObjects')) ?> #name"/>
           <input class="list" type="hidden" value="<?php echo url_for(array('module' => 'physicalobject', 'action' => 'autocomplete')) ?>"/>
         </div>

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -169,7 +169,7 @@
                   // Give user chance to type something, one second may still
                   // be too little,
                   // http://developer.yahoo.com/yui/autocomplete/#delay
-                  autoComplete.queryDelay = 1;
+                  autoComplete.queryDelay = +$(select).data('autocomplete-delay') || 1;
 
                   // Add other fields from the form to the autocomplete request
                   if ($(this).attr('name') == 'relatedAuthorityRecord[subType]')

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -169,7 +169,7 @@
                   // Give user chance to type something, one second may still
                   // be too little,
                   // http://developer.yahoo.com/yui/autocomplete/#delay
-                  autoComplete.queryDelay = +$(select).data('autocomplete-delay') || 1;
+                  autoComplete.queryDelay = parseFloat($(select).data('autocomplete-delay')) || 1;
 
                   // Add other fields from the form to the autocomplete request
                   if ($(this).attr('name') == 'relatedAuthorityRecord[subType]')


### PR DESCRIPTION
The autocomplete.js code now checks for a data-autocomplete-delay attribute on the input element to override the default 1 second delay.
