### PR TITLE
Move archivist notes to <processinfo><p> #8504

### DIFF
--- a/apps/qubit/modules/object/config/import/ead.yml
+++ b/apps/qubit/modules/object/config/import/ead.yml
@@ -406,8 +406,8 @@ information_object:
       Parameters: ["$options = array('note' => 'Preferred citation: ' . $nodeValue, 'noteTypeId' => QubitTerm::GENERAL_NOTE_ID)"]
 
     processinfo:
-      XPath:  "processinfo"
-      Method: importEadNote # Manually parsed, see case 'processinfo' in QubitXmlImport.class.php
+      XPath:  "processinfo/p[not(date)]"
+      Method: importEadNote
       Parameters: ["$options = array('note' => $nodeValue, 'noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID)"]
 
     archivistnote:

--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -456,46 +456,6 @@ class QubitXmlImport
 
             break;
 
-          case 'processinfo':
-            foreach ($nodeList2 as $item)
-            {
-              if (($childNode = $importDOM->xpath->query('p/date', $item)) !== null)
-              {
-                $currentObject->revisionHistory = $childNode->item(0)->nodeValue;
-              }
-
-              if (($childNode = $importDOM->xpath->query('p', $item)) !== null)
-              {
-                $note = '';
-
-                foreach ($childNode as $pNode)
-                {
-                  // A <p> node inside <processinfo> with no other children,
-                  // this is part of an archivist's note.
-                  if ($pNode->childNodes->length === 1 && $pNode->firstChild->nodeType === XML_TEXT_NODE)
-                  {
-                    // If this isn't our first <p> in the note, add newlines
-                    // to simulate paragraph.
-                    if (strlen($note) > 0)
-                    {
-                      $note .= "\n\n";
-                    }
-
-                    $note .= $pNode->nodeValue;
-                  }
-                }
-
-                if (strlen($note) > 0)
-                {
-                  $currentObject->importEadNote(array('note' => $note, 'noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID));
-                }
-              }
-
-              // TODO: Add more child node processing, for <note> <head> etc.
-            }
-
-            break;
-
           case 'flocat':
           case 'digital_object':
             $resources = array();

--- a/lib/task/digitalObjectRegenDerivativesTask.class.php
+++ b/lib/task/digitalObjectRegenDerivativesTask.class.php
@@ -151,7 +151,7 @@ EOF;
       if ($options['index'])
       {
         // Update index
-        QubitSearch::updateInformationObject($do->informationObject);
+        $do->save();
       }
 
       // Destroy out-of-scope objects
@@ -160,14 +160,11 @@ EOF;
     }
 
     // Warn user to manually update search index
-    if ($options['index'])
+    if (!$options['index'])
     {
-      // Commit batch
-      QubitSearch::getInstance()->getEngine()->commit();
+      $this->logSection('digital object', 'Please update the search index manually to reflect any changes');
     }
-    else
-    {
-      $this->logSection('Done!', 'Please update the search index manually to reflect any changes');
-    }
+
+    $this->logSection('digital object', 'Done!');
   }
 }

--- a/plugins/sfEadPlugin/lib/sfEadPlugin.class.php
+++ b/plugins/sfEadPlugin/lib/sfEadPlugin.class.php
@@ -401,4 +401,22 @@ class sfEadPlugin
     return count($materialTypes) || count($genres) || count($subjects) ||
            count($names) || count($places) || $hasNonCreationActorEvents;
   }
+
+  public function escapePhysDesc($value)
+  {
+    $xml = new DOMDocument;
+    $xml->loadXML('<xml>'.$value.'</xml>');
+
+    $xp = new DOMXPath($xml);
+
+    $nodes = $xp->query('//*[text()]');
+
+    foreach ($nodes as $node)
+    {
+      if (1||$node->nodeType == XML_TEXT_NODE)
+      {
+        printf('%s: %s<br/>', $node->nodeName, $node->nodeValue);
+      }
+    }
+  }
 }

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
@@ -6,11 +6,6 @@
       <?php if (0 < strlen($value = $resource->getTitle(array('cultureFallback' => true)))): ?>
         <titleproper encodinganalog="<?php echo $ead->getMetadataParameter('titleproper') ?>"><?php echo escape_dc(esc_specialchars($value)) ?></titleproper>
       <?php endif; ?>
-      <?php if (0 < count($archivistsNotes = $resource->getNotesByType(array('noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID)))): ?>
-        <?php foreach ($archivistsNotes as $note): ?>
-          <author encodinganalog="<?php echo $ead->getMetadataParameter('author') ?>"><?php echo escape_dc(esc_specialchars($note)) ?></author>
-        <?php endforeach; ?>
-      <?php endif; ?>
     </titlestmt>
     <?php
       // TODO: find out if we need this element as it's not imported by our EAD importer
@@ -256,9 +251,23 @@
   <?php if (0 < strlen($value = $resource->getArchivalHistory(array('cultureFallback' => true)))): ?>
     <custodhist encodinganalog="<?php echo $ead->getMetadataParameter('custodhist') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></custodhist>
   <?php endif; ?>
-  <?php if (0 < strlen($value = $resource->getRevisionHistory(array('cultureFallback' => true)))): ?>
-    <processinfo><p><date><?php echo escape_dc(esc_specialchars($value)) ?></date></p></processinfo>
+
+  <?php $archivistsNotes = $resource->getNotesByType(array('noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID)) ?>
+  <?php if (0 < strlen($value = $resource->getRevisionHistory(array('cultureFallback' => true))) || 0 < count($archivistsNotes)): ?>
+
+    <processinfo>
+      <?php if ($value): ?>
+        <p><date><?php echo escape_dc(esc_specialchars($value)) ?></date></p>
+      <?php endif; ?>
+
+      <?php if (0 < count($archivistsNotes)): ?>
+        <?php foreach ($archivistsNotes as $note): ?>
+          <p><?php echo escape_dc(esc_specialchars($note)) ?></p>
+        <?php endforeach; ?>
+      <?php endif; ?>
+    </processinfo>
   <?php endif; ?>
+
   <?php if (0 < strlen($value = $resource->getLocationOfOriginals(array('cultureFallback' => true)))): ?>
     <originalsloc encodinganalog="<?php echo $ead->getMetadataParameter('originalsloc') ?>"><p><?php echo escape_dc(esc_specialchars($value)) ?></p></originalsloc>
   <?php endif; ?>

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
@@ -93,7 +93,7 @@
 
   <?php if (0 < strlen($value = $$resourceVar->getExtentAndMedium(array('cultureFallback' => true)))): ?>
     <physdesc <?php if (0 < strlen($encoding = $ead->getMetadataParameter('extent'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>>
-        <?php echo escape_dc(esc_specialchars($value)) ?>
+        <?php echo $ead->escapePhysDesc($value) ?>
     </physdesc>
   <?php endif; ?>
 


### PR DESCRIPTION
Couple points:
`- Technically having #PCDATA (aka text straight in the tag like <processinfo>hi</processinfo> instead of inside <p> and <date> sub-tags) is illegal, so we no longer support that. I remove the hacky code in QubitXmlImport that was taking all the <p> tags and appending them together. From now on, each <processinfo><p> tag will be its own archivist's note.`
`- In indexSuccessBody.xml.php, with the count($archivistsNotes = ...) convention being used, for some reason $archivistsNotes was always returning null when I tried it that way, so I had to do the assignment on its own line. I have no idea why it didn't work in that case.`
