### PR TITLE
Fix edit actor/repository permisions for users, refs #8116

### DIFF
--- a/apps/qubit/modules/user/actions/editActorAclAction.class.php
+++ b/apps/qubit/modules/user/actions/editActorAclAction.class.php
@@ -48,7 +48,15 @@ class UserEditActorAclAction extends DefaultEditAction
     {
       foreach ($permissions as $item)
       {
-        $this->actors[$item->objectId][$item->action] = $item;
+        // In this context permissions for all objects (null) and root actor object are equivalent
+        if ($item->objectId === null)
+        {
+          $this->actors[QubitActor::ROOT_ID][$item->action] = $item;
+        }
+        else
+        {
+          $this->actors[$item->objectId][$item->action] = $item;
+        }
       }
     }
 

--- a/apps/qubit/modules/user/actions/editRepositoryAclAction.class.php
+++ b/apps/qubit/modules/user/actions/editRepositoryAclAction.class.php
@@ -48,7 +48,15 @@ class UserEditRepositoryAclAction extends DefaultEditAction
     {
       foreach ($permissions as $item)
       {
-        $this->repositories[$item->objectId][$item->action] = $item;
+        // In this context permissions for all objects (null) and root repository object are equivalent
+        if ($item->objectId === null)
+        {
+          $this->repositories[QubitRepository::ROOT_ID][$item->action] = $item;
+        }
+        else
+        {
+          $this->repositories[$item->objectId][$item->action] = $item;
+        }
       }
     }
 


### PR DESCRIPTION
Allowed languages for translation is creating a row with null object_id that is
creating an All table in those pages. In that context permissions for all objects (null)
and for the root actor/repository object are equivalent.
