### PR TITLE
Add date range query in adv. search, refs #8648

### DIFF
--- a/apps/qubit/modules/search/templates/_searchFields.php
+++ b/apps/qubit/modules/search/templates/_searchFields.php
@@ -2,9 +2,9 @@
 
   <p><?php echo __('Narrow down your search results.') ?></p>
 
-  <?php if (isset($criterias)): ?>
+  <?php if (isset($criteria)): ?>
 
-    <?php foreach ($criterias as $key => $item): ?>
+    <?php foreach ($criteria as $key => $item): ?>
 
       <div class="criteria">
 

--- a/apps/qubit/modules/search/templates/advancedSuccess.php
+++ b/apps/qubit/modules/search/templates/advancedSuccess.php
@@ -4,7 +4,7 @@
 
   <section id="advanced-search-filters">
 
-    <h4><?php echo __('Search filters') ?></h4>
+    <h3><?php echo __('Search filters') ?></h3>
 
     <div class="filter">
       <?php if (sfConfig::get('app_multi_repository')): ?>
@@ -43,6 +43,19 @@
     <div class="filter">
       <?php echo $form->c
         ->label(__('Copyright status'))
+        ->renderRow() ?>
+    </div>
+
+    <h3><?php echo __('Date range') ?></h3>
+
+    <div class="filter">
+      <?php echo $form->sd
+        ->label(__('Start'))
+        ->renderRow() ?>
+    </div>
+    <div class="filter">
+      <?php echo $form->ed
+        ->label(__('End'))
         ->renderRow() ?>
     </div>
 
@@ -88,7 +101,7 @@
   </div>
 <?php endif; ?>
 
-<?php echo get_partial('search/searchFields', array('criterias' => $criterias, 'template' => $template)) ?>
+<?php echo get_partial('search/searchFields', array('criteria' => $criteria, 'template' => $template)) ?>
 
 <section class="actions">
   <input type="submit" class="c-btn c-btn-submit" value="<?php echo __('Search') ?>"/>

--- a/js/advancedSearch.js
+++ b/js/advancedSearch.js
@@ -1,32 +1,25 @@
-// This function will attach datepickers to the date
-// range text fields in the advanced search form.
-
-jQuery(document).ready(function() {
-  var opts = {
-    changeYear: true,
-    changeMonth: true,
-    yearRange: "-70:+70",
-    dateFormat: "yymmdd",
-    defaultDate: new Date(1950, 0, 1),
-    constrainInput: false
-  };
-
-  function normalizeDateString()
+(function ($)
   {
-    this.value = jQuery.trim(this.value);
-    this.value = this.value.replace(/\//g, '');
-    this.value = this.value.replace(/-/g, '');
+    Drupal.behaviors.dateRangeDatepicker = {
+      attach: function (context)
+        {
+          var opts = {
+            changeYear: true,
+            changeMonth: true,
+            yearRange: '-100:+100',
+            dateFormat: 'yy-mm-dd',
+            defaultDate: new Date(),
+            constrainInput: false,
+            beforeShow: function (input, instance) {
+              var top  = $(this).offset().top + $(this).outerHeight();
+              setTimeout(function() {
+                instance.dpDiv.css({
+                  'top' : top,
+                });
+              }, 1);
+            }
+          };
 
-    if (this.value.match(/^\d{4}$/) !== null)
-    {
-      this.value = this.value + '01';
-    }
-    if (this.value.match(/^\d{6}$/) !== null)
-    {
-      this.value = this.value + '01';
-    }
-  }
-
-  jQuery("#startDate").focus(normalizeDateString).datepicker(opts);
-  jQuery("#endDate").focus(normalizeDateString).datepicker(opts);
-});
+          jQuery('#sd, #ed').datepicker(opts);
+        }};
+  })(jQuery);

--- a/lib/job/arSearchResultExportCsvJob.class.php
+++ b/lib/job/arSearchResultExportCsvJob.class.php
@@ -96,19 +96,25 @@ class arSearchResultExportCsvJob extends arBaseJob
   protected function addCriteriaBasedOnSearchParameters()
   {
     // Add criteria for main search fields
-    if (null !== $criterias = $this->parseQuery())
+    if (null !== $criteria = $this->parseQuery())
     {
-      $this->search->queryBool->addMust($criterias);
+      $this->search->queryBool->addMust($criteria);
     }
 
-    // Add criteria fo secondary search fields
+    // Add criteria for secondary search fields
     foreach (SearchAdvancedAction::$NAMES as $name)
     {
       if (!empty($this->searchParams[$name])
-        && (null !== $criterias = SearchAdvancedAction::fieldCriteria($name, $this->searchParams[$name])))
+        && (null !== $criteria = SearchAdvancedAction::fieldCriteria($name, $this->searchParams[$name])))
       {
-        $this->search->queryBool->addMust($criterias);
+        $this->search->queryBool->addMust($criteria);
       }
+    }
+
+    // Add criteria for date range
+    if (null !== $criteria = SearchAdvancedAction::getDateRangeQuery($this->searchParams['sd'], $this->searchParams['ed']))
+    {
+      $this->search->queryBool->addMust($criteria);
     }
 
     // Set query if criteria were added

--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -52,6 +52,7 @@ mapping:
       i18n: true
       nested_only: true
     dynamic: strict
+    type: nested
     properties:
       start_date: { type: date, include_in_all: false }
       end_date: { type: date, include_in_all: false }
@@ -68,6 +69,29 @@ mapping:
     dynamic: true
     properties:
       slug: { type: string, index: not_analyzed }
+
+  basis_right:
+    _attributes:
+      nested_only: true
+    dynamic: strict
+    properties:
+      basis: { type: string, index: analyzed, include_in_all: false }
+      start_date: { type: date, index: not_analyzed, include_in_all: false }
+      end_date: { type: date, index: not_analyzed, include_in_all: false }
+      copyright_status: { type: string, index: analyzed, include_in_all: false }
+      rights_holder: { type: string, index: analyzed, include_in_all: false }
+      rights_note: { type: string, index: analyzed, include_in_all: false }
+      license_terms: { type: string, index: analyzed, include_in_all: false }
+
+  act_right:
+    _attributes:
+      nested_only: true
+    dynamic: strict
+    properties:
+      act: { type: string, index: analyzed, include_in_all: false }
+      restriction: { type: string, index: analyzed, include_in_all: false }
+      start_date: { type: date, index: not_analyzed, include_in_all: false }
+      end_date: { type: date, index: not_analyzed, include_in_all: false }
 
   mediainfo_track:
     _attributes:
@@ -274,29 +298,6 @@ mapping:
       size_on_disk: { type: long, index: not_analyzed, include_in_all: false }
       digital_object_count: { type: integer, index: not_analyzed, include_in_all: false }
       created_at: { type: date, index: not_analyzed, include_in_all: false }
-
-  basis_right:
-    _attributes:
-      nested_only: true
-    dynamic: strict
-    properties:
-      basis: { type: string, index: analyzed, include_in_all: false }
-      start_date: { type: date, index: not_analyzed, include_in_all: false }
-      end_date: { type: date, index: not_analyzed, include_in_all: false }
-      copyright_status: { type: string, index: analyzed, include_in_all: false }
-      rights_holder: { type: string, index: analyzed, include_in_all: false }
-      rights_note: { type: string, index: analyzed, include_in_all: false }
-      license_terms: { type: string, index: analyzed, include_in_all: false }
-
-  act_right:
-    _attributes:
-      nested_only: true
-    dynamic: strict
-    properties:
-      act: { type: string, index: analyzed, include_in_all: false }
-      restriction: { type: string, index: analyzed, include_in_all: false }
-      start_date: { type: date, index: not_analyzed, include_in_all: false }
-      end_date: { type: date, index: not_analyzed, include_in_all: false }
 
   term:
     _attributes:

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchEvent.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchEvent.class.php
@@ -25,13 +25,13 @@ class arElasticSearchEvent extends arElasticSearchModelBase
 
     if (isset($event->start_date))
     {
-      $serialized['startDate'] = arElasticSearchPluginUtil::convertDate($event->start_date);
+      $serialized['startDate'] = arElasticSearchPluginUtil::normalizeDateWithoutMonthOrYear($event->start_date);
       $serialized['startDateString'] = Qubit::renderDate($event->start_date);
     }
 
     if (isset($event->end_date))
     {
-     $serialized['endDate'] = arElasticSearchPluginUtil::convertDate($event->end_date);
+     $serialized['endDate'] = arElasticSearchPluginUtil::normalizeDateWithoutMonthOrYear($event->end_date, true);
      $serialized['endDateString'] = Qubit::renderDate($event->end_date);
     }
 


### PR DESCRIPTION
- Uses Drupal jQuery datepicker and Symfony validation
- Make events nested type objects in the ES index to allow
  querying over the start and end dates from the same event
- Fix datepicker position to avoid overlapping the input field
- Included date range query in arSearchResultExportCsvJob
- Normalize event dates without month or day in the ES index
- Don't throw exception if adv. search form is not valid
