### PR TITLE
Moving cache clear function. refs #8122

### DIFF
--- a/lib/Qubit.class.php
+++ b/lib/Qubit.class.php
@@ -256,4 +256,20 @@ class Qubit
 
     return $error ? false : $dest;
   }
+
+  /**
+   * Clear Qubit's class-specific, in-memory caches
+   *
+   * @return void
+   */
+  public static function clearClassCaches()
+  {
+    foreach (get_declared_classes() as $c)
+    {
+      if (strpos($c, 'Qubit') === 0 && method_exists($c, 'clearCache'))
+      {
+        $c::clearCache();
+      }
+    }
+  }
 }

--- a/lib/flatfile/QubitFlatfileExport.class.php
+++ b/lib/flatfile/QubitFlatfileExport.class.php
@@ -350,7 +350,7 @@ class QubitFlatfileExport
       $appRoot = dirname(__FILE__) .'/../..';
       require_once(realpath($appRoot .'/lib/helper/QubitHelper.php'));
 
-      clear_class_caches();
+      Qubit::clearClassCaches();
     }
 
     $this->prepareRowFromResource();

--- a/lib/helper/QubitHelper.php
+++ b/lib/helper/QubitHelper.php
@@ -17,17 +17,6 @@
  * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
  */
 
-function clear_class_caches()
-{
-  foreach (get_declared_classes() as $c)
-  {
-    if (strpos($c, 'Qubit') === 0 && method_exists($c, 'clearCache'))
-    {
-      $c::clearCache();
-    }
-  }
-}
-
 function format_script($script_iso, $culture = null)
 {
   $c = sfCultureInfo::getInstance($culture === null ? sfContext::getInstance()->user->getCulture() : $culture);


### PR DESCRIPTION
Moving the utility function for clearing in-memory caches
out of the template helper file to a more logic place.
