### PR TITLE
#5094 - Recreate RAD events from EAD on import

### DIFF
--- a/apps/qubit/modules/object/config/import/ead.yml
+++ b/apps/qubit/modules/object/config/import/ead.yml
@@ -350,27 +350,27 @@ information_object:
     controlaccess_name:
       XPath:  "(controlaccess/name | controlaccess/controlaccess/name)"
       Method: setActorByName
-      Parameters: [$nodeValue, "$options = array('relation_type_id' => QubitTerm::NAME_ACCESS_POINT_ID)"]
+      Parameters: [$nodeValue, "$options = array('relation_type_id' => QubitTerm::NAME_ACCESS_POINT_ID, 'createRelation' => !$importDOM->xpath->query('@id', $domNode2)->length)"]
 
     controlaccess_corpname:
       XPath:   "(controlaccess/corpname | controlaccess/controlaccess/corpname)"
       Method:  setActorByName
-      Parameters: [$nodeValue, "$options = array('relation_type_id' => QubitTerm::NAME_ACCESS_POINT_ID, 'entity_type_id' => QubitTerm::CORPORATE_BODY_ID, 'source' => $importDOM->xpath->query('@source', $domNode2)->item(0)->nodeValue, 'rules' => $importDOM->xpath->query('@rules', $domNode2)->item(0)->nodeValue)"]
+      Parameters: [$nodeValue, "$options = array('relation_type_id' => QubitTerm::NAME_ACCESS_POINT_ID, 'entity_type_id' => QubitTerm::CORPORATE_BODY_ID, 'source' => $importDOM->xpath->query('@source', $domNode2)->item(0)->nodeValue, 'rules' => $importDOM->xpath->query('@rules', $domNode2)->item(0)->nodeValue, 'createRelation' => !$importDOM->xpath->query('@id', $domNode2)->length)"]
 
     controlaccess_persname:
       XPath:   "(controlaccess/persname | controlaccess/controlaccess/persname)"
       Method:  setActorByName
-      Parameters: [$nodeValue, "$options = array('relation_type_id' => QubitTerm::NAME_ACCESS_POINT_ID, 'entity_type_id' => QubitTerm::PERSON_ID, 'source' => $importDOM->xpath->query('@source', $domNode2)->item(0)->nodeValue, 'rules' => $importDOM->xpath->query('@rules', $domNode2)->item(0)->nodeValue)"]
+      Parameters: [$nodeValue, "$options = array('relation_type_id' => QubitTerm::NAME_ACCESS_POINT_ID, 'entity_type_id' => QubitTerm::PERSON_ID, 'source' => $importDOM->xpath->query('@source', $domNode2)->item(0)->nodeValue, 'rules' => $importDOM->xpath->query('@rules', $domNode2)->item(0)->nodeValue, 'createRelation' => !$importDOM->xpath->query('@id', $domNode2)->length)"]
 
     controlaccess_famname:
       XPath:   "(controlaccess/famname | controlaccess/controlaccess/famname)"
       Method:  setActorByName
-      Parameters: [$nodeValue, "$options = array('relation_type_id' => QubitTerm::NAME_ACCESS_POINT_ID, 'entity_type_id' => QubitTerm::FAMILY_ID, 'source' => $importDOM->xpath->query('@source', $domNode2)->item(0)->nodeValue, 'rules' => $importDOM->xpath->query('@rules', $domNode2)->item(0)->nodeValue)"]
+      Parameters: [$nodeValue, "$options = array('relation_type_id' => QubitTerm::NAME_ACCESS_POINT_ID, 'entity_type_id' => QubitTerm::FAMILY_ID, 'source' => $importDOM->xpath->query('@source', $domNode2)->item(0)->nodeValue, 'rules' => $importDOM->xpath->query('@rules', $domNode2)->item(0)->nodeValue, 'createRelation' => !$importDOM->xpath->query('@id', $domNode2)->length)"]
 
     controlaccess_geogname:
       XPath:   "(controlaccess/geogname | controlaccess/controlaccess/geogname)"
       Method:  setTermRelationByName
-      Parameters: [$nodeValue, "$options = array('taxonomyId' => QubitTaxonomy::PLACE_ID, 'source' => $importDOM->xpath->query('@source', $domNode2)->item(0)->nodeValue)"]
+      Parameters: [$nodeValue, "$options = array('taxonomyId' => QubitTaxonomy::PLACE_ID, 'source' => $importDOM->xpath->query('@source', $domNode2)->item(0)->nodeValue, 'createRelation' => !$importDOM->xpath->query('@id', $domNode2)->length)"]
 
     controlaccess_subject:
       XPath:   "(controlaccess/subject | controlaccess/controlaccess/subject)"

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -1401,7 +1401,9 @@ class QubitInformationObject extends BaseInformationObject
 
       $this->events[] = $event;
     }
-    else if (isset($options['relation_type_id']))
+    // In EAD import, the term relation is not always created at this point;
+    // it might be created afterwards.
+    else if (isset($options['relation_type_id']) && isset($options['createRelation']) && false !== $options['createRelation'])
     {
       // Only add actor as name access point if they are not already linked to
       // an event (i.e. they are not already a "creator", "accumulator", etc.)
@@ -2080,7 +2082,12 @@ class QubitInformationObject extends BaseInformationObject
       }
     }
 
-    $this->addTermRelation($term->id);
+    // In EAD import, the term relation is not always created at this point;
+    // it might be created afterwards.
+    if (isset($options['createRelation']) && false !== $options['createRelation'])
+    {
+      $this->addTermRelation($term->id);
+    }
 
     return $term;
   }

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -1426,6 +1426,8 @@ class QubitInformationObject extends BaseInformationObject
         $this->relationsRelatedBysubjectId[] = $relation;
       }
     }
+
+    return $actor;
   }
 
   /**
@@ -1988,6 +1990,8 @@ class QubitInformationObject extends BaseInformationObject
     $event->setDate($date);
 
     $this->events[] = $event;
+
+    return $event;
   }
 
   protected function getDefaultDateValue($date)
@@ -2077,6 +2081,8 @@ class QubitInformationObject extends BaseInformationObject
     }
 
     $this->addTermRelation($term->id);
+
+    return $term;
   }
 
   public function setPhysicalObjectByName($physicalObjectName, $options)

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
@@ -186,13 +186,13 @@
     <controlaccess>
       <?php foreach ($resource->getActorEvents() as $event): ?>
         <?php if ($event->getActor()->getEntityTypeId() == QubitTerm::PERSON_ID): ?>
-          <persname role="<?php echo $event->getType()->getRole() ?>"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))) ?></persname>
+          <persname role="<?php echo $event->getType()->getRole() ?>" id="<?php echo $event->id ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))) ?></persname>
         <?php elseif ($event->getActor()->getEntityTypeId() == QubitTerm::FAMILY_ID): ?>
-          <famname role="<?php echo $event->getType()->getRole() ?>"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))) ?></famname>
+          <famname role="<?php echo $event->getType()->getRole() ?>" id="<?php echo $event->id ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))) ?></famname>
         <?php elseif ($event->getActor()->getEntityTypeId() == QubitTerm::CORPORATE_BODY_ID): ?>
-          <corpname role="<?php echo $event->getType()->getRole() ?>"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))) ?></corpname>
+          <corpname role="<?php echo $event->getType()->getRole() ?>" id="<?php echo $event->id ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))) ?></corpname>
         <?php else: ?>
-          <name role="<?php echo $event->getType()->getRole() ?>"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))) ?></name>
+          <name role="<?php echo $event->getType()->getRole() ?>" id="<?php echo $event->id ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))) ?></name>
         <?php endif; ?>
       <?php endforeach; ?>
       <?php foreach ($names as $name): ?>
@@ -216,7 +216,7 @@
         <geogname><?php echo escape_dc(esc_specialchars($place->getTerm())) ?></geogname>
       <?php endforeach; ?>
       <?php foreach ($place_events as $place): ?>
-        <geogname role="<?php echo $place->getObject()->getType()->getRole() ?>"><?php echo escape_dc(esc_specialchars($place->getTerm())) ?></geogname>
+        <geogname role="<?php echo $place->getObject()->getType()->getRole() ?>" id="<?php echo $event->id ?>_place"><?php echo escape_dc(esc_specialchars($place->getTerm())) ?></geogname>
       <?php endforeach; ?>
     </controlaccess>
   <?php endif; ?>
@@ -302,11 +302,11 @@
 
             <?php foreach ($descendant->getActorEvents() as $event): ?>
               <?php if ($event->getActor()->getEntityTypeId() == QubitTerm::PERSON_ID): ?>
-                <persname role="<?php echo $event->getType()->getRole() ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('actorEventsName'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>><?php echo escape_dc(esc_specialchars(render_title($event->getActor(array('cultureFallback' => true))))) ?> </persname>
+                <persname role="<?php echo $event->getType()->getRole() ?>" id="<?php echo $event->id ?>_actor" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('actorEventsName'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>><?php echo escape_dc(esc_specialchars(render_title($event->getActor(array('cultureFallback' => true))))) ?> </persname>
               <?php elseif ($event->getActor()->getEntityTypeId() == QubitTerm::FAMILY_ID): ?>
-                <famname role="<?php echo $event->getType()->getRole() ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('actorEventsName'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>><?php echo escape_dc(esc_specialchars(render_title($event->getActor(array('cultureFallback' => true))))) ?> </famname>
+                <famname role="<?php echo $event->getType()->getRole() ?>" id="<?php echo $event->id ?>_actor" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('actorEventsName'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>><?php echo escape_dc(esc_specialchars(render_title($event->getActor(array('cultureFallback' => true))))) ?> </famname>
               <?php else: ?>
-                <corpname role="<?php echo $event->getType()->getRole() ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('actorEventsName'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>><?php echo escape_dc(esc_specialchars(render_title($event->getActor(array('cultureFallback' => true))))) ?> </corpname>
+                <corpname role="<?php echo $event->getType()->getRole() ?>" id="<?php echo $event->id ?>_actor" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('actorEventsName'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>><?php echo escape_dc(esc_specialchars(render_title($event->getActor(array('cultureFallback' => true))))) ?> </corpname>
               <?php endif; ?>
             <?php endforeach; ?>
 
@@ -335,7 +335,7 @@
             <?php endforeach; ?>
 
             <?php foreach ($place_events as $place): ?>
-              <geogname role="<?php echo $place->getObject()->getType()->getRole() ?>"><?php echo escape_dc(esc_specialchars($place->getTerm())) ?></geogname>
+              <geogname role="<?php echo $place->getObject()->getType()->getRole() ?>" id="<?php echo $event->id ?>_place"><?php echo escape_dc(esc_specialchars($place->getTerm())) ?></geogname>
             <?php endforeach; ?>
 
           </controlaccess>

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
@@ -88,7 +88,7 @@
   <?php endif; ?>
 
   <?php foreach ($$resourceVar->getDates() as $date): ?>
-    <unitdate <?php if ($date->typeId != QubitTerm::CREATION_ID): ?><?php if ($type = $date->getType()->__toString()): ?><?php echo 'datechar="'.strtolower($type).'" ' ?><?php endif; ?><?php endif; ?><?php if ($startdate = $date->getStartDate()): ?><?php echo 'normal="'?><?php echo Qubit::renderDate($startdate) ?><?php if (0 < strlen($enddate = $date->getEndDate())): ?><?php echo '/'?><?php echo Qubit::renderDate($enddate) ?><?php endif; ?><?php echo '"' ?><?php endif; ?> encodinganalog="<?php echo $ead->getMetadataParameter('unitdate') ?>"><?php echo escape_dc(esc_specialchars(Qubit::renderDateStartEnd($date->getDate(array('cultureFallback' => true)), $date->startDate, $date->endDate))) ?></unitdate>
+    <unitdate <?php if ($date->getActor() !== NULL || $date->getPlaces() !== NULL): ?> <?php echo 'id="'.$date->id.'_event"' ?> <?php endif; ?> <?php if ($date->typeId != QubitTerm::CREATION_ID): ?><?php if ($type = $date->getType()->__toString()): ?><?php echo 'datechar="'.strtolower($type).'" ' ?><?php endif; ?><?php endif; ?><?php if ($startdate = $date->getStartDate()): ?><?php echo 'normal="'?><?php echo Qubit::renderDate($startdate) ?><?php if (0 < strlen($enddate = $date->getEndDate())): ?><?php echo '/'?><?php echo Qubit::renderDate($enddate) ?><?php endif; ?><?php echo '"' ?><?php endif; ?> encodinganalog="<?php echo $ead->getMetadataParameter('unitdate') ?>"><?php echo escape_dc(esc_specialchars(Qubit::renderDateStartEnd($date->getDate(array('cultureFallback' => true)), $date->startDate, $date->endDate))) ?></unitdate>
   <?php endforeach; // dates ?>
 
   <?php if (0 < strlen($value = $$resourceVar->getExtentAndMedium(array('cultureFallback' => true)))): ?>


### PR DESCRIPTION
This updates the EAD import process to correctly recreate RAD events.

RAD events can have both places and actors associated with them. These places and actors are associated with the _event_ and not with the information object itself, which affects how they're displayed in the user interface. AtoM currently doesn't support exporting these to EAD or reimporting them. Prior to 61fb9c63f700a3efd5eccea2557ef09c0155431d, they weren't exported in EAD at all; now they are, with their role intact, but they will be imported as standard authorities instead of in association with their events.

This adds a new `id` attribute to events and to the places and actors associated with those events on export to EAD. On import, any actor or place with an ID will not have a relationship built to the information object and will instead be associated to its associated event.

This required a few extra bits of plumbing to support:
- `QubitInformationObject::setActorByName` and `::setTermRelationByName` now support the new `createRelation` parameter in the `$options` array. If set to false, it overrides the usual logic determining whether a relationship should be created and creates no relationship.
- `QubitInformationObject::setActorByName`, `::setTermRelationByName` and `::setDates`, which previously returned void, now return the created actor or term object if one is created. This shouldn't affect existing code.
