### PR TITLE
#7124 - Changes how actors are fetched or created in DIP upload and CSV and XML imports.

### DIFF
--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -1068,6 +1068,11 @@ class QubitFlatfileImport
           $actorOptions['history'] = $options['actorHistory'];
         }
 
+        if (isset($this->object->repositoryId))
+        {
+          $actorOptions['repositoryId'] = $this->object->repositoryId;
+        }
+
         $actor = $this->createOrFetchActor($options['actorName'], $actorOptions);
         $event->actorId = $actor->id;
       }
@@ -1142,16 +1147,48 @@ class QubitFlatfileImport
     $statement = QubitFlatfileImport::sqlQuery($query, array($name));
     $result = $statement->fetch(PDO::FETCH_OBJ);
 
-    if ($result)
+    // If we can't find a match create new actor
+    if (false === $result)
     {
-      $actor = QubitActor::getById($result->id);
-      $allowedProperties = array('history', 'entityTypeId');
-      QubitFlatfileImport::setPropertiesFromArray($actor, $options, $allowedProperties);
-      $actor->save();
-      return $actor;
-    } else {
       return QubitFlatfileImport::createActor($name, $options);
     }
+
+    // If there is a match and a repositoryId option is set, check
+    // if the actor is related to descriprions in the repository.
+    if (isset($options['repositoryId']))
+    {
+      $sql = "SELECT id FROM information_object
+        WHERE id IN (
+          SELECT subject_id AS id FROM relation
+            WHERE object_id=? AND type_id=?
+          UNION
+          SELECT information_object_id AS id FROM event
+            WHERE actor_id=? AND type_id=?)
+        AND repository_id=?";
+
+      $statement = QubitFlatfileImport::sqlQuery($sql, array(
+        $result->id,
+        QubitTerm::NAME_ACCESS_POINT_ID,
+        $result->id,
+        QubitTerm::CREATION_ID,
+        $options['repositoryId']));
+
+      unset($options['repositoryId']);
+
+      // If it's not related create new actor
+      if (false === $statement->fetch(PDO::FETCH_OBJ))
+      {
+        return QubitFlatfileImport::createActor($name, $options);
+      }
+    }
+
+    // Otherwise update and return existing actor
+    $actor = QubitActor::getById($result->id);
+    $allowedProperties = array('history', 'entityTypeId');
+    QubitFlatfileImport::setPropertiesFromArray($actor, $options, $allowedProperties);
+    $actor->save();
+
+    return $actor;
   }
 
   /**

--- a/lib/model/QubitActor.php
+++ b/lib/model/QubitActor.php
@@ -496,21 +496,15 @@ INNER JOIN actor_i18n i18n
 ON act.id=i18n.id
 WHERE i18n.authorized_form_of_name=?
 AND act.id IN (
-  SELECT object_id AS id FROM relation
-  WHERE subject_id IN (
-    SELECT id FROM information_object
+  SELECT r.object_id AS id FROM relation r
+    LEFT JOIN information_object io ON r.subject_id=io.id
     WHERE repository_id=?
-  )
-  UNION SELECT subject_id AS id FROM relation
-  WHERE object_id IN (
-    SELECT id FROM information_object
+  UNION SELECT r.subject_id AS id FROM relation r
+    LEFT JOIN information_object io ON r.object_id=io.id
     WHERE repository_id=?
-  )
-  UNION SELECT actor_id AS id FROM event
-  WHERE information_object_id IN (
-    SELECT id FROM information_object
-    WHERE repository_id=?
-  )
+  UNION SELECT e.actor_id AS id FROM event e
+    LEFT JOIN information_object io ON e.information_object_id=io.id
+    WHERE io.repository_id=?
 );
 
 sql;
@@ -530,21 +524,15 @@ INNER JOIN actor_i18n i18n
 ON act.id=i18n.id
 WHERE i18n.authorized_form_of_name=?
 AND act.id IN (
-  SELECT object_id AS id FROM relation
-  WHERE subject_id IN (
-    SELECT id FROM information_object
+  SELECT r.object_id AS id FROM relation r
+    LEFT JOIN information_object io ON r.subject_id=io.id
     WHERE repository_id IS NULL
-  )
-  UNION SELECT subject_id AS id FROM relation
-  WHERE object_id IN (
-    SELECT id FROM information_object
+  UNION SELECT r.subject_id AS id FROM relation r
+    LEFT JOIN information_object io ON r.object_id=io.id
     WHERE repository_id IS NULL
-  )
-  UNION SELECT actor_id AS id FROM event
-  WHERE information_object_id IN (
-    SELECT id FROM information_object
-    WHERE repository_id IS NULL
-  )
+  UNION SELECT e.actor_id AS id FROM event e
+    LEFT JOIN information_object io ON e.information_object_id=io.id
+    WHERE io.repository_id IS NULL
 );
 
 sql;

--- a/lib/model/QubitActor.php
+++ b/lib/model/QubitActor.php
@@ -500,28 +500,26 @@ AND act.id IN (
   WHERE subject_id IN (
     SELECT id FROM information_object
     WHERE repository_id=?
-  ) AND type_id=?
+  )
   UNION SELECT subject_id AS id FROM relation
   WHERE object_id IN (
     SELECT id FROM information_object
     WHERE repository_id=?
-  ) AND type_id=?
+  )
   UNION SELECT actor_id AS id FROM event
   WHERE information_object_id IN (
     SELECT id FROM information_object
     WHERE repository_id=?
-  ) AND type_id=?);
+  )
+);
 
 sql;
 
       $actorId = QubitPdo::fetchColumn($sql, array(
         $name,
         $repositoryId,
-        QubitTerm::NAME_ACCESS_POINT_ID,
         $repositoryId,
-        QubitTerm::NAME_ACCESS_POINT_ID,
-        $repositoryId,
-        QubitTerm::CREATION_ID));
+        $repositoryId));
     }
     else
     {
@@ -536,26 +534,22 @@ AND act.id IN (
   WHERE subject_id IN (
     SELECT id FROM information_object
     WHERE repository_id IS NULL
-  ) AND type_id=?
+  )
   UNION SELECT subject_id AS id FROM relation
   WHERE object_id IN (
     SELECT id FROM information_object
     WHERE repository_id IS NULL
-  ) AND type_id=?
+  )
   UNION SELECT actor_id AS id FROM event
   WHERE information_object_id IN (
     SELECT id FROM information_object
     WHERE repository_id IS NULL
-  ) AND type_id=?
+  )
 );
 
 sql;
 
-      $actorId = QubitPdo::fetchColumn($sql, array(
-        $name,
-        QubitTerm::NAME_ACCESS_POINT_ID,
-        QubitTerm::NAME_ACCESS_POINT_ID,
-        QubitTerm::CREATION_ID));
+      $actorId = QubitPdo::fetchColumn($sql, array($name));
     }
 
     if (false !== $actorId)

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -1314,7 +1314,7 @@ class QubitInformationObject extends BaseInformationObject
     // Information object must be saved before.
     // The id is needed to save the events and relations when
     // they are created instead of when the information object is saved
-    // to be able to execute raw queries over them
+    // to be able to execute raw queries over them (in QubitActor::getByNameAndRepositoryId)
     if (!isset($this->id))
     {
       $this->save();

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -1311,6 +1311,15 @@ class QubitInformationObject extends BaseInformationObject
       return;
     }
 
+    // Information object must be saved before.
+    // The id is needed to save the events and relations when
+    // they are created instead of when the information object is saved
+    // to be able to execute raw queries over them
+    if (!isset($this->id))
+    {
+      $this->save();
+    }
+
     // See if the actor record already exists
     $criteria = new Criteria;
     $criteria->addJoin(QubitActor::ID, QubitActorI18n::ID);
@@ -1400,6 +1409,12 @@ class QubitInformationObject extends BaseInformationObject
         $event->setDescription($options['event_note']);
       }
 
+      // Needs to be saved and added to $this->events
+      // to be able to execute raw queries and to be available
+      // for the following existingRelation foreach
+      $event->informationObjectId = $this->id;
+      $event->save();
+
       $this->events[] = $event;
     }
     else if (isset($options['relation_type_id']))
@@ -1421,6 +1436,8 @@ class QubitInformationObject extends BaseInformationObject
         $relation = new QubitRelation;
         $relation->objectId = $actor->id;
         $relation->typeId = QubitTerm::NAME_ACCESS_POINT_ID;
+        $relation->subjectId = $this->id;
+        $relation->save();
 
         $this->relationsRelatedBysubjectId[] = $relation;
       }

--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -681,6 +681,12 @@ EOF;
                 {
                   $actorOptions['history'] = $self->rowStatusVars['nameAccessPointHistories'][$index];
                 }
+
+                if (isset($self->object->repositoryId))
+                {
+                  $actorOptions['repositoryId'] = $self->object->repositoryId;
+                }
+
                 $actor = $self->createOrFetchActor($name, $actorOptions);
                 $self->createRelation($self->object->id, $actor->id, QubitTerm::NAME_ACCESS_POINT_ID);
               }

--- a/plugins/qtSwordPlugin/lib/qtPackageExtractorMETSArchivematicaDIP.class.php
+++ b/plugins/qtSwordPlugin/lib/qtPackageExtractorMETSArchivematicaDIP.class.php
@@ -144,7 +144,15 @@ class qtPackageExtractorMETSArchivematicaDIP extends qtPackageExtractorBase
 
     if ($options['actorName'])
     {
-      $actor = QubitFlatfileImport::createOrFetchActor($options['actorName']);
+      // Check actor creation with the target repository
+      if (null === $actor = QubitActor::getByNameAndRepositoryId($options['actorName'], $this->resource->repositoryId))
+      {
+        $actor = new QubitActor;
+        $actor->parentId = QubitActor::ROOT_ID;
+        $actor->setAuthorizedFormOfName($options['actorName']);
+        $actor->save();
+      }
+
       $event->actorId = $actor->id;
     }
 


### PR DESCRIPTION
Obtains the first actor with the given name and related to descriptions in the repository indicated in the import. 
If there isn't a repository indicated it checks relations with descriptions without repository.
All event and relation types are included.

The change affects actors created/fetched in DIP upload, in CSV import of accessions, events and archival descriptions, and XML import of:

DC: creator, publisher, contributor
EAD: name, persname, corpname, famname (in did/origination and controlaccess)
MODS: name/namePart
