### PR TITLE
Add <repository> info for more cases in EAD #6547

### DIFF
--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
@@ -19,7 +19,7 @@
         <edition><?php echo escape_dc(esc_specialchars($value)) ?></edition>
       </editionstmt>
     <?php endif; ?>
-    <?php if ($value = $resource->getRepository()): ?>
+    <?php if ($value = $resource->getRepository(array('inherit' => true))): ?>
       <publicationstmt>
         <publisher encodinganalog="<?php echo $ead->getMetadataParameter('publisher') ?>"><?php echo escape_dc(esc_specialchars($value->__toString())) ?></publisher>
         <?php if ($address = $value->getPrimaryContact()): ?>
@@ -92,9 +92,12 @@
   $resourceVar = 'resource';
   $counter = 0;
   $counterVar = 'counter';
+  $topLevelDid = true;
 
   include('indexSuccessBodyDidElement.xml.php');
   include('indexSuccessBodyBioghistElement.xml.php');
+
+  $topLevelDid = false;
   ?>
 
   <?php if ($resource->getPublicationStatus()): ?>

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
@@ -97,7 +97,7 @@
     </physdesc>
   <?php endif; ?>
 
-  <?php if ($value = $$resourceVar->getRepository()): ?>
+  <?php if ($value = $$resourceVar->getRepository(array('inherit' => $topLevelDid))): ?>
     <repository>
       <corpname><?php echo escape_dc(esc_specialchars($value->__toString())) ?></corpname>
       <?php if ($address = $value->getPrimaryContact()): ?>


### PR DESCRIPTION
If you export EAD on a non-top level description's page, previously it wouldn't
include repository information if that record inherited its repository. Now it will
always include <repository> info in the <archdesc>...<did> section if there is any.
