### PR TITLE
Fix link to external assets in showDownloadComponent, fixes #6548

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/showDownloadComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/showDownloadComponent.class.php
@@ -61,7 +61,7 @@ class DigitalObjectShowDownloadComponent extends sfComponent
     if ((QubitTerm::IMAGE_ID != $this->resource->mediaTypeId || QubitTerm::REFERENCE_ID == $this->usageType)
         && QubitAcl::check($this->resource->informationObject, 'readMaster'))
     {
-      $this->link = public_path($this->resource->getFullPath(), true);
+      $this->link = $this->resource->getPublicPath();
     }
   }
 }

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -1455,6 +1455,22 @@ class QubitDigitalObject extends BaseDigitalObject
   }
 
   /**
+   * Get public URL to asset; if asset path is a public URL,
+   * returns that path instead of constructing on the current server.
+   *
+   * @return string URL to asset
+   */
+  public function getPublicPath()
+  {
+    if ($this->usageId == QubitTerm::EXTERNAL_URI_ID) {
+      return $this->getPath();
+    } else {
+      return public_path($this->getFullPath(), true);
+    }
+  }
+
+
+  /**
    * Get absolute path to asset
    *
    * @return string absolute path to asset


### PR DESCRIPTION
This moves the construction of a public URL into an instance method on QubitDigitalObject, so consumers like showDownloadComponent don't need to actually care whether the target is local.

This fixes an issue that came up when displaying download components for components of an unknown type; the showDownloadComponent class is no longer aware of whether it's local, but it shouldn't need to care since the digital object itself retains that knowledge.
