### PR TITLE
#7322 - i18n keys hashmap is not populated after save()

### DIFF
--- a/lib/model/om/BaseActorI18n.php
+++ b/lib/model/om/BaseActorI18n.php
@@ -368,6 +368,11 @@ abstract class BaseActorI18n implements ArrayAccess
           $this->row[$offset] = $this->values[$column->getPhpName()];
         }
 
+        if ($this->new && $column->isPrimaryKey())
+        {
+          $this->keys[$column->getPhpName()] = $this->values[$column->getPhpName()];
+        }
+
         $offset++;
       }
     }

--- a/lib/model/om/BaseContactInformationI18n.php
+++ b/lib/model/om/BaseContactInformationI18n.php
@@ -350,6 +350,11 @@ abstract class BaseContactInformationI18n implements ArrayAccess
           $this->row[$offset] = $this->values[$column->getPhpName()];
         }
 
+        if ($this->new && $column->isPrimaryKey())
+        {
+          $this->keys[$column->getPhpName()] = $this->values[$column->getPhpName()];
+        }
+
         $offset++;
       }
     }

--- a/lib/model/om/BaseEventI18n.php
+++ b/lib/model/om/BaseEventI18n.php
@@ -348,6 +348,11 @@ abstract class BaseEventI18n implements ArrayAccess
           $this->row[$offset] = $this->values[$column->getPhpName()];
         }
 
+        if ($this->new && $column->isPrimaryKey())
+        {
+          $this->keys[$column->getPhpName()] = $this->values[$column->getPhpName()];
+        }
+
         $offset++;
       }
     }

--- a/lib/model/om/BaseFunctionI18n.php
+++ b/lib/model/om/BaseFunctionI18n.php
@@ -362,6 +362,11 @@ abstract class BaseFunctionI18n implements ArrayAccess
           $this->row[$offset] = $this->values[$column->getPhpName()];
         }
 
+        if ($this->new && $column->isPrimaryKey())
+        {
+          $this->keys[$column->getPhpName()] = $this->values[$column->getPhpName()];
+        }
+
         $offset++;
       }
     }

--- a/lib/model/om/BaseInformationObjectI18n.php
+++ b/lib/model/om/BaseInformationObjectI18n.php
@@ -384,6 +384,11 @@ abstract class BaseInformationObjectI18n implements ArrayAccess
           $this->row[$offset] = $this->values[$column->getPhpName()];
         }
 
+        if ($this->new && $column->isPrimaryKey())
+        {
+          $this->keys[$column->getPhpName()] = $this->values[$column->getPhpName()];
+        }
+
         $offset++;
       }
     }

--- a/lib/model/om/BaseMenuI18n.php
+++ b/lib/model/om/BaseMenuI18n.php
@@ -346,6 +346,11 @@ abstract class BaseMenuI18n implements ArrayAccess
           $this->row[$offset] = $this->values[$column->getPhpName()];
         }
 
+        if ($this->new && $column->isPrimaryKey())
+        {
+          $this->keys[$column->getPhpName()] = $this->values[$column->getPhpName()];
+        }
+
         $offset++;
       }
     }

--- a/lib/model/om/BaseNoteI18n.php
+++ b/lib/model/om/BaseNoteI18n.php
@@ -344,6 +344,11 @@ abstract class BaseNoteI18n implements ArrayAccess
           $this->row[$offset] = $this->values[$column->getPhpName()];
         }
 
+        if ($this->new && $column->isPrimaryKey())
+        {
+          $this->keys[$column->getPhpName()] = $this->values[$column->getPhpName()];
+        }
+
         $offset++;
       }
     }

--- a/lib/model/om/BaseOtherNameI18n.php
+++ b/lib/model/om/BaseOtherNameI18n.php
@@ -348,6 +348,11 @@ abstract class BaseOtherNameI18n implements ArrayAccess
           $this->row[$offset] = $this->values[$column->getPhpName()];
         }
 
+        if ($this->new && $column->isPrimaryKey())
+        {
+          $this->keys[$column->getPhpName()] = $this->values[$column->getPhpName()];
+        }
+
         $offset++;
       }
     }

--- a/lib/model/om/BasePhysicalObjectI18n.php
+++ b/lib/model/om/BasePhysicalObjectI18n.php
@@ -348,6 +348,11 @@ abstract class BasePhysicalObjectI18n implements ArrayAccess
           $this->row[$offset] = $this->values[$column->getPhpName()];
         }
 
+        if ($this->new && $column->isPrimaryKey())
+        {
+          $this->keys[$column->getPhpName()] = $this->values[$column->getPhpName()];
+        }
+
         $offset++;
       }
     }

--- a/lib/model/om/BasePropertyI18n.php
+++ b/lib/model/om/BasePropertyI18n.php
@@ -344,6 +344,11 @@ abstract class BasePropertyI18n implements ArrayAccess
           $this->row[$offset] = $this->values[$column->getPhpName()];
         }
 
+        if ($this->new && $column->isPrimaryKey())
+        {
+          $this->keys[$column->getPhpName()] = $this->values[$column->getPhpName()];
+        }
+
         $offset++;
       }
     }

--- a/lib/model/om/BaseRelationI18n.php
+++ b/lib/model/om/BaseRelationI18n.php
@@ -346,6 +346,11 @@ abstract class BaseRelationI18n implements ArrayAccess
           $this->row[$offset] = $this->values[$column->getPhpName()];
         }
 
+        if ($this->new && $column->isPrimaryKey())
+        {
+          $this->keys[$column->getPhpName()] = $this->values[$column->getPhpName()];
+        }
+
         $offset++;
       }
     }

--- a/lib/model/om/BaseRepositoryI18n.php
+++ b/lib/model/om/BaseRepositoryI18n.php
@@ -372,6 +372,11 @@ abstract class BaseRepositoryI18n implements ArrayAccess
           $this->row[$offset] = $this->values[$column->getPhpName()];
         }
 
+        if ($this->new && $column->isPrimaryKey())
+        {
+          $this->keys[$column->getPhpName()] = $this->values[$column->getPhpName()];
+        }
+
         $offset++;
       }
     }

--- a/lib/model/om/BaseRightsI18n.php
+++ b/lib/model/om/BaseRightsI18n.php
@@ -358,6 +358,11 @@ abstract class BaseRightsI18n implements ArrayAccess
           $this->row[$offset] = $this->values[$column->getPhpName()];
         }
 
+        if ($this->new && $column->isPrimaryKey())
+        {
+          $this->keys[$column->getPhpName()] = $this->values[$column->getPhpName()];
+        }
+
         $offset++;
       }
     }

--- a/lib/model/om/BaseSettingI18n.php
+++ b/lib/model/om/BaseSettingI18n.php
@@ -344,6 +344,11 @@ abstract class BaseSettingI18n implements ArrayAccess
           $this->row[$offset] = $this->values[$column->getPhpName()];
         }
 
+        if ($this->new && $column->isPrimaryKey())
+        {
+          $this->keys[$column->getPhpName()] = $this->values[$column->getPhpName()];
+        }
+
         $offset++;
       }
     }

--- a/lib/model/om/BaseStaticPageI18n.php
+++ b/lib/model/om/BaseStaticPageI18n.php
@@ -346,6 +346,11 @@ abstract class BaseStaticPageI18n implements ArrayAccess
           $this->row[$offset] = $this->values[$column->getPhpName()];
         }
 
+        if ($this->new && $column->isPrimaryKey())
+        {
+          $this->keys[$column->getPhpName()] = $this->values[$column->getPhpName()];
+        }
+
         $offset++;
       }
     }

--- a/lib/model/om/BaseTaxonomyI18n.php
+++ b/lib/model/om/BaseTaxonomyI18n.php
@@ -346,6 +346,11 @@ abstract class BaseTaxonomyI18n implements ArrayAccess
           $this->row[$offset] = $this->values[$column->getPhpName()];
         }
 
+        if ($this->new && $column->isPrimaryKey())
+        {
+          $this->keys[$column->getPhpName()] = $this->values[$column->getPhpName()];
+        }
+
         $offset++;
       }
     }

--- a/lib/model/om/BaseTermI18n.php
+++ b/lib/model/om/BaseTermI18n.php
@@ -344,6 +344,11 @@ abstract class BaseTermI18n implements ArrayAccess
           $this->row[$offset] = $this->values[$column->getPhpName()];
         }
 
+        if ($this->new && $column->isPrimaryKey())
+        {
+          $this->keys[$column->getPhpName()] = $this->values[$column->getPhpName()];
+        }
+
         $offset++;
       }
     }

--- a/lib/propel/builder/QubitObjectBuilder.php
+++ b/lib/propel/builder/QubitObjectBuilder.php
@@ -1363,6 +1363,11 @@ script;
           \$this->row[\$offset] = \$this->values[\$column->getPhpName()];
         }
 
+        if (\$this->new && \$column->isPrimaryKey())
+        {
+          \$this->keys[\$column->getPhpName()] = \$this->values[\$column->getPhpName()];
+        }
+
         \$offset++;
       }
     }

--- a/test/unit/issue7322Test.php
+++ b/test/unit/issue7322Test.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once dirname(__FILE__).'/../bootstrap/unit.php';
+
+$t = new lime_test(2, new lime_output_color);
+
+$t->diag('Initializing configuration.');
+$configuration = ProjectConfiguration::getApplicationConfiguration('qubit', 'test', true);
+sfContext::createInstance($configuration);
+
+$t->diag('Loading database settings.');
+sfConfig::add(QubitSetting::getSettingsArray());
+
+$title1 = uniqid('Description ');
+$title2 = uniqid('Description ');
+$actor1 = uniqid('Actor ');
+
+// Create information object
+$io = new QubitInformationObject;
+$io->parentId = QubitInformationObject::ROOT_ID;
+$io->title = $title1;
+# $io->setActorByName($actor1, array('event_type_id' => QubitTerm::PUBLICATION_ID));
+$io->save();
+$id = $io->id;
+$t->diag('The id is '.$id.'');
+
+// Check if the property is still available after save()
+$t->diag('Check the title equals to "'.$title1.'"');
+$t->is($io->title, $title1);
+
+// Update the title of the same object and save()
+$io->title = $title2;
+$io->save();
+$t->diag('Change title to "'.$title2.'"');
+
+// Populate a new object, same ID
+$io2 = QubitInformationObject::getById($id);
+$t->diag('Check that QubitInformationObject title="'.$title2.'"');
+$t->is($io2->title, $title2);


### PR DESCRIPTION
To reproduce:

``` sell
php symfony test:unit issue7322
```

Mike Gale (@MikeFE) has a similar script to reproduce the problem: http://pastebin.com/ERbbcs5t.

It's actually an old bug, reproducible in ICA-AtoM 1.3.1 too.

---

This is the SQL generated when the title is updated:

``` sql
UPDATE information_object_i18n
SET `TITLE`='Description 542b10d49ddb0', `ID`='389319'
WHERE information_object_i18n.ID IS NULL AND information_object_i18n.CULTURE IS NULL
```

It should be like the following:

``` sql
UPDATE information_object_i18n
SET `TITLE`='Description 542b10d49ddb0', `ID`='389319'
WHERE information_object_i18n.ID='389319' AND information_object_i18n.CULTURE='en'
```

The problem seems to be in [BaseInformationObjectI18n.php#L522](https://github.com/artefactual/atom/blob/qa/2.2.x/lib/model/om/BaseInformationObjectI18n.php#L522):

``` php
if ($column->isPrimaryKey())
{
  $selectCriteria->add($column->getFullyQualifiedName(), $this->keys[$column->getPhpName()]);
}
```

`$this->keys` happens to be empty, because it's not populated when the object is inserted/updated and new i18n rows are created.
