### PR TITLE
Avoid requiring the PHP readline extension if not necessary

### DIFF
--- a/lib/task/tools/addSuperuserTask.class.php
+++ b/lib/task/tools/addSuperuserTask.class.php
@@ -57,9 +57,10 @@ EOF;
    */
   public function execute($arguments = array(), $options = array())
   {
-    if (!function_exists('readline'))
+    $needsData = !$arguments['username'] || !$options['email'] || !$options['password'];
+    if ($needsData && !function_exists('readline'))
     {
-      throw new Exception('This tasks needs the PHP readline extension.');
+      throw new Exception('This tasks needs the PHP readline extension: not all the parameters have been supplied.');
     }
 
     sfContext::createInstance($this->configuration);


### PR DESCRIPTION
This commit allows the generation of a superuser also in systems where PHP readline is not available, but only if all the parameters have already been supplied in the command line.
