### PR TITLE
Display "Other" RAD notes like any other note

### DIFF
--- a/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
@@ -276,28 +276,26 @@
 
   <?php echo render_show(__('Accruals'), render_value($resource->getAccruals(array('cultureFallback' => true)))) ?>
 
-  <div class="field">
-    <h3><?php echo __('Other notes') ?></h3>
-    <div>
-      <ul>
-        <?php foreach ($resource->getNotesByTaxonomy(array('taxonomyId' => QubitTaxonomy::RAD_NOTE_ID)) as $item): ?>
+  <?php foreach ($resource->getNotesByTaxonomy(array('taxonomyId' => QubitTaxonomy::RAD_NOTE_ID)) as $item): ?>
 
-          <?php $type = $item->getType(array('sourceCulture' => true)) ?>
+    <?php $type = $item->getType(array('sourceCulture' => true)) ?>
 
-          <?php if ('General note' == $type && !check_field_visibility('app_element_visibility_rad_general_notes')): ?>
-            <?php continue; ?>
-          <?php endif; ?>
+    <?php if ('General note' == $type && !check_field_visibility('app_element_visibility_rad_general_notes')): ?>
+      <?php continue; ?>
+    <?php endif; ?>
 
-          <?php if ('Conservation' == $type && !check_field_visibility('app_element_visibility_rad_conservation_notes')): ?>
-            <?php continue; ?>
-          <?php endif; ?>
+    <?php if ('Conservation' == $type && !check_field_visibility('app_element_visibility_rad_conservation_notes')): ?>
+      <?php continue; ?>
+    <?php endif; ?>
 
-          <li><?php echo $item->type ?>: <?php echo render_value($item->getContent(array('cultureFallback' => true))) ?></li>
-
-        <?php endforeach; ?>
-      </ul>
+    <div class="field">
+      <h3><?php echo __($item->type) ?></h3>
+      <div>
+        <?php echo render_value($item->getContent(array('cultureFallback' => true))) ?>
+      </div>
     </div>
-  </div>
+
+  <?php endforeach; ?>
 
   <?php echo get_partial('informationobject/alternativeIdentifiersIndex', array('resource' => $resource)) ?>
 


### PR DESCRIPTION
This would change they way "other" (taxonomy-controlled) RAD nodes are rendered. 

Instead of a single label "Other notes" with sub-labels for each other note, each note is given a proper h3 label.  Change depicted in this image: 
![atom_other_notes_change](https://cloud.githubusercontent.com/assets/244041/6833828/a97f36e2-d30e-11e4-8a44-3ae281031b5b.png)

Or, to see the impact where there are multiple "other" notes, 
before: 
![atom_rad_other_notes_original](https://cloud.githubusercontent.com/assets/244041/6833844/b89993c0-d30e-11e4-8861-62feb204a448.png)

after: 
![atom_rad_other_notes_modified](https://cloud.githubusercontent.com/assets/244041/6833845/bdc56874-d30e-11e4-8439-00aa3aa1378e.png)

Just a proposal.
