### PR TITLE
Add option to export EAD like public user in CLI, refs #7743

### DIFF
--- a/lib/helper/QubitHelper.php
+++ b/lib/helper/QubitHelper.php
@@ -276,8 +276,14 @@ function is_using_cli()
   return php_sapi_name() === 'cli';
 }
 
-function check_field_visibility($fieldName)
+function check_field_visibility($fieldName, $options = array())
 {
+  // Check always field if public option is set to true
+  if (isset($options['public']) && $options['public'])
+  {
+    return sfConfig::get($fieldName, false);
+  }
+
   return (is_using_cli() || sfContext::getInstance()->user->isAuthenticated()) || sfConfig::get($fieldName, false);
 }
 

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -565,6 +565,28 @@ class QubitInformationObject extends BaseInformationObject
     }
   }
 
+  /**
+   * Returns non draft descendants order by lft. The childs of a draft descendant
+   * will not be added even if they are public
+   *
+   * @return array of QubitInformationObject objects.
+   */
+  public function getNonDraftDescendants()
+  {
+    $descendants = array();
+
+    foreach ($this->getChildren()->orderBy('lft') as $child)
+    {
+      if (QubitTerm::PUBLICATION_STATUS_DRAFT_ID != $child->getPublicationStatus()->statusId)
+      {
+        $descendants[] = $child;
+        $descendants = array_merge($descendants, $child->getNonDraftDescendants());
+      }
+    }
+
+    return $descendants;
+  }
+
   /***********************
    Actor/Event relations
   ************************/

--- a/lib/task/exportBulkTask.class.php
+++ b/lib/task/exportBulkTask.class.php
@@ -81,6 +81,9 @@ class eadExportTask extends sfBaseTask
     $configuration = ProjectConfiguration::getApplicationConfiguration('qubit', 'cli', false);
     $sf_context = sfContext::createInstance($configuration);
 
+    // QubitSetting are not available for tasks? See lib/SiteSettingsFilter.class.php
+    sfConfig::add(QubitSetting::getSettingsArray());
+
     $iso639convertor = new fbISO639_Map;
     $eadLevels = array('class', 'collection', 'file', 'fonds', 'item', 'otherlevel', 'recordgrp', 'series', 'subfonds', 'subgrp', 'subseries');
     $pluginName = 'sf'. ucfirst($options['format']) .'Plugin';

--- a/lib/task/exportBulkTask.class.php
+++ b/lib/task/exportBulkTask.class.php
@@ -47,7 +47,8 @@ class eadExportTask extends sfBaseTask
       new sfCommandOption('format', null, sfCommandOption::PARAMETER_OPTIONAL, 'XML format ("ead" or "mods")', 'ead'),
       new sfCommandOption('criteria', null, sfCommandOption::PARAMETER_OPTIONAL, 'Export criteria'),
       new sfCommandOption('current-level-only', null, sfCommandOption::PARAMETER_NONE, 'Do not export child descriptions of exported items'),
-      new sfCommandOption('single-id', null, sfCommandOption::PARAMETER_OPTIONAL, 'Export an EAD file for a single fonds or collection based on id')
+      new sfCommandOption('single-id', null, sfCommandOption::PARAMETER_OPTIONAL, 'Export an EAD file for a single fonds or collection based on id'),
+      new sfCommandOption('public', null, sfCommandOption::PARAMETER_NONE, 'Do not export child descriptions of exported items')
     ));
   }
 

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
@@ -269,8 +269,14 @@
   <?php if (!$options['current-level-only']): ?>
   <dsc type="combined">
 
+    <?php if (isset($options['public']) && $options['public']): ?>
+      <?php $descendants = $resource->getNonDraftDescendants(); ?>
+    <?php else: ?>
+      <?php $descendants = $resource->getDescendants()->orderBy('lft'); ?>
+    <?php endif; ?>
+
     <?php $nestedRgt = array() ?>
-    <?php foreach ($resource->getDescendants()->orderBy('lft') as $descendant): ?>
+    <?php foreach ($descendants as $descendant): ?>
 
       <c <?php echo $ead->renderLOD($descendant, $eadLevels) ?>>
 

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
@@ -1,6 +1,6 @@
 <did>
 
-  <?php if (check_field_visibility('app_element_visibility_physical_storage')): ?>
+  <?php if (check_field_visibility('app_element_visibility_physical_storage', $options)): ?>
     <?php $objects = $$resourceVar->getPhysicalObjects() ?>
     <?php foreach ($objects as $object): ?>
       <?php if (0 < strlen($object->location)): ?>


### PR DESCRIPTION
If the '--public' option is added when executing the exportBulk task
draft descriptions (and their descendants) are not added in EAD export.
It won't add physloc either if physical storage is hidden for public user

Refs #7743
