### PR TITLE
Enhanced autolink with optional text, refs #8410

### DIFF
--- a/lib/helper/QubitHelper.php
+++ b/lib/helper/QubitHelper.php
@@ -148,9 +148,7 @@ function render_title($value, $html = true)
 
 function render_value($value)
 {
-  ProjectConfiguration::getActive()->loadHelpers('Text');
-
-  $value = auto_link_text($value);
+  $value = qubit_auto_link_text($value);
 
   // Simple lists
   $value = preg_replace('/(?:^\*.*\r?\n)*(?:^\*.*)/m', "<ul>\n$0\n</ul>", $value);
@@ -520,4 +518,82 @@ function get_search_autocomplete_string($hit)
 function escape_dc($text)
 {
   return preg_replace('/\n/', '<lb/>', $text);
+}
+
+/**
+ * qubit_auto_link_text is like TextHelper::auto_link_text(), but it uses
+ * the local QubitHelper::qubit_auto_link_urls() instead of
+ * TextHelper::_auto_link_urls().
+ */
+function qubit_auto_link_text($text, $link = 'all', $href_options = array())
+{
+  require_once(dirname(__FILE__).'/../../vendor/symfony/lib/helper/TextHelper.php');
+
+  if ($link == 'all')
+  {
+    return qubit_auto_link_urls(_auto_link_email_addresses($text), $href_options);
+  }
+  else if ($link == 'email_addresses')
+  {
+    return _auto_link_email_addresses($text);
+  }
+  else if ($link == 'urls')
+  {
+    return qubit_auto_link_urls($text, $href_options);
+  }
+}
+
+if (!defined('AR_AUTO_LINK_RE'))
+{
+  define('AR_AUTO_LINK_RE', '~
+    (?:
+      (                                             # Leading text
+        <\w+.*?>|                                   #  - Leading HTML tag, or
+        [^=!:\'"/]|                                 #  - Leading punctuation, or
+        ^                                           #  - beginning of line
+      )|                                            # Or Redmine hyperlink
+      (?:&quot;|\")(?<label>.*?)(?:\&quot;|\")\:    #  - Double quote and colon
+    )
+    (
+      (?:https?://)|                                # protocol spec, or
+      (?:www\.)                                     # www.*
+    )
+    (
+      [-\w]+                                        # subdomain or domain
+      (?:\.[-\w]+)*                                 # remaining subdomains or domain
+      (?::\d+)?                                     # port
+      (?:/(?:(?:[\~\w\+%-]|(?:[,.;:][^\s$]))+)?)*   # path
+      (?:\?[\w\+%&=.;-]+)?                          # query string
+      (?:\#[\w\-/\?!=]*)?                           # trailing anchor
+    )
+    ([[:punct:]]|\s|<|$)                            # trailing text
+   ~x');
+}
+
+function qubit_auto_link_urls($text, $href_options = array())
+{
+  require_once(dirname(__FILE__).'/../../vendor/symfony/lib/helper/TagHelper.php');
+
+  $href_options = _tag_options($href_options);
+
+  $callback_function = '
+    if (!empty($matches[\'label\']))
+    {
+      return $matches[1].\'<a href="\'.$matches[3].$matches[4].\'">\'.$matches[\'label\'].\'</a>\'.$matches[5];
+    }
+
+    if (preg_match("/<a\s/i", $matches[1]))
+    {
+      return $matches[0];
+    }
+    else
+    {
+      return $matches[1].\'<a href="\'.($matches[3] == "www." ? "http://www." : $matches[3]).$matches[4].\'"'.$href_options.'>\'.$matches[3].$matches[4].\'</a>\'.$matches[5];
+    }
+    ';
+
+  return preg_replace_callback(
+    AR_AUTO_LINK_RE,
+    create_function('$matches', $callback_function),
+    $text);
 }

--- a/test/unit/QubitHelperTest.php
+++ b/test/unit/QubitHelperTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once dirname(__FILE__).'/../bootstrap/unit.php';
+
+require_once(dirname(__FILE__).'/../../lib/helper/QubitHelper.php');
+
+$t = new lime_test(18, new lime_output_color);
+
+/**
+ * qubit_auto_link_text()
+ */
+
+$t->diag('qubit_auto_link_text()');
+
+$t->is(
+  qubit_auto_link_text('Visit our "website":http://www.accesstomemory.org.'),
+  'Visit our <a href="http://www.accesstomemory.org">website</a>.',
+  'qubit_auto_link_text() converts Redmine links');
+
+$t->is(
+  qubit_auto_link_text('Foobar1 http://www.foobar1.com Foobar2 http://www.foobar2.com and special link "here":http://here.com.'),
+  'Foobar1 <a href="http://www.foobar1.com">http://www.foobar1.com</a> Foobar2 <a href="http://www.foobar2.com">http://www.foobar2.com</a> and special link <a href="http://here.com">here</a>.',
+  'qubit_auto_link_text() converts Redmine and URLs when they both appear in the same string');
+
+$t->is(
+  qubit_auto_link_text('&quot;Foobar&quot;:http://foobar.com/12345.'),
+  '<a href="http://foobar.com/12345">Foobar</a>.',
+  'qubit_auto_link_text() converts Redmine link with HTML entities (&quot;)');
+
+$email_raw = 'fabien.potencier@symfony-project.com';
+$email_result = '<a href="mailto:'.$email_raw.'">'.$email_raw.'</a>';
+$link_raw = 'http://www.google.com';
+$link_result = '<a href="'.$link_raw.'">'.$link_raw.'</a>';
+$link2_raw = 'www.google.com';
+$link2_result = '<a href="http://'.$link2_raw.'">'.$link2_raw.'</a>';
+
+$t->is(qubit_auto_link_text('hello '.$email_raw, 'email_addresses'), 'hello '.$email_result, 'qubit_auto_link_text() converts emails to links');
+$t->is(qubit_auto_link_text('Go to '.$link_raw, 'urls'), 'Go to '.$link_result, 'qubit_auto_link_text() converts absolute URLs to links');
+$t->is(qubit_auto_link_text('Go to '.$link_raw, 'email_addresses'), 'Go to '.$link_raw, 'qubit_auto_link_text() takes a second parameter');
+$t->is(qubit_auto_link_text('Go to '.$link_raw.' and say hello to '.$email_raw), 'Go to '.$link_result.' and say hello to '.$email_result, 'qubit_auto_link_text() converts emails and URLs if no second argument is given');
+$t->is(qubit_auto_link_text('<p>Link '.$link_raw.'</p>'), '<p>Link '.$link_result.'</p>', 'qubit_auto_link_text() converts URLs to links');
+$t->is(qubit_auto_link_text('<p>'.$link_raw.' Link</p>'), '<p>'.$link_result.' Link</p>', 'qubit_auto_link_text() converts URLs to links');
+$t->is(qubit_auto_link_text('Go to '.$link2_raw, 'urls'), 'Go to '.$link2_result, 'qubit_auto_link_text() converts URLs to links even if link does not start with http://');
+$t->is(qubit_auto_link_text('Go to '.$link2_raw, 'email_addresses'), 'Go to '.$link2_raw, 'qubit_auto_link_text() converts URLs to links');
+$t->is(qubit_auto_link_text('<p>Link '.$link2_raw.'</p>'), '<p>Link '.$link2_result.'</p>', 'qubit_auto_link_text() converts URLs to links');
+$t->is(qubit_auto_link_text('<p>'.$link2_raw.' Link</p>'), '<p>'.$link2_result.' Link</p>', 'qubit_auto_link_text() converts URLs to links');
+$t->is(qubit_auto_link_text('<p>http://www.google.com/?q=symfony Link</p>'), '<p><a href="http://www.google.com/?q=symfony">http://www.google.com/?q=symfony</a> Link</p>', 'qubit_auto_link_text() converts URLs to links');
+$t->is(qubit_auto_link_text('<p>http://twitter.com/#!/fabpot</p>'),'<p><a href="http://twitter.com/#!/fabpot">http://twitter.com/#!/fabpot</a></p>',"qubit_auto_link_text() converts URLs with complex fragments to links");
+$t->is(qubit_auto_link_text('<p>http://twitter.com/#!/fabpot is Fabien Potencier on Twitter</p>'),'<p><a href="http://twitter.com/#!/fabpot">http://twitter.com/#!/fabpot</a> is Fabien Potencier on Twitter</p>', "qubit_auto_link_text() converts URLs with complex fragments and trailing text to links");
+$t->is(qubit_auto_link_text('hello '.$email_result, 'email_addresses'), 'hello '.$email_result, "qubit_auto_link_text() does not double-link emails");
+$t->is(qubit_auto_link_text('<p>Link '.$link_result.'</p>'), '<p>Link '.$link_result.'</p>', "qubit_auto_link_text() does not double-link emails");


### PR DESCRIPTION
Redmine ticket: https://projects.artefactual.com/issues/8410

This commit customizes _auto_link_text() to transform hyperlinks of the
following form: "AtoM":http://accesstomemory.org to HTML link. This is the
style used in Redmine.

The test suite provided by TextHelper has been duplicated and updated
according to the new functionality.
