### PR TITLE
#7328 - Update EAD mappings

### DIFF
--- a/apps/qubit/modules/object/config/import/ead.yml
+++ b/apps/qubit/modules/object/config/import/ead.yml
@@ -59,22 +59,22 @@ information_object:
       Method:  setRepositoryByName
 
     creator:
-      XPath:  "did/origination/name"
+      XPath:  "(did/origination/name|origination/name)"
       Method:  setActorByName
       Parameters: [$nodeValue, "$options = array('event_type_id' => QubitTerm::CREATION_ID)"]
 
     creator_person:
-      XPath:   "did/origination/persname"
+      XPath:   "(did/origination/persname|origination/persname)"
       Method:  setActorByName
       Parameters: [$nodeValue, "$options = array('event_type_id' => QubitTerm::CREATION_ID, 'entity_type_id' => QubitTerm::PERSON_ID)"]
 
     creator_corporate_body:
-      XPath:   "did/origination/corpname"
+      XPath:   "(did/origination/corpname|origination/corpname)"
       Method:  setActorByName
       Parameters: [$nodeValue, "$options = array('event_type_id' => QubitTerm::CREATION_ID, 'entity_type_id' => QubitTerm::CORPORATE_BODY_ID)"]
 
     creator_family:
-      XPath:   "did/origination/famname"
+      XPath:   "(did/origination/famname|origination/famname)"
       Method:  setActorByName
       Parameters: [$nodeValue, "$options = array('event_type_id' => QubitTerm::CREATION_ID, 'entity_type_id' => QubitTerm::FAMILY_ID)"]
 

--- a/apps/qubit/modules/object/config/import/ead.yml
+++ b/apps/qubit/modules/object/config/import/ead.yml
@@ -420,17 +420,13 @@ information_object:
       Method: importEadNote # Manually parsed, see case 'processinfo' in QubitXmlImport.class.php
       Parameters: ["$options = array('note' => $nodeValue, 'noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID)"]
 
-    publicationdate:
-      XPath: "../eadheader/filedesc/publicationstmt/date"
-      Method: setPublicationDate
-
     archivistnote:
       XPath:  "../eadheader/filedesc/titlestmt/author[@encodinganalog='creator']"
       Method: importEadNote
       Parameters: ["$options = array('note' => $nodeValue, 'noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID)"]
 
     revision_history:
-      XPath:  "(processinfo/date | processinfo/p/date | descgrp/processinfo/date | descgrp/processinfo/p/date)"
+      XPath:  "(processinfo/date | processinfo/p/date | descgrp/processinfo/date | descgrp/processinfo/p/date | ../eadheader/filedesc/publicationstmt/date)"
       Method:  setRevisionHistory
 
     userestrict:

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -2272,24 +2272,6 @@ class QubitInformationObject extends BaseInformationObject
     return $this->setStatus($options = array('statusId' => $value, 'typeId' => QubitTerm::STATUS_TYPE_PUBLICATION_ID));
   }
 
-  /**
-   * Set publication date
-   * @param $value  The year the information object was published
-   */
-  public function setPublicationDate($value)
-  {
-    // We only support singular years right now...
-    if (!is_numeric($value))
-      return;
-
-    $publicationEvent = new QubitEvent;
-    $publicationEvent->typeId = QubitTerm::PUBLICATION_ID;
-    $publicationEvent->startDate = sprintf("%s-0-0", $value);
-    $publicationEvent->endDate = sprintf("%s-0-0", $value);
-
-    $this->events[] = $publicationEvent;
-  }
-
   /*****************************************************
    TreeView
   *****************************************************/


### PR DESCRIPTION
- Find `<origination>` values when `<origination>` is not parented inside the `<did>` element
- Map `<publicationstmt><date>` to revisionHistory. This field describes the date of publication of the _description_, but it was being mapped to a field that actually refers to the content being described.

The latter change orphaned the `setPublicationDate` method on `QubitInformationObject`, so it was removed.
