### PR TITLE
Improve search-box behaviour, refs #5538 and #6111

### DIFF
--- a/js/dominion.js
+++ b/js/dominion.js
@@ -235,6 +235,8 @@
         }
 
         this.$menu.on('mouseenter', 'li', $.proxy(this.mouseenter, this));
+        this.$menu.on('mouseleave', 'li', $.proxy(this.mouseleave, this));
+        this.$menu.on('click', 'li', $.proxy(this.click, this));
 
         this.$realm.on('change', 'input[type=radio]', $.proxy(this.changeRealm, this));
 
@@ -368,9 +370,51 @@
         return this;
       },
 
-    next: function (e) { },
-    prev: function (e) { },
-    select: function (e) { },
+    next: function (e)
+      {
+        var $items = this.$menu.find('li');
+        var $active = this.$menu.find('li.active:first');
+
+        if ($active.length)
+        {
+          $active.removeClass('active');
+          $items.eq($items.index($active) + 1).addClass('active');
+        }
+        else
+        {
+          $items.first().addClass('active');
+        }
+      },
+
+    prev: function (e)
+      {
+        var $items = this.$menu.find('li');
+        var $active = this.$menu.find('li.active:first');
+
+        if ($active.length)
+        {
+          $active.removeClass('active');
+          $items.eq($items.index($active) - 1).addClass('active');
+        }
+        else
+        {
+          $items.last().addClass('active');
+        }
+      },
+
+    select: function (e)
+      {
+        var $active = this.$menu.find('li.active:first');
+
+        if ($active.length)
+        {
+          $(location).attr('href', $active.find('a').attr('href'));
+        }
+        else
+        {
+          this.$form.submit();
+        }
+      },
 
     keyup: function (e)
       {
@@ -378,14 +422,6 @@
         {
           case 40: // Down arrow
           case 38: // Up arrow
-            break;
-
-          case 9: // Tab
-            if (!this.shown)
-            {
-              return;
-            }
-            this.select();
             break;
 
           case 27: // Escape
@@ -424,14 +460,13 @@
 
         switch (e.keyCode)
         {
-          case 9: // Tab
           case 27: // Escape
             e.preventDefault();
             break;
 
-          case 13:
+          case 13: // Enter
             e.preventDefault();
-            $(e.target).closest('form').get(0).submit();
+            this.select();
             break;
 
           case 38: // Up arrow
@@ -482,8 +517,18 @@
 
     mouseenter: function (e)
       {
-        this.$menu.find('active').removeClass('active');
         $(e.currentTarget).addClass('active');
+      },
+
+    mouseleave: function (e)
+      {
+        $(e.currentTarget).removeClass('active');
+      },
+
+    click: function (e)
+      {
+        e.preventDefault();
+        $(location).attr('href', $(e.currentTarget).find('a').attr('href'));
       }
   };
 

--- a/js/dominion.js
+++ b/js/dominion.js
@@ -238,6 +238,8 @@
         this.$menu.on('mouseleave', 'li', $.proxy(this.mouseleave, this));
         this.$menu.on('click', 'li', $.proxy(this.click, this));
 
+        this.$realm.on('mouseenter', 'div', $.proxy(this.mouseenter, this));
+        this.$realm.on('mouseleave', 'div', $.proxy(this.mouseleave, this));
         this.$realm.on('change', 'input[type=radio]', $.proxy(this.changeRealm, this));
 
         // Validate form
@@ -370,45 +372,68 @@
         return this;
       },
 
-    next: function (e)
+    move: function (direction)
       {
-        var $items = this.$menu.find('li');
-        var $active = this.$menu.find('li.active:first');
+        // Determine what dropdown is being displayed
+        // and move through the items
+        if (this.$menu.css('display') == 'block')
+        {
+          var $items = this.$menu.find('li');
+          var $active = this.$menu.find('li.active:first');
+        }
+        else
+        {
+          var $items = this.$realm.find('div');
+          var $active = this.$realm.find('div.active:first');
+        }
 
         if ($active.length)
         {
           $active.removeClass('active');
-          $items.eq($items.index($active) + 1).addClass('active');
+
+          var pos = $items.index($active) + direction;
+          if (pos >= 0)
+          {
+            $items.eq(pos).addClass('active');
+          }
         }
         else
         {
-          $items.first().addClass('active');
-        }
-      },
-
-    prev: function (e)
-      {
-        var $items = this.$menu.find('li');
-        var $active = this.$menu.find('li.active:first');
-
-        if ($active.length)
-        {
-          $active.removeClass('active');
-          $items.eq($items.index($active) - 1).addClass('active');
-        }
-        else
-        {
-          $items.last().addClass('active');
+          if (direction < 0)
+          {
+            $items.last().addClass('active');
+          }
+          else
+          {
+            $items.first().addClass('active');
+          }
         }
       },
 
     select: function (e)
       {
-        var $active = this.$menu.find('li.active:first');
+        // Determine what dropdown is being displayed
+        // and interact with the active element or submit the form
+        if (this.$menu.css('display') == 'block')
+        {
+          var $active = this.$menu.find('li.active:first');
+        }
+        else
+        {
+          var $active = this.$realm.find('div.active:first');
+        }
 
         if ($active.length)
         {
-          $(location).attr('href', $active.find('a').attr('href'));
+          var $radio = $active.find('input[type=radio]');
+          if ($radio.length)
+          {
+            $radio.click();
+          }
+          else
+          {
+            $(location).attr('href', $active.find('a').attr('href'));
+          }
         }
         else
         {
@@ -448,16 +473,6 @@
 
     keypress: function (e)
       {
-        if (13 == e.keyCode && !e.target.value.length)
-        {
-          e.preventDefault();
-          e.stopPropagation();
-
-          return;
-        }
-
-        // if (!this.shown) return;
-
         switch (e.keyCode)
         {
           case 27: // Escape
@@ -471,12 +486,12 @@
 
           case 38: // Up arrow
             e.preventDefault();
-            this.prev();
+            this.move(-1);
             break;
 
           case 40: // Down arrow
             e.preventDefault();
-            this.next();
+            this.move(1);
             break;
         }
 

--- a/plugins/arDominionPlugin/css/less/search.less
+++ b/plugins/arDominionPlugin/css/less/search.less
@@ -235,19 +235,23 @@ h1 {
   }
 
   ul {
-    padding: 4px 4px 0 18px;
+    padding-left: 10px;
     margin-bottom: 0;
   }
 
   li {
     display: block;
     float: none;
-    margin: 0 0 4px 0;
-    padding: 0;
+    padding: 3px;
+    margin: 0;
     white-space: nowrap;
-    width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
+    cursor: pointer;
+
+    &.active {
+      background-color: @grayLighter;
+    }
   }
 
   a {

--- a/plugins/arDominionPlugin/css/less/search.less
+++ b/plugins/arDominionPlugin/css/less/search.less
@@ -176,15 +176,24 @@ h1 {
 
   &#search-realm {
     background-color: @white;
-    padding: 5px 10px 0px 0;
+
+    div {
+      padding: 5px;
+
+      &.active {
+        background-color: @grayLighter;
+      }
+    }
+
     label {
       margin-left: 6px;
+      margin-bottom: 0;
       .text-overflow();
       input[type=radio] {
         background-color: @white !important;
         display: inline !important;
         width: auto !important;
-        margin: -4px 4px 0 4px;
+        padding: -4px 4px 0 4px;
       }
     }
   }
@@ -224,7 +233,7 @@ h1 {
   label {
     input {
       display: inline;
-      margin: 0 4px;
+      margin-bottom: 5px;
     }
   }
 


### PR DESCRIPTION
- Allows the use of the 'tab' key to get out of the search-box
- Adds support to move over the result using the arrow keys
- Adds gray background to the selected result in the drop-down
- All the record is clickable (not just the link)
- The 'enter' key will redirect to the selected result or it will perform
  the query if no result is selected
