### PR TITLE
Use new URL validator that uses filter_var #7466

### DIFF
--- a/apps/qubit/modules/informationobject/actions/addDigitalObjectAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/addDigitalObjectAction.class.php
@@ -39,7 +39,7 @@ class InformationObjectAddDigitalObjectAction extends sfAction
     // URL
     if (isset($request->url) && 'http://' != $request->url)
     {
-      $this->form->setValidator('url', new sfValidatorUrl);
+      $this->form->setValidator('url', new QubitValidatorUrl);
     }
 
     $this->form->setDefault('url', 'http://');

--- a/lib/validator/QubitValidatorUrl.class.php
+++ b/lib/validator/QubitValidatorUrl.class.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ /**
+  * Validate URLs, but also allow for intranet URLs such as 'http://localhost'.
+  */
+
+class QubitValidatorUrl extends sfValidatorBase
+{
+  /**
+   * @param array $options   An array of options
+   * @param array $messages  An array of error messages
+   *
+   * @see sfValidatorBase
+   */
+  protected function configure($options = array(), $messages = array())
+  {
+    $this->setMessage('invalid', '"%value%" is not a URL.');
+  }
+
+  /**
+   * @see sfValidatorBase
+   */
+  protected function doClean($value)
+  {
+    if (!filter_var($value, FILTER_VALIDATE_URL))
+    {
+      throw new sfValidatorError($this, 'invalid', array('value' => $value));
+    }
+
+    return $value;
+  }
+}

--- a/plugins/sfInstallPlugin/modules/sfInstallPlugin/actions/configureSiteAction.class.php
+++ b/plugins/sfInstallPlugin/modules/sfInstallPlugin/actions/configureSiteAction.class.php
@@ -38,7 +38,7 @@ class sfInstallPluginConfigureSiteAction extends sfAction
     $this->form->setValidator('siteTitle', new sfValidatorString(array('required' => true)));
     $this->form->setWidget('siteTitle', new sfWidgetFormInput);
 
-    $this->form->setValidator('siteBaseUrl', new sfValidatorUrl(array('required' => true)));
+    $this->form->setValidator('siteBaseUrl', new QubitValidatorUrl(array('required' => true)));
     $this->form->setWidget('siteBaseUrl', new sfWidgetFormInput);
     $this->form->setDefault('siteBaseUrl', 'http://'. $_SERVER['HTTP_HOST']);
 


### PR DESCRIPTION
- Create a new validator that uses PHP's built in
  URL validation for base URL configuration. This
  will allow us to use intranet hosts such as
  http://localhost.

Use QubitValidatorUrl for external digital objects
- Allow intranet URLs when user is linking to digital objects
  via a URL
