### PR TITLE
enable mods import, refs #4303

### DIFF
--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -102,7 +102,7 @@ class QubitXmlImport
       'dublinCore' => 'dc',
       'metadata' => 'dc',
       //'mets' => 'mets',
-      //'mods' => 'mods',
+      'mods' => 'mods',
       'ead' => 'ead',
       'add' => 'alouette',
       'http://www.w3.org/2004/02/skos/core#' => 'skos'


### PR DESCRIPTION
This just uncomments the reference to mods, which was causing the 500 error reported in #4303
