### PR TITLE
Respect UI-configured max image width generally

### DIFF
--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -2329,7 +2329,7 @@ class QubitDigitalObject extends BaseDigitalObject
   {
     if ($usageId == QubitTerm::REFERENCE_ID)
     {
-      $maxwidth = (sfConfig::get('app_reference_image_maxwidth')) ? sfConfig::get('app_reference_image_maxwidth') : 480;
+      $maxwidth = (QubitSetting::getByName('reference_image_maxwidth')) ? intval((string)QubitSetting::getByName('reference_image_maxwidth')) : 480;
       $maxheight = null;
     }
     else if ($usageId == QubitTerm::THUMBNAIL_ID)
@@ -2361,7 +2361,7 @@ class QubitDigitalObject extends BaseDigitalObject
     {
       case QubitTerm::REFERENCE_ID:
         // Backwards compatiblity - if maxwidth Qubit setting doesn't exist
-        if (!$maxwidth = sfConfig::get('app_reference_image_maxwidth'))
+        if (!$maxwidth = intval((string)QubitSetting::getByName('reference_image_maxwidth')))
         {
           $maxwidth = 480;
         }
@@ -2372,7 +2372,7 @@ class QubitDigitalObject extends BaseDigitalObject
         $maxheight = 1024;
         break;
       case QubitTerm::COMPOUND_ID:
-        if (!$maxwidth = sfConfig::get('app_reference_image_maxwidth'))
+        if (!$maxwidth = intval((string)QubitSetting::getByName('reference_image_maxwidth')))
         {
           $maxwidth = 480;
         }


### PR DESCRIPTION
When importing descriptions with digital objects either on the command-line or through the UI, the ui-configured maximum image width setting is not respected. This is likewise true when issuing the digitalobject:regen-derivatives command. It seems the wrong (legacy?) setting is checked. FWIW, changing reference_image_maxwidth in data/fixtures/settings.yml doesn't help. This change checks the UI value for maxwidth and uses it.

video: https://youtu.be/LEvv6N_mlnM

This little change works for me. the double casting is ugly, but I don't understand the object structure well enough to go directly for the integer value of the setting.
