### PR TITLE
Fix RAD General notes crosswalk, refs #6143

### DIFF
--- a/apps/qubit/modules/informationobject/actions/notesComponent.class.php
+++ b/apps/qubit/modules/informationobject/actions/notesComponent.class.php
@@ -48,7 +48,7 @@ class InformationObjectNotesComponent extends sfComponent
           $this->allNotes = $this->resource->getNotesByTaxonomy(array('taxonomyId' => $this->taxonomyId));
           $this->tableName = $this->context->i18n->__('Other notes');
           $this->arrayName = 'radOtherNotes';
-          $this->help = $this->context->i18n->__('Select a note type from the drop-down menu and enter note text in accordance with the following sections in RAD: 1.5E (Accompanying material); 1.8 B11 (Alpha-numeric designations); 1.8B9b (Conservation); 1.8B7 (Edition); 1.8B9 (Physical Description); 1.8B16b (Rights); 1.8B21 (General note).');
+          $this->help = $this->context->i18n->__('Select a note type from the drop-down menu and enter note text in accordance with the following sections in RAD: 1.5E (Accompanying material); 1.8 B11 (Alpha-numeric designations); 1.8B9b (Conservation); 1.8B7 (Edition); 1.8B9 (Physical Description); 1.8B16b (Rights).');
 
           $this->addField('type');
 
@@ -71,6 +71,16 @@ class InformationObjectNotesComponent extends sfComponent
           $this->tableName = $this->context->i18n->__('Publication notes');
           $this->arrayName = 'dacsPublicationNotes';
           $this->help = $this->context->i18n->__('Record a citation to, or information about, a publication that is about or is based on the use, study, or analysis of the materials being described. Provide sufficient information to indicate the relationship between the publication and the unit being described. This includes annotated editions. (DACS 6.4.4)');
+
+          break;
+
+        case 'radNotes':
+          $this->hiddenType = true;
+          $this->hiddenTypeId = QubitTerm::GENERAL_NOTE_ID;
+          $this->allNotes = $this->resource->getNotesByType(array('noteTypeId' => $this->hiddenTypeId));
+          $this->tableName = $this->context->i18n->__('General note(s)');
+          $this->arrayName = 'radNotes';
+          $this->help = $this->context->i18n->__('"Use this note to record any other descriptive information considered important but not falling within the definitions of the other notes." (RAD 1.8B21)');
 
           break;
 

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 122
+    value: 123
   milestone:
     name: milestone
     editable: 0

--- a/data/fixtures/taxonomyTerms.yml
+++ b/data/fixtures/taxonomyTerms.yml
@@ -3877,27 +3877,6 @@ QubitTerm:
       pt_BR: Direitos
       sl: Pravice
       th: สิทธิ
-  QubitTerm_245:
-    taxonomy_id: QubitTaxonomy_21
-    parent_id: QubitTerm_110
-    source_culture: en
-    name:
-      ca: 'Nota general'
-      de: 'Allgemeine Anmerkung'
-      en: 'General note'
-      es: 'Nota general'
-      fr: 'Note générale'
-      gl: 'Nota xeral'
-      id: 'Catatan Umum'
-      it: 'Nota generale'
-      ja: 一般の注記
-      ka: 'ძირითადი შენიშვნა'
-      nl: 'Algemene aantekening'
-      pt: 'Nota geral'
-      pt_BR: 'Nota geral'
-      sl: 'Splošna opomba'
-      th: หมายเหตุทั่วไป
-      vi: 'General note'
   QubitTerm_246:
     taxonomy_id: QubitTaxonomy_22
     parent_id: QubitTerm_110

--- a/lib/task/migrate/migrations/arMigration0123.class.php
+++ b/lib/task/migrate/migrations/arMigration0123.class.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Move RAD General notes to global General note and remove RAD General note term
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0123
+{
+  const
+    VERSION = 123, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  /**
+   * Upgrade
+   *
+   * @return bool True if the upgrade succeeded, False otherwise
+   */
+  public function up($configuration)
+  {
+    // Find RAD General note term (it doesn't have a fixed id)
+    $criteria = new Criteria;
+    $criteria->addJoin(QubitTerm::ID, QubitTermI18n::ID);
+    $criteria->add(QubitTerm::TAXONOMY_ID, QubitTaxonomy::RAD_NOTE_ID);
+    $criteria->add(QubitTermI18n::CULTURE, 'en');
+    $criteria->add(QubitTermI18n::NAME, 'General note');
+
+    if (null !== $term = QubitTerm::getOne($criteria))
+    {
+      // Get all RAD General notes
+      $criteria = new Criteria;
+      $criteria->add(QubitNote::TYPE_ID, $term->id);
+
+      foreach (QubitNote::get($criteria) as $note)
+      {
+        // Change type to global General note
+        $note->typeId = QubitTerm::GENERAL_NOTE_ID;
+        $note->save();
+      }
+
+      // Remove RAD General note term
+      $term->delete();
+    }
+
+    return true;
+  }
+}

--- a/plugins/sfEadPlugin/lib/sfEadPlugin.class.php
+++ b/plugins/sfEadPlugin/lib/sfEadPlugin.class.php
@@ -128,7 +128,7 @@ class sfEadPlugin
         'material'              => '1.5E',
         'alphanumericDesignation' => '1.8B11',
         'rights'        => '1.8B16b',
-        'general'        => '1.8B21',
+        'generalNote'    => '1.8B21',
         'nameDefault' => '1.4D',
         'nameManufacturer' => '1.4G',
         'geogDefault' => '1.4C',

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
@@ -149,8 +149,7 @@
     'Accompanying material'      => 'material',
     'Alpha-numeric designations' => 'alphanumericDesignation',
     "Publisher's series"         => 'bibSeries',
-    'Rights'                     => 'rights',
-    'General note'               => 'general'
+    'Rights'                     => 'rights'
   );
 
   foreach($radNotes as $name => $xmlType)

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
@@ -154,7 +154,7 @@
 
   <?php if (0 < count($notes = $$resourceVar->getNotesByType(array('noteTypeId' => QubitTerm::GENERAL_NOTE_ID)))): ?>
     <?php foreach ($notes as $note): ?>
-      <note type="generalNote">
+      <note type="generalNote" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('generalNote'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>>
         <p><?php echo escape_dc(esc_specialchars($note->getContent(array('cultureFallback' => true)))) ?></p>
       </note>
     <?php endforeach; ?>

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/actions/editAction.class.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/actions/editAction.class.php
@@ -122,6 +122,10 @@ class sfRadPluginEditAction extends InformationObjectEditAction
     $this->titleNotesComponent->resource = $this->resource;
     $this->titleNotesComponent->execute($this->request, $options = array('type' => 'radTitleNotes'));
 
+    $this->notesComponent = new InformationObjectNotesComponent($this->context, 'informationobject', 'notes');
+    $this->notesComponent->resource = $this->resource;
+    $this->notesComponent->execute($this->request, $options = array('type' => 'radNotes'));
+
     $this->otherNotesComponent = new InformationObjectNotesComponent($this->context, 'informationobject', 'notes');
     $this->otherNotesComponent->resource = $this->resource;
     $this->otherNotesComponent->execute($this->request, $options = array('type' => 'radOtherNotes'));
@@ -268,6 +272,8 @@ class sfRadPluginEditAction extends InformationObjectEditAction
     $this->eventComponent->processForm();
 
     $this->titleNotesComponent->processForm();
+
+    $this->notesComponent->processForm();
 
     $this->otherNotesComponent->processForm();
 

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/templates/editSuccess.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/templates/editSuccess.php
@@ -284,6 +284,8 @@
         <?php echo render_field($form->accruals
           ->help(__('"When the unit being described is not yet complete, e.g., an open fonds or series, make a note explaining that further accruals are expected... If no further accruals are expected, indicate that the unit is considered closed." (RAD 1.8B19)')), $resource, array('class' => 'resizable')) ?>
 
+        <?php echo get_partial('informationobject/notes', $sf_data->getRaw('notesComponent')->getVarHolder()->getAll()) ?>
+
         <?php echo get_partial('informationobject/notes', $sf_data->getRaw('otherNotesComponent')->getVarHolder()->getAll()) ?>
 
       </fieldset> <!-- #notesArea -->

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
@@ -276,13 +276,15 @@
 
   <?php echo render_show(__('Accruals'), render_value($resource->getAccruals(array('cultureFallback' => true)))) ?>
 
+  <?php if (check_field_visibility('app_element_visibility_rad_general_notes')): ?>
+    <?php foreach ($resource->getNotesByType(array('noteTypeId' => QubitTerm::GENERAL_NOTE_ID)) as $item): ?>
+      <?php echo render_show(__('General note'), render_value($item->getContent(array('cultureFallback' => true)))) ?>
+    <?php endforeach; ?>
+  <?php endif; ?>
+
   <?php foreach ($resource->getNotesByTaxonomy(array('taxonomyId' => QubitTaxonomy::RAD_NOTE_ID)) as $item): ?>
 
     <?php $type = $item->getType(array('sourceCulture' => true)) ?>
-
-    <?php if ('General note' == $type && !check_field_visibility('app_element_visibility_rad_general_notes')): ?>
-      <?php continue; ?>
-    <?php endif; ?>
 
     <?php if ('Conservation' == $type && !check_field_visibility('app_element_visibility_rad_conservation_notes')): ?>
       <?php continue; ?>


### PR DESCRIPTION
RAD General notes were added using a different term than ISAD and DACS general notes.
- Change type for all RAD General notes to the global General note type
- Remove RAD General note type term from database and fixtures
- Update version setting
- Add General note(s) field outside the RAD other notes group in the RAD edit form
- Fix/add form tooltips
- Show global General notes in the RAD template (remove unnecesary check in RAD other notes)
- Add encodinganalog value in global General notes EAD export
