### PR TITLE
Fix creators edit in ISAD and DACS, refs #8489

### DIFF
--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/actions/eventComponent.class.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/actions/eventComponent.class.php
@@ -111,7 +111,8 @@ class sfIsadPluginEventComponent extends InformationObjectEventComponent
     }
 
     // Delete the old events if they don't appear in the table (removed by multiRow.js)
-    foreach ($this->resource->events as $item)
+    // Check date events as they are the only ones added in this table
+    foreach ($this->resource->getDates() as $item)
     {
       if (isset($item->id) && false === array_search($item->id, $finalEventIds))
       {


### PR DESCRIPTION
The existing creators were deleted by the event component in those templates
because it was looking in all events to delete the removed rows, but only date
events are added in the event component table
