### PR TITLE
Hide elements in print view, refs #7445

### DIFF
--- a/plugins/arArchivesCanadaPlugin/config/arArchivesCanadaPluginConfiguration.class.php
+++ b/plugins/arArchivesCanadaPlugin/config/arArchivesCanadaPluginConfiguration.class.php
@@ -32,11 +32,11 @@ class arArchivesCanadaPluginConfiguration extends sfPluginConfiguration
     if ($context->getConfiguration()->isDebug())
     {
       $context->response->addJavaScript('/vendor/less.js');
-      $context->response->addStylesheet('/plugins/arArchivesCanadaPlugin/css/main.less', 'last', array('rel' => 'stylesheet/less', 'type' => 'text/css'));
+      $context->response->addStylesheet('/plugins/arArchivesCanadaPlugin/css/main.less', 'last', array('rel' => 'stylesheet/less', 'type' => 'text/css', 'media' => 'all'));
     }
     else
     {
-      $context->response->addStylesheet('/plugins/arArchivesCanadaPlugin/css/min.css', 'last', array('media' => 'screen'));
+      $context->response->addStylesheet('/plugins/arArchivesCanadaPlugin/css/min.css', 'last', array('media' => 'all'));
     }
   }
 

--- a/plugins/arArchivesCanadaPlugin/css/main.less
+++ b/plugins/arArchivesCanadaPlugin/css/main.less
@@ -69,6 +69,7 @@
 @import "../../arDominionPlugin/css/less/header.less";
 @import "../../arDominionPlugin/css/less/treeview.less";
 @import "../../arDominionPlugin/css/less/popovers.less";
+@import "../../arDominionPlugin/css/less/print.less";
 @import "../../arDominionPlugin/css/less/description.less";
 @import "../../arDominionPlugin/css/less/import.less";
 @import "../../arDominionPlugin/css/less/forms.less";

--- a/plugins/arDominionPlugin/config/arDominionPluginConfiguration.class.php
+++ b/plugins/arDominionPlugin/config/arDominionPluginConfiguration.class.php
@@ -32,11 +32,11 @@ class arDominionPluginConfiguration extends sfPluginConfiguration
     if ($context->getConfiguration()->isDebug())
     {
       $context->response->addJavaScript('/vendor/less.js');
-      $context->response->addStylesheet('/plugins/arDominionPlugin/css/main.less', 'last', array('rel' => 'stylesheet/less', 'type' => 'text/css'));
+      $context->response->addStylesheet('/plugins/arDominionPlugin/css/main.less', 'last', array('rel' => 'stylesheet/less', 'type' => 'text/css', 'media' => 'all'));
     }
     else
     {
-      $context->response->addStylesheet('/plugins/arDominionPlugin/css/main.css', 'last', array('media' => 'screen'));
+      $context->response->addStylesheet('/plugins/arDominionPlugin/css/main.css', 'last', array('media' => 'all'));
     }
   }
 

--- a/plugins/arDominionPlugin/css/less/print.less
+++ b/plugins/arDominionPlugin/css/less/print.less
@@ -1,0 +1,17 @@
+@media print {
+
+  /* Hide */
+
+  #update-check,
+  header,
+  #site-slogan,
+  #sidebar,
+  #context-menu,
+  section.actions,
+  footer,
+  #sfWebDebug
+  {
+    display: none;
+  }
+
+}

--- a/plugins/arDominionPlugin/css/main.less
+++ b/plugins/arDominionPlugin/css/main.less
@@ -58,6 +58,7 @@
 @import "less/header.less";
 @import "less/treeview.less";
 @import "less/popovers.less";
+@import "less/print.less";
 @import "less/description.less";
 @import "less/import.less";
 @import "less/forms.less";


### PR DESCRIPTION
Adds print.less file in arDominionPlugin less folder
Used in Dominion and ArchivesCanada themes
Adds the css/less file with media=all in the header to allow print rules
