### PR TITLE
Fixes in EAD bioghist import/export, refs #7124 (updates #7 and #8)

### DIFF
--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -405,7 +405,7 @@ class QubitXmlImport
 
                 foreach ($childNode as $pNode)
                 {
-                  // A <p> node inside <processinfo> with no other children, 
+                  // A <p> node inside <processinfo> with no other children,
                   // this is part of an archivist's note.
                   if ($pNode->childNodes->length === 1 && $pNode->firstChild->nodeType === XML_TEXT_NODE)
                   {
@@ -826,7 +826,7 @@ class QubitXmlImport
       $nodeValue .= $node->nodeValue;
     }
 
-    return $nodeValue;
+    return trim($nodeValue);
   }
 
   /**

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -1676,6 +1676,7 @@ class QubitInformationObject extends BaseInformationObject
    * Import creation-related data from an <bioghist> tag in EAD2002
    *
    * @param $biogHistNode  DOMNode  EAD bioghist DOM node
+   * @param $key Position of the current bioghist node
    */
   public function importBioghistEadData($biogHistNode, $key)
   {

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -1800,26 +1800,37 @@ class QubitInformationObject extends BaseInformationObject
         }
       }
 
-      // Add bioghist if there is a creator in the position and it doesn't have history
-      if (isset($creators[$key]) && !isset($creators[$key]->history))
+      // Add bioghist
+      if (strlen($history = QubitXmlImport::normalizeNodeValue($biogHistNode)) > 0)
       {
-        $creators[$key]->history = QubitXmlImport::normalizeNodeValue($biogHistNode);
-        $creators[$key]->save();
-      }
-      else
-      {
-        // Otherwise create new 'Untitled' actor
-        $actor = new QubitActor;
-        $actor->parentId = QubitActor::ROOT_ID;
-        $actor->setHistory(QubitXmlImport::normalizeNodeValue($biogHistNode));
-        $actor->save();
+        // Options:
+        // 1. If there isn't an actor in the current position:
+        //   - Create new 'Untitled' actor with bioghist value as history and new event
+        // 2. If the actor in the current position doesn't have history:
+        //   - Add bioghist value to the actor's history
+        // 3. If the actor in the current position has history and it's different to the bioghist value:
+        //   - Create new 'Untitled' actor with bioghist value as history and new event
+        // 4. If the actor in the current position has history and it's equal to the bioghist value:
+        //   - Do nothing
+        if (!isset($creators[$key]) ||
+          (isset($creators[$key]->history) && $creators[$key]->history !== $history))
+        {
+          $actor = new QubitActor;
+          $actor->parentId = QubitActor::ROOT_ID;
+          $actor->setHistory($history);
+          $actor->save();
 
-        // And add it to a new creation event for the resource
-        $event = new QubitEvent;
-        $event->setActorId($actor->id);
-        $event->setTypeId(QubitTerm::CREATION_ID);
+          $event = new QubitEvent;
+          $event->setActorId($actor->id);
+          $event->setTypeId(QubitTerm::CREATION_ID);
 
-        $this->events[] = $event;
+          $this->events[] = $event;
+        }
+        else if (!isset($creators[$key]->history))
+        {
+          $creators[$key]->history = $history;
+          $creators[$key]->save();
+        }
       }
     }
   }

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyBioghistElement.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyBioghistElement.xml.php
@@ -23,14 +23,16 @@
       <?php endif; ?>
     </origination>
 
-    <bioghist id="<?php echo 'md5-' . md5(url_for(array($creator, 'module' => 'actor'), true)) ?>" encodinganalog="<?php echo $ead->getMetadataParameter('bioghist') ?>">
-      <?php if ($value = $creator->getHistory(array('cultureFallback' => true))): ?>
-        <note><p><?php echo escape_dc(esc_specialchars($value)) ?></p></note>
-      <?php endif; ?>
-      <?php if ($creator->datesOfExistence): ?>
-        <date type="existence"><?php echo escape_dc(esc_specialchars($creator->datesOfExistence)) ?></date>
-      <?php endif; ?>
-    </bioghist>
+    <?php if (($value = $creator->getHistory(array('cultureFallback' => true))) || $creator->datesOfExistence): ?>
+      <bioghist id="<?php echo 'md5-' . md5(url_for(array($creator, 'module' => 'actor'), true)) ?>" encodinganalog="<?php echo $ead->getMetadataParameter('bioghist') ?>">
+        <?php if ($value): ?>
+          <note><p><?php echo escape_dc(esc_specialchars($value)) ?></p></note>
+        <?php endif; ?>
+        <?php if ($creator->datesOfExistence): ?>
+          <date type="existence"><?php echo escape_dc(esc_specialchars($creator->datesOfExistence)) ?></date>
+        <?php endif; ?>
+      </bioghist>
+    <?php endif; ?>
 
   <?php endforeach; ?>
 <?php endif; ?>


### PR DESCRIPTION
- Don't add empty bioghist elements in EAD export
- Don't create new 'Untitled' actors if bioghist value match
  the history value of the creator in the same position
- Improve comments showing different options on import
