### PR TITLE
Disassociate notes from users on deletion #4812

### DIFF
--- a/apps/qubit/modules/user/templates/deleteSuccess.php
+++ b/apps/qubit/modules/user/templates/deleteSuccess.php
@@ -5,6 +5,12 @@
 <?php end_slot() ?>
 
 <?php slot('content') ?>
+  <?php if ($noteCount = $resource->getNotes()->count()): ?>
+    <div id="content"><h2>
+      <?php echo __('This user has %1% note(s) in the system. These notes will not be deleted, but their association with this user will be removed.',
+                    array('%1%' => $noteCount)) ?>
+    </h2></div>
+  <?php endif; ?>
 
   <?php echo $form->renderFormTag(url_for(array($resource, 'module' => 'user', 'action' => 'delete')), array('method' => 'delete')) ?>
 

--- a/apps/qubit/modules/user/templates/indexSuccess.php
+++ b/apps/qubit/modules/user/templates/indexSuccess.php
@@ -2,12 +2,9 @@
 
 <?php echo get_component('user', 'aclMenu') ?>
 
-<?php if (0 < $notesCount || !$resource->active): ?>
+<?php if (!$resource->active): ?>
   <div class="messages error">
     <ul>
-      <?php if (0 < $notesCount): ?>
-        <li><?php echo __('This user has %1% notes in the system and therefore it cannot be removed', array('%1%' => $notesCount)) ?></li>
-      <?php endif; ?>
       <?php if (!$resource->active): ?>
         <li><?php echo __('This user is inactive') ?></li>
       <?php endif; ?>

--- a/lib/model/QubitUser.php
+++ b/lib/model/QubitUser.php
@@ -60,6 +60,18 @@ class QubitUser extends BaseUser
     return $this;
   }
 
+  public function delete($connection = null)
+  {
+    // Remove user's association with notes before deletion.
+    foreach ($this->getNotes() as $note)
+    {
+      $note->userId = null;
+      $note->save();
+    }
+
+    parent::delete($connection);
+  }
+
   public function setPassword($password)
   {
     $salt = md5(rand(100000, 999999).$this->getEmail());


### PR DESCRIPTION
Users that have notes associated with them can now be deleted safely in AtoM instead of throwing a 500 error. AtoM will now simply disassociate the user from the notes prior to deletion. Ideally, a more long term solution would be to change the db schema to use a string for the username related to a note instead of a foreign key to the user table.
