### PR TITLE
Remove login options in read only mode, refs #7913

### DIFF
--- a/apps/qubit/modules/menu/actions/userMenuComponent.class.php
+++ b/apps/qubit/modules/menu/actions/userMenuComponent.class.php
@@ -21,6 +21,11 @@ class MenuUserMenuComponent extends sfComponent
 {
   public function execute($request)
   {
+    if (Qubit::isReadOnly())
+    {
+      return sfView::NONE;
+    }
+
     $this->form = new sfForm;
 
     $this->form->setValidator('next', new sfValidatorString);

--- a/apps/qubit/modules/menu/actions/userMenuComponent.class.php
+++ b/apps/qubit/modules/menu/actions/userMenuComponent.class.php
@@ -21,7 +21,7 @@ class MenuUserMenuComponent extends sfComponent
 {
   public function execute($request)
   {
-    if (Qubit::isReadOnly())
+    if (sfConfig::get('app_read_only', false))
     {
       return sfView::NONE;
     }

--- a/apps/qubit/modules/user/actions/loginAction.class.php
+++ b/apps/qubit/modules/user/actions/loginAction.class.php
@@ -25,7 +25,8 @@ class UserLoginAction extends sfAction
     $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
 
     // Redirect to @homepage if the user is already authenticated
-    if ($this->context->user->isAuthenticated())
+    // or the read only mode is enabled
+    if ($this->context->user->isAuthenticated() || Qubit::isReadOnly())
     {
       $this->redirect('@homepage');
     }

--- a/apps/qubit/modules/user/actions/loginAction.class.php
+++ b/apps/qubit/modules/user/actions/loginAction.class.php
@@ -26,7 +26,7 @@ class UserLoginAction extends sfAction
 
     // Redirect to @homepage if the user is already authenticated
     // or the read only mode is enabled
-    if ($this->context->user->isAuthenticated() || Qubit::isReadOnly())
+    if (sfConfig::get('app_read_only', false) || $this->context->user->isAuthenticated())
     {
       $this->redirect('@homepage');
     }

--- a/lib/Qubit.class.php
+++ b/lib/Qubit.class.php
@@ -214,4 +214,33 @@ class Qubit
       return false;
     }
   }
+
+  /**
+   * Check if the app is in read only mode looking at the
+   * env. variable "ATOM_READ_ONLY" and the setting
+   * "read_only" in app.yml, giving priority to the env. variable
+   *
+   * @return boolean
+   */
+  public static function isReadOnly()
+  {
+    // The env. variable is set to 'true', '1', 'on' or 'yes'
+    if (filter_var(getenv('ATOM_READ_ONLY'), FILTER_VALIDATE_BOOLEAN))
+    {
+      return true;
+    }
+
+    // The env. variable doesn't exist and the setting is set to 'true'
+    if (false === getenv('ATOM_READ_ONLY')
+      && sfConfig::get('app_read_only', false))
+    {
+      return true;
+    }
+
+    // Otherwise:
+    // - The env. variable and the setting don't exist
+    // - The env. variable is set to anything different than 'true', '1', 'on' or 'yes'
+    // - The env. varibale doesn't exist and the setting is set to anything different than 'true'
+    return false;
+  }
 }

--- a/lib/Qubit.class.php
+++ b/lib/Qubit.class.php
@@ -214,33 +214,4 @@ class Qubit
       return false;
     }
   }
-
-  /**
-   * Check if the app is in read only mode looking at the
-   * env. variable "ATOM_READ_ONLY" and the setting
-   * "read_only" in app.yml, giving priority to the env. variable
-   *
-   * @return boolean
-   */
-  public static function isReadOnly()
-  {
-    // The env. variable is set to 'true', '1', 'on' or 'yes'
-    if (filter_var(getenv('ATOM_READ_ONLY'), FILTER_VALIDATE_BOOLEAN))
-    {
-      return true;
-    }
-
-    // The env. variable doesn't exist and the setting is set to 'true'
-    if (false === getenv('ATOM_READ_ONLY')
-      && sfConfig::get('app_read_only', false))
-    {
-      return true;
-    }
-
-    // Otherwise:
-    // - The env. variable and the setting don't exist
-    // - The env. variable is set to anything different than 'true', '1', 'on' or 'yes'
-    // - The env. varibale doesn't exist and the setting is set to anything different than 'true'
-    return false;
-  }
 }

--- a/lib/filter/QubitSettingsFilter.class.php
+++ b/lib/filter/QubitSettingsFilter.class.php
@@ -49,6 +49,8 @@ class QubitSettingsFilter extends sfFilter
       {
         case 'boolean':
           $value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+
+          break;
       }
 
       $key = strtolower(str_replace('ATOM', 'app', $env));

--- a/lib/filter/QubitSettingsFilter.class.php
+++ b/lib/filter/QubitSettingsFilter.class.php
@@ -36,6 +36,25 @@ class QubitSettingsFilter extends sfFilter
       $cache->set($cacheKey, serialize($settings));
     }
 
+    // Check environment vairables and overwrite/populate settings
+    $envHashmap  = array('ATOM_READ_ONLY' => 'boolean');
+    foreach ($envHashmap as $env => $type)
+    {
+      if (false === $value = getenv($env))
+      {
+        continue;
+      }
+
+      switch ($type)
+      {
+        case 'boolean':
+          $value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+      }
+
+      $key = strtolower(str_replace('ATOM', 'app', $env));
+      $settings[$key] = $value;
+    }
+
     // Overwrite/populate settings into sfConfig object
     sfConfig::add($settings);
 


### PR DESCRIPTION
Checks if the app is in read only mode looking at the env. variable
ATOM_READ_ONLY and the setting read_only in app.yml,
giving priority to the env. variable.

If the app is in read only mode, the login button will be removed
and the '.../user/login' url will redirect to the homepage
