### PR TITLE
Fix EAD XML whitespace issues #6145

### DIFF
--- a/lib/helper/QubitHelper.php
+++ b/lib/helper/QubitHelper.php
@@ -510,3 +510,16 @@ function escape_dc($text)
 {
   return preg_replace('/\n/', '<lb/>', $text);
 }
+
+/**
+ * Format poorly formatted XML strings
+ */
+function tidy_xml($xml)
+{
+  $dom = new DOMDocument;
+  $dom->preserveWhiteSpace = false;
+  $dom->formatOutput = true;
+  $dom->loadXML($xml);
+
+  return $dom->saveXML();
+}

--- a/lib/task/eacExportTask.class.php
+++ b/lib/task/eacExportTask.class.php
@@ -66,7 +66,7 @@ class eacExportTask extends exportBulkBaseTask
 
           try
           {
-            $xml = $this->tidyXml($rawXml);
+            $xml = tidy_xml($rawXml);
           }
           catch (Exception $e)
           {

--- a/lib/task/export/exportBulkBaseTask.class.php
+++ b/lib/task/export/exportBulkBaseTask.class.php
@@ -139,25 +139,6 @@ abstract class exportBulkBaseTask extends sfBaseTask
     return $output;
   }
 
-  protected function tidyXml($rawXml)
-  {
-    $xml = simplexml_load_string($rawXml);
-
-    if (empty($xml))
-    {
-      throw new sfException('Invalid XML');
-    }
-    else {
-      $dom = new DOMDocument("1.0");
-      $dom->preserveWhiteSpace = false;
-      $dom->formatOutput = true;
-      $dom->loadXML($xml->asXML());
-      $cleanXml = $dom->saveXML();
-    }
-
-    return $cleanXml;
-  }
-
   protected function generateSortableFilename($objectId, $formatAbbreviation)
   {
     // Pad ID with zeros so filenames can be sorted in creation order for imports

--- a/lib/task/exportBulkTask.class.php
+++ b/lib/task/exportBulkTask.class.php
@@ -69,7 +69,7 @@ class exportBulkTask extends exportBulkBaseTask
       try
       {
         $rawXml = $this->captureResourceExportTemplateOutput($resource, $options['format'], $options);
-        $xml = $this->tidyXml($rawXml);
+        $xml = tidy_xml($rawXml);
       }
       catch (Exception $e)
       {

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccess.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccess.xml.php
@@ -1,2 +1,8 @@
-<?php include('indexSuccessHeader.xml.php'); ?>
-<?php include('indexSuccessBody.xml.php'); ?>
+<?php ob_start() ?>
+
+<?php include('indexSuccessHeader.xml.php') ?>
+<?php include('indexSuccessBody.xml.php') ?>
+
+<?php $result = ob_get_contents() ?>
+<?php ob_end_clean() ?>
+<?php echo tidy_xml($result) ?>


### PR DESCRIPTION
This code will tidy up all the weird XML spacing issues in AtoM. We are already using this method for CLI bulk:export since Mike C refactored that code. I tested tidy_url() against a 20MB XML file and it only added on 3-4 seconds of processing time. I think this is a fair trade off; UI users will timeout if they are exporting files that large anyway, and on typical, smaller files the extra processing time is negligible.

This code also refactors tidy_xml to be a general helper function so we can use it across AtoM.
