### PR TITLE
Add 'Part of' info to search/browse results #7651

### DIFF
--- a/apps/qubit/modules/informationobject/templates/browseSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/browseSuccess.php
@@ -158,7 +158,7 @@
 
 <?php foreach ($pager->getResults() as $hit): ?>
   <?php $doc = $hit->getData() ?>
-  <?php echo include_partial('search/searchResult', array('hit' => $hit, 'doc' => $doc, 'pager' => $pager, 'culture' => $selectedCulture)) ?>
+  <?php echo get_partial('search/searchResult', array('hit' => $hit, 'doc' => $doc, 'pager' => $pager, 'culture' => $selectedCulture)) ?>
 <?php endforeach; ?>
 
 <?php slot('after-content') ?>

--- a/apps/qubit/modules/search/templates/_searchResult.php
+++ b/apps/qubit/modules/search/templates/_searchResult.php
@@ -64,7 +64,10 @@
       <?php if (isset($doc['publicationStatusId']) && QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $doc['publicationStatusId']): ?>
         <li class="publication-status"><?php echo QubitCache::getLabel($doc['publicationStatusId'], 'QubitTerm') ?></li>
       <?php endif; ?>
-
+      <?php if (isset($doc['partOf'])): ?>
+        <p><?php echo __('Part of '), link_to(render_title(get_search_i18n($doc['partOf'], 'title', array('allowEmpty' => false, 'culture' => $culture))),
+                 array('slug' => $doc['partOf']['slug'], 'module' => 'informationobject')) ?></p>
+      <?php endif; ?>
     </ul>
 
     <?php if (null !== $scopeAndContent = get_search_i18n($doc, 'scopeAndContent', array('culture' => $culture))): ?>

--- a/apps/qubit/modules/search/templates/indexSuccess.php
+++ b/apps/qubit/modules/search/templates/indexSuccess.php
@@ -154,7 +154,7 @@
 
 <?php foreach ($pager->getResults() as $hit): ?>
   <?php $doc = $hit->getData() ?>
-  <?php echo include_partial('search/searchResult', array('hit' => $hit, 'pager' => $pager, 'culture' => $selectedCulture)) ?>
+  <?php echo get_partial('search/searchResult', array('hit' => $hit, 'pager' => $pager, 'culture' => $selectedCulture)) ?>
 <?php endforeach; ?>
 
 <?php slot('after-content') ?>

--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -242,6 +242,12 @@ mapping:
       timestamp: true
       autocompleteFields: [title]
       rawFields:  [title]
+    _partial_foreign_types:
+      part_of:
+        _i18nFields: [title]
+        dynamic: strict
+        properties:
+          slug: { type: string, index: not_analyzed }
     _foreign_types:
       repository: repository
       names: actor


### PR DESCRIPTION
Results for browse and search will now shot "Part of: <top level description title" next to them if they aren't top levels of description. The Part of: title should also link to the parent's archival description.
