### PR TITLE
Add top-level description filter, refs #7570

### DIFF
--- a/apps/qubit/modules/informationobject/actions/browseAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/browseAction.class.php
@@ -132,6 +132,36 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
     }
   }
 
+  /**
+   * Determine url parameters based on if the "top-level descriptions" or "all descriptions"
+   * radio buttons are selected. Also determine which radio button is 'checked'.
+   *
+   * Filter out non-top level descriptions from the ES query if the user has selected
+   * "top-level descriptions."
+   */
+  private function handleTopLevelDescriptionsOnlyFilter()
+  {
+    $this->topLvlDescUrl = $this->context->routing->generate(null, array('topLod' => true) +
+                           $this->request->getParameterHolder()->getAll());
+
+
+    $this->allLvlDescUrl = $this->context->routing->generate(null, array('topLod' => false) +
+                           $this->request->getParameterHolder()->getAll());
+
+    if ($this->request->topLod)
+    {
+      $this->checkedTopDesc = 'checked';
+      $this->checkedAllDesc = '';
+
+      $this->queryBool->addMust(new \Elastica\Query\Term(array('parentId' => QubitInformationObject::ROOT_ID)));
+    }
+    else
+    {
+      $this->checkedTopDesc = '';
+      $this->checkedAllDesc = 'checked';
+    }
+  }
+
   public function execute($request)
   {
     parent::execute($request);
@@ -192,6 +222,14 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
         return;
       }
     }
+
+    // Default to show top level descriptions only when browsing.
+    if (!isset($request->topLod))
+    {
+      $request->topLod = true;
+    }
+
+    $this->handleTopLevelDescriptionsOnlyFilter();
 
     if (isset($request->onlyMedia))
     {

--- a/apps/qubit/modules/informationobject/templates/browseSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/browseSuccess.php
@@ -70,7 +70,12 @@
         'label' => __('Level of description'),
         'facet' => 'levels',
         'pager' => $pager,
-        'filters' => $filters)) ?>
+        'filters' => $filters,
+        'topLvlDescUrl' => $topLvlDescUrl,
+        'allLvlDescUrl' => $allLvlDescUrl,
+        'checkedTopDesc' => $checkedTopDesc,
+        'checkedAllDesc' => $checkedAllDesc,
+        'open' => true)) ?>
 
       <?php echo get_partial('search/facet', array(
         'target' => '#facet-mediaTypes',
@@ -112,6 +117,15 @@
         <?php $params = $sf_request->getGetParameters() ?>
         <?php unset($params['onlyMedia']) ?>
         <?php unset($params['page']) ?>
+        <a href="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse') + $params) ?>" class="remove-filter"><i class="icon-remove"></i></a>
+      </span>
+    <?php endif; ?>
+
+    <?php if (isset($sf_request->topLod) && $sf_request->topLod): ?>
+      <span class="search-filter">
+        <?php echo __('Only top-level descriptions') ?>
+        <?php $params = $sf_request->getGetParameters() ?>
+        <?php $params['topLod'] = 0 ?>
         <a href="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse') + $params) ?>" class="remove-filter"><i class="icon-remove"></i></a>
       </span>
     <?php endif; ?>

--- a/apps/qubit/modules/search/actions/indexAction.class.php
+++ b/apps/qubit/modules/search/actions/indexAction.class.php
@@ -129,6 +129,36 @@ class SearchIndexAction extends DefaultBrowseAction
     }
   }
 
+  /**
+   * Determine url parameters based on if the "top-level descriptions" or "all descriptions"
+   * radio buttons are selected. Also determine which radio button is 'checked'.
+   *
+   * Filter out non-top level descriptions from the ES query if the user has selected
+   * "top-level descriptions."
+   */
+  private function handleTopLevelDescriptionsOnlyFilter()
+  {
+    $this->topLvlDescUrl = $this->context->routing->generate(null, array('topLod' => true) +
+                           $this->request->getParameterHolder()->getAll());
+
+
+    $this->allLvlDescUrl = $this->context->routing->generate(null, array('topLod' => false) +
+                           $this->request->getParameterHolder()->getAll());
+
+    if (isset($this->request->topLod) && $this->request->topLod)
+    {
+      $this->checkedTopDesc = 'checked';
+      $this->checkedAllDesc = '';
+
+      $this->queryBool->addMust(new \Elastica\Query\Term(array('parentId' => QubitInformationObject::ROOT_ID)));
+    }
+    else
+    {
+      $this->checkedTopDesc = '';
+      $this->checkedAllDesc = 'checked';
+    }
+  }
+
   public function execute($request)
   {
     parent::execute($request);
@@ -171,6 +201,7 @@ class SearchIndexAction extends DefaultBrowseAction
       $this->queryBool->addMust(new \Elastica\Query\Term(array('hasDigitalObject' => true)));
     }
 
+    $this->handleTopLevelDescriptionsOnlyFilter();
     $this->query->setQuery($this->queryBool);
 
     // Add suggestion

--- a/apps/qubit/modules/search/templates/_facet.php
+++ b/apps/qubit/modules/search/templates/_facet.php
@@ -12,6 +12,20 @@
   <div class="facet-body" id="<?php echo $target ?>">
 
     <ul>
+      <?php if ($facet === 'levels'): ?>
+        <div class="lod-filter btn-group" data-toggle="buttons">
+          <li>
+            <label>
+              <input type="radio" name="lod-filter" data-link="<?php echo $topLvlDescUrl ?>" <?php echo $checkedTopDesc ?>>
+              <?php echo __('Top-level descriptions') ?>
+            </label>
+            <label>
+              <input type="radio" name="lod-filter" data-link="<?php echo $allLvlDescUrl ?>" <?php echo $checkedAllDesc ?>>
+              <?php echo __('All descriptions') ?>
+            </label>
+          </li>
+        </div>
+      <?php endif; ?>
 
       <?php if (!isset($filters[$facet])): ?>
         <li class="active">

--- a/apps/qubit/modules/search/templates/indexSuccess.php
+++ b/apps/qubit/modules/search/templates/indexSuccess.php
@@ -30,6 +30,15 @@
       </span>
     <?php endif; ?>
 
+    <?php if (isset($sf_request->topLod) && $sf_request->topLod): ?>
+      <span class="search-filter">
+        <?php echo __('Only top-level descriptions') ?>
+        <?php $params = $sf_request->getGetParameters() ?>
+        <?php $params['topLod'] = 0 ?>
+        <a href="<?php echo url_for(array('module' => 'search', 'action' => 'index') + $params) ?>" class="remove-filter"><i class="icon-remove"></i></a>
+      </span>
+    <?php endif; ?>
+
   </section>
 
 <?php end_slot() ?>
@@ -71,6 +80,10 @@
       'facet' => 'levels',
       'pager' => $pager,
       'filters' => $filters,
+      'topLvlDescUrl' => $topLvlDescUrl,
+      'allLvlDescUrl' => $allLvlDescUrl,
+      'checkedTopDesc' => $checkedTopDesc,
+      'checkedAllDesc' => $checkedAllDesc,
       'open' => true)) ?>
 
     <?php echo get_partial('search/facet', array(

--- a/js/dominion.js
+++ b/js/dominion.js
@@ -133,6 +133,13 @@
         }).addClass('open');
     });
 
+    $(document).ready(function () {
+        $('.lod-filter [type=radio]').change(function (ev) {
+            var link = ev.target.getAttribute('data-link');
+            document.location.replace(link);
+        });
+    });
+
   /****
    ****
    ****  Date facets


### PR DESCRIPTION
The user can now use a radio button to specify whether to
show top level archival descriptions when searching/browsing,
or to display all descriptions.

When the user is browsing archival descriptions, the default
setting is now to display top level descriptions only (as it
was in ICA-AtoM).
