### PR TITLE
Oai sets for collections

### DIFF
--- a/apps/qubit/modules/settings/actions/oaiAction.class.php
+++ b/apps/qubit/modules/settings/actions/oaiAction.class.php
@@ -72,6 +72,7 @@ class SettingsOaiAction extends sfAction
     $oaiRepositoryIdentifier = QubitOai::getRepositoryIdentifier();
     $sampleOaiIdentifier = QubitOai::getSampleIdentifier();
     $resumptionTokenLimit = QubitSetting::getByName('resumption_token_limit');
+    $oaiAdditionalSetsEnabled = QubitSetting::getByName('oai_additional_sets_enabled');
 
     // Set defaults for global form
     $this->oaiRepositoryForm->setDefaults(array(
@@ -80,7 +81,8 @@ class SettingsOaiAction extends sfAction
       'oai_repository_identifier' => $oaiRepositoryIdentifier,
       'oai_admin_emails' => $oaiAdminEmails,
       'sample_oai_identifier' => $sampleOaiIdentifier,
-      'resumption_token_limit' => (isset($resumptionTokenLimit)) ? $resumptionTokenLimit->getValue(array('sourceCulture'=>true)) : null
+      'resumption_token_limit' => (isset($resumptionTokenLimit)) ? $resumptionTokenLimit->getValue(array('sourceCulture'=>true)) : null,
+      'oai_additional_sets_enabled' => (isset($oaiAdditionalSetsEnabled)) ? intval($oaiAdditionalSetsEnabled->getValue(array('sourceCulture'=>true))) : 0
     ));
   }
 
@@ -118,6 +120,12 @@ class SettingsOaiAction extends sfAction
       $setting->setValue($resumptionTokenLimit, array('sourceCulture' => true));
       $setting->save();
     }
+
+    // OAI additional sets enabled radio button
+    $oaiAdditionalSetsEnabledValue = $thisForm->getValue('oai_additional_sets_enabled');
+    $setting = QubitSetting::getByName('oai_additional_sets_enabled');
+    $setting->setValue($oaiAdditionalSetsEnabledValue, array('sourceCulture' => true));
+    $setting->save();
 
     return $this;
   }

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 120
+    value: 122
   milestone:
     name: milestone
     editable: 0
@@ -522,6 +522,12 @@ QubitSetting:
     deleteable: 0
     source_culture: en
     value: ''
+  QubitSetting_oai_additional_sets_enabled:
+    name: oai_additional_sets_enabled
+    scope: oai
+    editable: 1
+    deleteable: 0
+    value: 0
   QubitSetting_inherit_code_informationobject:
     name: inherit_code_informationobject
     editable: 1

--- a/lib/QubitOai.class.php
+++ b/lib/QubitOai.class.php
@@ -220,9 +220,13 @@ class QubitOai
       $oaiSets[] = new QubitOaiCollectionSet($collection);
     }
 
-    foreach (QubitOai::$additionalOaiSets as $oaiSet)
-    {
-      $oaiSets[] = $oaiSet;
+    $useAdditionalOaiSets = QubitSetting::getByName('oai_additional_sets_enabled');
+
+    if ($useAdditionalOaiSets && $useAdditionalOaiSets->value) {
+      foreach (QubitOai::$additionalOaiSets as $oaiSet)
+      {
+        $oaiSets[] = $oaiSet;
+      }
     }
 
     return $oaiSets;

--- a/lib/QubitOai.class.php
+++ b/lib/QubitOai.class.php
@@ -28,6 +28,10 @@
 
 class QubitOai
 {
+  /* Any custom OAI set implementations that are available (in addition to the
+   * standard collection sets) */
+  private static $additionalOaiSets = array();
+
   /**
    * Mail error report
    *
@@ -215,7 +219,22 @@ class QubitOai
     {
       $oaiSets[] = new QubitOaiCollectionSet($collection);
     }
+
+    foreach (QubitOai::$additionalOaiSets as $oaiSet)
+    {
+      $oaiSets[] = $oaiSet;
+    }
+
     return $oaiSets;
+  }
+
+  /**
+   * Add a new OAI set to the available list
+   *
+   */
+  public static function addOaiSet($oaiSet)
+  {
+    QubitOai::$additionalOaiSets[] = $oaiSet;
   }
 
   /**

--- a/lib/QubitOai.class.php
+++ b/lib/QubitOai.class.php
@@ -213,7 +213,7 @@ class QubitOai
 
     foreach ($collections as $collection)
     {
-      $collectionTable[] = array('setSpec'=>$collection->getOaiIdentifier(), 'lft' => $collection->getLft(), 'rgt' => $collection->getRgt());
+      $collectionTable[] = new QubitOaiCollectionSet($collection);
     }
     return $collectionTable;
   }
@@ -224,13 +224,12 @@ class QubitOai
    * @param int $left left side of information object
    * @return string oai identifier of the element's collection
    */
-  public static function getSetSpec($left, $collectionTable)
+  public static function getSetSpec($record, $collectionTable)
   {
     foreach ($collectionTable as $collection)
     {
-      if ($collection['lft'] <= $left AND $collection['rgt'] > $left)
-      {
-        return $collection['setSpec'];
+      if ($collection->contains($record)) {
+        return $collection->setSpec();
       }
     }
     return 'None';
@@ -246,7 +245,7 @@ class QubitOai
   {
     foreach ($collectionsTable as $collection)
     {
-      if ($collection['setSpec'] == $setSpec)
+      if ($collection->setSpec() == $setSpec)
       {
         return $collection;
       }

--- a/lib/QubitOai.class.php
+++ b/lib/QubitOai.class.php
@@ -202,71 +202,54 @@ class QubitOai
   }
 
   /**
-   * Load array of collections
+   * Load array of OAI sets
    *
-   * @return array associative array of collection information
+   * @return array of available OAI sets
    */
-  public static function getCollectionArray()
+  public static function getOaiSets()
   {
     $collections = QubitInformationObject::getCollections();
-    $collectionTable = array();
+    $oaiSets = array();
 
     foreach ($collections as $collection)
     {
-      $collectionTable[] = new QubitOaiCollectionSet($collection);
+      $oaiSets[] = new QubitOaiCollectionSet($collection);
     }
-    return $collectionTable;
+    return $oaiSets;
   }
 
   /**
-   * Returns collection identifier for the element with $left element
+   * Returns the setSpec for the OAI set containiner $record
    *
-   * @param int $left left side of information object
+   * @param mixed $record, an Information Object record
+   * @param array of available OAI sets
+
    * @return string oai identifier of the element's collection
    */
-  public static function getSetSpec($record, $collectionTable)
+  public static function getSetSpec($record, $oaiSets)
   {
-    foreach ($collectionTable as $collection)
+    foreach ($oaiSets as $oaiSet)
     {
-      if ($collection->contains($record)) {
-        return $collection->setSpec();
+      if ($oaiSet->contains($record)) {
+        return $oaiSet->setSpec();
       }
     }
     return 'None';
   }
 
   /**
-   * Returns collection info for the element with $setSpec
+   * Returns the OAI set matching $setSpec
    *
-   * @param int $setSpec left side of information object
-   * @return string oai identifier of the element's collection
+   * @param string $setSpec, the setSpec of an OAI set
+   * @return QubitOaiSet/boolean the OAI set matched (or false if none matched)
    */
-  public static function getCollectionInfo($setSpec, $collectionsTable)
+  public static function getMatchingOaiSet($setSpec, $oaiSets)
   {
-    foreach ($collectionsTable as $collection)
+    foreach ($oaiSets as $oaiSet)
     {
-      if ($collection->setSpec() == $setSpec)
+      if ($oaiSet->setSpec() == $setSpec)
       {
-        return $collection;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Gets limits of the collection
-   *
-   * @param string $setSpec the collection id
-   * @return array associative array of collection with setSpec
-   */
-  public static function getCollectionLimits($setSpec)
-  {
-    $collectionTable = oai::getCollectionArray();
-    foreach ($collectionTable as $collection)
-    {
-      if ($collection['setSpec'] == $setSpec)
-      {
-        return $collection;
+        return $oaiSet;
       }
     }
     return false;

--- a/lib/form/SettingsOaiRepositoryForm.class.php
+++ b/lib/form/SettingsOaiRepositoryForm.class.php
@@ -40,7 +40,8 @@ class SettingsOaiRepositoryForm extends sfForm
       'oai_admin_emails' => new sfWidgetFormTextarea,
       'oai_repository_identifier' => new sfWidgetFormInput(array(), array('class'=>'disabled', 'disabled'=>true)),
       'sample_oai_identifier' => new sfWidgetFormInput(array(), array('class'=>'disabled', 'disabled'=>true)),
-      'resumption_token_limit' => new sfWidgetFormInput
+      'resumption_token_limit' => new sfWidgetFormInput,
+      'oai_additional_sets_enabled' => new sfWidgetFormSelectRadio(array('choices'=>array(1=>'yes', 0=>'no')), array('class'=>'radio'))
     ));
 
     // Add labels
@@ -50,7 +51,8 @@ class SettingsOaiRepositoryForm extends sfForm
       'oai_admin_emails' => $i18n->__('Administrator email(s)'),
       'oai_repository_identifier' => $i18n->__('OAI repository identifier'),
       'sample_oai_identifier' => $i18n->__('Sample OAI identifier'),
-      'resumption_token_limit' => $i18n->__('Resumption token limit')
+      'resumption_token_limit' => $i18n->__('Resumption token limit'),
+      'oai_additional_sets_enabled' => $i18n->__('Enable additional OAI sets')
     ));
 
     // Add helper text
@@ -60,7 +62,8 @@ class SettingsOaiRepositoryForm extends sfForm
       'oai_admin_emails' => $i18n->__('Enter the email address(es) of at least one administrator for the repository. Multiple addresses can be entered, separated by commas. The address(es) will be exposed as part of a response to an Identify request.'),
       'oai_repository_identifier' => $i18n->__('This is an auto-generated setting that produces an OAI compliant repository identifier, which includes the OAI repository code value if it is set'),
       'sample_oai_identifier' => $i18n->__('This is an example of the auto-generated, OAI compliant identifier which is created for each item in this particular OAI repository'),
-      'resumption_token_limit' => $i18n->__('The number of entities to include in a single OAI response list before inserting a resumption token')
+      'resumption_token_limit' => $i18n->__('The number of entities to include in a single OAI response list before inserting a resumption token'),
+      'oai_additional_sets_enabled' => $i18n->__('If "no", just show one OAI set per collection')
     ));
 
     // Reference image max. width validator
@@ -82,6 +85,7 @@ class SettingsOaiRepositoryForm extends sfForm
     $this->validatorSchema['oai_admin_emails'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['oai_repository_identifier'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['sample_oai_identifier'] = new sfValidatorString(array('required' => false));
+    $this->validatorSchema['oai_additional_sets_enabled'] = new sfValidatorInteger(array('required' => false));
 
     // Set decorator
     $decorator = new QubitWidgetFormSchemaFormatterList($this->widgetSchema);

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -402,8 +402,7 @@ class QubitInformationObject extends BaseInformationObject
 
     if ($set != '')
     {
-      $criteria->add(QubitInformationObject::LFT, $set['lft'], Criteria::GREATER_EQUAL);
-      $criteria->add(QubitInformationObject::RGT, $set['rgt'], Criteria::LESS_EQUAL);
+      $set->apply($criteria);
     }
 
     $criteria->add(QubitInformationObject::PARENT_ID, null, Criteria::ISNOTNULL);

--- a/lib/oai/QubitOaiCollectionSet.php
+++ b/lib/oai/QubitOaiCollectionSet.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * An OAI set for a single collection
+ *
+ * @package    AccesstoMemory
+ * @subpackage oai
+ * @author     Mark Triggs <mark@teaspoon-consulting.com>
+ */
+
+class QubitOaiCollectionSet implements QubitOaiSet
+{
+  private $collection;
+
+  public function __construct($collection) {
+    $this->collection = $collection;
+  }
+
+  public function contains($record) {
+    $lft = $record->getLft();
+    return ($this->collection['lft'] <= $lft AND $this->collection['rgt'] > $lft);
+  }
+
+  public function setSpec() {
+    return $this->collection->getOaiIdentifier();
+  }
+
+  public function getName() {
+    return new sfIsadPlugin($this->collection);
+  }
+
+  public function apply($criteria) {
+    $criteria->add(QubitInformationObject::LFT, $this->collection['lft'], Criteria::GREATER_EQUAL);
+    $criteria->add(QubitInformationObject::RGT, $this->collection['rgt'], Criteria::LESS_EQUAL);
+  }
+}

--- a/lib/oai/QubitOaiSet.class.php
+++ b/lib/oai/QubitOaiSet.class.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The interface provided by OAI set implementations
+ *
+ * @package    AccesstoMemory
+ * @subpackage oai
+ * @author     Mark Triggs <mark@teaspoon-consulting.com>
+ */
+
+interface QubitOaiSet
+{
+  /**
+   * Query OAI set membership by record
+   *
+   * @param mixed $record A record that can be part of an OAI set
+   *
+   * @return boolean true if $record is contained in this OAI set.
+   */
+
+  public function contains($record);
+
+  /**
+   * The OAI set specification for the current set
+   *
+   * @return string An OAI set specification
+   */
+
+  public function setSpec();
+
+  /**
+   * The name of the current OAI set
+   *
+   * @return string A display name
+   */
+
+  public function getName();
+
+  /**
+   * Apply the current set's restrictions to $criteria
+   *
+   * @param Criteria $criteria The search criteria to be modified
+   *
+   */
+
+  public function apply($criteria);
+}

--- a/lib/oai/QubitOaiTopLevelSet.php
+++ b/lib/oai/QubitOaiTopLevelSet.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * An OAI set for all top-level (collection) records
+ *
+ * @package    AccesstoMemory
+ * @subpackage oai
+ * @author     Mark Triggs <mark@teaspoon-consulting.com>
+ */
+
+class QubitOaiTopLevelSet implements QubitOaiSet
+{
+  public function contains($record) {
+    /* Allow the collection set to take responsibility for records to preserve
+     * the current behaviour. */
+    return false;
+  }
+
+  public function setSpec() {
+    return "oai:virtual:top-level-records";
+  }
+
+  public function getName() {
+    return "Top-level collection record set";
+  }
+
+  public function apply($criteria) {
+    $criteria->addAlias('parent', QubitInformationObject::TABLE_NAME);
+    $criteria->addJoin(QubitInformationObject::PARENT_ID, 'parent.id');
+
+    $criteria->add(QubitInformationObject::RGT, QubitInformationObject::RGT.' > ('.QubitInformationObject::LFT.' + 1)', Criteria::CUSTOM);
+    $criteria->add('parent.lft', 1);
+  }
+}

--- a/lib/task/migrate/migrations/arMigration0122.class.php
+++ b/lib/task/migrate/migrations/arMigration0122.class.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add setting for additional OAI sets
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0122
+{
+  const
+    VERSION = 122, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  /**
+   * Upgrade
+   *
+   * @return bool True if the upgrade succeeded, False otherwise
+   */
+  public function up($configuration)
+  {
+    $setting = new QubitSetting;
+    $setting->setName('oai_additional_sets_enabled');
+    $setting->setSourceCulture('en');
+    $setting->setValue(0);
+    $setting->setEditable(1);
+    $setting->setDeleteable(0);
+    $setting->setScope('oai');
+    $setting->save();
+
+    return true;
+  }
+}

--- a/plugins/arOaiPlugin/config/arOaiPluginConfiguration.class.php
+++ b/plugins/arOaiPlugin/config/arOaiPluginConfiguration.class.php
@@ -28,5 +28,8 @@ class arOaiPluginConfiguration extends sfPluginConfiguration
     $enabledModules = sfConfig::get('sf_enabled_modules');
     $enabledModules[] = 'arOaiPlugin';
     sfConfig::set('sf_enabled_modules', $enabledModules);
+
+    /* Custom OAI set definitions */
+    QubitOai::addOaiSet(new QubitOaiTopLevelSet());
   }
 }

--- a/plugins/arOaiPlugin/lib/arOaiPluginComponent.class.php
+++ b/plugins/arOaiPlugin/lib/arOaiPluginComponent.class.php
@@ -68,6 +68,15 @@ abstract class arOaiPluginComponent extends sfComponent
       $this->until = $request->until;
     }
 
+    if (!isset($request->set))
+    {
+      $this->set = '';
+    }
+    else
+    {
+      $this->set = $request->set;
+    }
+
     /*
      * If cursor not supplied, define as 0
      */
@@ -87,13 +96,13 @@ abstract class arOaiPluginComponent extends sfComponent
     /*
      * If set is not supplied, define it as ''
      */
-    if (!isset($request->set))
+    if (!isset($this->set))
     {
       $collection = '';
     }
     else
     {
-      $collection = QubitOai::getCollectionInfo($request->set, $this->collectionsTable);
+      $collection = QubitOai::getCollectionInfo($this->set, $this->collectionsTable);
     }
 
     //Get the records according to the limit dates and collection

--- a/plugins/arOaiPlugin/lib/arOaiPluginComponent.class.php
+++ b/plugins/arOaiPlugin/lib/arOaiPluginComponent.class.php
@@ -91,18 +91,18 @@ abstract class arOaiPluginComponent extends sfComponent
 
   public function getUpdates()
   {
-    $this->collectionsTable = QubitOai::getCollectionArray();
+    $this->oaiSets = QubitOai::getOaiSets();
 
     /*
      * If set is not supplied, define it as ''
      */
     if (!isset($this->set))
     {
-      $collection = '';
+      $oaiSet = '';
     }
     else
     {
-      $collection = QubitOai::getCollectionInfo($this->set, $this->collectionsTable);
+      $oaiSet = QubitOai::getMatchingOaiSet($this->set, $this->oaiSets);
     }
 
     //Get the records according to the limit dates and collection
@@ -111,7 +111,7 @@ abstract class arOaiPluginComponent extends sfComponent
       $this->until,
       $this->cursor,
       QubitSetting::getByName('resumption_token_limit')->__toString(),
-      $collection
+      $oaiSet
     );
     $this->publishedRecords = $update['data'];
     $this->remaining        = $update['remaining'];

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/actions/getRecordComponent.class.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/actions/getRecordComponent.class.php
@@ -37,7 +37,7 @@ class arOaiPluginGetRecordComponent extends arOaiPluginComponent
     $this->informationObject = QubitInformationObject::getRecordByOaiID($oai_local_identifier_id);
     $request->setAttribute('informationObject', $this->informationObject);
 
-    $this->collectionsTable = QubitOai::getCollectionArray();
+    $this->oaiSets = QubitOai::getOaiSets();
 
     $this->path = $request->getUriPrefix().$request->getPathInfo();
 

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/actions/indexAction.class.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/actions/indexAction.class.php
@@ -186,6 +186,14 @@ class arOaiPluginIndexAction extends sfAction
         $this->forward('arOaiPlugin', 'error');
       }
 
+
+      // If the 'set' parameter is provided, it should refer to an existing set
+      if ($this->request->set && !QubitOai::getMatchingOaiSet($this->request->set, QubitOai::getOaiSets())) {
+        $request->setParameter('errorCode', 'badArgument');
+        $request->setParameter('errorMsg', 'The requested OAI set is not known by this repository.');
+        $this->forward('arOaiPlugin', 'error');
+      }
+
       switch ($this->request->verb)
       {
         case 'Identify':

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/actions/listSetsComponent.class.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/actions/listSetsComponent.class.php
@@ -45,10 +45,6 @@ class arOaiPluginlistSetsComponent extends sfComponent
       $this->requestAttributes .= ' '.$key.'="'.$this->attributes[$key].'"';
     }
 
-    $this->sets = array();
-    foreach (QubitInformationObject::getCollections() as $el)
-    {
-      $this->sets[] = new sfIsadPlugin($el);
-    }
+    $this->sets = QubitOAI::getCollectionArray();
   }
 }

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/actions/listSetsComponent.class.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/actions/listSetsComponent.class.php
@@ -45,6 +45,6 @@ class arOaiPluginlistSetsComponent extends sfComponent
       $this->requestAttributes .= ' '.$key.'="'.$this->attributes[$key].'"';
     }
 
-    $this->sets = QubitOAI::getCollectionArray();
+    $this->sets = QubitOAI::getOaiSets();
   }
 }

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_getRecord.xml.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_getRecord.xml.php
@@ -3,7 +3,7 @@
       <header>
         <identifier><?php echo $informationObject->getOaiIdentifier() ?></identifier>
         <datestamp><?php echo QubitOai::getDate($informationObject->getUpdatedAt())?></datestamp>
-        <setSpec><?php echo QubitOai::getSetSpec($informationObject, $collectionsTable)?></setSpec>
+        <setSpec><?php echo QubitOai::getSetSpec($informationObject, $oaiSets)?></setSpec>
       </header>
       <metadata>
         <?php echo get_component('sfDcPlugin', 'dc', array('resource' => $informationObject)) ?>

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_getRecord.xml.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_getRecord.xml.php
@@ -3,7 +3,7 @@
       <header>
         <identifier><?php echo $informationObject->getOaiIdentifier() ?></identifier>
         <datestamp><?php echo QubitOai::getDate($informationObject->getUpdatedAt())?></datestamp>
-        <setSpec><?php echo QubitOai::getSetSpec($informationObject->getLft(), $collectionsTable)?></setSpec>
+        <setSpec><?php echo QubitOai::getSetSpec($informationObject, $collectionsTable)?></setSpec>
       </header>
       <metadata>
         <?php echo get_component('sfDcPlugin', 'dc', array('resource' => $informationObject)) ?>

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_listIdentifiers.xml.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_listIdentifiers.xml.php
@@ -6,7 +6,7 @@
     <header>
       <identifier><?php echo $record->getOaiIdentifier() ?></identifier>
       <datestamp><?php echo QubitOai::getDate($record->getUpdatedAt())?></datestamp>
-      <setSpec><?php echo QubitOai::getSetSpec($record->getLft(), $collectionsTable)?></setSpec>
+      <setSpec><?php echo QubitOai::getSetSpec($record, $collectionsTable)?></setSpec>
     </header>
 <?php endforeach; ?>
   <?php if ($remaining > 0): ?>

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_listIdentifiers.xml.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_listIdentifiers.xml.php
@@ -6,7 +6,7 @@
     <header>
       <identifier><?php echo $record->getOaiIdentifier() ?></identifier>
       <datestamp><?php echo QubitOai::getDate($record->getUpdatedAt())?></datestamp>
-      <setSpec><?php echo QubitOai::getSetSpec($record, $collectionsTable)?></setSpec>
+      <setSpec><?php echo QubitOai::getSetSpec($record, $oaiSets)?></setSpec>
     </header>
 <?php endforeach; ?>
   <?php if ($remaining > 0): ?>

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_listRecords.xml.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_listRecords.xml.php
@@ -8,7 +8,7 @@
     <header>
       <identifier><?php echo $record->getOaiIdentifier() ?></identifier>
       <datestamp><?php echo QubitOai::getDate($record->getUpdatedAt())?></datestamp>
-      <setSpec><?php echo QubitOai::getSetSpec($record, $collectionsTable)?></setSpec>
+      <setSpec><?php echo QubitOai::getSetSpec($record, $oaiSets)?></setSpec>
     </header>
     <metadata>
       <?php echo get_component('sfDcPlugin', 'dc', array('resource' => $record)) ?>

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_listRecords.xml.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_listRecords.xml.php
@@ -8,7 +8,7 @@
     <header>
       <identifier><?php echo $record->getOaiIdentifier() ?></identifier>
       <datestamp><?php echo QubitOai::getDate($record->getUpdatedAt())?></datestamp>
-      <setSpec><?php echo QubitOai::getSetSpec($record->getLft(), $collectionsTable)?></setSpec>
+      <setSpec><?php echo QubitOai::getSetSpec($record, $collectionsTable)?></setSpec>
     </header>
     <metadata>
       <?php echo get_component('sfDcPlugin', 'dc', array('resource' => $record)) ?>

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_listSets.xml.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_listSets.xml.php
@@ -1,8 +1,8 @@
   <ListSets>
-    <?php foreach ($sets as $set): ?>
-      <set>
-        <setSpec><?php echo $set->title ?></setSpec>
-        <setName><?php echo $set ?></setName>
-      </set>
-    <?php endforeach; ?>
+    <?php foreach($sets as $set): ?>
+        <set>
+           <setSpec><?php echo $set->setSpec() ?></setSpec>
+           <setName><?php echo $set->getName() ?></setName>
+        </set>
+    <?php endforeach ?>
   </ListSets>


### PR DESCRIPTION
Hi all,

I wrote to the users list about some OAI changes here:

https://groups.google.com/d/msgid/ica-atom-users/871tkl26oy.fsf%40teaspoon-consulting.com

and it was suggested that I send my proposed changes as a PR for discussion.

My goal is to generalise the way OAI sets work so that there doesn't have to be a 1:1 mapping between OAI sets and collections.  In my case, I'd like to be able to define an OAI set containing all top-level (collection) records.

The current OAI implementation defines an OAI set with three pieces of information:
- a setSpec
- a `lft` value
- a `rgt` value

This is oriented around the "one set per collection" that is currently implemented.  These three values are used throughout the OAI code in a couple of ways:
- Searching the list of OAI sets by `lft` value to find which set a given Information Object belongs to.
- Searching the list of OAI sets by `setSpec` to find the definition of a requested OAI set.
- Applying the `lft` and `rgt` values of a given OAI set as `Criteria` to find matching Information Objects

To generalise this, I've pulled the concept of an OAI set into its own class.  An OAI set satisfies the above use cases pretty directly:
- You can ask an OAI set for its setSpec
- You can ask an OAI set whether it contains a given Information Object
- You can pass it a `Criteria` object and have it apply its own set restrictions

I've refactored the existing places that use the old OAI set format to use the new object interface instead.

I realise there's a lot to review here, so I've tried to break the work into smaller logical pieces:
- 98944ad Generalise the OAI set implementation
  
  This makes the fundamental changes described above.  This is really where the action is.  This commit also addresses this issue: https://projects.artefactual.com/issues/6436.
- 2754416 Change OAI terminology from "collection" to "OAI set"
  
  This changes method names and comments to reflect the fact that we're not collection-centric anymore.  It switches the terminology to "OAI Set" where relevant.  It's a messy commit, but isn't intended to change behaviour.
- 72a8026 Add a new "virtual" OAI set matching top-level records
  
  Add a new OAI Set for collection-level records (the one I wanted originally).
- 53041a7 Add new configuration option for additional OAI sets
  
  Add a configuration option to turn these new OAI sets off.  This includes a database migration to add the new option, and it defaults to "disabled" to preserve backwards compatibility.

Sorry for the essay, and please let me know if I can clarify or change anything.  I'll add some notes regarding my testing as a separate comment.
