### PR TITLE
Display only applicable reports under "Select report"

### DIFF
--- a/apps/qubit/modules/informationobject/actions/reportsAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/reportsAction.class.php
@@ -55,13 +55,12 @@ class InformationObjectReportsAction extends sfAction
           $choices[$this->context->routing->generate(null, array($this->resource, 'module' => 'informationobject', 'action' => 'boxLabelCsv'))] = $this->context->i18n->__('Box label CSV');
         }
 
-
         $this->reportsAvailable = !empty($choices);
 
         if ($this->reportsAvailable) {
           $available_routes = array_keys($choices);
           $this->form->setDefault($name, $available_routes[0]);
-          $this->form->setValidator($name, new sfValidatorChoice(array('choices' => array_keys($choices))));
+          $this->form->setValidator($name, new sfValidatorChoice(array('choices' => $available_routes)));
           $this->form->setWidget($name, new sfWidgetFormChoice(array(
             'expanded' => true,
             'choices' => $choices)));

--- a/apps/qubit/modules/informationobject/actions/reportsAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/reportsAction.class.php
@@ -34,10 +34,15 @@ class InformationObjectReportsAction extends sfAction
         // Hide if DC or MODS since they don't use such levels of description
         if (!in_array($this->resource->sourceStandard, array('Dublin Core Simple version 1.1', 'MODS version 3.3')))
         {
-          $choices = array(
-            $this->context->routing->generate(null, array($this->resource, 'module' => 'informationobject', 'action' => 'fileList')) => $this->context->i18n->__('File list'),
-            $this->context->routing->generate(null, array($this->resource, 'module' => 'informationobject', 'action' => 'itemList')) => $this->context->i18n->__('Item list'),
-          );
+          $choices = array();
+
+          if ($this->resource->containsLevelOfDescription('File')) {
+            $choices[$this->context->routing->generate(null, array($this->resource, 'module' => 'informationobject', 'action' => 'fileList'))] = $this->context->i18n->__('File list');
+          }
+
+          if ($this->resource->containsLevelOfDescription('Item')) {
+            $choices[$this->context->routing->generate(null, array($this->resource, 'module' => 'informationobject', 'action' => 'itemList'))] = $this->context->i18n->__('Item list');
+          }
         }
         else
         {
@@ -50,11 +55,17 @@ class InformationObjectReportsAction extends sfAction
           $choices[$this->context->routing->generate(null, array($this->resource, 'module' => 'informationobject', 'action' => 'boxLabelCsv'))] = $this->context->i18n->__('Box label CSV');
         }
 
-        $this->form->setDefault($name, $this->context->routing->generate(null, array($this->resource, 'module' => 'informationobject', 'action' => 'fileList')));
-        $this->form->setValidator($name, new sfValidatorChoice(array('choices' => array_keys($choices))));
-        $this->form->setWidget($name, new sfWidgetFormChoice(array(
-          'expanded' => true,
-          'choices' => $choices)));
+
+        $this->reportsAvailable = !empty($choices);
+
+        if ($this->reportsAvailable) {
+          $available_routes = array_keys($choices);
+          $this->form->setDefault($name, $available_routes[0]);
+          $this->form->setValidator($name, new sfValidatorChoice(array('choices' => array_keys($choices))));
+          $this->form->setWidget($name, new sfWidgetFormChoice(array(
+            'expanded' => true,
+            'choices' => $choices)));
+        }
 
         break;
     }

--- a/apps/qubit/modules/informationobject/templates/reportsSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/reportsSuccess.php
@@ -18,7 +18,11 @@
 
   <div class="fieldset-wrapper">
 
+  <?php if ($reportsAvailable): ?>
     <?php echo render_field($form->report->label(__('Select report')), $resource) ?>
+  <?php else: ?>
+    <?php echo __('There are no relevant reports for this item') ?>
+  <?php endif; ?>
 
   </div>
 

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -26,6 +26,7 @@
  * @author Peter Van Garderen <peter@artefactual.com>
  * @author David Juhasz <david@artefactual.com>
  * @author Mathieu Fortin Library and Archives Canada <mathieu.fortin@lac-bac.gc.ca>
+ * @author Mark Triggs, Teaspoon Consulting Pty Ltd <mark@teaspoon-consulting.com>
  */
 class QubitInformationObject extends BaseInformationObject
 {
@@ -609,6 +610,24 @@ class QubitInformationObject extends BaseInformationObject
 
     return $descendants;
   }
+
+  /* True if this information object or any descendant uses a LOD of $level. */
+  public function containsLevelOfDescription($level)
+  {
+    $sql = "
+      SELECT 1 FROM information_object
+      INNER JOIN term on term.id = information_object.level_of_description_id
+      INNER JOIN term_i18n on term_i18n.id = term.id
+      WHERE information_object.lft > ? and information_object.rgt < ?
+      AND term_i18n.culture = 'en' AND term_i18n.name = ?
+      LIMIT 1
+    ";
+
+    $rows = QubitPdo::fetchAll($sql, array($this->lft, $this->rgt, $level));
+
+    return count($rows) == 1;
+  }
+
 
   /***********************
    Actor/Event relations

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -612,18 +612,17 @@ class QubitInformationObject extends BaseInformationObject
   }
 
   /* True if this information object or any descendant uses a LOD of $level. */
-  public function containsLevelOfDescription($level)
+  public function containsLevelOfDescription($level, $culture = 'en')
   {
     $sql = "
       SELECT 1 FROM information_object
-      INNER JOIN term on term.id = information_object.level_of_description_id
-      INNER JOIN term_i18n on term_i18n.id = term.id
+      INNER JOIN term_i18n on term_i18n.id = information_object.level_of_description_id
       WHERE information_object.lft > ? and information_object.rgt < ?
-      AND term_i18n.culture = 'en' AND term_i18n.name = ?
+      AND term_i18n.culture = ? AND term_i18n.name = ?
       LIMIT 1
     ";
 
-    $rows = QubitPdo::fetchAll($sql, array($this->lft, $this->rgt, $level));
+    $rows = QubitPdo::fetchAll($sql, array($this->lft, $this->rgt, $culture, $level));
 
     return count($rows) == 1;
   }


### PR DESCRIPTION
Previously, the report list would always show "File" and "Item" level
reports, even if the current record tree contained no file or item-level
records.

Use an inexpensive check against the database to determine whether a
given report is applicable before offering it to the user.

There is some additional discussion on the group for context:

  https://groups.google.com/forum/#!topic/ica-atom-users/Wrje33St8go
