### PR TITLE
#7329 - Do not output spaces around subfields' titles

### DIFF
--- a/apps/qubit/modules/informationobject/templates/_creatorDetail.php
+++ b/apps/qubit/modules/informationobject/templates/_creatorDetail.php
@@ -15,13 +15,13 @@
 
       <?php if (0 < count($resource->getCreators())): ?>
         <div class="field">
-          <h3>
-            <?php if (QubitTerm::CORPORATE_BODY_ID == $item->entityTypeId): ?>
-              <?php echo __('Administrative history') ?>
-            <?php else: ?>
-              <?php echo __('Biographical history') ?>
-            <?php endif; ?>
-          </h3><div>
+          <?php if (QubitTerm::CORPORATE_BODY_ID == $item->entityTypeId): ?>
+            <?php $history_kind = __('Administrative history'); ?>
+          <?php else: ?>
+            <?php $history_kind = __('Biographical history'); ?>
+          <?php endif; ?>
+          <h3><?php echo $history_kind; ?></h3>
+          <div>
             <?php echo render_value($item->getHistory(array('cultureFallback' => true))) ?>
           </div>
         </div>


### PR DESCRIPTION
Having spaces inside the `<h3>` element creates artifacts in combination
with CSS rules like `h3:after { content: ...; }`.

BTW, for the sake of i18n, the whole sentence (text + colon) should be
generated, not just the field name.

PS: the patch can be backported without any changes to `stable/2.1.x` and `qa/2.1.x`.
