### PR TITLE
Fix various EAD issues to become DTD compliant

### DIFF
--- a/plugins/sfEadPlugin/lib/sfEadPlugin.class.php
+++ b/plugins/sfEadPlugin/lib/sfEadPlugin.class.php
@@ -369,4 +369,36 @@ class sfEadPlugin
 
     return $renderedLOD;
   }
+
+  /*
+   * Get various <controlaccess> fields from specified information object.
+   * @return  bool  True if there are controlaccess fields present, false if not
+   */
+  public function getControlAccessFields($io, &$materialTypes, &$genres, &$subjects, &$names, &$places, &$placeEvents)
+  {
+    $materialTypes = $io->getMaterialTypes();
+    $genres = $io->getTermRelations(QubitTaxonomy::GENRE_ID);
+    $subjects = $io->getSubjectAccessPoints();
+    $names = $io->getNameAccessPoints();
+    $places = $io->getPlaceAccessPoints();
+    $placeEvents = $io->getPlaceAccessPoints(array('events' => true));
+
+    // Special case: we don't add actors from creation events to <controlaccess>, to
+    // prevent duplication during round tripping (AtoM will get the creator from <origination>).
+    // So we need to take this into account for our return value when indicating if there are any
+    // <controlaccess> fields or not.
+
+    $hasNonCreationActorEvents = false;
+    foreach ($io->getActorEvents() as $event)
+    {
+      if ($event->getType()->getRole() != 'Creator')
+      {
+        $hasNonCreationActorEvents = true;
+        break;
+      }
+    }
+
+    return count($materialTypes) || count($genres) || count($subjects) ||
+           count($names) || count($places) || $hasNonCreationActorEvents;
+  }
 }

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
@@ -252,7 +252,7 @@
     <custodhist encodinganalog="<?php echo $ead->getMetadataParameter('custodhist') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></custodhist>
   <?php endif; ?>
   <?php if (0 < strlen($value = $resource->getRevisionHistory(array('cultureFallback' => true)))): ?>
-    <processinfo><date><?php echo escape_dc(esc_specialchars($value)) ?></date></processinfo>
+    <processinfo><p><date><?php echo escape_dc(esc_specialchars($value)) ?></date></p></processinfo>
   <?php endif; ?>
   <?php if (0 < strlen($value = $resource->getLocationOfOriginals(array('cultureFallback' => true)))): ?>
     <originalsloc encodinganalog="<?php echo $ead->getMetadataParameter('originalsloc') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></originalsloc>
@@ -377,7 +377,7 @@
       <?php endif; ?>
 
       <?php if (0 < strlen($value = $descendant->getRevisionHistory(array('cultureFallback' => true)))): ?>
-        <processinfo><date><?php echo escape_dc(esc_specialchars($value)) ?></date></processinfo>
+        <processinfo><p><date><?php echo escape_dc(esc_specialchars($value)) ?></date><p></processinfo>
       <?php endif; ?>
 
       <?php if (0 < count($archivistsNotes = $descendant->getNotesByType(array('noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID)))): ?>

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
@@ -84,14 +84,14 @@
   </profiledesc>
 </eadheader>
 
-<?php // TODO: <frontmatter></frontmatter> ?>
-
 <archdesc <?php echo $ead->renderLOD($resource, $eadLevels) ?> relatedencoding="<?php echo $ead->getMetadataParameter('relatedencoding') ?>">
   <?php
 
   $resourceVar = 'resource';
   $counter = 0;
   $counterVar = 'counter';
+  $creators = $$resourceVar->getCreators();
+  $events = $$resourceVar->getActorEvents(array('eventTypeId' => QubitTerm::CREATION_ID));
 
   include('indexSuccessBodyDidElement.xml.php');
   include('indexSuccessBodyBioghistElement.xml.php');
@@ -288,6 +288,9 @@
 
       <?php
         $resourceVar = 'descendant';
+        $creators = $$resourceVar->getCreators();
+        $events = $$resourceVar->getActorEvents(array('eventTypeId' => QubitTerm::CREATION_ID));
+
         include('indexSuccessBodyDidElement.xml.php');
         include('indexSuccessBodyBioghistElement.xml.php');
       ?>

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
@@ -190,20 +190,8 @@
     <scopecontent encodinganalog="<?php echo $ead->getMetadataParameter('scopecontent') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></scopecontent><?php endif; ?>
   <?php if (0 < strlen($value = $resource->getArrangement(array('cultureFallback' => true)))): ?>
     <arrangement encodinganalog="<?php echo $ead->getMetadataParameter('arrangement') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></arrangement><?php endif; ?>
-  <?php
-  $materialtypes = $resource->getMaterialTypes();
-  $genres = $resource->getTermRelations(QubitTaxonomy::GENRE_ID);
-  $subjects = $resource->getSubjectAccessPoints();
-  $names = $resource->getNameAccessPoints();
-  $places = $resource->getPlaceAccessPoints();
-  $place_events = $resource->getPlaceAccessPoints(array('events' => true));
 
-  if ((0 < count($materialtypes)) ||
-     (0 < count($genres)) ||
-     (0 < count($subjects)) ||
-     (0 < count($names)) ||
-     (0 < count($places)) ||
-     (0 < count($resource->getActors()))): ?>
+  <?php if ($ead->getControlAccessFields($resource, $materialTypes, $genres, $subjects, $names, $places, $placeEvents)): ?>
     <controlaccess>
       <?php foreach ($resource->getActorEvents() as $event): ?>
         <?php if ($event->getType()->getRole() != 'Creator'): ?>
@@ -231,7 +219,7 @@
           <name role="subject"><?php echo escape_dc(esc_specialchars($name->getObject())) ?></name>
         <?php endif; ?>
       <?php endforeach; ?>
-      <?php foreach ($materialtypes as $materialtype): ?>
+      <?php foreach ($materialTypes as $materialtype): ?>
         <genreform source="rad" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('materialType'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>><?php echo escape_dc(escape_dc(esc_specialchars($materialtype->getTerm()))) ?></genreform>
       <?php endforeach; ?>
       <?php foreach ($genres as $genre): ?>
@@ -243,7 +231,7 @@
       <?php foreach ($places as $place): ?>
         <geogname><?php echo escape_dc(esc_specialchars($place->getTerm())) ?></geogname>
       <?php endforeach; ?>
-      <?php foreach ($place_events as $place): ?>
+      <?php foreach ($placeEvents as $place): ?>
         <geogname role="<?php echo $place->getObject()->getType()->getRole() ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('geog'.$place->getObject()->getType()->getRole()))): ?>encodinganalog="<?php echo $encoding ?>"<?php elseif (0 < strlen($encoding = $ead->getMetadataParameter('geogDefault'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?> id="atom_<?php echo $event->id ?>_place"><?php echo escape_dc(esc_specialchars($place->getTerm())) ?></geogname>
       <?php endforeach; ?>
     </controlaccess>
@@ -312,145 +300,131 @@
         <arrangement encodinganalog="<?php echo $ead->getMetadataParameter('arrangement') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></arrangement>
       <?php endif; ?>
 
-      <?php
+      <?php if ($ead->getControlAccessFields($descendant, $materialTypes, $genres, $subjects, $names, $places, $placeEvents)): ?>
 
-        $materialtypes = $descendant->getMaterialTypes();
-        $genres = $descendant->getTermRelations(QubitTaxonomy::GENRE_ID);
-        $subjects = $descendant->getSubjectAccessPoints();
-        $names = $descendant->getNameAccessPoints();
-        $places = $descendant->getPlaceAccessPoints();
-        $place_events = $descendant->getPlaceAccessPoints(array('events' => true));
+        <controlaccess>
 
-        if ((0 < count($materialtypes)) ||
-            (0 < count($genres)) ||
-            (0 < count($subjects)) ||
-            (0 < count($names)) ||
-            (0 < count($places)) ||
-            (0 < count($descendant->getActors()))): ?>
+          <?php foreach ($descendant->getActorEvents() as $event): ?>
+            <?php if ($event->getType()->getRole() != 'Creator'): ?>
 
-          <controlaccess>
-
-            <?php foreach ($descendant->getActorEvents() as $event): ?>
-              <?php if ($event->getType()->getRole() != 'Creator'): ?>
-
-                <?php if ($event->getActor()->getEntityTypeId() == QubitTerm::PERSON_ID): ?>
-                  <persname role="<?php echo $event->getType()->getRole() ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()))): ?>encodinganalog="<?php echo $encoding ?>"<?php elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?> id="atom_<?php echo $event->id ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor(array('cultureFallback' => true))))) ?> </persname>
-                <?php elseif ($event->getActor()->getEntityTypeId() == QubitTerm::FAMILY_ID): ?>
-                  <famname role="<?php echo $event->getType()->getRole() ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()))): ?>encodinganalog="<?php echo $encoding ?>"<?php elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?> id="atom_<?php echo $event->id ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor(array('cultureFallback' => true))))) ?> </famname>
-                <?php elseif ($event->getActor()->getEntityTypeId() == QubitTerm::CORPORATE_BODY_ID): ?>
-                  <corpname role="<?php echo $event->getType()->getRole() ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()))): ?>encodinganalog="<?php echo $encoding ?>"<?php elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?> id="atom_<?php echo $event->id ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor(array('cultureFallback' => true))))) ?> </corpname>
-                <?php else: ?>
-                  <name role="<?php echo $event->getType()->getRole() ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()))): ?>encodinganalog="<?php echo $encoding ?>"<?php elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?> id="atom_<?php echo $event->id ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor(array('cultureFallback' => true))))) ?> </name>
-                <?php endif; ?>
-
-              <?php endif; ?>
-            <?php endforeach; ?>
-
-            <?php foreach ($names as $name): ?>
-              <?php if ($name->getObject()->getEntityTypeId() == QubitTerm::PERSON_ID): ?>
-                <persname role="subject"><?php echo escape_dc(esc_specialchars($name->getObject())) ?></persname>
-              <?php elseif ($name->getObject()->getEntityTypeId() == QubitTerm::FAMILY_ID): ?>
-                <famname role="subject"><?php echo escape_dc(esc_specialchars($name->getObject())) ?></famname>
-              <?php elseif ($name->getObject()->getEntityTypeId() == QubitTerm::CORPORATE_BODY_ID): ?>
-                <corpname role="subject"><?php echo escape_dc(esc_specialchars($name->getObject())) ?></corpname>
+              <?php if ($event->getActor()->getEntityTypeId() == QubitTerm::PERSON_ID): ?>
+                <persname role="<?php echo $event->getType()->getRole() ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()))): ?>encodinganalog="<?php echo $encoding ?>"<?php elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?> id="atom_<?php echo $event->id ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor(array('cultureFallback' => true))))) ?> </persname>
+              <?php elseif ($event->getActor()->getEntityTypeId() == QubitTerm::FAMILY_ID): ?>
+                <famname role="<?php echo $event->getType()->getRole() ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()))): ?>encodinganalog="<?php echo $encoding ?>"<?php elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?> id="atom_<?php echo $event->id ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor(array('cultureFallback' => true))))) ?> </famname>
+              <?php elseif ($event->getActor()->getEntityTypeId() == QubitTerm::CORPORATE_BODY_ID): ?>
+                <corpname role="<?php echo $event->getType()->getRole() ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()))): ?>encodinganalog="<?php echo $encoding ?>"<?php elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?> id="atom_<?php echo $event->id ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor(array('cultureFallback' => true))))) ?> </corpname>
               <?php else: ?>
-                <name role="subject"><?php echo escape_dc(esc_specialchars($name->getObject())) ?></name>
+                <name role="<?php echo $event->getType()->getRole() ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()))): ?>encodinganalog="<?php echo $encoding ?>"<?php elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?> id="atom_<?php echo $event->id ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor(array('cultureFallback' => true))))) ?> </name>
               <?php endif; ?>
-            <?php endforeach; ?>
 
-            <?php foreach ($materialtypes as $materialtype): ?>
-              <genreform source="rad" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('materialType'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>><?php echo escape_dc(esc_specialchars($materialtype->getTerm())) ?></genreform>
-            <?php endforeach; ?>
-
-            <?php foreach ($genres as $genre): ?>
-              <genreform <?php if (0 < strlen($encoding = $ead->getMetadataParameter('genreform'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>><?php echo escape_dc(escape_dc(esc_specialchars($genre->getTerm()))) ?></genreform>
-            <?php endforeach; ?>
-
-            <?php foreach ($subjects as $subject): ?>
-              <subject><?php echo escape_dc(esc_specialchars($subject->getTerm())) ?></subject>
-            <?php endforeach; ?>
-
-            <?php foreach ($places as $place): ?>
-              <geogname><?php echo escape_dc(esc_specialchars($place->getTerm())) ?></geogname>
-            <?php endforeach; ?>
-
-            <?php foreach ($place_events as $place): ?>
-              <geogname role="<?php echo $place->getObject()->getType()->getRole() ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('geog'.$place->getObject()->getType()->getRole()))): ?>encodinganalog="<?php echo $encoding ?>"<?php elseif (0 < strlen($encoding = $ead->getMetadataParameter('geogDefault'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?> id="atom_<?php echo $event->id ?>_place"><?php echo escape_dc(esc_specialchars($place->getTerm())) ?></geogname>
-            <?php endforeach; ?>
-
-          </controlaccess>
-
-        <?php endif; ?>
-
-        <?php if (0 < strlen($value = $descendant->getPhysicalCharacteristics(array('cultureFallback' => true)))): ?>
-          <phystech encodinganalog="<?php echo $ead->getMetadataParameter('phystech') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></phystech>
-        <?php endif; ?>
-
-        <?php if (0 < strlen($value = $descendant->getAppraisal(array('cultureFallback' => true)))): ?>
-          <appraisal <?php if (0 < strlen($encoding = $ead->getMetadataParameter('appraisal'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>><p><?php echo escape_dc(esc_specialchars($value)) ?></p></appraisal>
-        <?php endif; ?>
-
-        <?php if (0 < strlen($value = $descendant->getAcquisition(array('cultureFallback' => true)))): ?>
-          <acqinfo encodinganalog="<?php echo $ead->getMetadataParameter('acqinfo') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></acqinfo>
-        <?php endif; ?>
-
-        <?php if (0 < strlen($value = $descendant->getAccruals(array('cultureFallback' => true)))): ?>
-          <accruals encodinganalog="<?php echo $ead->getMetadataParameter('accruals') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></accruals>
-        <?php endif; ?>
-
-        <?php if (0 < strlen($value = $descendant->getArchivalHistory(array('cultureFallback' => true)))): ?>
-          <custodhist encodinganalog="<?php echo $ead->getMetadataParameter('custodhist') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></custodhist>
-        <?php endif; ?>
-
-        <?php if (0 < strlen($value = $descendant->getRevisionHistory(array('cultureFallback' => true)))): ?>
-          <processinfo><date><?php echo escape_dc(esc_specialchars($value)) ?></date></processinfo>
-        <?php endif; ?>
-
-        <?php if (0 < count($archivistsNotes = $descendant->getNotesByType(array('noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID)))): ?>
-          <?php foreach ($archivistsNotes as $note): ?>
-            <processinfo><p><?php echo escape_dc(esc_specialchars($note)) ?></p></processinfo>
-          <?php endforeach; ?>
-        <?php endif; ?>
-
-        <?php if (0 < strlen($value = $descendant->getLocationOfOriginals(array('cultureFallback' => true)))): ?>
-          <originalsloc encodinganalog="<?php echo $ead->getMetadataParameter('originalsloc') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></originalsloc>
-        <?php endif; ?>
-
-        <?php if (0 < strlen($value = $descendant->getLocationOfCopies(array('cultureFallback' => true)))): ?>
-          <altformavail encodinganalog="<?php echo $ead->getMetadataParameter('altformavail') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></altformavail>
-        <?php endif; ?>
-
-        <?php if (0 < strlen($value = $descendant->getRelatedUnitsOfDescription(array('cultureFallback' => true)))): ?>
-          <relatedmaterial encodinganalog="<?php echo $ead->getMetadataParameter('relatedmaterial') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></relatedmaterial>
-        <?php endif; ?>
-
-        <?php if (0 < strlen($value = $descendant->getAccessConditions(array('cultureFallback' => true)))): ?>
-          <accessrestrict encodinganalog="<?php echo $ead->getMetadataParameter('accessrestrict') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></accessrestrict>
-        <?php endif; ?>
-
-        <?php if (0 < strlen($value = $descendant->getReproductionConditions(array('cultureFallback' => true)))): ?>
-          <userestrict encodinganalog="<?php echo $ead->getMetadataParameter('userestrict') ?>"><p><?php echo escape_dc(esc_specialchars($value))  ?></p></userestrict>
-        <?php endif; ?>
-
-        <?php if (0 < strlen($value = $descendant->getFindingAids(array('cultureFallback' => true)))): ?>
-          <otherfindaid encodinganalog="<?php echo $ead->getMetadataParameter('otherfindaid') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></otherfindaid>
-        <?php endif; ?>
-
-        <?php if (0 < count($publicationNotes = $descendant->getNotesByType(array('noteTypeId' => QubitTerm::PUBLICATION_NOTE_ID)))): ?>
-          <?php foreach ($publicationNotes as $note): ?>
-            <bibliography <?php if (0 < strlen($encoding = $ead->getMetadataParameter('bibliography'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>><p><?php echo escape_dc(esc_specialchars($note)) ?></p></bibliography>
-          <?php endforeach; ?>
-        <?php endif; ?>
-
-        <?php foreach($radNotes as $name => $xmlType): ?>
-            <?php $noteTypeId = array_search($name, $termData['radNoteTypes']); ?>
-
-            <?php if (0 < count($notes = $descendant->getNotesByType(array('noteTypeId' => $noteTypeId)))): ?>
-              <?php foreach ($notes as $note): ?>
-                <odd type="<?php echo $xmlType ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter($xmlType))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>><p><?php echo escape_dc(esc_specialchars($note)) ?></p></odd>
-              <?php endforeach; ?>
             <?php endif; ?>
+          <?php endforeach; ?>
+
+          <?php foreach ($names as $name): ?>
+            <?php if ($name->getObject()->getEntityTypeId() == QubitTerm::PERSON_ID): ?>
+              <persname role="subject"><?php echo escape_dc(esc_specialchars($name->getObject())) ?></persname>
+            <?php elseif ($name->getObject()->getEntityTypeId() == QubitTerm::FAMILY_ID): ?>
+              <famname role="subject"><?php echo escape_dc(esc_specialchars($name->getObject())) ?></famname>
+            <?php elseif ($name->getObject()->getEntityTypeId() == QubitTerm::CORPORATE_BODY_ID): ?>
+              <corpname role="subject"><?php echo escape_dc(esc_specialchars($name->getObject())) ?></corpname>
+            <?php else: ?>
+              <name role="subject"><?php echo escape_dc(esc_specialchars($name->getObject())) ?></name>
+            <?php endif; ?>
+          <?php endforeach; ?>
+
+          <?php foreach ($materialTypes as $materialtype): ?>
+            <genreform source="rad" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('materialType'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>><?php echo escape_dc(esc_specialchars($materialtype->getTerm())) ?></genreform>
+          <?php endforeach; ?>
+
+          <?php foreach ($genres as $genre): ?>
+            <genreform <?php if (0 < strlen($encoding = $ead->getMetadataParameter('genreform'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>><?php echo escape_dc(escape_dc(esc_specialchars($genre->getTerm()))) ?></genreform>
+          <?php endforeach; ?>
+
+          <?php foreach ($subjects as $subject): ?>
+            <subject><?php echo escape_dc(esc_specialchars($subject->getTerm())) ?></subject>
+          <?php endforeach; ?>
+
+          <?php foreach ($places as $place): ?>
+            <geogname><?php echo escape_dc(esc_specialchars($place->getTerm())) ?></geogname>
+          <?php endforeach; ?>
+
+          <?php foreach ($placeEvents as $place): ?>
+            <geogname role="<?php echo $place->getObject()->getType()->getRole() ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('geog'.$place->getObject()->getType()->getRole()))): ?>encodinganalog="<?php echo $encoding ?>"<?php elseif (0 < strlen($encoding = $ead->getMetadataParameter('geogDefault'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?> id="atom_<?php echo $event->id ?>_place"><?php echo escape_dc(esc_specialchars($place->getTerm())) ?></geogname>
+          <?php endforeach; ?>
+
+        </controlaccess>
+
+      <?php endif; ?>
+
+      <?php if (0 < strlen($value = $descendant->getPhysicalCharacteristics(array('cultureFallback' => true)))): ?>
+        <phystech encodinganalog="<?php echo $ead->getMetadataParameter('phystech') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></phystech>
+      <?php endif; ?>
+
+      <?php if (0 < strlen($value = $descendant->getAppraisal(array('cultureFallback' => true)))): ?>
+        <appraisal <?php if (0 < strlen($encoding = $ead->getMetadataParameter('appraisal'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>><p><?php echo escape_dc(esc_specialchars($value)) ?></p></appraisal>
+      <?php endif; ?>
+
+      <?php if (0 < strlen($value = $descendant->getAcquisition(array('cultureFallback' => true)))): ?>
+        <acqinfo encodinganalog="<?php echo $ead->getMetadataParameter('acqinfo') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></acqinfo>
+      <?php endif; ?>
+
+      <?php if (0 < strlen($value = $descendant->getAccruals(array('cultureFallback' => true)))): ?>
+        <accruals encodinganalog="<?php echo $ead->getMetadataParameter('accruals') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></accruals>
+      <?php endif; ?>
+
+      <?php if (0 < strlen($value = $descendant->getArchivalHistory(array('cultureFallback' => true)))): ?>
+        <custodhist encodinganalog="<?php echo $ead->getMetadataParameter('custodhist') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></custodhist>
+      <?php endif; ?>
+
+      <?php if (0 < strlen($value = $descendant->getRevisionHistory(array('cultureFallback' => true)))): ?>
+        <processinfo><date><?php echo escape_dc(esc_specialchars($value)) ?></date></processinfo>
+      <?php endif; ?>
+
+      <?php if (0 < count($archivistsNotes = $descendant->getNotesByType(array('noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID)))): ?>
+        <?php foreach ($archivistsNotes as $note): ?>
+          <processinfo><p><?php echo escape_dc(esc_specialchars($note)) ?></p></processinfo>
         <?php endforeach; ?>
+      <?php endif; ?>
+
+      <?php if (0 < strlen($value = $descendant->getLocationOfOriginals(array('cultureFallback' => true)))): ?>
+        <originalsloc encodinganalog="<?php echo $ead->getMetadataParameter('originalsloc') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></originalsloc>
+      <?php endif; ?>
+
+      <?php if (0 < strlen($value = $descendant->getLocationOfCopies(array('cultureFallback' => true)))): ?>
+        <altformavail encodinganalog="<?php echo $ead->getMetadataParameter('altformavail') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></altformavail>
+      <?php endif; ?>
+
+      <?php if (0 < strlen($value = $descendant->getRelatedUnitsOfDescription(array('cultureFallback' => true)))): ?>
+        <relatedmaterial encodinganalog="<?php echo $ead->getMetadataParameter('relatedmaterial') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></relatedmaterial>
+      <?php endif; ?>
+
+      <?php if (0 < strlen($value = $descendant->getAccessConditions(array('cultureFallback' => true)))): ?>
+        <accessrestrict encodinganalog="<?php echo $ead->getMetadataParameter('accessrestrict') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></accessrestrict>
+      <?php endif; ?>
+
+      <?php if (0 < strlen($value = $descendant->getReproductionConditions(array('cultureFallback' => true)))): ?>
+        <userestrict encodinganalog="<?php echo $ead->getMetadataParameter('userestrict') ?>"><p><?php echo escape_dc(esc_specialchars($value))  ?></p></userestrict>
+      <?php endif; ?>
+
+      <?php if (0 < strlen($value = $descendant->getFindingAids(array('cultureFallback' => true)))): ?>
+        <otherfindaid encodinganalog="<?php echo $ead->getMetadataParameter('otherfindaid') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></otherfindaid>
+      <?php endif; ?>
+
+      <?php if (0 < count($publicationNotes = $descendant->getNotesByType(array('noteTypeId' => QubitTerm::PUBLICATION_NOTE_ID)))): ?>
+        <?php foreach ($publicationNotes as $note): ?>
+          <bibliography <?php if (0 < strlen($encoding = $ead->getMetadataParameter('bibliography'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>><p><?php echo escape_dc(esc_specialchars($note)) ?></p></bibliography>
+        <?php endforeach; ?>
+      <?php endif; ?>
+
+      <?php foreach($radNotes as $name => $xmlType): ?>
+          <?php $noteTypeId = array_search($name, $termData['radNoteTypes']); ?>
+
+          <?php if (0 < count($notes = $descendant->getNotesByType(array('noteTypeId' => $noteTypeId)))): ?>
+            <?php foreach ($notes as $note): ?>
+              <odd type="<?php echo $xmlType ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter($xmlType))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>><p><?php echo escape_dc(esc_specialchars($note)) ?></p></odd>
+            <?php endforeach; ?>
+          <?php endif; ?>
+      <?php endforeach; ?>
 
       <?php if ($descendant->rgt == $descendant->lft + 1): ?>
         </c>

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyBioghistElement.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyBioghistElement.xml.php
@@ -1,27 +1,7 @@
-<?php
-  $creators = $$resourceVar->getCreators();
-  $events = $$resourceVar->getActorEvents(array('eventTypeId' => QubitTerm::CREATION_ID));
-?>
 
 <?php if (0 < count($creators)): ?>
   <?php foreach($events as $date): ?>
     <?php $creator = QubitActor::getById($date->actorId); ?>
-
-    <origination encodinganalog="<?php echo $ead->getMetadataParameter('origination') ?>">
-      <?php if ($type = $creator->getEntityTypeId()): ?>
-        <?php if (QubitTerm::PERSON_ID == $type): ?>
-          <persname><?php echo escape_dc(esc_specialchars($creator->getAuthorizedFormOfName(array('cultureFallback' => true)))) ?></persname>
-        <?php endif; ?>
-        <?php if (QubitTerm::FAMILY_ID == $type): ?>
-          <famname><?php echo escape_dc(esc_specialchars($creator->getAuthorizedFormOfName(array('cultureFallback' => true)))) ?></famname>
-        <?php endif; ?>
-        <?php if (QubitTerm::CORPORATE_BODY_ID == $type): ?>
-          <corpname><?php echo escape_dc(esc_specialchars($creator->getAuthorizedFormOfName(array('cultureFallback' => true)))) ?></corpname>
-        <?php endif; ?>
-      <?php else: ?>
-        <name><?php echo escape_dc(esc_specialchars($creator->getAuthorizedFormOfName(array('cultureFallback' => true)))) ?></name>
-      <?php endif; ?>
-    </origination>
 
     <?php if (($value = $creator->getHistory(array('cultureFallback' => true))) || $creator->datesOfExistence): ?>
       <bioghist id="<?php echo 'md5-' . md5(url_for(array($creator, 'module' => 'actor'), true)) ?>" encodinganalog="<?php echo $ead->getMetadataParameter('bioghist') ?>">

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyBioghistElement.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyBioghistElement.xml.php
@@ -9,7 +9,7 @@
           <note><p><?php echo escape_dc(esc_specialchars($value)) ?></p></note>
         <?php endif; ?>
         <?php if ($creator->datesOfExistence): ?>
-          <date type="existence"><?php echo escape_dc(esc_specialchars($creator->datesOfExistence)) ?></date>
+          <note><p><date type="existence"><?php echo escape_dc(esc_specialchars($creator->datesOfExistence)) ?></date></p></note>
         <?php endif; ?>
       </bioghist>
     <?php endif; ?>

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
@@ -188,4 +188,26 @@
     <?php endif; ?>
   <?php endif; ?>
 
+  <?php if (0 < count($creators)): ?>
+    <?php foreach($events as $date): ?>
+      <?php $creator = QubitActor::getById($date->actorId); ?>
+
+      <origination encodinganalog="<?php echo $ead->getMetadataParameter('origination') ?>">
+        <?php if ($type = $creator->getEntityTypeId()): ?>
+          <?php if (QubitTerm::PERSON_ID == $type): ?>
+            <persname><?php echo escape_dc(esc_specialchars($creator->getAuthorizedFormOfName(array('cultureFallback' => true)))) ?></persname>
+          <?php endif; ?>
+          <?php if (QubitTerm::FAMILY_ID == $type): ?>
+            <famname><?php echo escape_dc(esc_specialchars($creator->getAuthorizedFormOfName(array('cultureFallback' => true)))) ?></famname>
+          <?php endif; ?>
+          <?php if (QubitTerm::CORPORATE_BODY_ID == $type): ?>
+            <corpname><?php echo escape_dc(esc_specialchars($creator->getAuthorizedFormOfName(array('cultureFallback' => true)))) ?></corpname>
+          <?php endif; ?>
+        <?php else: ?>
+          <name><?php echo escape_dc(esc_specialchars($creator->getAuthorizedFormOfName(array('cultureFallback' => true)))) ?></name>
+        <?php endif; ?>
+      </origination>
+    <?php endforeach; ?>
+  <?php endif; ?>
+
 </did>


### PR DESCRIPTION
The following DTD issues need to be addressed:
- `The <origination> element is appearing illegally in the <archdesc> element. It should be moved within the <did> of each level to be valid.`
- `The <bioghist> element contains a <date> for the dates of existence of the related actor, but <date> isn't allowed in <bioghist>. Instead, we would have to make it something like <bioghist><note><p><date>`
- `We are including empty <controlaccess></controlaccess> elements on export in the EAD, which we shouldn't - it causes a DTD error on roundtrip`
- `<processinfo> cannot contain <date> directly; if we want to use it, we need it to be <p><date>`
