### PR TITLE
Fix repository index page, refs #8187

### DIFF
--- a/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
@@ -37,7 +37,7 @@
     </div>
   <?php endif; ?>
 
-  <?php if (!empty($sf_data->getRaw('htmlSnippet'))): ?>
+  <?php if ($sf_data->getRaw('htmlSnippet')): ?>
     <div class="row" id="repository-html-snippet">
       <div class="span7">
         <?php echo $sf_data->getRaw('htmlSnippet') // Using htmlpurifier ?>


### PR DESCRIPTION
empty() needs to access value by reference in order to check whether that reference points to something that exists, and PHP before 5.5 didn't support references to temporary values returned from functions
