### PR TITLE
Add Finding Aid format setting, refs #7615

### DIFF
--- a/apps/qubit/modules/settings/actions/listAction.class.php
+++ b/apps/qubit/modules/settings/actions/listAction.class.php
@@ -236,6 +236,7 @@ class SettingsListAction extends sfAction
     $showTooltips = QubitSetting::getByName('show_tooltips');
     $defaultPubStatus = QubitSetting::getByName('defaultPubStatus');
     $swordDepositDir = QubitSetting::getByName('sword_deposit_dir');
+    $findingAidFormat = QubitSetting::getByName('findingAidFormat');
 
     // Set defaults for global form
     $this->globalForm->setDefaults(array(
@@ -255,7 +256,8 @@ class SettingsListAction extends sfAction
       'explode_multipage_files' => (isset($explodeMultipageFiles)) ? intval($explodeMultipageFiles->getValue(array('sourceCulture'=>true))) : 1,
       'show_tooltips' => (isset($showTooltips)) ? intval($showTooltips->getValue(array('sourceCulture'=>true))) : 1,
       'defaultPubStatus' => (isset($defaultPubStatus)) ? $defaultPubStatus->getValue(array('sourceCulture'=>true)) : QubitTerm::PUBLICATION_STATUS_DRAFT_ID,
-      'sword_deposit_dir' => (isset($swordDepositDir)) ? $swordDepositDir->getValue(array('sourceCulture'=>true)) : null
+      'sword_deposit_dir' => (isset($swordDepositDir)) ? $swordDepositDir->getValue(array('sourceCulture'=>true)) : null,
+      'finding_aid_format' => (isset($findingAidFormat)) ? $findingAidFormat->getValue(array('sourceCulture'=>true)) : 'pdf'
     ));
   }
 
@@ -447,6 +449,16 @@ class SettingsListAction extends sfAction
 
       // Force sourceCulture update to prevent discrepency in settings between cultures
       $setting->setValue($swordDepositDir, array('sourceCulture' => true));
+      $setting->save();
+    }
+
+    // Finding Aids format
+    if (null !== $findingAidFormat = $thisForm->getValue('finding_aid_format'))
+    {
+      $setting = QubitSetting::getByName('findingAidFormat');
+
+      // Force sourceCulture update to prevent discrepency in settings between cultures
+      $setting->setValue($findingAidFormat, array('sourceCulture' => true));
       $setting->save();
     }
 

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 111
+    value: 112
   milestone:
     name: milestone
     editable: 0
@@ -762,3 +762,10 @@ QubitSetting:
     name: isad_description_control_area
     scope: element_visibility
     value: 1
+  Qubit_Settings_findingAidFormat:
+    name: findingAidFormat
+    editable: 1
+    deleteable: 0
+    source_culture: en
+    value:
+      en: pdf

--- a/lib/form/SettingsGlobalForm.class.php
+++ b/lib/form/SettingsGlobalForm.class.php
@@ -55,7 +55,8 @@ class SettingsGlobalForm extends sfForm
       'explode_multipage_files' => new sfWidgetFormSelectRadio(array('choices'=>array(1=>'yes', 0=>'no')), array('class'=>'radio')),
       'show_tooltips' => new sfWidgetFormSelectRadio(array('choices'=>array(1=>'yes', 0=>'no')), array('class'=>'radio')),
       'defaultPubStatus' => new sfWidgetFormSelectRadio(array('choices'=>array(QubitTerm::PUBLICATION_STATUS_DRAFT_ID=>__('Draft'), QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID=>__('Published'))), array('class'=>'radio')),
-      'sword_deposit_dir' => new sfWidgetFormInput
+      'sword_deposit_dir' => new sfWidgetFormInput,
+      'finding_aid_format' =>  new sfWidgetFormSelect(array('choices'=>array('pdf' => 'PDF', 'rtf' => 'RTF', 'txt' => 'TXT')))
     ));
 
     // Add labels
@@ -79,7 +80,8 @@ class SettingsGlobalForm extends sfForm
       'defaultPubStatus' => __('Default publication status'),
       'sword_deposit_dir' => __('SWORD deposit directory'),
       'require_ssl_admin' => __('Require SSL for all administrator funcionality'),
-      'require_strong_passwords' => __('Require strong passwords')
+      'require_strong_passwords' => __('Require strong passwords'),
+      'finding_aid_format' => __('Finding Aid format')
     ));
 
     // Add helper text
@@ -146,6 +148,7 @@ class SettingsGlobalForm extends sfForm
     $this->validatorSchema['show_tooltips'] = new sfValidatorInteger(array('required' => false));
     $this->validatorSchema['defaultPubStatus'] = new sfValidatorChoice(array('choices' => array(QubitTerm::PUBLICATION_STATUS_DRAFT_ID, QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID)));
     $this->validatorSchema['sword_deposit_dir'] = new sfValidatorString(array('required' => false));
+    $this->validatorSchema['finding_aid_format'] = new sfValidatorString(array('required' => false));
 
     // Set decorator
     $decorator = new QubitWidgetFormSchemaFormatterList($this->widgetSchema);

--- a/lib/task/migrate/migrations/arMigration0112.class.php
+++ b/lib/task/migrate/migrations/arMigration0112.class.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add Finding Aid format setting
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0112
+{
+  const
+    VERSION = 112, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  /**
+   * Upgrade
+   *
+   * @return bool True if the upgrade succeeded, False otherwise
+   */
+  public function up($configuration)
+  {
+    $setting = QubitSetting::getByName('findingAidFormat');
+
+    if (!isset($setting))
+    {
+      $setting = new QubitSetting;
+    }
+
+    $setting->setName('findingAidFormat');
+    $setting->setSourceCulture('en');
+    $setting->setValue('pdf', array('culture' => 'en'));
+    $setting->setEditable(1);
+    $setting->setDeleteable(0);
+    $setting->save();
+
+    return true;
+  }
+}


### PR DESCRIPTION
- Setting added at the bottom of the global form. The settings forms will be improved after (see https://projects.artefactual.com/issues/7474#note-2)
- Added setting data in fixtures and migration script
- Formats available: PDF, RTF and TXT
