### PR TITLE
Dev/issue 8122 piped field issues

### DIFF
--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -895,8 +895,8 @@ class QubitFlatfileImport
   }
 
   /**
-   * Handle mapping of column, containing multiple values delimitd by a
-   * character, to an array
+   * Handle mapping of column, containing multiple values delimited by a
+   * character, to an array. Any values set to 'NULL' will be filtered out.
    *
    * @param string $column  column name
    * @param array $delimiter  delimiting character

--- a/lib/flatfile/config/QubitInformationObject-isad.yml
+++ b/lib/flatfile/config/QubitInformationObject-isad.yml
@@ -12,7 +12,6 @@ columnNames:
   - creationDatesType
   - creationDatesStart
   - creationDatesEnd
-  - creationDateNotes
   - levelOfDescription
   - extentAndMedium
   - repository

--- a/lib/flatfile/config/QubitInformationObject-rad.yml
+++ b/lib/flatfile/config/QubitInformationObject-rad.yml
@@ -31,7 +31,6 @@ columnNames:
   - creationDatesType
   - creationDatesStart
   - creationDatesEnd
-  - creationDateNotes
   - extentAndMedium
   - radTitleProperOfPublishersSeries
   - radParallelTitlesOfPublishersSeries

--- a/lib/flatfile/csvInformationObjectExport.class.php
+++ b/lib/flatfile/csvInformationObjectExport.class.php
@@ -32,7 +32,7 @@ class csvInformationObjectExport extends QubitFlatfileExport
   protected $titleNoteMap;
 
   // Taxonomy cache properties
-  protected $commonNoteTypeIds       = array(); 
+  protected $commonNoteTypeIds       = array();
   protected $radNoteTypeIds          = array();
   protected $titleNoteTypeIds        = array();
   protected $levelOfDescriptionTerms = array();
@@ -232,32 +232,38 @@ class csvInformationObjectExport extends QubitFlatfileExport
    */
   protected function setCreationColumns()
   {
-    $creators           = array();
-    $creatorHistories   = array();
-    $creationDates      = array();
-    $creationDateNotes  = array();
-    $creationStartDates = array();
-    $creationEndDates   = array();
-    $creationDateTypes  = array();
+    $creationEvents = array();
 
-    foreach($this->resource->getCreationEvents() as $event)
+    foreach ($this->resource->getCreationEvents() as $event)
     {
-      $creators[]           = $event->actor->authorizedFormOfName;
-      $creatorHistories[]   = $event->actor->history;
-      $creationDates[]      = $event->date;
-      $creationDateNotes[]  = $event->description;
-      $creationStartDates[] = $event->startDate;
-      $creationEndDates[]   = $event->endDate;
-      $creationDateTypes[]  = $this->eventTypeTerms[$event->typeId];
+      $creationEvents['creators'][]           = $event->actor->authorizedFormOfName;
+      $creationEvents['creatorHistories'][]   = $event->actor->history;
+      $creationEvents['creationDates'][]      = $event->date;
+      $creationEvents['creationDateNotes'][]  = $event->description;
+      $creationEvents['creationStartDates'][] = $event->startDate;
+      $creationEvents['creationEndDates'][]   = $event->endDate;
+      $creationEvents['creationDateTypes'][]  = $this->eventTypeTerms[$event->typeId];
     }
 
-    $this->setColumn('creators', $creators);
-    $this->setColumn('creatorHistories', $creatorHistories);
-    $this->setColumn('creationDates', $creationDates);
-    $this->setColumn('creationDateNotes', $creationDateNotes);
-    $this->setColumn('creationDatesStart', $creationStartDates);
-    $this->setColumn('creationDatesEnd', $creationEndDates);
-    $this->setColumn('creationDatesType', $creationDateTypes);
+    // Convert null values to the string 'NULL'. We use this to ensure we have the same number of values across
+    // multiple piped fields that correspond to each other.
+    //
+    // e.g.: If we have 3 dates but only the first and last ones have notes, we'll get this:
+    //       column 'creationDates':     2005|2006|2007
+    //       column 'creationDateNotes': hello|NULL|world
+
+    foreach ($creationEvents as &$eventField)
+    {
+      $eventField = array_map(function($x) { return $x === null ? 'NULL' : $x; }, $eventField);
+    }
+
+    $this->setColumn('creators', $creationEvents['creators']);
+    $this->setColumn('creatorHistories', $creationEvents['creatorHistories']);
+    $this->setColumn('creationDates', $creationEvents['creationDates']);
+    $this->setColumn('creationDateNotes', $creationEvents['creationDateNotes']);
+    $this->setColumn('creationDatesStart', $creationEvents['creationStartDates']);
+    $this->setColumn('creationDatesEnd', $creationEvents['creationEndDates']);
+    $this->setColumn('creationDatesType', $creationEvents['creationDateTypes']);
   }
 
   /*

--- a/lib/task/import/csvImportBaseTask.class.php
+++ b/lib/task/import/csvImportBaseTask.class.php
@@ -203,45 +203,49 @@ abstract class csvImportBaseTask extends sfBaseTask
 
     // add creators and creation events
     $createEvents = array();
-    if (isset($import->rowStatusVars['creators'])
-      && count($import->rowStatusVars['creators']))
+    if (isset($import->rowStatusVars['creators']) && count($import->rowStatusVars['creators']))
     {
-      foreach($import->rowStatusVars['creators'] as $index => $creator)
+      foreach ($import->rowStatusVars['creators'] as $index => $creator)
       {
-        // Init eventData array and add creator name
-        $eventData = array('actorName' => $creator);
+        // Init eventData array and add creator name. Ignore fields with value: 'NULL'.
+        $eventData = array();
+
+        if ($creator !== 'NULL')
+        {
+          $eventData['actorName'] = $creator;
+        }
 
         setupEventDateData($import, $eventData, $index);
 
         // Add creator history if specified
-        if(isset($import->rowStatusVars['creatorHistories'][$index]))
+        if (isset($import->rowStatusVars['creatorHistories'][$index]) &&
+            $import->rowStatusVars['creatorHistories'][$index] !== 'NULL')
         {
           $eventData['actorHistory'] = $import->rowStatusVars['creatorHistories'][$index];
         }
 
-        array_push($createEvents, $eventData);
+        if (count($eventData))
+        {
+          array_push($createEvents, $eventData);
+        }
       }
     }
-    else if(
-      isset($import->rowStatusVars['creationDatesStart'])
-      || isset($import->rowStatusVars['creationDatesEnd'])
-    )
+    else if (isset($import->rowStatusVars['creationDatesStart']) ||
+             isset($import->rowStatusVars['creationDatesEnd']))
     {
-      foreach($import->rowStatusVars['creationDatesStart'] as $index => $date)
+      foreach ($import->rowStatusVars['creationDatesStart'] as $index => $date)
       {
         $eventData = array();
-
         setupEventDateData($import, $eventData, $index);
 
         array_push($createEvents, $eventData);
       }
     }
-    else if(isset($import->rowStatusVars['creationDates']))
+    else if (isset($import->rowStatusVars['creationDates']))
     {
-      foreach($import->rowStatusVars['creationDates'] as $index => $date)
+      foreach ($import->rowStatusVars['creationDates'] as $index => $date)
       {
         $eventData = array();
-
         setupEventDateData($import, $eventData, $index);
 
         array_push($createEvents, $eventData);
@@ -266,12 +270,9 @@ abstract class csvImportBaseTask extends sfBaseTask
         }
       }
 
-      foreach($createEvents as $eventData)
+      foreach ($createEvents as $eventData)
       {
-        $event = $import->createOrUpdateEvent(
-          QubitTerm::CREATION_ID,
-          $eventData
-        );
+        $event = $import->createOrUpdateEvent(QubitTerm::CREATION_ID, $eventData);
       }
     }
   }

--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -1120,45 +1120,45 @@ function array_search_case_insensitive($search, $array)
   return array_search(strtolower($search), array_map('strtolower', $array));
 }
 
+/**
+ * Parse creation event data.
+ *
+ * Note: if the string 'NULL' is encountered as a value, ignore it. This is a special value
+ *       for lining up piped fields across multiple columns when they are related.
+ */
 function setupEventDateData(&$self, &$eventData, $index)
 {
   // add dates if specified
-  if (
-    isset($self->rowStatusVars['creationDates'][$index])
-    || isset($self->rowStatusVars['creationDatesStart'][$index])
-  )
+  if (isset($self->rowStatusVars['creationDates'][$index]) ||
+      isset($self->rowStatusVars['creationDatesStart'][$index]))
   {
     // Start and end date
-    foreach(array(
-        'creationDatesEnd' => 'endDate',
-        'creationDatesStart' => 'startDate'
-      )
-      as $statusVar => $eventProperty
-    )
+    foreach (array('creationDatesEnd' => 'endDate', 'creationDatesStart' => 'startDate') as $statusVar => $eventProperty)
     {
-      if (!empty($self->rowStatusVars[$statusVar][$index]))
+      if (!empty($self->rowStatusVars[$statusVar][$index]) && $self->rowStatusVars[$statusVar][$index] !== 'NULL')
       {
         $eventData[$eventProperty] = $self->rowStatusVars[$statusVar][$index] .'-00-00';
       }
     }
 
+    $otherDateInfo = array(
+      'creationDateNotes' => 'description',
+      'creationDates'     => 'date',
+      'creationDatesType' => 'typeId'
+    );
+
     // Other date info
-    foreach(array(
-        'creationDateNotes' => 'description',
-        'creationDates' => 'date',
-        'creationDatesType' => 'typeId'
-      )
-      as $statusVar => $eventProperty
-    )
+    foreach ($otherDateInfo  as $statusVar => $eventProperty)
     {
-      if (!empty($self->rowStatusVars[$statusVar][$index]))
+      if (!empty($self->rowStatusVars[$statusVar][$index]) && $self->rowStatusVars[$statusVar][$index] !== 'NULL')
       {
         if ($eventProperty == 'typeId')
         {
           $eventType = $self->rowStatusVars[$statusVar][$index];
           $eventData[$eventProperty] = (strtolower($eventType) == 'accumulation') ? QubitTerm::ACCUMULATION_ID : QubitTerm::CREATION_ID;
         }
-        else {
+        else
+        {
           $eventData[$eventProperty] = $self->rowStatusVars[$statusVar][$index];
         }
       }


### PR DESCRIPTION
```
Fix piped field bugs for #8122

- Previously, exporting creation events not associated with an actor
  (like in ISAD records sometimes) would produce blank pipes (|) in the 'creators' and
  'creatorHistories' fields, which would then break AtoM when round
  tripping with an import.

- Also, now creation event fields will be padded with NULLs if there
  isn't the same amount of piped values for all of said fields.

  e.g.: If we have 3 dates but only the first and last ones have notes,
        we'll pad the field like so:
                        column 'creationDates':     2005|2006|2007
                        column 'creationDateNotes': hello|NULL|world

  This way the appropriate creationDates will be associated with the
  appropriate date notes.
```

Also note that the 'old way' should still work of just leaving creators/creatorHistories blank (as opposed to NULL) while filling in the creatorDates and things like that for ISAD events not associated with actors.
