### PR TITLE
Fix red images in Chrome print view, refs #7548

### DIFF
--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -2412,7 +2412,7 @@ class QubitDigitalObject extends BaseDigitalObject
     // Create a thumbnail
     try
     {
-      $newImage = new sfThumbnail($width, $height, true, false, 75, $adapter, array('extract' => 1));
+      $newImage = new sfThumbnail($width, $height, true, false, 75, $adapter, array('extract' => 1, 'colorspace' => 'YUV'));
       $newImage->loadFile($originalImageName);
     }
     catch (Exception $e)

--- a/plugins/sfThumbnailPlugin/lib/sfImageMagickAdapter.class.php
+++ b/plugins/sfThumbnailPlugin/lib/sfImageMagickAdapter.class.php
@@ -348,6 +348,11 @@ class sfImageMagickAdapter
       $command .= ' -quality '.$this->quality.'% ';
     }
 
+    if (isset($this->options['colorspace']))
+    {
+      $command .= ' -colorspace '.$this->options['colorspace'];
+    }
+
     // extract images such as pages from a pdf doc
     $extract = $this->getExtract();
 


### PR DESCRIPTION
B&W access copies for AtoM digital objects (reference y thumbnail) are printed
in red ussing Chrome. Changing the colorspace to YUV when they are created
with ImageMagick fix this problem
