### PR TITLE
Added CLI arg for site URL to EAD bulk export.

### DIFF
--- a/lib/task/exportBulkTask.class.php
+++ b/lib/task/exportBulkTask.class.php
@@ -36,6 +36,7 @@ class eadExportTask extends sfBaseTask
   protected function configure()
   {
     $this->addArguments(array(
+      new sfCommandArgument('site-url', sfCommandArgument::REQUIRED, 'The base URL of your AtoM site (example: "http://www.example.com").'),
       new sfCommandArgument('folder', sfCommandArgument::REQUIRED, 'The destination folder for XML export files.')
     ));
 
@@ -54,6 +55,8 @@ class eadExportTask extends sfBaseTask
    */
   public function execute($arguments = array(), $options = array())
   {
+    // Make sure arguments are valid
+    $siteBaseUrl = $this->checkAndNormalizeSiteUrl($arguments['site-url']);
     $this->checkForValidFolder($arguments['folder']);
 
     $databaseManager = new sfDatabaseManager($this->configuration);
@@ -103,6 +106,19 @@ class eadExportTask extends sfBaseTask
 
       $itemsExported++;
     }
+  }
+
+  protected function checkAndNormalizeSiteUrl($url)
+  {
+    if (filter_var($url, FILTER_VALIDATE_URL) === False)
+    {
+      throw new sfException('Invalid URL');
+    }
+
+    // Add trailing slash to URL if it's not already there
+    $url = (substr($url, -1) != '/') ? $url .'/' : $url;
+
+    return $url;
   }
 
   protected function checkForValidFolder($folder)

--- a/plugins/sfEadPlugin/lib/sfEadPlugin.class.php
+++ b/plugins/sfEadPlugin/lib/sfEadPlugin.class.php
@@ -155,7 +155,7 @@ class sfEadPlugin
     return $hasNonBlankNotes;
   }
 
-  public function renderEadId()
+  public function renderEadId($siteBaseUrl = false)
   {
     $countryCode = $mainAgencyCode = '';
 
@@ -177,7 +177,9 @@ class sfEadPlugin
       }
     }
 
-    $url = url_for(array($this->resource, 'module' => 'informationobject'), $absolute = true);
+    $url = ($siteBaseUrl)
+      ? $siteBaseUrl . $this->resource->slug
+      : url_for(array($this->resource, 'module' => 'informationobject'), $absolute = true);
 
     if (null === $identifier = $this->resource->descriptionIdentifier)
     {

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
@@ -1,6 +1,6 @@
 <ead>
 <eadheader langencoding="iso639-2b" countryencoding="iso3166-1" dateencoding="iso8601" repositoryencoding="iso15511" scriptencoding="iso15924" relatedencoding="DC">
-  <?php echo $ead->renderEadId() ?>
+  <?php echo $ead->renderEadId($siteBaseUrl) ?>
   <filedesc>
     <titlestmt>
       <?php if (0 < strlen($value = $resource->getTitle(array('cultureFallback' => true)))): ?>


### PR DESCRIPTION
CLI tasks have no knowledge of hostname, etc., so can't automatically
generate a full base URL for exported XML. Added a CLI arg to the
EAD bulk export tool to specify a URL. Integrated this into the existing
EAD template.
