### PR TITLE
Repository records - additional access points and facets.

### DIFF
--- a/apps/qubit/modules/repository/actions/browseAction.class.php
+++ b/apps/qubit/modules/repository/actions/browseAction.class.php
@@ -39,6 +39,18 @@ class RepositoryBrowseAction extends DefaultBrowseAction
       'regions' =>
         array('type' => 'term',
               'field' => 'contactInformations.i18n.en.region.untouched',
+              'size' => 10),
+      'geographicSubregions' =>
+        array('type' => 'term',
+              'field' => 'geographicSubregions',
+              'size' => 10),
+      'locality' =>
+        array('type' => 'term',
+              'field' => 'contactInformations.i18n.en.city.untouched',
+              'size' => 10),
+      'thematicAreas' =>
+        array('type' => 'term',
+              'field' => 'thematicAreas',
               'size' => 10));
 
   protected function populateFacet($name, $ids)
@@ -46,6 +58,8 @@ class RepositoryBrowseAction extends DefaultBrowseAction
     switch ($name)
     {
       case 'types':
+      case 'geographicSubregions':
+      case 'thematicAreas':
         $criteria = new Criteria;
         $criteria->add(QubitTerm::ID, array_keys($ids), Criteria::IN);
 
@@ -57,6 +71,7 @@ class RepositoryBrowseAction extends DefaultBrowseAction
         break;
 
       case 'regions':
+      case 'locality':
         foreach ($ids as $key => $count)
         {
           $this->types[$key] = $key;

--- a/apps/qubit/modules/repository/actions/editAction.class.php
+++ b/apps/qubit/modules/repository/actions/editAction.class.php
@@ -101,6 +101,60 @@ class RepositoryEditAction extends DefaultEditAction
 
         break;
 
+      case 'thematicArea':
+        $criteria = new Criteria;
+        $criteria = $this->resource->addObjectTermRelationsRelatedByObjectIdCriteria($criteria);
+        $criteria->addJoin(QubitObjectTermRelation::TERM_ID, QubitTerm::ID);
+        $criteria->add(QubitTerm::TAXONOMY_ID, QubitTaxonomy::THEMATIC_AREA_ID);
+
+        $value = array();
+        foreach ($this->thematicAreaRelations = QubitObjectTermRelation::get($criteria) as $item)
+        {
+          $value[] = $this->context->routing->generate(null, array($item->term, 'module' => 'term'));
+        }
+
+        $this->form->setDefault('thematicArea', $value);
+        $this->form->setValidator('thematicArea', new sfValidatorPass);
+
+        $choices = array();
+        foreach (QubitTaxonomy::getTermsById(QubitTaxonomy::THEMATIC_AREA_ID) as $item)
+        {
+          $choices[$this->context->routing->generate(null, array($item, 'module' => 'term'))] = $item->__toString();
+        }
+
+        $choice[] = asort($choices);
+
+        $this->form->setWidget('thematicArea', new sfWidgetFormSelect(array('choices' => $choices, 'multiple' => true)));
+
+        break;
+
+      case 'geographicSubregion':
+        $criteria = new Criteria;
+        $criteria = $this->resource->addObjectTermRelationsRelatedByObjectIdCriteria($criteria);
+        $criteria->addJoin(QubitObjectTermRelation::TERM_ID, QubitTerm::ID);
+        $criteria->add(QubitTerm::TAXONOMY_ID, QubitTaxonomy::GEOGRAPHIC_SUBREGION_ID);
+
+        $value = array();
+        foreach ($this->geographicSubregionRelations = QubitObjectTermRelation::get($criteria) as $item)
+        {
+          $value[] = $this->context->routing->generate(null, array($item->term, 'module' => 'term'));
+        }
+
+        $this->form->setDefault('geographicSubregion', $value);
+        $this->form->setValidator('geographicSubregion', new sfValidatorPass);
+
+        $choices = array();
+        foreach (QubitTaxonomy::getTermsById(QubitTaxonomy::GEOGRAPHIC_SUBREGION_ID) as $item)
+        {
+          $choices[$this->context->routing->generate(null, array($item, 'module' => 'term'))] = $item->__toString();
+        }
+
+        $choice[] = asort($choices);
+
+        $this->form->setWidget('geographicSubregion', new sfWidgetFormSelect(array('choices' => $choices, 'multiple' => true)));
+
+        break;
+
       case 'descDetail':
       case 'descStatus':
         $this->form->setDefault($name, $this->context->routing->generate(null, array($this->resource[$name], 'module' => 'term')));
@@ -183,6 +237,68 @@ class RepositoryEditAction extends DefaultEditAction
         }
 
         foreach ($this->relations as $item)
+        {
+          if (isset($value[$item->termId]))
+          {
+            unset($filtered[$item->termId]);
+          }
+          else
+          {
+            $item->delete();
+          }
+        }
+
+        foreach ($filtered as $item)
+        {
+          $relation = new QubitObjectTermRelation;
+          $relation->term = $item;
+
+          $this->resource->objectTermRelationsRelatedByobjectId[] = $relation;
+        }
+
+        break;
+
+      case 'geographicSubregion':
+        $value = $filtered = array();
+        foreach ($this->form->getValue('geographicSubregion') as $item)
+        {
+          $params = $this->context->routing->parse(Qubit::pathInfo($item));
+          $resource = $params['_sf_route']->resource;
+          $value[$resource->id] = $filtered[$resource->id] = $resource;
+        }
+
+        foreach ($this->geographicSubregionRelations as $item)
+        {
+          if (isset($value[$item->termId]))
+          {
+            unset($filtered[$item->termId]);
+          }
+          else
+          {
+            $item->delete();
+          }
+        }
+
+        foreach ($filtered as $item)
+        {
+          $relation = new QubitObjectTermRelation;
+          $relation->term = $item;
+
+          $this->resource->objectTermRelationsRelatedByobjectId[] = $relation;
+        }
+
+        break;
+
+      case 'thematicArea':
+        $value = $filtered = array();
+        foreach ($this->form->getValue('thematicArea') as $item)
+        {
+          $params = $this->context->routing->parse(Qubit::pathInfo($item));
+          $resource = $params['_sf_route']->resource;
+          $value[$resource->id] = $filtered[$resource->id] = $resource;
+        }
+
+        foreach ($this->thematicAreaRelations as $item)
         {
           if (isset($value[$item->termId]))
           {

--- a/apps/qubit/modules/repository/templates/browseSuccess.php
+++ b/apps/qubit/modules/repository/templates/browseSuccess.php
@@ -40,8 +40,29 @@
 
       <?php echo get_partial('search/facet', array(
         'target' => '#facet-province',
-        'label' => __('Region'),
+        'label' => __('Geographic Region'),
         'facet' => 'regions',
+        'pager' => $pager,
+        'filters' => $filters)) ?>
+
+      <?php echo get_partial('search/facet', array(
+        'target' => '#facet-geographicsubregion',
+        'label' => __('Geographic Subregion'),
+        'facet' => 'geographicSubregions',
+        'pager' => $pager,
+        'filters' => $filters)) ?>
+
+      <?php echo get_partial('search/facet', array(
+        'target' => '#facet-locality',
+        'label' => __('Locality'),
+        'facet' => 'locality',
+        'pager' => $pager,
+        'filters' => $filters)) ?>
+
+      <?php echo get_partial('search/facet', array(
+        'target' => '#facet-thematicarea',
+        'label' => __('Thematic Area'),
+        'facet' => 'thematicAreas',
         'pager' => $pager,
         'filters' => $filters)) ?>
 

--- a/data/fixtures/taxonomyTerms.yml
+++ b/data/fixtures/taxonomyTerms.yml
@@ -679,6 +679,22 @@ QubitTaxonomy:
     parent_id: QubitTaxonomy_root
     name:
       en: 'AIP types'
+  QubitTaxonomy_thematic_areas:
+    source_culture: en
+    id: 72
+    parent_id: QubitTaxonomy_root
+    name:
+      en: 'Thematic Area'
+    note:
+      en: 'These themes can assist in identifying major collecting areas, but should not be taken as comprehensive. Used as optional access point for ISDIAH repository records.'
+  QubitTaxonomy_geographic_subregions:
+    source_culture: en
+    id: 73
+    parent_id: QubitTaxonomy_root
+    name:
+      en: 'Geographic Subregion'
+    note:
+      en: 'Geographic subregions, based on local standards/common terminology if available. Used as optional access point for ISDIAH repository records in multi-repository databases.'
 QubitTerm:
   QubitTerm_110:
     taxonomy_id: 30
@@ -4442,6 +4458,167 @@ QubitTerm:
       gl: 'DACS, 2nd ed. Society of American Archivists'
       it: 'DACS, 2nd ed. Society of American Archivists'
       sl: 'Arhivsko popisovanje: vsebinski standard (DACS), 2. izdaja, Društvo ameriških arhivistov'
+  QubitTerm_thematic_areas_aboriginal:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Aboriginal Peoples
+      fr: Peuples autochtones
+  QubitTerm_thematic_areas_agriculture:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Agriculture
+      fr: Agriculture
+  QubitTerm_thematic_areas_arts:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Arts and Culture
+      fr: Arts et culture
+  QubitTerm_thematic_areas_communication:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Communication
+      fr: Communication
+  QubitTerm_thematic_areas_education:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Education
+      fr: Éducation
+  QubitTerm_thematic_areas_environment:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Environment
+      fr: Environnement
+  QubitTerm_thematic_areas_family:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Family / Domestic Life
+      fr: Vie privée
+  QubitTerm_thematic_areas_genealogical:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Genealogical
+      fr: Généalogique
+  QubitTerm_thematic_areas_geography:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Geography
+      fr: Géographie
+  QubitTerm_thematic_areas_industry:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Industry, Manufacturing and Commerce
+      fr: Industries, fabrication, et commerce
+  QubitTerm_thematic_areas_labour:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Labour
+      fr: Travail
+  QubitTerm_thematic_areas_law:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Law and Justice
+      fr: Droit et justice
+  QubitTerm_thematic_areas_medicine:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Medicine and Health
+      fr: Médecine et santé
+  QubitTerm_thematic_areas_military:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Military
+      fr: Forces armées
+  QubitTerm_thematic_areas_natural_resources:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Natural Resources
+      fr: Richesses naturelles
+  QubitTerm_thematic_areas_politics:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Politics and Government
+      fr: Politique et gouvernement
+  QubitTerm_thematic_areas_populations:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Populations
+      fr: Populations
+  QubitTerm_thematic_areas_recreation:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Recreation / Leisure / Sports
+      fr: Loisirs et sports
+  QubitTerm_thematic_areas_religion:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Religion
+      fr: Religion
+  QubitTerm_thematic_areas_science:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Science and Technology
+      fr: Sciences et technologie
+  QubitTerm_thematic_areas_social_organizations:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Social Organizations and Activities
+      fr: Vie sociale
+  QubitTerm_thematic_areas_transportation:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Transportation
+      fr: Transport
+  QubitTerm_thematic_areas_travel:
+    taxonomy_id: QubitTaxonomy_thematic_areas
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: Travel and Exploration
+      fr: Voyages et exploration
 QubitNote:
   QubitNote_1:
     object_id: QubitTerm_111

--- a/lib/model/QubitRepository.php
+++ b/lib/model/QubitRepository.php
@@ -310,6 +310,70 @@ class QubitRepository extends BaseRepository
     $this->objectTermRelationsRelatedByobjectId[] = $relation;
   }
 
+  public function setThematicAreaByName($name)
+  {
+    // see if type term already exists
+    $criteria = new Criteria;
+    $criteria->addJoin(QubitTerm::ID, QubitTermI18n::ID);
+    $criteria->add(QubitTerm::TAXONOMY_ID, QubitTaxonomy::THEMATIC_AREA_ID);
+    $criteria->add(QubitTermI18n::NAME, $name);
+
+    if (null === $term = QubitTerm::getOne($criteria))
+    {
+      $term = new QubitTerm;
+      $term->setTaxonomyId(QubitTaxonomy::THEMATIC_AREA_ID);
+      $term->setName($name);
+      $term->setRoot();
+      $term->save();
+    }
+
+    foreach (self::getTermRelations(QubitTaxonomy::THEMATIC_AREA_ID) as $item)
+    {
+      // Faster than $item->term == $term
+      if ($item->termId == $term->id)
+      {
+        return;
+      }
+    }
+
+    $relation = new QubitObjectTermRelation;
+    $relation->term = $term;
+
+    $this->objectTermRelationsRelatedByobjectId[] = $relation;
+  }
+
+  public function setGeographicSubregionByName($name)
+  {
+    // see if type term already exists
+    $criteria = new Criteria;
+    $criteria->addJoin(QubitTerm::ID, QubitTermI18n::ID);
+    $criteria->add(QubitTerm::TAXONOMY_ID, QubitTaxonomy::GEOGRAPHIC_SUBREGION_ID);
+    $criteria->add(QubitTermI18n::NAME, $name);
+
+    if (null === $term = QubitTerm::getOne($criteria))
+    {
+      $term = new QubitTerm;
+      $term->setTaxonomyId(QubitTaxonomy::GEOGRAPHIC_SUBREGION_ID);
+      $term->setName($name);
+      $term->setRoot();
+      $term->save();
+    }
+
+    foreach (self::getTermRelations(QubitTaxonomy::GEOGRAPHIC_SUBREGION_ID) as $item)
+    {
+      // Faster than $item->term == $term
+      if ($item->termId == $term->id)
+      {
+        return;
+      }
+    }
+
+    $relation = new QubitObjectTermRelation;
+    $relation->term = $term;
+
+    $this->objectTermRelationsRelatedByobjectId[] = $relation;
+  }
+
   /**
    * Get the current repository uploads directory
    *

--- a/lib/model/QubitTaxonomy.php
+++ b/lib/model/QubitTaxonomy.php
@@ -70,7 +70,10 @@ class QubitTaxonomy extends BaseTaxonomy
     INFORMATION_OBJECT_TEMPLATE_ID = 70,
 
     // Metadata templates
-    AIP_TYPE_ID = 71;
+    AIP_TYPE_ID = 71,
+
+    THEMATIC_AREA_ID = 72,
+    GEOGRAPHIC_SUBREGION_ID = 73;
 
   public static
     $lockedTaxonomies = array(

--- a/lib/model/QubitTerm.php
+++ b/lib/model/QubitTerm.php
@@ -438,6 +438,16 @@ class QubitTerm extends BaseTerm
     return QubitTaxonomy::getTermsById(QubitTaxonomy::MODS_TITLE_TYPE_ID, $options);
   }
 
+  public static function getThematicAreas($options = array())
+  {
+    return QubitTaxonomy::getTermsById(QubitTaxonomy::THEMATIC_AREA_ID, $options);
+  }
+
+  public static function getGeographicSubregions($options = array())
+  {
+    return QubitTaxonomy::getTermsById(QubitTaxonomy::GEOGRAPHIC_SUBREGION_ID, $options);
+  }
+
   /**
    * Return a list of all Physical Object terms
    *

--- a/lib/task/migrate/migrations/arMigration0109.class.php
+++ b/lib/task/migrate/migrations/arMigration0109.class.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add display_standard_id column to information object and information object
+ * templates taxonomy and terms
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0109
+{
+  const
+    VERSION = 109, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  /**
+   * Upgrade
+   *
+   * @return bool True if the upgrade succeeded, False otherwise
+   */
+  public function up($configuration)
+  {
+    // Add the "Thematic Areas" taxonomy
+    QubitMigrate::bumpTaxonomy(QubitTaxonomy::THEMATIC_AREA_ID, $configuration);
+    $taxonomy = new QubitTaxonomy;
+    $taxonomy->id = QubitTaxonomy::THEMATIC_AREA_ID;
+    $taxonomy->parentId = QubitTaxonomy::ROOT_ID;
+    $taxonomy->name = 'Thematic Area';
+    $taxonomy->note = 'These themes can assist in identifying major collecting areas, but should not be taken as comprehensive. Used as optional access point for ISDIAH repository records.';
+    $taxonomy->culture = 'en';
+    $taxonomy->save();
+
+    // Add the "Geographic Subregions" taxonomy
+    QubitMigrate::bumpTaxonomy(QubitTaxonomy::GEOGRAPHIC_SUBREGION_ID, $configuration);
+    $taxonomy = new QubitTaxonomy;
+    $taxonomy->id = QubitTaxonomy::GEOGRAPHIC_SUBREGION_ID;
+    $taxonomy->parentId = QubitTaxonomy::ROOT_ID;
+    $taxonomy->name = 'Geographic Subregion';
+    $taxonomy->note = 'Geographic subregions, based on local standards/common terminology if available. Used as optional access point for ISDIAH repository records in multi-repository databases.';
+    $taxonomy->culture = 'en';
+    $taxonomy->save();
+
+    // Add the "Thematic Areas" terms
+    foreach (array(
+      array('en' => 'Aboriginal Peoples',                   'fr' => 'Peuples autochtones'),
+      array('en' => 'Agriculture',                          'fr' => 'Agriculture'),
+      array('en' => 'Arts and Culture',                     'fr' => 'Arts et culture'),
+      array('en' => 'Communication',                        'fr' => 'Communication'),
+      array('en' => 'Education',                            'fr' => 'Éducation'),
+      array('en' => 'Environment',                          'fr' => 'Environnement'),
+      array('en' => 'Family / Domestic Life',               'fr' => 'Vie privée'),
+      array('en' => 'Genealogical',                         'fr' => 'Généalogique'),
+      array('en' => 'Geography',                            'fr' => 'Géographie'),
+      array('en' => 'Industry, Manufacturing and Commerce', 'fr' => 'Industries, fabrication, et commerce'),
+      array('en' => 'Labour',                               'fr' => 'Travail'),
+      array('en' => 'Law and Justice',                      'fr' => 'Droit et justice'),
+      array('en' => 'Medicine and Health',                  'fr' => 'Médecine et santé'),
+      array('en' => 'Military',                             'fr' => 'Forces armées'),
+      array('en' => 'Natural Resources',                    'fr' => 'Richesses naturelles'),
+      array('en' => 'Politics and Government',              'fr' => 'Politique et gouvernement'),
+      array('en' => 'Populations',                          'fr' => 'Populations'),
+      array('en' => 'Recreation / Leisure / Sports',        'fr' => 'Loisirs et sports'),
+      array('en' => 'Religion',                             'fr' => 'Religion'),
+      array('en' => 'Science and Technology',               'fr' => 'Sciences et technologie'),
+      array('en' => 'Social Organizations and Activities',  'fr' => 'Vie sociale'),
+      array('en' => 'Transportation',                       'fr' => 'Transport'),
+      array('en' => 'Travel and Exploration',               'fr' => 'Voyages et exploration')) as $termNames)
+    {
+      $term = new QubitTerm;
+      $term->parentId = QubitTerm::ROOT_ID;
+      $term->taxonomyId = QubitTaxonomy::THEMATIC_AREA_ID;
+      $term->sourceCulture = 'en';
+      foreach ($termNames as $key => $value) {
+        $term->setName($value, array('culture' => $key));
+      }
+      $term->save();
+    }
+    return true;
+  }
+}

--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -204,6 +204,9 @@ mapping:
       slug: { type: string, index: not_analyzed }
       identifier: { type: string, index: not_analyzed }
       types: { type: integer, index: not_analyzed, include_in_all: false }
+      geographic_subregions: { type: integer, index: not_analyzed, include_in_all: false }
+      locality: { type: string, index: not_analyzed }
+      thematic_areas: { type: integer, index: not_analyzed, include_in_all: false }
 
   information_object:
     _attributes:

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchRepository.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchRepository.class.php
@@ -51,6 +51,16 @@ class arElasticSearchRepository extends arElasticSearchModelBase
       $serialized['types'][] = $relation->termId;
     }
 
+    foreach ($object->getTermRelations(QubitTaxonomy::THEMATIC_AREA_ID) as $relation)
+    {
+      $serialized['thematicAreas'][] = $relation->termId;
+    }
+
+    foreach ($object->getTermRelations(QubitTaxonomy::GEOGRAPHIC_SUBREGION_ID) as $relation)
+    {
+      $serialized['geographicSubregions'][] = $relation->termId;
+    }
+
     foreach ($object->contactInformations as $contactInformation)
     {
       $serialized['contactInformations'][] = arElasticSearchContactInformation::serialize($contactInformation);

--- a/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/actions/editAction.class.php
+++ b/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/actions/editAction.class.php
@@ -58,7 +58,9 @@ class sfIsdiahPluginEditAction extends RepositoryEditAction
       'language',
       'script',
       'descSources',
-      'maintenanceNotes');
+      'maintenanceNotes',
+      'geographicSubregion',
+      'thematicArea');
 
   protected function earlyExecute()
   {

--- a/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/editSuccess.php
+++ b/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/editSuccess.php
@@ -184,6 +184,40 @@
 
       </fieldset>
 
+      <fieldset class="collapsible collapsed" id="accessPointsArea">
+
+        <legend><?php echo __('Access points') ?></legend>
+
+        <div class="form-item">
+          <?php echo $form->thematicArea
+            ->label(__('Thematic area'))
+            ->renderLabel() ?>
+          <?php echo $form->thematicArea->render(array('class' => 'form-autocomplete')) ?>
+          <?php if (QubitAcl::check(QubitTaxonomy::getById(QubitTaxonomy::THEMATIC_AREA_ID), 'createTerm')): ?>
+            <input class="add" type="hidden" value="<?php echo url_for(array('module' => 'term', 'action' => 'add', 'taxonomy' => url_for(array(QubitTaxonomy::getById(QubitTaxonomy::THEMATIC_AREA_ID), 'module' => 'taxonomy')))) ?> #name"/>
+          <?php endif; ?>
+          <input class="list" type="hidden" value="<?php echo url_for(array('module' => 'term', 'action' => 'autocomplete', 'taxonomy' => url_for(array(QubitTaxonomy::getById(QubitTaxonomy::THEMATIC_AREA_ID), 'module' => 'taxonomy')))) ?>"/>
+          <?php echo $form->thematicArea
+            ->help(__("Search for an existing term in the Thematic Areas taxonomy by typing the first few characters of the term name. This should be used to identify major collecting areas."))
+            ->renderHelp() ?>
+        </div>
+
+        <div class="form-item">
+          <?php echo $form->geographicSubregion
+            ->label(__('Geographic subregion'))
+            ->renderLabel() ?>
+          <?php echo $form->geographicSubregion->render(array('class' => 'form-autocomplete')) ?>
+          <?php if (QubitAcl::check(QubitTaxonomy::getById(QubitTaxonomy::GEOGRAPHIC_SUBREGION_ID), 'createTerm')): ?>
+            <input class="add" type="hidden" value="<?php echo url_for(array('module' => 'term', 'action' => 'add', 'taxonomy' => url_for(array(QubitTaxonomy::getById(QubitTaxonomy::GEOGRAPHIC_SUBREGION_ID), 'module' => 'taxonomy')))) ?> #name"/>
+          <?php endif; ?>
+          <input class="list" type="hidden" value="<?php echo url_for(array('module' => 'term', 'action' => 'autocomplete', 'taxonomy' => url_for(array(QubitTaxonomy::getById(QubitTaxonomy::GEOGRAPHIC_SUBREGION_ID), 'module' => 'taxonomy')))) ?>"/>
+          <?php echo $form->geographicSubregion
+            ->help(__("Search for an existing term in the Geographic Subregion taxonomy by typing the first few characters of the term name."))
+            ->renderHelp() ?>
+        </div>
+
+      </fieldset>
+
     </section>
 
     <section class="actions">

--- a/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
@@ -220,6 +220,23 @@
 
 </section>
 
+<section id="accessPointsArea">
+
+  <?php echo link_to_if(SecurityPriviliges::editCredentials($sf_user, 'repository'), '<h2>'.__('Access points').'</h2>', array($resource, 'module' => 'repository', 'action' => 'edit'), array('anchor' => 'accessPointsArea', 'title' => __('Edit access points'))) ?>
+  <div class="field">
+    <h3><?php echo __('Access Points') ?></h3>
+    <div>
+      <ul>
+        <?php foreach ($resource->getTermRelations(QubitTaxonomy::THEMATIC_AREA_ID) as $item): ?>
+          <li><?php echo __(render_value($item->term)) ?> (Thematic area)</li>
+        <?php endforeach; ?>
+        <?php foreach ($resource->getTermRelations(QubitTaxonomy::GEOGRAPHIC_SUBREGION_ID) as $item): ?>
+          <li><?php echo __(render_value($item->term)) ?> (Geographic subregion)</li>
+        <?php endforeach; ?>
+      </ul>
+    </div>
+  </div>
+</section>
 
 <?php if (QubitAcl::check($resource, array('update', 'delete', 'create'))): ?>
 


### PR DESCRIPTION
Currently in 2.0, when browsing archival institutions there are facets for:
- archive type
- region (i.e. province in the Canadian context)

This enhancement would add two access points to the ISDIAH record:
- geographic subregion (e.g., Southwestern Saskatchewan, Northern Saskatchewan)
- thematic area (e.g., Agriculture, Local/regional history, Aboriginal peoples)

...and add facets to the repository browse:
- locality (city/community)
- geographic subregion
- thematic area

Default thematic areas are created for new installs and migrations.
