### PR TITLE
Fix partial call in advancedSearch, fixes #7726

### DIFF
--- a/apps/qubit/modules/informationobject/templates/browseSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/browseSuccess.php
@@ -157,8 +157,7 @@
 <?php endif; ?>
 
 <?php foreach ($pager->getResults() as $hit): ?>
-  <?php $doc = $hit->getData() ?>
-  <?php echo get_partial('search/searchResult', array('hit' => $hit, 'doc' => $doc, 'pager' => $pager, 'culture' => $selectedCulture)) ?>
+  <?php echo get_partial('search/searchResult', array('hit' => $hit, 'culture' => $selectedCulture)) ?>
 <?php endforeach; ?>
 
 <?php slot('after-content') ?>

--- a/apps/qubit/modules/search/templates/advancedSuccess.php
+++ b/apps/qubit/modules/search/templates/advancedSuccess.php
@@ -84,8 +84,7 @@
 
   <?php if ($pager->hasResults()): ?>
     <?php foreach ($pager->getResults() as $hit): ?>
-      <?php $doc = $hit->getData() ?>
-      <?php echo include_partial('search/searchResult', array('doc' => $doc, 'pager' => $pager)) ?>
+      <?php echo get_partial('search/searchResult', array('hit' => $hit, 'culture' => $sf_context->user->getCulture())) ?>
     <?php endforeach; ?>
   <?php else: ?>
     <section id="no-search-results">

--- a/apps/qubit/modules/search/templates/indexSuccess.php
+++ b/apps/qubit/modules/search/templates/indexSuccess.php
@@ -153,8 +153,7 @@
 <?php endif; ?>
 
 <?php foreach ($pager->getResults() as $hit): ?>
-  <?php $doc = $hit->getData() ?>
-  <?php echo get_partial('search/searchResult', array('hit' => $hit, 'pager' => $pager, 'culture' => $selectedCulture)) ?>
+  <?php echo get_partial('search/searchResult', array('hit' => $hit, 'culture' => $selectedCulture)) ?>
 <?php endforeach; ?>
 
 <?php slot('after-content') ?>


### PR DESCRIPTION
The searchResult partial uses now the ES hit instead of the doc data,
and the selected/current culture. Other calls to the same partial have been
normalized
