### PR TITLE
Add hyperlinks back to records in job status page #8228

### DIFF
--- a/apps/qubit/modules/jobs/templates/browseSuccess.php
+++ b/apps/qubit/modules/jobs/templates/browseSuccess.php
@@ -46,6 +46,12 @@
           <?php endif; ?>
 
           <?php echo ucfirst($job->getStatusString()) ?>
+
+          <?php if ($job->getObjectModule() && $job->getObjectSlug()): ?>
+            <a href="<?php echo url_for(array('module' => $job->getObjectModule(),
+                    'slug' => $job->getObjectSlug())) ?>" class="icon-share-alt"></a>
+
+          <?php endif; ?>
         </td>
 
         <!-- Job notes -->

--- a/apps/qubit/modules/right/actions/manageAction.class.php
+++ b/apps/qubit/modules/right/actions/manageAction.class.php
@@ -79,7 +79,8 @@ class RightManageAction extends sfAction
       {
         // Set job params
         $jobParams = $this->form->getValues();
-        $jobParams['information_object_id'] = $this->resource->getId();
+        $jobParams['objectId'] = $this->resource->getId();
+
         $jobParams['name'] = $this->context->i18n->__('Inherit rights');
 
         $desc = $this->context->i18n->__('Children inheriting rights from record: ') .

--- a/lib/job/arInheritRightsJob.class.php
+++ b/lib/job/arInheritRightsJob.class.php
@@ -32,14 +32,13 @@ class arInheritRightsJob extends arBaseJob
    * @see arBaseJob::$requiredParameters
    */
   protected $extraRequiredParameters = array(
-    'information_object_id',
     'overwrite_or_combine',  // values: overwrite, combine
     'all_or_digital_only'  // values: all, digital_only
   );
 
   public function runJob($parameters)
   {
-    $ioId = $parameters['information_object_id'];
+    $ioId = $parameters['objectId'];
 
     if (($io = QubitInformationObject::getById($ioId)) === null)
     {

--- a/lib/model/QubitJob.php
+++ b/lib/model/QubitJob.php
@@ -136,6 +136,34 @@ class QubitJob extends BaseJob
   }
 
   /**
+   * Get the module type for this job's corresponding object.
+   * e.g., informationobject, actor, etc.
+   *
+   * @return mixed  A string indicating the module type of the object for this job,
+   * or else null.
+   */
+  public function getObjectModule()
+  {
+    $className = QubitPdo::fetchColumn('SELECT class_name FROM object WHERE id = ?', array($this->objectId));
+    if (!$className)
+    {
+      return null;
+    }
+
+    return strtolower(str_replace('Qubit', '', $className));
+  }
+
+  /**
+   * Get the associated object's slug for this job.
+   *
+   * @return mixed  A string indicating the object's slug. If none, return null.
+   */
+  public function getObjectSlug()
+  {
+    return QubitPdo::fetchColumn('SELECT slug FROM slug WHERE object_id = ?', array($this->objectId));
+  }
+
+  /**
    * Add a basic note to this job. This function creates/saves a new note.
    * @param  string  $contents  The text for the note
    */


### PR DESCRIPTION
Add a hyper link next to the job status on the job management page. These links will (if the job has any), lead the user back to the information object / actor / etc. the job was running for.
