### PR TITLE
#7120 - Alter language facet to count unique documents regardless of culture

### DIFF
--- a/apps/qubit/modules/actor/actions/browseAction.class.php
+++ b/apps/qubit/modules/actor/actions/browseAction.class.php
@@ -83,7 +83,7 @@ class ActorBrowseAction extends DefaultBrowseAction
     {
       // I don't think that this is going to scale, but let's leave it for now
       case 'alphabetic':
-        $field = sprintf('i18n.%s.authorizedFormOfName.untouched', $this->context->user->getCulture());
+        $field = sprintf('i18n.%s.authorizedFormOfName.untouched', $this->selectedCulture);
         $this->query->setSort(array($field => 'asc'));
 
         break;

--- a/apps/qubit/modules/actor/templates/_searchResult.php
+++ b/apps/qubit/modules/actor/templates/_searchResult.php
@@ -4,7 +4,7 @@
 
   <div class="search-result-description">
 
-    <p class="title"><?php echo link_to(get_search_i18n($doc, 'authorizedFormOfName'), array('module' => 'actor', 'slug' => $doc['slug'])) ?></p>
+    <p class="title"><?php echo link_to(get_search_i18n($doc, 'authorizedFormOfName', true, false, $culture), array('module' => 'actor', 'slug' => $doc['slug'])) ?></p>
 
     <ul class="result-details">
 
@@ -16,7 +16,7 @@
         <li><?php echo $types[$doc['entityTypeId']] ?></li>
       <?php endif; ?>
 
-      <li><?php echo get_search_i18n($doc, 'datesOfExistence') ?></li>
+      <li><?php echo get_search_i18n($doc, 'datesOfExistence', true, true, $culture) ?></li>
 
     </ul>
 

--- a/apps/qubit/modules/actor/templates/_searchResult.php
+++ b/apps/qubit/modules/actor/templates/_searchResult.php
@@ -4,7 +4,7 @@
 
   <div class="search-result-description">
 
-    <p class="title"><?php echo link_to(get_search_i18n($doc, 'authorizedFormOfName', true, false, $culture), array('module' => 'actor', 'slug' => $doc['slug'])) ?></p>
+    <p class="title"><?php echo link_to(get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false, 'culture' => $culture)), array('module' => 'actor', 'slug' => $doc['slug'])) ?></p>
 
     <ul class="result-details">
 
@@ -16,7 +16,7 @@
         <li><?php echo $types[$doc['entityTypeId']] ?></li>
       <?php endif; ?>
 
-      <li><?php echo get_search_i18n($doc, 'datesOfExistence', true, true, $culture) ?></li>
+      <li><?php echo get_search_i18n($doc, 'datesOfExistence', array('culture' => $culture)) ?></li>
 
     </ul>
 

--- a/apps/qubit/modules/actor/templates/browseSuccess.php
+++ b/apps/qubit/modules/actor/templates/browseSuccess.php
@@ -66,7 +66,7 @@
 
 <?php foreach ($pager->getResults() as $hit): ?>
   <?php $doc = $hit->getData() ?>
-  <?php echo include_partial('actor/searchResult', array('doc' => $doc, 'pager' => $pager)) ?>
+  <?php echo include_partial('actor/searchResult', array('doc' => $doc, 'pager' => $pager, 'culture' => $selectedCulture)) ?>
 <?php endforeach; ?>
 
 <?php slot('after-content') ?>

--- a/apps/qubit/modules/default/actions/browseAction.class.php
+++ b/apps/qubit/modules/default/actions/browseAction.class.php
@@ -266,5 +266,14 @@ class DefaultBrowseAction extends sfAction
 
       $this->addFilters();
     }
+
+    if (isset($this->filters['languages']))
+    {
+      $this->selectedCulture = $this->filters['languages'];
+    }
+    else
+    {
+      $this->selectedCulture = $this->context->user->getCulture();
+    }
   }
 }

--- a/apps/qubit/modules/default/actions/browseAction.class.php
+++ b/apps/qubit/modules/default/actions/browseAction.class.php
@@ -199,14 +199,14 @@ class DefaultBrowseAction extends sfAction
 
           $facets[$name]['terms']['unique'] = array(
             'count' => $resultSetWithoutLanguageFilter->getTotalHits(),
-            'term' => 'Unique descriptions');
+            'term' => 'Unique documents');
         }
         // Without language filter the count equals the number of hits
         else
         {
           $facets[$name]['terms']['unique'] = array(
             'count' => $resultSet->getTotalHits(),
-            'term' => 'Unique descriptions');
+            'term' => 'Unique documents');
         }
       }
     }

--- a/apps/qubit/modules/digitalobject/templates/browseSuccess.php
+++ b/apps/qubit/modules/digitalobject/templates/browseSuccess.php
@@ -60,7 +60,7 @@
           <?php echo link_to(image_tag('question-mark'), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?>
         <?php endif; ?>
       </div>
-      <p class="description"><?php echo render_title(get_search_i18n($doc, 'title')) ?></p>
+      <p class="description"><?php echo render_title(get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture))) ?></p>
       <?php if ('1' == sfConfig::get('app_inherit_code_informationobject', 1) && isset($doc['inheritReferenceCode']) && !empty($doc['inheritReferenceCode'])) : ?>
         <div class="bottom"><p><?php echo $doc['inheritReferenceCode'] ?></p></div>
       <?php elseif (!empty($doc['identifier'])) : ?>

--- a/apps/qubit/modules/informationobject/actions/browseAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/browseAction.class.php
@@ -142,7 +142,7 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
     {
       $queryText = new \Elastica\Query\QueryString($request->subquery);
       $queryText->setDefaultOperator('AND');
-      $queryText->setDefaultField(sprintf('i18n.%s.title', $this->context->user->getCulture()));
+      $queryText->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.title'));
 
       $this->queryBool->addMust($queryText);
     }

--- a/apps/qubit/modules/informationobject/actions/browseAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/browseAction.class.php
@@ -204,7 +204,7 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
 
       // I don't think that this is going to scale, but let's leave it for now
       case 'alphabetic':
-        $field = sprintf('i18n.%s.title.untouched', $this->context->user->getCulture());
+        $field = sprintf('i18n.%s.title.untouched', $this->selectedCulture);
         $this->query->addSort(array($field => 'asc'));
 
         break;

--- a/apps/qubit/modules/informationobject/templates/browseSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/browseSuccess.php
@@ -144,7 +144,7 @@
 
 <?php foreach ($pager->getResults() as $hit): ?>
   <?php $doc = $hit->getData() ?>
-  <?php echo include_partial('search/searchResult', array('doc' => $doc, 'pager' => $pager)) ?>
+  <?php echo include_partial('search/searchResult', array('doc' => $doc, 'pager' => $pager, 'culture' => $selectedCulture)) ?>
 <?php endforeach; ?>
 
 <?php slot('after-content') ?>

--- a/apps/qubit/modules/repository/actions/browseAction.class.php
+++ b/apps/qubit/modules/repository/actions/browseAction.class.php
@@ -109,7 +109,7 @@ class RepositoryBrowseAction extends DefaultBrowseAction
       case 'identifier':
         $this->query->addSort(array('identifier' => 'asc'));
       case 'alphabetic':
-        $field = sprintf('i18n.%s.authorizedFormOfName.untouched', $this->context->user->getCulture());
+        $field = sprintf('i18n.%s.authorizedFormOfName.untouched', $this->selectedCulture);
         $this->query->addSort(array($field => 'asc'));
 
         break;

--- a/apps/qubit/modules/repository/templates/_contextMenu.php
+++ b/apps/qubit/modules/repository/templates/_contextMenu.php
@@ -11,7 +11,7 @@
   <ul>
     <?php foreach ($resultSet->getResults() as $hit): ?>
       <?php $doc = $hit->getData() ?>
-      <li><?php echo link_to(get_search_i18n($doc, 'title'), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?></li>
+      <li><?php echo link_to(get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture)), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?></li>
     <?php endforeach; ?>
   </ul>
 

--- a/apps/qubit/modules/repository/templates/browseSuccess.php
+++ b/apps/qubit/modules/repository/templates/browseSuccess.php
@@ -98,7 +98,7 @@
 
     <?php foreach ($pager->getResults() as $hit): ?>
       <?php $doc = $hit->getData() ?>
-      <?php $authorizedFormOfName = render_title(get_search_i18n($doc, 'authorizedFormOfName')) ?>
+      <?php $authorizedFormOfName = render_title(get_search_i18n($doc, 'authorizedFormOfName', true, false, $selectedCulture)) ?>
       <?php $hasLogo = file_exists(sfConfig::get('sf_upload_dir').'/r/'.$doc['slug'].'/conf/logo.png') ?>
       <?php if ($hasLogo): ?>
         <div class="brick">

--- a/apps/qubit/modules/repository/templates/browseSuccess.php
+++ b/apps/qubit/modules/repository/templates/browseSuccess.php
@@ -98,7 +98,7 @@
 
     <?php foreach ($pager->getResults() as $hit): ?>
       <?php $doc = $hit->getData() ?>
-      <?php $authorizedFormOfName = render_title(get_search_i18n($doc, 'authorizedFormOfName', true, false, $selectedCulture)) ?>
+      <?php $authorizedFormOfName = render_title(get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false, 'culture' => $selectedCulture))) ?>
       <?php $hasLogo = file_exists(sfConfig::get('sf_upload_dir').'/r/'.$doc['slug'].'/conf/logo.png') ?>
       <?php if ($hasLogo): ?>
         <div class="brick">

--- a/apps/qubit/modules/search/actions/advancedAction.class.php
+++ b/apps/qubit/modules/search/actions/advancedAction.class.php
@@ -313,42 +313,42 @@ class SearchAdvancedAction extends DefaultBrowseAction
 
         case 'title':
           $queryField = new \Elastica\Query\QueryString($query);
-          $queryField->setDefaultField('i18n.'.$culture.'.title');
+          $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.title'));
           $queryField->setDefaultOperator('OR');
 
           break;
 
         case 'scopeAndContent':
           $queryField = new \Elastica\Query\QueryString($query);
-          $queryField->setDefaultField('i18n.'.$culture.'.scopeAndContent');
+          $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.scopeAndContent'));
           $queryField->setDefaultOperator('OR');
 
           break;
 
         case 'archivalHistory':
           $queryField = new \Elastica\Query\QueryString($query);
-          $queryField->setDefaultField('i18n.'.$culture.'.archivalHistory');
+          $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.archivalHistory'));
           $queryField->setDefaultOperator('OR');
 
           break;
 
         case 'extentAndMedium':
           $queryField = new \Elastica\Query\QueryString($query);
-          $queryField->setDefaultField('i18n.'.$culture.'.extentAndMedium');
+          $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.extentAndMedium'));
           $queryField->setDefaultOperator('OR');
 
           break;
 
         case 'subject':
           $queryField = new \Elastica\Query\QueryString($query);
-          $queryField->setDefaultField('subjects.i18n.'.$culture.'.name');
+          $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('subjects.i18n.%s.name'));
           $queryField->setDefaultOperator('OR');
 
           break;
 
         case 'name':
           $queryField = new \Elastica\Query\QueryString($query);
-          $queryField->setDefaultField('names.i18n.'.$culture.'.authorizedFormOfName');
+          $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('names.i18n.%s.authorizedFormOfName'));
           $queryField->setDefaultOperator('OR');
 
           break;
@@ -357,12 +357,12 @@ class SearchAdvancedAction extends DefaultBrowseAction
           $queryField = new \Elastica\Query\Bool();
 
           $queryPlaceTermName = new \Elastica\Query\QueryString($query);
-          $queryPlaceTermName->setDefaultField('places.i18n.'.$culture.'.name');
+          $queryPlaceTermName->setFields(arElasticSearchPluginUtil::getI18nFieldNames('places.i18n.%s.name'));
           $queryPlaceTermName->setDefaultOperator('OR');
           $queryField->addShould($queryPlaceTermName);
 
           $queryPlaceTermUseFor = new \Elastica\Query\QueryString($query);
-          $queryPlaceTermUseFor->setDefaultField('places.useFor.i18n.'.$culture.'.name');
+          $queryPlaceTermUseFor->setFields(arElasticSearchPluginUtil::getI18nFieldNames('places.useFor.i18n.%s.name'));
           $queryPlaceTermUseFor->setDefaultOperator('OR');
           $queryField->addShould($queryPlaceTermUseFor);
 

--- a/apps/qubit/modules/search/actions/indexAction.class.php
+++ b/apps/qubit/modules/search/actions/indexAction.class.php
@@ -179,7 +179,7 @@ class SearchIndexAction extends DefaultBrowseAction
         'term' => array(
           'size' => 1,
           'sort' => 'frequency',
-          'field' => sprintf('i18n.%s.title', $this->context->user->getCulture())))));
+          'field' => sprintf('i18n.%s.title', $this->selectedCulture)))));
 
     // Filter drafts
     QubitAclSearch::filterDrafts($this->filterBool);

--- a/apps/qubit/modules/search/templates/_facetLanguage.php
+++ b/apps/qubit/modules/search/templates/_facetLanguage.php
@@ -17,7 +17,7 @@
       <?php else: ?>
         <li>
       <?php endif; ?>
-        <?php echo link_to(__('Unique descriptions'), array(
+        <?php echo link_to(__('Unique documents'), array(
           $facet => null,
           'page' => null) + $sf_request->getParameterHolder()->getAll()) ?>
         <span class="facet-count"><?php echo $pager->facets[$facet]['terms']['unique']['count'] ?></span>

--- a/apps/qubit/modules/search/templates/_facetLanguage.php
+++ b/apps/qubit/modules/search/templates/_facetLanguage.php
@@ -12,16 +12,29 @@
 
     <ul>
 
+      <?php if (!isset($filters[$facet])): ?>
+        <li class="active">
+      <?php else: ?>
+        <li>
+      <?php endif; ?>
+        <?php echo link_to(__('Unique descriptions'), array(
+          $facet => null,
+          'page' => null) + $sf_request->getParameterHolder()->getAll()) ?>
+        <span class="facet-count"><?php echo $pager->facets[$facet]['terms']['unique']['count'] ?></span>
+      </li>
+
       <?php if (isset($pager->facets[$facet])): ?>
         <?php foreach ($pager->facets[$facet]['terms'] as $id => $term): ?>
-          <li <?php if ($id == $filters[$facet]) echo 'class="active"' ?>>
-            <?php echo link_to(
-              $term['term'],
-              array(
-                $facet => $id,
-                'page' => null) + $sf_request->getParameterHolder()->getAll()) ?>
-            <span class="facet-count"><?php echo $term['count'] ?></span>
-          </li>
+          <?php if ($id != 'unique'): ?>
+            <li <?php if (isset($filters[$facet]) && $id == $filters[$facet]) echo 'class="active"' ?>>
+              <?php echo link_to(
+                $term['term'],
+                array(
+                  $facet => $id,
+                  'page' => null) + $sf_request->getParameterHolder()->getAll()) ?>
+              <span class="facet-count"><?php echo $term['count'] ?></span>
+            </li>
+          <?php endif; ?>
         <?php endforeach; ?>
       <?php endif; ?>
 

--- a/apps/qubit/modules/search/templates/_searchResult.php
+++ b/apps/qubit/modules/search/templates/_searchResult.php
@@ -23,7 +23,7 @@
 
   <div class="search-result-description">
 
-    <p class="title"><?php echo link_to(render_title(get_search_i18n($doc, 'title', true, false, $culture)), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?></p>
+    <p class="title"><?php echo link_to(render_title(get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture))), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?></p>
 
     <ul class="result-details">
 
@@ -42,9 +42,9 @@
         <?php foreach ($doc['dates'] as $date): ?>
           <?php if (isset($date['startDateString'])
             || isset($date['endDateString'])
-            || null != get_search_i18n($date, 'date', true, true, $culture)): ?>
+            || null != get_search_i18n($date, 'date', array('culture' => $culture))): ?>
 
-            <li class="dates"><?php echo Qubit::renderDateStartEnd(get_search_i18n($date, 'date', true, true, $culture),
+            <li class="dates"><?php echo Qubit::renderDateStartEnd(get_search_i18n($date, 'date', array('culture' => $culture)),
               isset($date['startDateString']) ? $date['startDateString'] : null,
               isset($date['endDateString']) ? $date['endDateString'] : null) ?></li>
 
@@ -60,7 +60,7 @@
 
     </ul>
 
-    <?php if (null !== $scopeAndContent = get_search_i18n($doc, 'scopeAndContent', true, true, $culture)): ?>
+    <?php if (null !== $scopeAndContent = get_search_i18n($doc, 'scopeAndContent', array('culture' => $culture))): ?>
       <p><?php echo truncate_text($scopeAndContent, 250) ?></p>
     <?php endif; ?>
 

--- a/apps/qubit/modules/search/templates/_searchResult.php
+++ b/apps/qubit/modules/search/templates/_searchResult.php
@@ -23,7 +23,7 @@
 
   <div class="search-result-description">
 
-    <p class="title"><?php echo link_to(render_title(get_search_i18n($doc, 'title')), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?></p>
+    <p class="title"><?php echo link_to(render_title(get_search_i18n($doc, 'title', true, false, $culture)), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?></p>
 
     <ul class="result-details">
 
@@ -42,9 +42,9 @@
         <?php foreach ($doc['dates'] as $date): ?>
           <?php if (isset($date['startDateString'])
             || isset($date['endDateString'])
-            || null != get_search_i18n($date, 'date')): ?>
+            || null != get_search_i18n($date, 'date', true, true, $culture)): ?>
 
-            <li class="dates"><?php echo Qubit::renderDateStartEnd(get_search_i18n($date, 'date'),
+            <li class="dates"><?php echo Qubit::renderDateStartEnd(get_search_i18n($date, 'date', true, true, $culture),
               isset($date['startDateString']) ? $date['startDateString'] : null,
               isset($date['endDateString']) ? $date['endDateString'] : null) ?></li>
 
@@ -60,11 +60,11 @@
 
     </ul>
 
-    <?php if (null !== $scopeAndContent = get_search_i18n($doc, 'scopeAndContent')): ?>
+    <?php if (null !== $scopeAndContent = get_search_i18n($doc, 'scopeAndContent', true, true, $culture)): ?>
       <p><?php echo truncate_text($scopeAndContent, 250) ?></p>
     <?php endif; ?>
 
-    <?php if (null !== $creationDetails = get_search_creation_details($doc)): ?>
+    <?php if (null !== $creationDetails = get_search_creation_details($doc, $culture)): ?>
       <p class="creation-details"><?php echo $creationDetails ?></p>
     <?php endif; ?>
 

--- a/apps/qubit/modules/search/templates/_searchResults.php
+++ b/apps/qubit/modules/search/templates/_searchResults.php
@@ -2,7 +2,7 @@
 
   <?php foreach ($pager->getResults() as $hit): ?>
     <?php $doc = $hit->getData() ?>
-    <?php echo get_partial('search/searchResult', array('doc' => $doc, 'pager' => $pager)) ?>
+    <?php echo get_partial('search/searchResult', array('doc' => $doc, 'pager' => $pager, 'culture' => $culture)) ?>
   <?php endforeach; ?>
 
 <?php else: ?>

--- a/apps/qubit/modules/search/templates/indexSuccess.php
+++ b/apps/qubit/modules/search/templates/indexSuccess.php
@@ -141,7 +141,7 @@
 
 <?php foreach ($pager->getResults() as $hit): ?>
   <?php $doc = $hit->getData() ?>
-  <?php echo include_partial('search/searchResult', array('doc' => $doc, 'pager' => $pager)) ?>
+  <?php echo include_partial('search/searchResult', array('doc' => $doc, 'pager' => $pager, 'culture' => $selectedCulture)) ?>
 <?php endforeach; ?>
 
 <?php slot('after-content') ?>

--- a/apps/qubit/modules/taxonomy/actions/indexAction.class.php
+++ b/apps/qubit/modules/taxonomy/actions/indexAction.class.php
@@ -105,20 +105,22 @@ class TaxonomyIndexAction extends sfAction
       switch ($request->subqueryField)
       {
         case 'Preferred label':
-          $queryString->setDefaultField('i18n.'.$culture.'.name');
+          $queryString->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.name'));
 
           break;
 
         case '\'Use for\' labels':
         case "\'Use for\' labels":
-           $queryString->setDefaultField('useFor.i18n.'.$culture.'.name');
+          $queryString->setFields(arElasticSearchPluginUtil::getI18nFieldNames('useFor.i18n.%s.name'));
 
           break;
 
         case 'All labels':
         default:
           // Search over preferred label (boosted by five) and "Use for" labels
-          $queryString->setFields(array('i18n.'.$culture.'.name^5', 'useFor.i18n.'.$culture.'.name'));
+          $fields = array('i18n.%s.name', 'useFor.i18n.%s.name');
+          $boost = array('i18n.%s.name' => 5);
+          $queryString->setFields(arElasticSearchPluginUtil::getI18nFieldNames($fields, null, $boost));
           $queryString->setDefaultOperator('OR');
 
           break;

--- a/apps/qubit/modules/taxonomy/templates/indexSuccess.php
+++ b/apps/qubit/modules/taxonomy/templates/indexSuccess.php
@@ -62,9 +62,9 @@
         <tr>
           <td>
             <?php if ($doc['isProtected']): ?>
-              <?php echo link_to(get_search_i18n($doc, 'name', true, false), array('module' => 'term', 'slug' => $doc['slug']), array('class' => 'readOnly')) ?>
+              <?php echo link_to(get_search_i18n($doc, 'name', array('allowEmpty' => false)), array('module' => 'term', 'slug' => $doc['slug']), array('class' => 'readOnly')) ?>
             <?php else: ?>
-              <?php echo link_to(get_search_i18n($doc, 'name', true, false), array('module' => 'term', 'slug' => $doc['slug'])) ?>
+              <?php echo link_to(get_search_i18n($doc, 'name', array('allowEmpty' => false)), array('module' => 'term', 'slug' => $doc['slug'])) ?>
             <?php endif; ?>
 
             <?php if (0 < $doc['numberOfDescendants']): ?>
@@ -72,7 +72,7 @@
             <?php endif; ?>
 
             <?php if (isset($doc['useFor']) && count($doc['useFor']) > 0): ?>
-              <p><?php echo 'Use for: '.get_search_i18n(array_pop($doc['useFor']), 'name', true, false) ?><?php foreach ($doc['useFor'] as $label): ?><?php echo ', '.get_search_i18n($label, 'name', true, false) ?><?php endforeach; ?></p>
+              <p><?php echo 'Use for: '.get_search_i18n(array_pop($doc['useFor']), 'name', array('allowEmpty' => false)) ?><?php foreach ($doc['useFor'] as $label): ?><?php echo ', '.get_search_i18n($label, 'name', true, false) ?><?php endforeach; ?></p>
             <?php endif; ?>
 
           </td><td>

--- a/apps/qubit/modules/term/actions/indexAction.class.php
+++ b/apps/qubit/modules/term/actions/indexAction.class.php
@@ -91,7 +91,14 @@ class TermIndexAction extends DefaultBrowseAction
       $this->forward404();
     }
 
-    $this->culture = $this->context->user->getCulture();
+    if (isset($request->languages))
+    {
+      $this->culture = $request->languages;
+    }
+    else
+    {
+      $this->culture = $this->context->user->getCulture();
+    }
 
     if (1 > strlen($title = $this->resource->__toString()))
     {

--- a/apps/qubit/modules/term/templates/_treeView.php
+++ b/apps/qubit/modules/term/templates/_treeView.php
@@ -125,9 +125,9 @@
 
             <li>
               <?php if ($doc['isProtected']): ?>
-                <?php echo link_to(get_search_i18n($doc, 'name', true, false), array('module' => 'term', 'slug' => $doc['slug']), array('class' => 'readOnly')) ?>
+                <?php echo link_to(get_search_i18n($doc, 'name', array('allowEmpty' => false)), array('module' => 'term', 'slug' => $doc['slug']), array('class' => 'readOnly')) ?>
               <?php else: ?>
-                <?php echo link_to(get_search_i18n($doc, 'name', true, false), array('module' => 'term', 'slug' => $doc['slug'])) ?>
+                <?php echo link_to(get_search_i18n($doc, 'name', array('allowEmpty' => false)), array('module' => 'term', 'slug' => $doc['slug'])) ?>
               <?php endif; ?>
             </li>
 

--- a/apps/qubit/modules/term/templates/browseTermSuccess.php
+++ b/apps/qubit/modules/term/templates/browseTermSuccess.php
@@ -74,7 +74,7 @@
 
 <?php end_slot() ?>
 
-<?php echo get_partial('search/searchResults', array('pager' => $pager)) ?>
+<?php echo get_partial('search/searchResults', array('pager' => $pager, 'culture' => $selectedCulture)) ?>
 
 <?php slot('after-content') ?>
   <?php echo get_partial('default/pager', array('pager' => $pager)) ?>

--- a/apps/qubit/modules/term/templates/indexSuccess.php
+++ b/apps/qubit/modules/term/templates/indexSuccess.php
@@ -262,7 +262,7 @@
         </div>
       <?php endif; ?>
 
-      <?php echo get_partial('search/searchResults', array('pager' => $pager)) ?>
+      <?php echo get_partial('search/searchResults', array('pager' => $pager, 'culture' => $culture)) ?>
 
     </div>
   <?php endif; ?>

--- a/lib/helper/QubitHelper.php
+++ b/lib/helper/QubitHelper.php
@@ -281,7 +281,7 @@ function check_field_visibility($fieldName)
   return (is_using_cli() || sfContext::getInstance()->user->isAuthenticated()) || sfConfig::get($fieldName, false);
 }
 
-function get_search_i18n($hit, $fieldName, $cultureFallback = true, $allowEmpty = true, $selectedCulture = null)
+function get_search_i18n($hit, $fieldName, $options = array())
 {
   $userCulture = sfContext::getInstance()->user->getCulture();
 
@@ -292,20 +292,22 @@ function get_search_i18n($hit, $fieldName, $cultureFallback = true, $allowEmpty 
 
   $value = null;
 
-  if (isset($selectedCulture) && isset($hit['i18n'][$selectedCulture][$fieldName]))
+  if (isset($options['culture']) && isset($hit['i18n'][$options['culture']][$fieldName]))
   {
-    $value = $hit['i18n'][$selectedCulture][$fieldName];
+    $value = $hit['i18n'][$options['culture']][$fieldName];
   }
   else if (isset($hit['i18n'][$userCulture][$fieldName]))
   {
     $value = $hit['i18n'][$userCulture][$fieldName];
   }
-  else if ($cultureFallback && isset($hit['i18n'][$hit['sourceCulture']][$fieldName]))
+  else if ((!isset($options['cultureFallback']) || $options['cultureFallback'])
+    && isset($hit['i18n'][$hit['sourceCulture']][$fieldName]))
   {
     $value = $hit['i18n'][$hit['sourceCulture']][$fieldName];
   }
 
-  if (!$allowEmpty && ($value == null || $value == ''))
+  if (($value == null || $value == '')
+    && isset($options['allowEmpty']) && !$options['allowEmpty']))
   {
     $value = sfContext::getInstance()->i18n->__('Untitled');
   }
@@ -313,15 +315,15 @@ function get_search_i18n($hit, $fieldName, $cultureFallback = true, $allowEmpty 
   return $value;
 }
 
-function get_search_i18n_highlight(\Elastica\Result $hit, $fieldName, $culture = null)
+function get_search_i18n_highlight(\Elastica\Result $hit, $fieldName, $options = array())
 {
-  if (!isset($culture))
+  if (!isset($options['culture']))
   {
-    $culture = sfContext::getInstance()->user->getCulture();
+    $options['culture'] = sfContext::getInstance()->user->getCulture();
   }
 
   $highlights = $hit->getHighlights();
-  $field = 'i18n.'.$culture.'.'.$fieldName;
+  $field = 'i18n.'.$options['culture'].'.'.$fieldName;
 
   if (isset($highlights[$field]))
   {

--- a/plugins/qtAccessionPlugin/modules/accession/actions/browseAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/browseAction.class.php
@@ -71,21 +71,32 @@ class AccessionBrowseAction extends sfAction
     {
       $queryString = new \Elastica\Query\QueryString($request->subquery);
 
-      // TODO: Add boost options to arElasticSearchPluginUtil::setAllFields function
-      $queryString->setFields(array(
-        'identifier^10',
-        'donors.i18n.'.$culture.'.authorizedFormOfName^10',
-        'i18n.'.$culture.'.title^10',
-        'i18n.'.$culture.'.scopeAndContent^10',
-        'i18n.'.$culture.'.locationInformation^5',
-        'i18n.'.$culture.'.processingNotes^5',
-        'i18n.'.$culture.'.sourceOfAcquisition^5',
-        'i18n.'.$culture.'.archivalHistory^5',
-        'i18n.'.$culture.'.appraisal',
-        'i18n.'.$culture.'.physicalCharacteristics',
-        'i18n.'.$culture.'.receivedExtentUnits',
-        'donors.contactInformations.contactPerson',
-        'creators.i18n.'.$culture.'.authorizedFormOfName'));
+      $boost = array(
+        'donors.i18n.%s.authorizedFormOfName' => 10,
+        'i18n.%s.title' => 10,
+        'i18n.%s.scopeAndContent' => 10,
+        'i18n.%s.locationInformation' => 5,
+        'i18n.%s.processingNotes' => 5,
+        'i18n.%s.sourceOfAcquisition' => 5,
+        'i18n.%s.archivalHistory' => 5);
+
+      $fields = arElasticSearchPluginUtil::getI18nFieldNames(array(
+        'donors.i18n.%s.authorizedFormOfName',
+        'i18n.%s.title',
+        'i18n.%s.scopeAndContent',
+        'i18n.%s.locationInformation',
+        'i18n.%s.processingNotes',
+        'i18n.%s.sourceOfAcquisition',
+        'i18n.%s.archivalHistory',
+        'i18n.%s.appraisal',
+        'i18n.%s.physicalCharacteristics',
+        'i18n.%s.receivedExtentUnits',
+        'creators.i18n.%s.authorizedFormOfName'), null, $boost);
+
+      $fields[] = 'identifier^10';
+      $fields[] = 'donors.contactInformations.contactPerson';
+
+      $queryString->setFields($fields);
 
       $this->queryBool->addMust($queryString);
 


### PR DESCRIPTION
Redmine ticket: https://projects.artefactual.com/issues/7120
- Add 'Unique documents' count to languages facet: shows the number of documents that match the query regardless the language. When a language is selected it needs a second query without language filter to know the real count.
- Makes ES queries over all available cultures (except autocompletes)
- Change sort field and result values to the selected language facet
- Allows boost options when all culture fields are being set
