### PR TITLE
#6989 - Digital object linking to external resource is broken

### DIFF
--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -1703,7 +1703,7 @@ class QubitDigitalObject extends BaseDigitalObject
       throw new sfException('Couldn\'t find related information object for digital object');
     }
 
-    if ($this->usageId == QubitTerm::MASTER_ID)
+    if ($this->usageId == QubitTerm::MASTER_ID || $this->parent->usageId == QubitTerm::EXTERNAL_URI_ID)
     {
       $id = (string) $infoObject->id;
 


### PR DESCRIPTION
Redmine: https://projects.artefactual.com/issues/6989

External digital objects are special in that they are similar to master but we don't seem to have a way to refer to both globally.
