### PR TITLE
Check IO visibility in EAD export and OAI plugin, refs #7406

### DIFF
--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -525,9 +525,9 @@ class QubitInformationObject extends BaseInformationObject
 
   /**
    * Get all info objects that have the root node as a parent, and have children
-   * (not orphans)
+   * (not orphans). Checking ACL
    *
-   * @return QubitQuery collection of QubitInformationObjects
+   * @return array collection of QubitInformationObjects
    */
   public static function getCollections()
   {
@@ -540,7 +540,17 @@ class QubitInformationObject extends BaseInformationObject
     $criteria->add(QubitInformationObject::RGT, QubitInformationObject::RGT.' > ('.QubitInformationObject::LFT.' + 1)', Criteria::CUSTOM);
     $criteria->add('parent.lft', 1);
 
-    return QubitInformationObject::get($criteria);
+    $collections = array();
+
+    foreach (QubitInformationObject::get($criteria) as $item)
+    {
+      if (QubitAcl::check($item, 'read'))
+      {
+        $collections[] = $item;
+      }
+    }
+
+    return $collections;
   }
 
   public function getCollectionRoot()

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
@@ -269,14 +269,8 @@
   <?php if (!$options['current-level-only']): ?>
   <dsc type="combined">
 
-    <?php if (isset($options['public']) && $options['public']): ?>
-      <?php $descendants = $resource->getNonDraftDescendants(); ?>
-    <?php else: ?>
-      <?php $descendants = $resource->getDescendants()->orderBy('lft'); ?>
-    <?php endif; ?>
-
     <?php $nestedRgt = array() ?>
-    <?php foreach ($descendants as $descendant): ?>
+    <?php foreach ($resource->getDescendantsForExport($options) as $descendant): ?>
 
       <c <?php echo $ead->renderLOD($descendant, $eadLevels) ?>>
 


### PR DESCRIPTION
Check descendants visibility in EAD export and collection visibility in getCollections(), used in the OAI plugin.

The other part that gets IOs in the OAI plugin is already checking for published records - getUpdatedRecords().
