### PR TITLE
QubitDigitalObject: make timeout configurable, refs #6549

### DIFF
--- a/config/app.yml
+++ b/config/app.yml
@@ -9,6 +9,9 @@ all:
   #  Positive integer  => Number of gigabytes
   upload_limit: -1
 
+  # Timeout for fetching digital objects from external services, in seconds
+  download_timeout: 10
+
   # Use sfMemcacheCache if you want a distributed cache.
   # sfAPCCache can do the trick for a single instance (sfAPCuCache in PHP 5.5).
   cache_engine: sfAPCCache

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -1355,7 +1355,8 @@ class QubitDigitalObject extends BaseDigitalObject
     $uriComponents = parse_url($uri);
 
     // Initialize web browser
-    $browser = new sfWebBrowser(array(), null, array('Timeout' => 10));
+    $timeout = sfConfig::get("app_download_timeout");
+    $browser = new sfWebBrowser(array(), null, array('Timeout' => $timeout));
     $browser->get($uri);
 
     if ($browser->get($uri)->responseIsError() || 1 > strlen(($filename = basename($uriComponents['path']))))


### PR DESCRIPTION
This adds a new config parameter for the download timeout for external digital object imports; previously that was hardcoded to 10 seconds.
