### PR TITLE
Improve actor/repository match in actor import, refs #7124

### DIFF
--- a/lib/QubitMetsParser.class.php
+++ b/lib/QubitMetsParser.class.php
@@ -373,7 +373,13 @@ class QubitMetsParser
       if ($creation['actorName'])
       {
         // Check actor creation with the target repository
-        if (null === $actor = QubitActor::getByNameAndRepositoryId($creation['actorName'], $this->resource->repositoryId))
+        $repoId = null;
+        if (null !== $repo = $this->resource->getRepository(array('inherit' => true)))
+        {
+          $repoId = $repo->id;
+        }
+
+        if (null === $actor = QubitActor::getByNameAndRepositoryId($creation['actorName'], $repoId))
         {
           $actor = new QubitActor;
           $actor->parentId = QubitActor::ROOT_ID;

--- a/lib/model/QubitActor.php
+++ b/lib/model/QubitActor.php
@@ -489,7 +489,7 @@ class QubitActor extends BaseActor
     // with descriptions without repository
     if (isset($repositoryId))
     {
-      $repositoryCondition = 'WHERE io.repository_id=?';
+      $repositoryCondition = 'WHERE anc.repository_id=?';
       $params = array($name, $repositoryId, $repositoryId, $repositoryId);
     }
     else
@@ -504,12 +504,15 @@ class QubitActor extends BaseActor
     $sql .= 'AND act.id IN (';
     $sql .= 'SELECT r.object_id AS id FROM relation r ';
     $sql .= 'LEFT JOIN information_object io ON r.subject_id=io.id ';
+    $sql .= 'JOIN information_object anc ON io.lft >= anc.lft AND io.rgt <= anc.rgt ';
     $sql .= $repositoryCondition;
     $sql .= ' UNION SELECT r.subject_id AS id FROM relation r ';
     $sql .= 'LEFT JOIN information_object io ON r.object_id=io.id ';
+    $sql .= 'JOIN information_object anc ON io.lft >= anc.lft AND io.rgt <= anc.rgt ';
     $sql .= $repositoryCondition;
     $sql .= ' UNION SELECT e.actor_id AS id FROM event e ';
     $sql .= 'LEFT JOIN information_object io ON e.information_object_id=io.id ';
+    $sql .= 'JOIN information_object anc ON io.lft >= anc.lft AND io.rgt <= anc.rgt ';
     $sql .= $repositoryCondition;
     $sql .= ')';
 

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -1518,7 +1518,13 @@ class QubitInformationObject extends BaseInformationObject
     // Check relations with other descriptions in the repository
     if (!$actor)
     {
-      $actor = QubitActor::getByNameAndRepositoryId($name, $this->repositoryId);
+      $repoId = null;
+      if (null !== $repo = $this->getRepository(array('inherit' => true)))
+      {
+        $repoId = $repo->id;
+      }
+
+      $actor = QubitActor::getByNameAndRepositoryId($name, $repoId);
     }
 
     // If there isn't a match create a new actor

--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -744,9 +744,9 @@ EOF;
                 $actorOptions['history'] = $self->rowStatusVars['nameAccessPointHistories'][$index];
               }
 
-              if (isset($self->object->repositoryId))
+              if (null !== $repo = $self->object->getRepository(array('inherit' => true)))
               {
-                $actorOptions['repositoryId'] = $self->object->repositoryId;
+                $actorOptions['repositoryId'] = $repo->id;
               }
 
               $actor = $self->createOrFetchActor($name, $actorOptions);


### PR DESCRIPTION
An actor may be related with an information object wich repository is inherit
from one of its ancestors. Use the inherit repository from the info. object to
check for a related actor and query over the ancestors of the possible related
information objects.
