### PR TITLE
Dev/issue 8563 search export fixes

### DIFF
--- a/apps/qubit/modules/search/actions/exportCsvAction.class.php
+++ b/apps/qubit/modules/search/actions/exportCsvAction.class.php
@@ -32,7 +32,7 @@ class SearchExportCsvAction extends sfAction
       // let user know export has started
       sfContext::getInstance()->getConfiguration()->loadHelpers(array('Url'));
       $jobManageUrl = url_for(array('module' => 'jobs', 'action' => 'browse'));
-      $message = '<strong>Export of published descriptions initiated.</strong> Check <a href="'. $jobManageUrl . '">job management</a> page to download the results when it has completed.';
+      $message = '<strong>Export of descriptions initiated.</strong> Check <a href="'. $jobManageUrl . '">job management</a> page to download the results when it has completed.';
       $this->getUser()->setFlash('notice', $message);
     }
 

--- a/lib/job/arSearchResultExportCsvJob.class.php
+++ b/lib/job/arSearchResultExportCsvJob.class.php
@@ -47,6 +47,9 @@ class arSearchResultExportCsvJob extends arBaseJob
     // Sort by ID so parents can import properly from resulting export file
     $this->search->query->setSort(array('lft' => 'asc'));
 
+    // Increase limit from default
+    $this->search->query->setLimit(1000000000);
+
     // If not using RAD, default to ISAD CSV export format
     if (QubitSetting::getByNameAndScope('informationobject', 'default_template') == 'rad')
     {

--- a/lib/job/arSearchResultExportCsvJob.class.php
+++ b/lib/job/arSearchResultExportCsvJob.class.php
@@ -44,11 +44,6 @@ class arSearchResultExportCsvJob extends arBaseJob
     $this->search = new arElasticSearchPluginQuery();
     $this->addCriteriaBasedOnSearchParameters();
 
-    // Don't show *any* draft info objects
-    $filter = new \Elastica\Filter\Term();
-    $filter->setTerm('publicationStatusId', QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID);
-    $this->search->query->setFilter($filter);
-
     // Sort by ID so parents can import properly from resulting export file
     $this->search->query->setSort(array('lft' => 'asc'));
 


### PR DESCRIPTION
Fixed a couple of issues with CSV export of advanced search results:
- Removed filtering out of drafts
- Set search result limit to 1 billion (as there doesn't seem to be a way to return all in Elastica: https://groups.google.com/forum/#!topic/elastica-php-client/us512h6gv-s)
