### PR TITLE
Improve exception handling in jobs, refs #7822

### DIFF
--- a/lib/job/arBaseJob.class.php
+++ b/lib/job/arBaseJob.class.php
@@ -27,12 +27,14 @@
 
 class arBaseJob extends Net_Gearman_Job_Common
 {
-  // Required parameters for all jobs:
-  // - Parameters that are mandatory for all jobs
-  // - They are checked at the begining of the job in checkRequiredParameters() function
-  // - Required parameters for each job can be declared in the subclases
-  // - The job will fail if any of the required paramaters are missing
-  private $requiredParametersForAllJobs = array('id', 'name');
+  /*
+   * Required parameters:
+   *
+   * Declares parameters that are mandatory for the jobs execution. They can be
+   * extended on each job subclasse using the $extraRequiredParameters property.
+   * If any of the required paramareters is missing the job will fail.
+   */
+  private $requiredParameters = array('id', 'name');
 
   public function run($parameters)
   {
@@ -73,16 +75,12 @@ class arBaseJob extends Net_Gearman_Job_Common
    */
   protected function checkRequiredParameters($parameters)
   {
-    if (isset($this->requiredParameters))
+    if (isset($this->extraRequiredParameters))
     {
-      $toCheckParameters = array_merge($this->requiredParametersForAllJobs, $this->requiredParameters);
-    }
-    else
-    {
-      $toCheckParameters = $this->requiredParametersForAllJobs;
+      $this->requiredParameters = array_merge($this->requiredParameters, $this->extraRequiredParameters);
     }
 
-    foreach ($toCheckParameters as $paramName)
+    foreach ($this->requiredParameters as $paramName)
     {
       if (!isset($parameters[$paramName]))
       {

--- a/lib/job/arBaseJob.class.php
+++ b/lib/job/arBaseJob.class.php
@@ -31,6 +31,25 @@ class arBaseJob extends Net_Gearman_Job_Common
 
   public function run($parameters)
   {
+    // Catch all possible exceptions in job execution and throw
+    // Net_Gearman_Job_Exception to avoid breaking the worker
+    try
+    {
+      $this->runJob($parameters);
+    }
+    catch (Exception $e)
+    {
+      // TODO: Create undoJob() functions in subclasses for cleanups
+
+      // Mark QubitJob as failed
+      $this->error('Exception: '.$e->getMessage());
+
+      throw new Net_Gearman_Job_Exception($e->getMessage());
+    }
+  }
+
+  public function runJob($parameters)
+  {
     $this->addRequiredParameters(array('id', 'name'));
     $this->checkRequiredParameters($parameters);
 
@@ -39,7 +58,7 @@ class arBaseJob extends Net_Gearman_Job_Common
 
     if ($this->job === null)
     {
-      throw new Exception('Called a Gearman worker with an invalid QubitJob id.');
+      throw new Net_Gearman_Job_Exception('Called a Gearman worker with an invalid QubitJob id.');
     }
 
     $this->clearCache();
@@ -69,7 +88,7 @@ class arBaseJob extends Net_Gearman_Job_Common
     {
       if (!isset($parameters[$paramName]))
       {
-        throw new Exception("Required parameter not found for job: $paramName");
+        throw new Net_Gearman_Job_Exception("Required parameter not found for job: $paramName");
       }
     }
   }
@@ -84,7 +103,7 @@ class arBaseJob extends Net_Gearman_Job_Common
   {
     if (!isset($this->job) || !isset($this->job->name))
     {
-      throw new Exception('Called arBaseJob::error() before QubitJob fetched.');
+      throw new Net_Gearman_Job_Exception('Called arBaseJob::error() before QubitJob fetched.');
     }
 
     $this->logger->err($this->formatLogMsg($message));
@@ -101,7 +120,7 @@ class arBaseJob extends Net_Gearman_Job_Common
   {
     if (!isset($this->job->name))
     {
-      throw new Exception('Called arBaseJob::info() before QubitJob fetched.');
+      throw new Net_Gearman_Job_Exception('Called arBaseJob::info() before QubitJob fetched.');
     }
 
     $this->logger->info($this->formatLogMsg($message));

--- a/lib/job/arGenerateFindingAidJob.class.php
+++ b/lib/job/arGenerateFindingAidJob.class.php
@@ -24,13 +24,17 @@
 
 class arGenerateFindingAidJob extends arBaseJob
 {
+  // Required parameters:
+  // - Parameters that are mandatory for the job
+  // - They are checked at the begining of the job from arBaseJob run() function
+  // - 'id' and 'name' are required parameters for all jobs and they are added in arBaseJob
+  // - The job will fail if any of the required paramaters are missing
+  protected $requiredParameters = array('objectId');
+
   private $resourceId = 0;
 
   public function runJob($parameters)
   {
-    $this->addRequiredParameters(array('objectId'));
-    parent::runJob($parameters);
-
     $appRoot = rtrim(sfConfig::get('sf_root_dir'), '/');
 
     $this->resourceId = $parameters['objectId'];

--- a/lib/job/arGenerateFindingAidJob.class.php
+++ b/lib/job/arGenerateFindingAidJob.class.php
@@ -24,12 +24,10 @@
 
 class arGenerateFindingAidJob extends arBaseJob
 {
-  // Required parameters:
-  // - Parameters that are mandatory for the job
-  // - They are checked at the begining of the job from arBaseJob run() function
-  // - 'id' and 'name' are required parameters for all jobs and they are added in arBaseJob
-  // - The job will fail if any of the required paramaters are missing
-  protected $requiredParameters = array('objectId');
+  /**
+   * @see arBaseJob::$requiredParameters
+   */
+  protected $extraRequiredParameters = array('objectId');
 
   private $resourceId = 0;
 

--- a/lib/job/arInheritRightsJob.class.php
+++ b/lib/job/arInheritRightsJob.class.php
@@ -28,12 +28,10 @@
 
 class arInheritRightsJob extends arBaseJob
 {
-  // Required parameters:
-  // - Parameters that are mandatory for the job
-  // - They are checked at the begining of the job from arBaseJob run() function
-  // - 'id' and 'name' are required parameters for all jobs and they are added in arBaseJob
-  // - The job will fail if any of the required paramaters are missing
-  protected $requiredParameters = array(
+  /**
+   * @see arBaseJob::$requiredParameters
+   */
+  protected $extraRequiredParameters = array(
     'information_object_id',
     'overwrite_or_combine',  // values: overwrite, combine
     'all_or_digital_only'  // values: all, digital_only

--- a/lib/job/arInheritRightsJob.class.php
+++ b/lib/job/arInheritRightsJob.class.php
@@ -28,7 +28,7 @@
 
 class arInheritRightsJob extends arBaseJob
 {
-  public function run($parameters)
+  public function runJob($parameters)
   {
     // This will be an array of required parameter names
     $this->addRequiredParameters(array(
@@ -37,101 +37,93 @@ class arInheritRightsJob extends arBaseJob
       'all_or_digital_only'  // values: all, digital_only
     ));
 
-    // parent::run() will check parameters and throw an exception if any are missing
-    parent::run($parameters);
+    // parent::runJob() will check parameters and throw an exception if any are missing
+    parent::runJob($parameters);
 
-    try
+    $ioId = $parameters['information_object_id'];
+
+    if (($io = QubitInformationObject::getById($ioId)) === null)
     {
-      $ioId = $parameters['information_object_id'];
-
-      if (($io = QubitInformationObject::getById($ioId)) === null)
-      {
-        $this->error("Invalid information object id: $ioId");
-        return false;
-      }
-
-      $idsToUpdate = array(); // Info object IDs to recalculate rights based on PREMIS
-
-      foreach ($io->descendants as $descendant)
-      {
-        // if digital only and descendant isn't a digital object, skip
-        if ('digital_only' === $parameters['all_or_digital_only'] && null === $descendant->getDigitalObject())
-        {
-          $this->info("skipping descendant {$descendant->getId()}\n");
-          continue;
-        }
-
-        $idsToUpdate[] = $descendant->id;
-
-        // delete existing rights if overwriting rights
-        if ('overwrite' === $parameters['overwrite_or_combine']) {
-          // the object property of the relation($item) is the right
-          foreach ($descendant->getRights() as $item) {
-            $item->object->delete();
-          }
-        }
-
-        // lastly, copy all rights from $io to $descendants
-        foreach ($io->getRights() as $parentRelation) {
-          $right = $parentRelation->object;
-          // duplicate the right
-          $newRight = new QubitRights;
-          $newRight->startDate                   = $right->startDate;
-          $newRight->endDate                     = $right->endDate;
-          $newRight->basisId                     = $right->basisId;
-          $newRight->rightsHolderId              = $right->rightsHolderId;
-          $newRight->copyrightStatusId           = $right->copyrightStatusId;
-          $newRight->copyrightStatusDate         = $right->copyrightStatusDate;
-          $newRight->copyrightJurisdiction       = $right->copyrightJurisdiction;
-          $newRight->statuteDeterminationDate    = $right->statuteDeterminationDate;
-          $newRight->sourceCulture               = $right->sourceCulture;
-
-          $newRight->rightsNote                  = $right->rightsNote;
-          $newRight->copyrightNote               = $right->copyrightNote;
-          $newRight->identifierValue             = $right->identifierValue;
-          $newRight->identifierType              = $right->identifierType;
-          $newRight->identifierRole              = $right->identifierRole;
-          $newRight->licenseTerms                = $right->licenseTerms;
-          $newRight->licenseNote                 = $right->licenseNote;
-          $newRight->statuteJurisdiction         = $right->statuteJurisdiction;
-          $newRight->statuteCitation             = $right->statuteCitation;
-          $newRight->statuteNote                 = $right->statuteNote;
-          $newRight->culture                     = $right->culture;
-
-          // duplicate the related granted_rights
-          foreach($right->grantedRights as $gr)
-          {
-            $newGr = new QubitGrantedRight;
-            $newGr->rightsId      = $gr->rightsId;
-            $newGr->actId         = $gr->actId;
-            $newGr->restriction   = $gr->restriction;
-            $newGr->startDate     = $gr->startDate;
-            $newGr->endDate       = $gr->endDate;
-            $newGr->notes         = $gr->notes;
-
-            $newRight->grantedRights[] = $newGr;
-          }
-
-          $newRight->save();
-
-          // create a relation record associating the new right to the descendant
-          $newRelation = new QubitRelation;
-          $newRelation->objectId  = $newRight->getId();
-          $newRelation->typeId    = QubitTerm::RIGHT_ID;
-          $newRelation->subjectId = $descendant->getId();
-
-          $newRelation->save();
-        }
-      }
-
-      $this->job->setStatusCompleted();
-      $this->job->save();
-    }
-    catch (Exception $e)
-    {
-      $this->error('Unhandled exception - ' . $e);
+      $this->error("Invalid information object id: $ioId");
       return false;
     }
+
+    $idsToUpdate = array(); // Info object IDs to recalculate rights based on PREMIS
+
+    foreach ($io->descendants as $descendant)
+    {
+      // if digital only and descendant isn't a digital object, skip
+      if ('digital_only' === $parameters['all_or_digital_only'] && null === $descendant->getDigitalObject())
+      {
+        $this->info("skipping descendant {$descendant->getId()}\n");
+        continue;
+      }
+
+      $idsToUpdate[] = $descendant->id;
+
+      // delete existing rights if overwriting rights
+      if ('overwrite' === $parameters['overwrite_or_combine']) {
+        // the object property of the relation($item) is the right
+        foreach ($descendant->getRights() as $item) {
+          $item->object->delete();
+        }
+      }
+
+      // lastly, copy all rights from $io to $descendants
+      foreach ($io->getRights() as $parentRelation) {
+        $right = $parentRelation->object;
+        // duplicate the right
+        $newRight = new QubitRights;
+        $newRight->startDate                   = $right->startDate;
+        $newRight->endDate                     = $right->endDate;
+        $newRight->basisId                     = $right->basisId;
+        $newRight->rightsHolderId              = $right->rightsHolderId;
+        $newRight->copyrightStatusId           = $right->copyrightStatusId;
+        $newRight->copyrightStatusDate         = $right->copyrightStatusDate;
+        $newRight->copyrightJurisdiction       = $right->copyrightJurisdiction;
+        $newRight->statuteDeterminationDate    = $right->statuteDeterminationDate;
+        $newRight->sourceCulture               = $right->sourceCulture;
+
+        $newRight->rightsNote                  = $right->rightsNote;
+        $newRight->copyrightNote               = $right->copyrightNote;
+        $newRight->identifierValue             = $right->identifierValue;
+        $newRight->identifierType              = $right->identifierType;
+        $newRight->identifierRole              = $right->identifierRole;
+        $newRight->licenseTerms                = $right->licenseTerms;
+        $newRight->licenseNote                 = $right->licenseNote;
+        $newRight->statuteJurisdiction         = $right->statuteJurisdiction;
+        $newRight->statuteCitation             = $right->statuteCitation;
+        $newRight->statuteNote                 = $right->statuteNote;
+        $newRight->culture                     = $right->culture;
+
+        // duplicate the related granted_rights
+        foreach($right->grantedRights as $gr)
+        {
+          $newGr = new QubitGrantedRight;
+          $newGr->rightsId      = $gr->rightsId;
+          $newGr->actId         = $gr->actId;
+          $newGr->restriction   = $gr->restriction;
+          $newGr->startDate     = $gr->startDate;
+          $newGr->endDate       = $gr->endDate;
+          $newGr->notes         = $gr->notes;
+
+          $newRight->grantedRights[] = $newGr;
+        }
+
+        $newRight->save();
+
+        // create a relation record associating the new right to the descendant
+        $newRelation = new QubitRelation;
+        $newRelation->objectId  = $newRight->getId();
+        $newRelation->typeId    = QubitTerm::RIGHT_ID;
+        $newRelation->subjectId = $descendant->getId();
+
+        $newRelation->save();
+      }
+    }
+
+    $this->job->setStatusCompleted();
+    $this->job->save();
 
     return true;
   }

--- a/lib/job/arInheritRightsJob.class.php
+++ b/lib/job/arInheritRightsJob.class.php
@@ -28,18 +28,19 @@
 
 class arInheritRightsJob extends arBaseJob
 {
+  // Required parameters:
+  // - Parameters that are mandatory for the job
+  // - They are checked at the begining of the job from arBaseJob run() function
+  // - 'id' and 'name' are required parameters for all jobs and they are added in arBaseJob
+  // - The job will fail if any of the required paramaters are missing
+  protected $requiredParameters = array(
+    'information_object_id',
+    'overwrite_or_combine',  // values: overwrite, combine
+    'all_or_digital_only'  // values: all, digital_only
+  );
+
   public function runJob($parameters)
   {
-    // This will be an array of required parameter names
-    $this->addRequiredParameters(array(
-      'information_object_id',
-      'overwrite_or_combine',  // values: overwrite, combine
-      'all_or_digital_only'  // values: all, digital_only
-    ));
-
-    // parent::runJob() will check parameters and throw an exception if any are missing
-    parent::runJob($parameters);
-
     $ioId = $parameters['information_object_id'];
 
     if (($io = QubitInformationObject::getById($ioId)) === null)

--- a/lib/job/arTestJob.class.php
+++ b/lib/job/arTestJob.class.php
@@ -27,13 +27,6 @@
 
 class arTestJob extends arBaseJob
 {
-  // Required parameters:
-  // - Parameters that are mandatory for the job
-  // - They are checked at the begining of the job from arBaseJob run() function
-  // - 'id' and 'name' are required parameters for all jobs and they are added in arBaseJob
-  // - The job will fail if any of the required paramaters are missing
-  protected $requiredParameters = array();
-
   public function runJob($parameters)
   {
     $this->info("Got a test job! id: {$this->job->id}\n");

--- a/lib/job/arTestJob.class.php
+++ b/lib/job/arTestJob.class.php
@@ -27,14 +27,15 @@
 
 class arTestJob extends arBaseJob
 {
+  // Required parameters:
+  // - Parameters that are mandatory for the job
+  // - They are checked at the begining of the job from arBaseJob run() function
+  // - 'id' and 'name' are required parameters for all jobs and they are added in arBaseJob
+  // - The job will fail if any of the required paramaters are missing
+  protected $requiredParameters = array();
+
   public function runJob($parameters)
   {
-    // This will be an array of required parameter names
-    $this->addRequiredParameters(array());
-
-    // parent::runJob() will check parameters and throw an exception if any are missing
-    parent::runJob($parameters);
-
     $this->info("Got a test job! id: {$this->job->id}\n");
 
     if (isset($parameters['error']))

--- a/lib/job/arTestJob.class.php
+++ b/lib/job/arTestJob.class.php
@@ -27,13 +27,13 @@
 
 class arTestJob extends arBaseJob
 {
-  public function run($parameters)
+  public function runJob($parameters)
   {
     // This will be an array of required parameter names
     $this->addRequiredParameters(array());
 
-    // parent::run() will check parameters and throw an exception if any are missing
-    parent::run($parameters);
+    // parent::runJob() will check parameters and throw an exception if any are missing
+    parent::runJob($parameters);
 
     $this->info("Got a test job! id: {$this->job->id}\n");
 

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPlugin.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPlugin.class.php
@@ -108,10 +108,19 @@ class arElasticSearchPlugin extends QubitSearchEngine
     // If there are still documents in the batch queue, send them
     if ($this->config['batch_mode'] && count($this->batchDocs) > 0)
     {
-      $this->index->addDocuments($this->batchDocs);
-      $this->index->flush();
+      try
+      {
+        $this->index->addDocuments($this->batchDocs);
+        $this->index->flush();
+      }
+      catch (Exception $e)
+      {
+        // Clear batchDocs if something went wrong too
+        $this->batchDocs = array();
 
-      // And clear them
+        throw $e;
+      }
+
       $this->batchDocs = array();
     }
 

--- a/plugins/qtSwordPlugin/lib/qtSwordPluginWorker.class.php
+++ b/plugins/qtSwordPlugin/lib/qtSwordPluginWorker.class.php
@@ -19,12 +19,10 @@
 
 class qtSwordPluginWorker extends arBaseJob
 {
-  // Required parameters:
-  // - Parameters that are mandatory for the job
-  // - They are checked at the begining of the job from arBaseJob run() function
-  // - 'id' and 'name' are required parameters for all jobs and they are added in arBaseJob
-  // - The job will fail if any of the required paramaters are missing
-  protected $requiredParameters = array('information_object_id');
+  /**
+   * @see arBaseJob::$requiredParameters
+   */
+  protected $extraRequiredParameters = array('information_object_id');
 
   protected $dispatcher = null;
 

--- a/plugins/qtSwordPlugin/lib/qtSwordPluginWorker.class.php
+++ b/plugins/qtSwordPlugin/lib/qtSwordPluginWorker.class.php
@@ -27,10 +27,10 @@ class qtSwordPluginWorker extends arBaseJob
       array('message' => $message)));
   }
 
-  public function run($package)
+  public function runJob($package)
   {
     $this->addRequiredParameters(array('information_object_id'));
-    parent::run($package);
+    parent::runJob($package);
 
     $this->dispatcher = sfContext::getInstance()->getEventDispatcher();
 
@@ -38,7 +38,7 @@ class qtSwordPluginWorker extends arBaseJob
 
     if (!is_writable(sfConfig::get('sf_web_dir').DIRECTORY_SEPARATOR.sfConfig::get('app_upload_dir')))
     {
-      $this->log('ERROR: Read-write access needed in {sf_web_dir}/{app_upload_dir}.');
+      $this->log('Job failed: Read-write access needed in {sf_web_dir}/{app_upload_dir}.');
       $this->error('Read-write access needed in {sf_web_dir}/{app_upload_dir}.');
 
       return false;
@@ -56,32 +56,22 @@ class qtSwordPluginWorker extends arBaseJob
 
     $this->log(sprintf('Processing...'));
 
-    try
-    {
-      $resource = QubitInformationObject::getById($package['information_object_id']);
+    $resource = QubitInformationObject::getById($package['information_object_id']);
 
-      $this->log(sprintf('Object slug: %s', $resource->slug));
+    $this->log(sprintf('Object slug: %s', $resource->slug));
 
-      $extractor = qtPackageExtractorFactory::build($package['format'],
-        $package + array('resource' => $resource, 'job' => $job));
+    $extractor = qtPackageExtractorFactory::build($package['format'],
+      $package + array('resource' => $resource, 'job' => $job));
 
-      $extractor->run();
-    }
-    catch (Exception $e)
-    {
-      $this->log(sprintf('Exception: %s', $e->getMessage()));
-      $this->error(sprintf('Exception: %s', $e->getMessage()));
-
-      return false;
-    }
-
-    $this->job->setStatusCompleted();
-    $this->job->save();
+    $extractor->run();
 
     // Save ES documents in the batch queue
     // We need to call the magic method explictly
     // because the object isn't destroyed in a worker
     QubitSearch::getInstance()->__destruct();
+
+    $this->job->setStatusCompleted();
+    $this->job->save();
 
     $this->log(sprintf('Job finished.'));
 

--- a/plugins/qtSwordPlugin/lib/qtSwordPluginWorker.class.php
+++ b/plugins/qtSwordPlugin/lib/qtSwordPluginWorker.class.php
@@ -19,6 +19,13 @@
 
 class qtSwordPluginWorker extends arBaseJob
 {
+  // Required parameters:
+  // - Parameters that are mandatory for the job
+  // - They are checked at the begining of the job from arBaseJob run() function
+  // - 'id' and 'name' are required parameters for all jobs and they are added in arBaseJob
+  // - The job will fail if any of the required paramaters are missing
+  protected $requiredParameters = array('information_object_id');
+
   protected $dispatcher = null;
 
   protected function log($message)
@@ -29,9 +36,6 @@ class qtSwordPluginWorker extends arBaseJob
 
   public function runJob($package)
   {
-    $this->addRequiredParameters(array('information_object_id'));
-    parent::runJob($package);
-
     $this->dispatcher = sfContext::getInstance()->getEventDispatcher();
 
     $this->log('A new job has started to being processed.');

--- a/vendor/net_gearman/Net/Gearman/Worker.php
+++ b/vendor/net_gearman/Net/Gearman/Worker.php
@@ -437,7 +437,7 @@ class Net_Gearman_Worker
      *
      * @return void
      */
-    protected function fail($handle, $job, PEAR_Exception $error)
+    protected function fail($handle, $job, Exception $error)
     {
         if (count($this->callback[self::JOB_FAIL]) == 0) {
             return; // No callbacks to run


### PR DESCRIPTION
- Catch all possible exceptions in job execution and throw Net_Gearman_Job_Exception
  to avoid breaking the worker
- Change fail function in worker to acept Exception (inheritance in
  Net_Gearman exception was changed to avoid using PEAR_Exception)
- Change exceptions manually thrown to Net_Gearman_Job_Exception
- Remove unneeded try/catch in jobs and jobWorker class
- Add JOB_FAIL callback to the worker to log the exception message
- Remove batchDocs from the queue even if the dump to the index fails
