### PR TITLE
ElasticSearch map issue workaround. refs #8744

### DIFF
--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -12,7 +12,10 @@ mapping:
 
   # Other notes:
   # - Field names are camelized
-  # - Objects can be embedded using _foreign_types
+  # - Objects can be embedded using _foreign_types, allowing hierarchal data within a document:
+  #   note that if a "child" type itself embeds other types then the "child" type must be defined
+  #   in this file before the "parent" type or the ElasticSearch mapping won't be properly set
+  #   and indexing errors may result
   # - Objects can be embedded using _patial_foreign_types, specifying properties and i18n fields
   # - The other matters, embedded types must be defined first
 
@@ -313,18 +316,6 @@ mapping:
       is_protected: { type: boolean, index: not_analyzed, include_in_all: false }
       number_of_descendants: { type: integer, index: not_analyzed, include_in_all: false }
 
-  accession:
-    _attributes:
-      i18n: true
-      timestamp: true
-      rawFields:  [title]
-    _foreign_types: { donors: donor, creators: actor }
-    dynamic: strict
-    properties:
-      slug: { type: string, index: not_analyzed }
-      identifier: { type: string, index: not_analyzed }
-      date: { type: date, include_in_all: false }
-
   actor:
     _attributes:
       i18n: true
@@ -341,6 +332,18 @@ mapping:
       description_identifier: { type:string, index: not_analyzed }
       corporate_body_identifiers: { type: string, index: not_analyzed }
       entity_type_id: { type: integer, index: not_analyzed, include_in_all: false }
+
+  accession:
+    _attributes:
+      i18n: true
+      timestamp: true
+      rawFields:  [title]
+    _foreign_types: { donors: donor, creators: actor }
+    dynamic: strict
+    properties:
+      slug: { type: string, index: not_analyzed }
+      identifier: { type: string, index: not_analyzed }
+      date: { type: date, include_in_all: false }
 
   repository:
     _attributes:


### PR DESCRIPTION
This tweak to the mapping YAML file fixes an issue where ElasticSearch
indexing (via the search:populate task) halts prematurely with an error.

Mapping for each ElasticSearch document type is set, in AtoM, in a
YAML file. In the YAML, a type can have a "_foreign_types" property
set, which allows it to include the mapping of another type defined
in same YAML file. This allows, for example, an "accession" type to
include the properties of the "actor" type as the property "creators".
This allows creator data to be nested within an accession document.

An issue with how we render mapping from YAML is that the expansion of
the "_foreign_types" property is non-recursive. The result of this is
that if a type that has a "_foreign_types" property is included in the
mapping of another type before its own "_foreign_types" have been expanded
then the mapping that's rendered and sent to ElasticSearch will be
incomplete and when AtoM tries to index it will try to put data into
properties that haven't been defined in the mapping and with halt with
an error.

At some point we should make "_foreign_types" expansion recursive
(maybe with a maximum depth to prevent circular references), but the
meantime we can work around this by making sure "child" types (included by
other types) are placed in the mapping YAML file before "parent" types
so the child's "_foreign_types" property will be expanded before it's
included by other types.
