### PR TITLE
#5094 - bioghist: banish <chronlist>

### DIFF
--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -777,9 +777,27 @@ class QubitInformationObject extends BaseInformationObject
     return $this->getTermRelations(QubitTaxonomy::SUBJECT_ID);
   }
 
-  public function getPlaceAccessPoints()
+  public function getPlaceAccessPoints(array $options = array('events' => false))
   {
-    return $this->getTermRelations(QubitTaxonomy::PLACE_ID);
+    $criteria = new Criteria;
+
+    // Places are either associated with the information object directly
+    // (for standard authorities) or with events (for places added in
+    // the events module).
+    if ($options['events'])
+    {
+      $criteria->addJoin(QubitObjectTermRelation::OBJECT_ID, QubitEvent::ID);
+      $criteria->add(QubitEvent::INFORMATION_OBJECT_ID, $this->id);
+    }
+    else
+    {
+      $criteria->add(QubitObjectTermRelation::OBJECT_ID, $this->id);
+    }
+
+    $criteria->addJoin(QubitObjectTermRelation::TERM_ID, QubitTerm::ID);
+    $criteria->add(QubitTerm::TAXONOMY_ID, QubitTaxonomy::PLACE_ID);
+
+    return QubitObjectTermRelation::get($criteria);
   }
 
   /**************

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
@@ -176,6 +176,7 @@
   $subjects = $resource->getSubjectAccessPoints();
   $names = $resource->getNameAccessPoints();
   $places = $resource->getPlaceAccessPoints();
+  $place_events = $resource->getPlaceAccessPoints(array('events' => true));
 
   if ((0 < count($materialtypes)) ||
      (0 < count($subjects)) ||
@@ -213,6 +214,9 @@
       <?php endforeach; ?>
       <?php foreach ($places as $place): ?>
         <geogname><?php echo escape_dc(esc_specialchars($place->getTerm())) ?></geogname>
+      <?php endforeach; ?>
+      <?php foreach ($place_events as $place): ?>
+        <geogname role="<?php echo $place->getObject()->getType()->getRole() ?>"><?php echo escape_dc(esc_specialchars($place->getTerm())) ?></geogname>
       <?php endforeach; ?>
     </controlaccess>
   <?php endif; ?>
@@ -286,6 +290,7 @@
         $subjects = $descendant->getSubjectAccessPoints();
         $names = $descendant->getNameAccessPoints();
         $places = $descendant->getPlaceAccessPoints();
+        $place_events = $descendant->getPlaceAccessPoints(array('events' => true));
 
         if ((0 < count($materialtypes)) ||
             (0 < count($subjects)) ||
@@ -327,6 +332,10 @@
 
             <?php foreach ($places as $place): ?>
               <geogname><?php echo escape_dc(esc_specialchars($place->getTerm())) ?></geogname>
+            <?php endforeach; ?>
+
+            <?php foreach ($place_events as $place): ?>
+              <geogname role="<?php echo $place->getObject()->getType()->getRole() ?>"><?php echo escape_dc(esc_specialchars($place->getTerm())) ?></geogname>
             <?php endforeach; ?>
 
           </controlaccess>

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
@@ -186,13 +186,13 @@
     <controlaccess>
       <?php foreach ($resource->getActorEvents() as $event): ?>
         <?php if ($event->getActor()->getEntityTypeId() == QubitTerm::PERSON_ID): ?>
-          <persname role="<?php echo $event->getType()->getRole(array('cultureFallback' => true)) ?>"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))) ?></persname>
+          <persname role="<?php echo $event->getType()->getRole() ?>"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))) ?></persname>
         <?php elseif ($event->getActor()->getEntityTypeId() == QubitTerm::FAMILY_ID): ?>
-          <famname role="<?php echo $event->getType()->getRole(array('cultureFallback' => true)) ?>"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))) ?></famname>
+          <famname role="<?php echo $event->getType()->getRole() ?>"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))) ?></famname>
         <?php elseif ($event->getActor()->getEntityTypeId() == QubitTerm::CORPORATE_BODY_ID): ?>
-          <corpname role="<?php echo $event->getType()->getRole(array('cultureFallback' => true)) ?>"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))) ?></corpname>
+          <corpname role="<?php echo $event->getType()->getRole() ?>"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))) ?></corpname>
         <?php else: ?>
-          <name role="<?php echo $event->getType()->getRole(array('cultureFallback' => true)) ?>"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))) ?></name>
+          <name role="<?php echo $event->getType()->getRole() ?>"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))) ?></name>
         <?php endif; ?>
       <?php endforeach; ?>
       <?php foreach ($names as $name): ?>

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyBioghistElement.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyBioghistElement.xml.php
@@ -7,39 +7,29 @@
   <?php foreach($events as $date): ?>
     <?php $creator = QubitActor::getById($date->actorId); ?>
     <bioghist id="<?php echo 'md5-' . md5(url_for(array($creator, 'module' => 'actor'), true)) ?>" encodinganalog="<?php echo $ead->getMetadataParameter('bioghist') ?>">
-      <chronlist>
-        <chronitem>
-          <?php echo $ead->renderEadDateFromEvent('creation', $date) ?>
-          <eventgrp>
-            <event>
-              <?php if ($value = $date->getDescription(array('cultureFallback' => true))): ?>
-                <note type="eventNote"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></note>
-              <?php endif; ?>
-              <?php if ($value = $creator->getHistory(array('cultureFallback' => true))): ?>
-                <note><p><?php echo escape_dc(esc_specialchars($value)) ?></p></note>
-              <?php endif; ?>
-              <origination encodinganalog="<?php echo $ead->getMetadataParameter('origination') ?>">
-                <?php if ($type = $creator->getEntityTypeId()): ?>
-                  <?php if (QubitTerm::PERSON_ID == $type): ?>
-                    <persname><?php echo escape_dc(esc_specialchars($creator->getAuthorizedFormOfName(array('cultureFallback' => true)))) ?></persname>
-                  <?php endif; ?>
-                  <?php if (QubitTerm::FAMILY_ID == $type): ?>
-                    <famname><?php echo escape_dc(esc_specialchars($creator->getAuthorizedFormOfName(array('cultureFallback' => true)))) ?></famname>
-                  <?php endif; ?>
-                  <?php if (QubitTerm::CORPORATE_BODY_ID == $type): ?>
-                    <corpname><?php echo escape_dc(esc_specialchars($creator->getAuthorizedFormOfName(array('cultureFallback' => true)))) ?></corpname>
-                  <?php endif; ?>
-                <?php else: ?>
-                  <name><?php echo escape_dc(esc_specialchars($creator->getAuthorizedFormOfName(array('cultureFallback' => true)))) ?></name>
-                <?php endif; ?>
-              </origination>
-              <?php if ($creator->datesOfExistence): ?>
-                <date type="existence"><?php echo escape_dc(esc_specialchars($creator->datesOfExistence)) ?></date>
-              <?php endif; ?>
-            </event>
-          </eventgrp>
-        </chronitem>
-      </chronlist>
+      <?php if ($value = $creator->getHistory(array('cultureFallback' => true))): ?>
+        <note><p><?php echo escape_dc(esc_specialchars($value)) ?></p></note>
+      <?php endif; ?>
+      <?php if ($creator->datesOfExistence): ?>
+        <date type="existence"><?php echo escape_dc(esc_specialchars($creator->datesOfExistence)) ?></date>
+      <?php endif; ?>
     </bioghist>
+
+    <origination encodinganalog="<?php echo $ead->getMetadataParameter('origination') ?>">
+      <?php if ($type = $creator->getEntityTypeId()): ?>
+        <?php if (QubitTerm::PERSON_ID == $type): ?>
+          <persname><?php echo escape_dc(esc_specialchars($creator->getAuthorizedFormOfName(array('cultureFallback' => true)))) ?></persname>
+        <?php endif; ?>
+        <?php if (QubitTerm::FAMILY_ID == $type): ?>
+          <famname><?php echo escape_dc(esc_specialchars($creator->getAuthorizedFormOfName(array('cultureFallback' => true)))) ?></famname>
+        <?php endif; ?>
+        <?php if (QubitTerm::CORPORATE_BODY_ID == $type): ?>
+          <corpname><?php echo escape_dc(esc_specialchars($creator->getAuthorizedFormOfName(array('cultureFallback' => true)))) ?></corpname>
+        <?php endif; ?>
+      <?php else: ?>
+        <name><?php echo escape_dc(esc_specialchars($creator->getAuthorizedFormOfName(array('cultureFallback' => true)))) ?></name>
+      <?php endif; ?>
+    </origination>
+
   <?php endforeach; ?>
 <?php endif; ?>


### PR DESCRIPTION
As proposed by Dan in ticket 5094, this eliminates AtoM's complex `<chronlist>` field when exporting EAD in favour of a simplified, more standard pair of non-nested `<bioghist>` and `<origination>` fields.

TODO:
- [x] Add a `@role` attribute to `<geogname>` elements in the event that they've been added in the events module, to distinguish from regular place access points
