### PR TITLE
Dev/issue 8629 rename dialog fixes

### DIFF
--- a/apps/qubit/modules/informationobject/actions/renameAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/renameAction.class.php
@@ -89,8 +89,20 @@ class InformationObjectRenameAction extends sfAction
       $filename = QubitSlug::slugify($fileParts['filename']) .'.'. QubitSlug::slugify($fileParts['extension']);
 
       $digitalObject = $resource->digitalObjects[0];
+
+      // Rename master file
+      $basePath = sfConfig::get('sf_web_dir') . $digitalObject->path;
+      $oldFilePath = $basePath . DIRECTORY_SEPARATOR . $digitalObject->name;
+      $newFilePath = $basePath . DIRECTORY_SEPARATOR . $filename;
+      rename($oldFilePath, $newFilePath);
+      chmod($newFilePath, 0644);
+
+      // Change name in database
       $digitalObject->name = $filename;
       $digitalObject->save();
+
+      // Regeneraate derivatives
+      digitalObjectRegenDerivativesTask::regenerateDerivatives($digitalObject);
     }
 
     $resource->save();

--- a/apps/qubit/modules/informationobject/actions/renameAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/renameAction.class.php
@@ -84,8 +84,12 @@ class InformationObjectRenameAction extends sfAction
     // Update digital object filename, if requested
     if (isset($postData['filename']) && count($resource->digitalObjects))
     {
+      // Parse filename so special characters can be removed
+      $fileParts = pathinfo(trim($postData['filename']));
+      $filename = QubitSlug::slugify($fileParts['filename']) .'.'. QubitSlug::slugify($fileParts['extension']);
+
       $digitalObject = $resource->digitalObjects[0];
-      $digitalObject->name = $postData['filename'];
+      $digitalObject->name = $filename;
       $digitalObject->save();
     }
 

--- a/apps/qubit/modules/informationobject/actions/slugPreviewAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/slugPreviewAction.class.php
@@ -40,7 +40,7 @@ class InformationObjectSlugPreviewAction extends sfAction
     return $this->renderText(json_encode($response));
   }
 
-  private function determineAvailableSlug($title)
+  public static function determineAvailableSlug($title)
   {
     $originalTitle = $title;
 

--- a/apps/qubit/modules/informationobject/templates/_renameModal.php
+++ b/apps/qubit/modules/informationobject/templates/_renameModal.php
@@ -1,4 +1,5 @@
 <?php $sf_response->addJavaScript('renameModal'); ?>
+<?php $sf_response->addJavaScript('description'); ?>
 
 <div class="modal hide" id="renameModal">
   <div class="modal-header">
@@ -9,10 +10,16 @@
   <form id="renameModalForm" action="<?php echo url_for(array('module' => 'informationobject', 'action' => 'rename', 'slug' => $resource->slug)) ?>" method="POST">
 
   <div class="modal-body">
+    <div class="alert">Use this interface to update the description title, slug (permalink), and/or digital object filename.</div>
+
     <div>
       <div style="float:right"><input id="renameModalEnableTitle" type="checkbox" checked="checked" /> <?php echo __('Update title') ?></div>
       <label><?php echo __('Description title') ?></label>
       <input id="renameModalTitle" name="title" type="text" value="<?php echo $resource->title ?>" />
+      <div class="description">
+        Editing the description title will automatically update the slug
+        field if the "Update slug" checkbox is selected - you can still edit it after.
+      </div>
       <p><?php echo __('Original title') ?>: <em><?php echo $resource->title ?></em></p>
     </div>
 
@@ -20,6 +27,12 @@
       <div style="float:right"><input id="renameModalEnableSlug" type="checkbox" checked="checked" /> <?php echo __('Update slug') ?></div>
       <label><?php echo __('Slug') ?></label>
       <input id="renameModalSlug" name="slug" type="text" value="<?php echo $resource->slug ?>" />
+      <div class="description">
+        Do not use any special characters or spaces in the slug - only lower case
+        alphanumeric characters (a-z, 0-9) and dashes (-) will be saved. Other characters
+        will be stripped out or replaced.
+        Editing the slug or file name will not automaticlly update the other fields.
+      </div>
       <p><?php echo __('Original slug') ?>: <em><?php echo $resource->slug ?></em></p>
     </div>
 

--- a/apps/qubit/modules/informationobject/templates/_renameModal.php
+++ b/apps/qubit/modules/informationobject/templates/_renameModal.php
@@ -31,7 +31,7 @@
         Do not use any special characters or spaces in the slug - only lower case
         alphanumeric characters (a-z, 0-9) and dashes (-) will be saved. Other characters
         will be stripped out or replaced.
-        Editing the slug or file name will not automaticlly update the other fields.
+        Editing the slug will not automatically update the other fields.
       </div>
       <p><?php echo __('Original slug') ?>: <em><?php echo $resource->slug ?></em></p>
     </div>
@@ -41,6 +41,12 @@
       <div style="float:right"><input id="renameModalEnableFilename" type="checkbox" /> <?php echo __('Update filename') ?></div>
       <label><?php echo __('File name') ?></label>
       <input id="renameModalFilename" name="filename" type="text" value="<?php echo $resource->digitalObjects[0]->name ?>" />
+      <div class="description">
+        Do not use any special characters or spaces in the filename - only lower case
+        alphanumeric characters (a-z, 0-9) and dashes (-) will be saved. Other characters
+        will be stripped out or replaced.
+        Editing the filename will not automatically update the other fields.
+      </div>
       <p><?php echo __('Original filename') ?>: <em><?php echo $resource->digitalObjects[0]->name ?></em></p>
     </div>
     <?php endif; ?>

--- a/apps/qubit/modules/informationobject/templates/_renameModal.php
+++ b/apps/qubit/modules/informationobject/templates/_renameModal.php
@@ -10,15 +10,14 @@
   <form id="renameModalForm" action="<?php echo url_for(array('module' => 'informationobject', 'action' => 'rename', 'slug' => $resource->slug)) ?>" method="POST">
 
   <div class="modal-body">
-    <div class="alert">Use this interface to update the description title, slug (permalink), and/or digital object filename.</div>
+    <div class="alert"><?php echo __('Use this interface to update the description title, slug (permalink), and/or digital object filename.') ?></div>
 
     <div>
       <div style="float:right"><input id="renameModalEnableTitle" type="checkbox" checked="checked" /> <?php echo __('Update title') ?></div>
       <label><?php echo __('Description title') ?></label>
       <input id="renameModalTitle" name="title" type="text" value="<?php echo $resource->title ?>" />
       <div class="description">
-        Editing the description title will automatically update the slug
-        field if the "Update slug" checkbox is selected - you can still edit it after.
+        <?php echo __('Editing the description title will automatically update the slug field if the "Update slug" checkbox is selected - you can still edit it after.') ?>
       </div>
       <p><?php echo __('Original title') ?>: <em><?php echo $resource->title ?></em></p>
     </div>
@@ -27,12 +26,7 @@
       <div style="float:right"><input id="renameModalEnableSlug" type="checkbox" checked="checked" /> <?php echo __('Update slug') ?></div>
       <label><?php echo __('Slug') ?></label>
       <input id="renameModalSlug" name="slug" type="text" value="<?php echo $resource->slug ?>" />
-      <div class="description">
-        Do not use any special characters or spaces in the slug - only lower case
-        alphanumeric characters (a-z, 0-9) and dashes (-) will be saved. Other characters
-        will be stripped out or replaced.
-        Editing the slug will not automatically update the other fields.
-      </div>
+      <div class="description"><?php echo __('Do not use any special characters or spaces in the slug - only lower case alphanumeric characters (a-z, 0-9) and dashes (-) will be saved. Other characters will be stripped out or replaced. Editing the slug will not automatically update the other fields.') ?></div>
       <p><?php echo __('Original slug') ?>: <em><?php echo $resource->slug ?></em></p>
     </div>
 
@@ -41,12 +35,7 @@
       <div style="float:right"><input id="renameModalEnableFilename" type="checkbox" /> <?php echo __('Update filename') ?></div>
       <label><?php echo __('File name') ?></label>
       <input id="renameModalFilename" name="filename" type="text" value="<?php echo $resource->digitalObjects[0]->name ?>" />
-      <div class="description">
-        Do not use any special characters or spaces in the filename - only lower case
-        alphanumeric characters (a-z, 0-9) and dashes (-) will be saved. Other characters
-        will be stripped out or replaced.
-        Editing the filename will not automatically update the other fields.
-      </div>
+      <div class="description"><?php echo __('Do not use any special characters or spaces in the filename - only lower case alphanumeric characters (a-z, 0-9) and dashes (-) will be saved. Other characters will be stripped out or replaced. Editing the filename will not automatically update the other fields.') ?></div>
       <p><?php echo __('Original filename') ?>: <em><?php echo $resource->digitalObjects[0]->name ?></em></p>
     </div>
     <?php endif; ?>

--- a/js/description.js
+++ b/js/description.js
@@ -15,6 +15,13 @@
 
                 // Specific case for tooltips in YUI dialogs
                 var $dialog = $this.closest('div.yui-panel');
+
+                // If no YUI dialogs found, look for Bootstrap dialogs
+                if (!$dialog.length)
+                {
+                  var $dialog = $this.closest('div.modal');
+                }
+
                 if ($dialog.length)
                 {
                   var positionateDialog = function()
@@ -87,6 +94,7 @@
                   .hide();
 
                 $('div.yui-panel > .description-dialog').remove();
+                $('div.modal > .description-dialog').remove();
               });
         } };
   })(jQuery);

--- a/lib/task/digitalobject/digitalObjectRegenDerivativesTask.class.php
+++ b/lib/task/digitalobject/digitalObjectRegenDerivativesTask.class.php
@@ -147,32 +147,7 @@ EOF;
       $this->logSection('digital object', sprintf('Regenerating derivatives for %s... (%ss)',
         $do->name, $timer->elapsed()));
 
-      // Delete existing derivatives
-      foreach ($do->descendants as $derivative)
-      {
-        $derivative->delete();
-      }
-
-      // Delete existing transcripts
-      foreach ($do->propertys as $property)
-      {
-        if ('transcript' == $property->name)
-        {
-          $property->delete();
-        }
-      }
-
-      $do->createRepresentations(QubitTerm::MASTER_ID, $conn);
-
-      if ($options['index'])
-      {
-        // Update index
-        $do->save();
-      }
-
-      // Destroy out-of-scope objects
-      QubitDigitalObject::clearCache();
-      QubitInformationObject::clearCache();
+      digitalObjectRegenDerivativesTask::regenerateDerivatives($do);
     }
 
     // Warn user to manually update search index
@@ -182,5 +157,35 @@ EOF;
     }
 
     $this->logSection('digital object', 'Done!');
+  }
+
+  public static function regenerateDerivatives(&$digitalObject)
+  {
+    // Delete existing derivatives
+    foreach ($digitalObject->descendants as $derivative)
+    {
+      $derivative->delete();
+    }
+
+    // Delete existing transcripts
+    foreach ($digitalObject->propertys as $property)
+    {
+      if ('transcript' == $property->name)
+      {
+        $property->delete();
+      }
+    }
+
+    $digitalObject->createRepresentations(QubitTerm::MASTER_ID, $conn);
+
+    if ($options['index'])
+    {
+      // Update index
+      $digitalObject->save();
+    }
+
+    // Destroy out-of-scope objects
+    QubitDigitalObject::clearCache();
+    QubitInformationObject::clearCache();
   }
 }


### PR DESCRIPTION
Fixes and improvements to rename modal:
- Added ability to add tooltips to Bootstrap modals
- Added tooltips to rename modal
- Added notification if submitted slug had to be modified
- Added removal of special characters from filenames
