### PR TITLE
Allow slugs to be gen'd by title or ref code #8638

### DIFF
--- a/apps/qubit/modules/settings/actions/globalAction.class.php
+++ b/apps/qubit/modules/settings/actions/globalAction.class.php
@@ -89,6 +89,8 @@ class SettingsGlobalAction extends sfAction
     $showTooltips = QubitSetting::getByName('show_tooltips');
     $defaultPubStatus = QubitSetting::getByName('defaultPubStatus');
     $swordDepositDir = QubitSetting::getByName('sword_deposit_dir');
+    $slugTypeInformationObject = QubitSetting::getByName('slug_basis_informationobject');
+
 
     // Set defaults for global form
     $this->globalForm->setDefaults(array(
@@ -108,6 +110,7 @@ class SettingsGlobalAction extends sfAction
       'multi_repository' => (isset($multiRepository)) ? intval($multiRepository->getValue(array('sourceCulture'=>true))) : 1,
       'repository_quota' => (isset($repositoryQuota)) ? $repositoryQuota->getValue(array('sourceCulture'=>true)) : 0,
       'explode_multipage_files' => (isset($explodeMultipageFiles)) ? intval($explodeMultipageFiles->getValue(array('sourceCulture'=>true))) : 1,
+      'slug_basis_informationobject' => (isset($slugTypeInformationObject)) ? intval($slugTypeInformationObject->getValue(array('sourceCulture'=>true))) : QubitSlug::SLUG_BASIS_TITLE,
       'show_tooltips' => (isset($showTooltips)) ? intval($showTooltips->getValue(array('sourceCulture'=>true))) : 1,
       'defaultPubStatus' => (isset($defaultPubStatus)) ? $defaultPubStatus->getValue(array('sourceCulture'=>true)) : QubitTerm::PUBLICATION_STATUS_DRAFT_ID,
       'sword_deposit_dir' => (isset($swordDepositDir)) ? $swordDepositDir->getValue(array('sourceCulture'=>true)) : null
@@ -291,6 +294,15 @@ class SettingsGlobalAction extends sfAction
 
       // Force sourceCulture update to prevent discrepency in settings between cultures
       $setting->setValue($explodeMultipageFiles, array('sourceCulture' => true));
+      $setting->save();
+    }
+
+    if (null !== $slugTypeInformationObject = $thisForm->getValue('slug_basis_informationobject'))
+    {
+      $setting = QubitSetting::getByName('slug_basis_informationobject');
+
+      // Force sourceCulture update to prevent discrepency in settings between cultures
+      $setting->setValue($slugTypeInformationObject, array('sourceCulture' => true));
       $setting->save();
     }
 

--- a/lib/form/SettingsGlobalForm.class.php
+++ b/lib/form/SettingsGlobalForm.class.php
@@ -57,6 +57,7 @@ class SettingsGlobalForm extends sfForm
       'upload_quota' => new arWidgetFormUploadQuota,
       'explode_multipage_files' => new sfWidgetFormSelectRadio(array('choices'=>array(1=>'yes', 0=>'no')), array('class'=>'radio')),
       'show_tooltips' => new sfWidgetFormSelectRadio(array('choices'=>array(1=>'yes', 0=>'no')), array('class'=>'radio')),
+      'slug_basis_informationobject' => new sfWidgetFormSelectRadio(array('choices'=>array(QubitSlug::SLUG_BASIS_TITLE=>'title', QubitSlug::SLUG_BASIS_REFERENCE_CODE=>'reference code')), array('class'=>'radio')),
       'defaultPubStatus' => new sfWidgetFormSelectRadio(array('choices'=>array(QubitTerm::PUBLICATION_STATUS_DRAFT_ID=>$i18n->__('Draft'), QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID=>$i18n->__('Published'))), array('class'=>'radio')),
       'sword_deposit_dir' => new sfWidgetFormInput
     ));
@@ -84,6 +85,7 @@ class SettingsGlobalForm extends sfForm
       'defaultPubStatus' => $i18n->__('Default publication status'),
       'sword_deposit_dir' => $i18n->__('SWORD deposit directory'),
       'require_ssl_admin' => $i18n->__('Require SSL for all administrator funcionality'),
+      'slug_basis_informationobject' => $i18n->__('Generate description permalinks from'),
       'require_strong_passwords' => $i18n->__('Require strong passwords')
     ));
 
@@ -101,7 +103,8 @@ class SettingsGlobalForm extends sfForm
       'sort_treeview_informationobject' => $i18n->__('Determines whether to sort siblings in the information object treeview control and, if so, what sort criteria to use'),
       'multi_repository' => $i18n->__('When set to &quot;no&quot;, the repository name is excluded from certain displays because it will be too repetitive'),
       'repository_quota' => $i18n->__('Default %1% upload limit for a new %2%.  A value of &quot;0&quot; (zero) disables file upload.  A value of &quot;-1&quot; allows unlimited uploads', array('%1%' => strtolower(sfConfig::get('app_ui_label_digitalobject')), '%2%' => strtolower(sfConfig::get('app_ui_label_repository')))),
-      'defaultPubStatus' => $i18n->__('Default publication status for newly created or imported %1%', array('%1%' => sfConfig::get('app_ui_label_informationobject')))
+      'defaultPubStatus' => $i18n->__('Default publication status for newly created or imported %1%', array('%1%' => sfConfig::get('app_ui_label_informationobject'))),
+      'slug_basis_informationobject' => $i18n->__('Choose whether permalinks for descriptions are generated from reference code or title'),
       // 'explode_multipage_files' => $i18n->__('')
       // 'show_tooltips' => $i18n->__('')
       // 'sword_deposit_dir' => $i18n->__('')
@@ -147,6 +150,7 @@ class SettingsGlobalForm extends sfForm
     $this->validatorSchema['sort_browser_anonymous'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['multi_repository'] = new sfValidatorInteger(array('required' => false));
     $this->validatorSchema['default_repository_browse_view'] = new sfValidatorString(array('required' => false));
+    $this->validatorSchema['slug_basis_informationobject'] = new sfValidatorChoice(array('choices' => array(QubitSlug::SLUG_BASIS_REFERENCE_CODE, QubitSlug::SLUG_BASIS_TITLE)));
 
     $this->validatorSchema['repository_quota'] = new sfValidatorNumber(
       array('required' => true, 'min' => -1),

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -115,42 +115,7 @@ class QubitInformationObject extends BaseInformationObject
 
         if (sfConfig::get('app_inherit_code_informationobject'))
         {
-          if (!isset($this->identifier))
-          {
-            return;
-          }
-
-          $identifier = array();
-          $repository = null;
-          foreach ($this->ancestors->andSelf()->orderBy('lft') as $item)
-          {
-            if (isset($item->identifier))
-            {
-              $identifier[] = $item->identifier;
-            }
-
-            if (isset($item->repository))
-            {
-              $repository = $item->repository;
-            }
-          }
-          $identifier = implode(sfConfig::get('app_separator_character', '-'), $identifier);
-
-          if (isset($repository->identifier))
-          {
-            $identifier = "$repository->identifier $identifier";
-          }
-
-          if (isset($repository))
-          {
-            $countryCode = $repository->getCountryCode();
-            if (isset($countryCode))
-            {
-              $identifier = "$countryCode $identifier";
-            }
-          }
-
-          return $identifier;
+          return $this->getInheritedReferenceCode();
         }
 
         return $this->identifier;
@@ -230,7 +195,7 @@ class QubitInformationObject extends BaseInformationObject
   {
     if (!isset($this->slug))
     {
-      $this->slug = QubitSlug::slugify($this->__get('title', array('sourceCulture' => true)));
+      $this->slug = $this->generateSlug();
     }
 
     return parent::insert($connection);
@@ -2912,5 +2877,78 @@ class QubitInformationObject extends BaseInformationObject
   public function getCleanExtentAndMedium($options = array())
   {
     return strip_tags($this->getExtentAndMedium($options));
+  }
+
+  /**
+   * Generate a slug for this information object. This might be based
+   * on title, identifier (reference code), or other properties in the future.
+   *
+   * @return string  The generated slug.
+   */
+  private function generateSlug()
+  {
+    switch ((int)QubitSetting::getByName('slug_basis_informationobject'))
+    {
+      case QubitSlug::SLUG_BASIS_REFERENCE_CODE:
+        return QubitSlug::slugify($this->getInheritedReferenceCode(), false);
+
+      case QubitSlug::SLUG_BASIS_TITLE:
+      default:
+        return QubitSlug::slugify($this->getTitle(array('sourceCulture' => true)), false);
+    }
+  }
+
+  /**
+   * Return this information object's full, inherited reference code.
+   *
+   * @return string
+   */
+  public function getInheritedReferenceCode()
+  {
+    if (!isset($this->identifier))
+    {
+      return;
+    }
+
+    $identifier = array();
+    $repository = null;
+
+    $item = $this;
+
+    // Ascend the hierarchy to build the inherited identifier manually,
+    // as this method may be called before saving and getAncestors() can work.
+    while ($item && $item->id != QubitInformationObject::ROOT_ID)
+    {
+      if (isset($item->identifier))
+      {
+        array_unshift($identifier, $item->identifier);
+      }
+
+      if (isset($item->repository))
+      {
+        $repository = $item->repository;
+      }
+
+      $item = $item->parent;
+    }
+
+    $identifier = implode(sfConfig::get('app_separator_character', '-'), $identifier);
+
+    if (isset($repository->identifier))
+    {
+      $identifier = "$repository->identifier $identifier";
+    }
+
+    if (isset($repository))
+    {
+      $countryCode = $repository->getCountryCode();
+
+      if (isset($countryCode))
+      {
+        $identifier = "$countryCode $identifier";
+      }
+    }
+
+    return $identifier;
   }
 }

--- a/lib/model/QubitSlug.php
+++ b/lib/model/QubitSlug.php
@@ -19,6 +19,10 @@
 
 class QubitSlug extends BaseSlug
 {
+  const
+    SLUG_BASIS_TITLE = 0,
+    SLUG_BASIS_REFERENCE_CODE = 1;
+
   public static function random($length = 12)
   {
     $separator = sfConfig::get('app_separator_character', '-');
@@ -44,7 +48,15 @@ class QubitSlug extends BaseSlug
     return $slug;
   }
 
-  public static function slugify($slug)
+  /**
+   * Slugify a specified string
+   *
+   * @param string $slug  The string we want to slugify
+   *
+   * @param bool $dropArticles  Whether or not to drop English articles from the slug.
+   *                            We can disable this when we generate slugs by identifier.
+   */
+  public static function slugify($slug, $dropArticles = true)
   {
     // Handle exotic characters gracefully
     $slug = iconv('utf-8', 'ascii//TRANSLIT', $slug);
@@ -58,11 +70,15 @@ class QubitSlug extends BaseSlug
     // characters with dash
     $slug = preg_replace('/[^0-9a-z]+/', '-', $slug);
 
-    // Drop (English) articles
     $slug = "-$slug-";
-    $slug = str_replace('-a-', '-', $slug);
-    $slug = str_replace('-an-', '-', $slug);
-    $slug = str_replace('-the-', '-', $slug);
+
+    // Drop (English) articles
+    if ($dropArticles)
+    {
+      $slug = str_replace('-a-', '-', $slug);
+      $slug = str_replace('-an-', '-', $slug);
+      $slug = str_replace('-the-', '-', $slug);
+    }
 
     $slug = trim($slug, '-');
 

--- a/lib/task/migrate/migrations/arMigration0131.class.php
+++ b/lib/task/migrate/migrations/arMigration0131.class.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add setting for slug type (generate slugs from title or ref code)
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0131
+{
+  const
+    VERSION = 131, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  /**
+   * Upgrade
+   *
+   * @return bool True if the upgrade succeeded, False otherwise
+   */
+  public function up($configuration)
+  {
+    $setting = new QubitSetting;
+    $setting->name = 'slug_basis_informationobject';
+    $setting->value = QubitSlug::SLUG_BASIS_TITLE;
+    $setting->culture = 'en';
+    $setting->save();
+
+    return true;
+  }
+}


### PR DESCRIPTION
Add option for user to set whether we generated slugs for information objects based on their title or reference code.

Also take this new setting into account when using the propel:generate-slugs task.
