### PR TITLE
Fix for generic thumbs not showing. ref #8107

### DIFF
--- a/apps/qubit/modules/search/templates/_searchResult.php
+++ b/apps/qubit/modules/search/templates/_searchResult.php
@@ -8,24 +8,19 @@
 <?php endif; ?>
 
   <?php if (isset($doc['hasDigitalObject']) && true === $doc['hasDigitalObject']): ?>
-
     <div class="search-result-preview">
-
-      <?php if (isset($doc['digitalObject']['thumbnailPath'])): ?>
-
-        <a href="<?php echo url_for(array('module' => 'informationobject', 'slug' => $doc['slug'])) ?>">
-          <div class="preview-container">
-            <?php if (QubitAcl::check(QubitInformationObject::getById($hit->getId()), 'readThumbnail') &&
-                      QubitGrantedRight::checkPremis($hit->getId(), 'readThumb')): ?>
-              <?php echo image_tag($doc['digitalObject']['thumbnailPath']) ?>
-            <?php else: ?>
-              <?php echo image_tag(QubitDigitalObject::getGenericIconPathByMediaTypeId($doc['digitalObject']['mediaTypeId'])) ?>
-            <?php endif; ?>
-          </div>
-        </a>
-      <?php endif; ?>
+      <a href="<?php echo url_for(array('module' => 'informationobject', 'slug' => $doc['slug'])) ?>">
+        <div class="preview-container">
+          <?php if (isset($doc['digitalObject']['thumbnailPath']) &&
+                    QubitAcl::check(QubitInformationObject::getById($hit->getId()), 'readThumbnail') &&
+                    QubitGrantedRight::checkPremis($hit->getId(), 'readThumb')): ?>
+            <?php echo image_tag($doc['digitalObject']['thumbnailPath']) ?>
+          <?php else: ?>
+            <?php echo image_tag(QubitDigitalObject::getGenericIconPathByMediaTypeId($doc['digitalObject']['mediaTypeId'])) ?>
+          <?php endif; ?>
+        </div>
+      </a>
     </div>
-
   <?php endif; ?>
 
   <div class="search-result-description">


### PR DESCRIPTION
Simplified search results template thumbnail display logic
and fixed issue with generic thumbs not showing for digital
objects without generated thumbnails (like audio files).
