### PR TITLE
Link to 'browse all descriptions' within quick search needs topLod=0

### DIFF
--- a/apps/qubit/modules/search/actions/indexAction.class.php
+++ b/apps/qubit/modules/search/actions/indexAction.class.php
@@ -229,7 +229,7 @@ class SearchIndexAction extends DefaultBrowseAction
         $response['results'][] = $result;
       }
 
-      $url = url_for(array('module' => 'informationobject', 'action' => 'browse', 'collection' =>  $request->collection, 'query' => $request->query));
+      $url = url_for(array('module' => 'informationobject', 'action' => 'browse', 'collection' =>  $request->collection, 'query' => $request->query, 'topLod' => '0'));
       $link = $this->context->i18n->__('Browse all descriptions');
       $response['more'] = <<<EOF
 <div class="more">


### PR DESCRIPTION
Demonstration of issue:
https://www.youtube.com/watch?v=4R5-v4hEN7Q
