### PR TITLE
WIP: New access statements per basis, refs #8887

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/showComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/showComponent.class.php
@@ -105,20 +105,10 @@ class DigitalObjectShowComponent extends sfComponent
     $curInfoObjectId = $this->resource->informationObject->id;
     $denyReason = '';
 
-    $conditionalWarning = QubitSetting::getByName('access_conditional_warning');
-    $deniedWarning = QubitSetting::getByName('access_disallow_warning');
-
     if (!QubitGrantedRight::checkPremis($curInfoObjectId, 'readReference', $denyReason) ||
         !QubitAcl::check($this->resource->informationObject, 'readReference'))
     {
-      if ($denyReason === 'conditional')
-      {
-        return $conditionalWarning ? $conditionalWarning->getValue() : '';
-      }
-      else
-      {
-        return $deniedWarning ? $deniedWarning->getValue() : '';
-      }
+      return $denyReason;
     }
 
     return false;

--- a/apps/qubit/modules/digitalobject/templates/viewCopyrightStatementSuccess.php
+++ b/apps/qubit/modules/digitalobject/templates/viewCopyrightStatementSuccess.php
@@ -1,7 +1,15 @@
 <?php decorate_with('layout_1col') ?>
 
 <?php slot('title') ?>
+
+  <?php if (isset($preview)): ?>
+    <div class="copyright-statement-preview alert alert-info">
+      <?php echo __('Copyright statement preview') ?>
+    </div>
+  <?php endif; ?>
+
   <h1><?php echo render_title($resource->getTitle(array('cultureFallback' => true))) ?></h1>
+
 <?php end_slot() ?>
 
 <div class="page">
@@ -16,7 +24,12 @@
   <form method="post">
     <section class="actions">
       <ul>
-        <li><button class="c-btn c-btn-submit" type="submit"><?php echo __('Agree') ?></button></li>
+        <?php if (isset($preview)): ?>
+          <li><button class="c-btn c-btn-submit" type="submit" disabled="disabled"><?php echo __('Agree') ?></button></li>
+          <li><a class="c-btn" href="javascript:window.close();"><?php echo __('Close') ?></a>
+        <?php else: ?>
+          <li><button class="c-btn c-btn-submit" type="submit"><?php echo __('Agree') ?></button></li>
+        <?php endif; ?>
       </ul>
     </section>
   </form>

--- a/apps/qubit/modules/settings/actions/permissionsAction.class.php
+++ b/apps/qubit/modules/settings/actions/permissionsAction.class.php
@@ -45,6 +45,24 @@ class SettingsPermissionsAction extends sfAction
     // Handle POST data (form submit)
     if ($request->isMethod('post'))
     {
+      // Give the user the ability to preview the copyright statement before
+      // we persist the changes. We are reusing the viewCopyrightStatement
+      // template, populating the properties that are needed.
+      if ($request->hasParameter('preview'))
+      {
+        $this->setTemplate('viewCopyrightStatement', 'digitalobject');
+
+        $this->preview = true;
+        $this->resource = new QubitInformationObject;
+
+        $this->permissionsCopyrightStatementForm->bind($request->getPostParameters());
+        $statement = $this->permissionsCopyrightStatementForm->getValue('copyrightStatement');
+        $statement = QubitHtmlPurifier::getInstance()->purify($statement);
+        $this->copyrightStatement = $this->permissionsCopyrightStatementForm->getValue('copyrightStatement');
+
+        return sfView::SUCCESS;
+      }
+
       QubitCache::getInstance()->removePattern('settings:i18n:*');
 
       // PREMIS access permissions

--- a/apps/qubit/modules/settings/templates/permissionsSuccess.php
+++ b/apps/qubit/modules/settings/templates/permissionsSuccess.php
@@ -131,6 +131,8 @@
           ->label(__('Copyright statement'))
           ->renderRow() ?>
 
+        <input class="btn" type="submit" name="preview" value="<?php echo __('Preview') ?>"/>
+
       </fieldset>
 
     </div>

--- a/apps/qubit/modules/settings/templates/permissionsSuccess.php
+++ b/apps/qubit/modules/settings/templates/permissionsSuccess.php
@@ -114,6 +114,34 @@
 
       </fieldset>
 
+      <fieldset class="collapsible" id="premisAccessStatementsArea">
+
+        <legend><?php echo __('PREMIS access statements') ?></legend>
+
+        <div class="tabbable tabs-left">
+          <ul class="nav nav-tabs">
+            <?php foreach ($basis as $basisSlug => $basisName): ?>
+              <li><a href="<?php echo "#tab{$basisSlug}" ?>" data-toggle="tab"><?php echo $basisName ?></a></li>
+            <?php endforeach; ?>
+          </ul>
+          <div class="tab-content">
+            <?php $settings = $permissionsAccessStatementsForm->getSettings() ?>
+            <?php foreach ($basis as $basisSlug => $basisName): ?>
+              <div class="tab-pane" id="<?php echo "tab{$basisSlug}" ?>">
+                <?php $name = "{$basisSlug}_disallow" ?>
+                <?php $field = $permissionsAccessStatementsForm[$name] ?>
+                <?php echo render_field($field->label(__('Disallow statement')), $settings[$name], array('name' => 'value')) ?>
+
+                <?php $name = "{$basisSlug}_conditional" ?>
+                <?php $field = $permissionsAccessStatementsForm[$name] ?>
+                <?php echo render_field($field->label(__('Conditional statement')), $settings[$name], array('name' => 'value')) ?>
+              </div>
+            <?php endforeach; ?>
+          </div>
+        </div>
+
+      </fieldset>
+
       <fieldset class="collapsible" id="copyrightStatementArea">
 
         <legend><?php echo __('Copyright statement') ?></legend>

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 135
+    value: 136
   milestone:
     name: milestone
     editable: 0
@@ -630,39 +630,6 @@ QubitSetting:
       sr: 'Сузи резултате по:'
       vi: 'Thu hẹp kết quả của bạn bằng cách'
       zh: '通过 减少结果'
-  QubitSetting_access_disallow_warning:
-    name: access_disallow_warning
-    scope: ui_label
-    editable: 1
-    deleteable: 0
-    source_culture: en
-    value:
-      de: 'Der Zugang zu diesen Unterlagen ist beschränkt, da sie personenbezogene oder vertrauliche Informationen enthalten. Bitte nehmen Sie Kontakt mit dem zuständigen Archivar auf, um mehr Informationen über die Nutzung dieser Unterlagen zu erhalten.'
-      en: 'Access to this record is restricted because it contains personal or confidential information. Please contact the Reference Archivist for more information on accessing this record.'
-      es: 'El acceso a este registro está restringido, ya que contiene información personal o confidencial. Por favor, póngase en contacto con el Archivero de referencia para obtener más información sobre cómo acceder a este registro.'
-      fr: 'L''accès à ce dossier est limité car il contient des informations personnelles ou confidentielles. S''il vous plaît, communiquer avec l''archiviste pour plus d''informations sur l''accès à ce dossier.'
-      hu: 'Nincsen hozzáférése ehhez a dokumentumhoz mert személyes vagy bizalmas információt tartalmaz. Az dokumentumhoz való hozzáféréssel kapcsolatban kérjük, lépjen kapcsolatba az ajánlott levéltárossal!'
-      ko: '이 레코드는 개인 정보 또는 비밀 정보를 담고있기 때문에 접근이 제한됩니다. 이 레코드에 접근하려면 참조 기록관리인와 상의하세요.'
-      pt: 'O acesso a este registo é restrito porque contem informação pessoal ou confidencial. Por favor contacte o Arquivista responsável para mais informação.'
-      pt-BR: 'O acesso a este registro é restrito por conter informação pessoal ou confidencial. Entre em contato com o Arquivista para obter maiores informações sobre como ter acesso a esse registro.'
-      sl: 'Dostop do dokumentacije je omejen, ker vsebuje osebne ali zaupne informacije. Prosimo, obrnite se na arhivarja in pridobite več informacij o dostopu.'
-      sr: 'Приступ овом документу је ограничен јер садржи личне или поверљиве информације. Молимо вас контактирајте архивисту информатора за више информација.'
-      zh: '该记录包含个人或机密信息, 其检索受限制. 如果需要更多有关检索该记录的信息, 请与档案馆员联系.'
-  QubitSetting_access_conditional_warning:
-    name: access_conditional_warning
-    scope: ui_label
-    editable: 1
-    deleteable: 0
-    source_culture: en
-    value:
-      en: 'This record has not yet been reviewed for personal or confidential information. Please contact the Reference Archivist to request access and initiate an access review.'
-      fr: 'Cet enregistrement n''a pas encore fait l''objet d''une vérification pour les informations personnelles ou confidentielles. S''il vous plaît communiquer avec l''archiviste de référence pour demander l''accès et procéder à une vérification.'
-      hu: 'Ez az irat még nem volt felülvizsgálva személyes vagy bizalmas információk szempontjából. Lépjen kapcsolatba az ajánlott levéltárossal, hogy hozzáférést kérjen és elinduljon a hozzáférési vizsgálat.'
-      pt: 'Este registo ainda não foi revisto para obter informações pessoais ou confidenciais. Por favor contacte o Arquivista em referência para solicitar o acesso e começar uma revisão de acesso.'
-      pt-BR: 'Este registro ainda não foi revisado como informações pessoais ou confidenciais. Entre em contato com o Arquivista para solicitar acesso e iniciar um reexame deste.'
-      sl: 'Ni še ugotovljeno, ali zapis vsebuje osebne ali zaupne podatke. Prosimo, obrnite se na arhivarja in zaprosite za dostop ali dajte pobudo za preverbo dostopa.'
-      sr: 'Лични и поверљиви подаци у овом документу још нису прегледани. Молимо Вас обратите се архивисти информатору да затражите приступ и покренете оцену приступа.'
-      zh: '该记录由于个人或保密信息尚未被评论. 如需检索并创建首个检索评论, 请联系参考文献员.'
   QubitSetting_genre:
     name: genre
     scope: ui_label

--- a/js/permissionsSettings.js
+++ b/js/permissionsSettings.js
@@ -99,6 +99,18 @@
 
       });
 
+      $('input[name=preview]').click(function (e)
+        {
+          e.preventDefault();
+
+          var $form = $(this).closest('form').attr('target', '_blank');
+          var $input = $('<input/>').attr({'type': 'hidden', 'name': 'preview', 'value': 'true' }).appendTo($form);
+
+          $form.submit();
+          $form.removeAttr('target');
+          $input.remove();
+        });
+
     });
   }
 )(jQuery);

--- a/js/permissionsSettings.js
+++ b/js/permissionsSettings.js
@@ -111,6 +111,10 @@
           $input.remove();
         });
 
+      var $premisAccessStatementsArea = $('#premisAccessStatementsArea');
+      $premisAccessStatementsArea.find('.nav-tabs li:first-child').addClass('active');
+      $premisAccessStatementsArea.find('.tab-content .tab-pane:first-child').addClass('active');
+
     });
   }
 )(jQuery);

--- a/lib/form/SettingsPermissionsAccessStatementsForm.class.php
+++ b/lib/form/SettingsPermissionsAccessStatementsForm.class.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class SettingsPermissionsAccessStatementsForm extends sfForm
+{
+  public function configure()
+  {
+    $this->widgetSchema->setNameFormat('accessStatements[%s]');
+
+    $this->settings = array();
+
+    foreach (QubitTaxonomy::getTermsById(QubitTaxonomy::RIGHT_BASIS_ID) as $item)
+    {
+      foreach (array("{$item->slug}_disallow", "{$item->slug}_conditional") as $name)
+      {
+        $this->setWidget($name, new sfWidgetFormTextarea);
+        $this->setValidator($name, new sfValidatorString);
+
+        $setting = $this->settings[$name] = $this->getSetting($name);
+        if (null !== $setting)
+        {
+          $this->setDefault($name, $setting->getValue());
+        }
+      }
+    }
+  }
+
+  protected function getSetting($name)
+  {
+    return QubitSetting::getByNameAndScope($name, 'access_statement');
+  }
+
+  public function getSettings()
+  {
+    return $this->settings;
+  }
+}

--- a/lib/form/SettingsPermissionsCopyrightStatementForm.class.php
+++ b/lib/form/SettingsPermissionsCopyrightStatementForm.class.php
@@ -21,8 +21,6 @@ class SettingsPermissionsCopyrightStatementForm extends sfForm
 {
   public function configure()
   {
-    $i18n = sfContext::getInstance()->i18n;
-
     $this->getValidatorSchema()->setOption('allow_extra_fields', true);
 
     $this->setWidget('copyrightStatementEnabled', new sfWidgetFormSelectRadio(array('choices'=> array(1 => 'yes', 0 => 'no')), array('class'=>'radio')));

--- a/lib/model/QubitGrantedRight.php
+++ b/lib/model/QubitGrantedRight.php
@@ -111,7 +111,7 @@ class QubitGrantedRight extends BaseGrantedRight
           unset($groupIds[$key]);
           if ($denyReason !== null)
           {
-            $denyReason = $restriction;
+            $denyReason = self::getAccessWarning($basisSlug, $restriction);
           }
         }
 
@@ -120,6 +120,25 @@ class QubitGrantedRight extends BaseGrantedRight
     }
 
     return $groupIds;
+  }
+
+  private static function getAccessWarning($basisSlug, $restriction)
+  {
+    if ($restriction === 'conditional')
+    {
+      $setting = QubitSetting::getByNameAndScope("{$basisSlug}_conditional", 'access_statement');
+    }
+    else
+    {
+      $setting = QubitSetting::getByNameAndScope("{$basisSlug}_disallow", 'access_statement');
+    }
+
+    if ($setting === null)
+    {
+      return false;
+    }
+
+    return $setting->getValue(array('cultureFallback' => true));
   }
 
   /**

--- a/lib/task/migrate/arUpgradeSqlTask.class.php
+++ b/lib/task/migrate/arUpgradeSqlTask.class.php
@@ -201,7 +201,7 @@ EOF;
         if (2 == $class::MIN_MILESTONE && 1 == $previousMilestone && 2 == $currentMilestone)
         {
           // Run migration but don't bump dbversion
-          if (true !== $class::up($this->configuration)) throw new sfException('Failed to apply upgrade '.get_class($class));
+          if (true !== $class->up($this->configuration)) throw new sfException('Failed to apply upgrade '.get_class($class));
         }
       }
       // New upgrades, not applied yet
@@ -211,7 +211,7 @@ EOF;
         if (1 != $previousMilestone || 1 != $currentMilestone)
         {
           // Run migration
-          if (true !== $class::up($this->configuration)) throw new sfException('Failed to apply upgrade '.get_class($class));
+          if (true !== $class->up($this->configuration)) throw new sfException('Failed to apply upgrade '.get_class($class));
           $this->updateDatabaseVersion(++$version);
         }
       }

--- a/lib/task/migrate/migrations/arMigration0136.class.php
+++ b/lib/task/migrate/migrations/arMigration0136.class.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Update access statements
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0136
+{
+  const
+    VERSION = 136, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  public function up($configuration)
+  {
+    // Obtain the different translations of the previous settings
+    $accessDisallowWarningI18nValues = $this->getSettingI18nValues('access_disallow_warning', 'ui_label');
+    $accessConditionalWarningI18nValues = $this->getSettingI18nValues('access_conditional_warning', 'ui_label');
+
+    // Populate new settings, there are going to be two statements per each basis
+    // available in the RIGHTS_BASIS_ID taxonomy. By default, we populate alz
+    // the statements like the used to be before, making sure that all the
+    // translations are also migrated.
+    foreach (QubitTaxonomy::getTermsById(QubitTaxonomy::RIGHT_BASIS_ID) as $item)
+    {
+      $setting = new QubitSetting;
+      $setting->name = "{$item->slug}_disallow";
+      $setting->scope = 'access_statement';
+      foreach ($accessDisallowWarningI18nValues as $langCode => $value)
+      {
+        $setting->setValue($value, array('culture' => $langCode));
+      }
+      $setting->save();
+
+      $setting = new QubitSetting;
+      $setting->name = "{$item->slug}_conditional";
+      $setting->scope = 'access_statement';
+      foreach ($accessConditionalWarningI18nValues as $langCode => $value)
+      {
+        $setting->setValue($value, array('culture' => $langCode));
+      }
+      $setting->save();
+    }
+
+    // Delete UI labels access_disallow_warning and access_conditional_warning
+    foreach (array('access_disallow_warning', 'access_conditional_warning') as $item)
+    {
+      $setting = QubitSetting::getByNameAndScope($item, 'ui_label');
+      if (null !== $setting)
+      {
+        $setting->delete();
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Build a dictionary with all the different translations for a given setting.
+   * The translations are indexed in the dictionary with their language codes.
+   */
+  protected function getSettingI18nValues($name, $scope)
+  {
+    $values = array();
+    $sql = "SELECT `setting_i18n`.`value`, `setting_i18n`.`culture` FROM `setting` LEFT JOIN `setting_i18n` ON (`setting`.`id` = `setting_i18n`.`id`) WHERE `setting`.`name` = ? AND `setting`.`scope` = ?;";
+    foreach (QubitPdo::fetchAll($sql, array($name, $scope)) as $item)
+    {
+      if (empty($item->value))
+      {
+        continue;
+      }
+
+      $values[$item->culture] = $item->value;
+    }
+
+    return $values;
+  }
+}

--- a/plugins/arDominionPlugin/css/less/forms.less
+++ b/plugins/arDominionPlugin/css/less/forms.less
@@ -366,3 +366,23 @@ button.delete-small {
   font-size: 11px;
   margin-top: -10px;
 }
+
+// Tabbable area
+
+.fieldset-wrapper {
+
+  .tabbable {
+    ul {
+      background-color: #f3f3f3;
+    }
+    .active a {
+      #gradient > .horizontal(#eee, #f3f3f3);
+      border-right-color: #f3f3f3 !important;
+    }
+    .tab-content {
+      border-top: 1px solid #ddd;
+      padding: 10px 10px 10px 20px;
+    }
+  }
+
+}

--- a/plugins/arDominionPlugin/css/less/scaffolding.less
+++ b/plugins/arDominionPlugin/css/less/scaffolding.less
@@ -1721,3 +1721,7 @@ body.login #content {
   }
 
 }
+
+.copyright-statement-preview {
+  margin-top: 10px;
+}

--- a/plugins/sfInstallPlugin/lib/sfInstall.class.php
+++ b/plugins/sfInstallPlugin/lib/sfInstall.class.php
@@ -452,6 +452,25 @@ class sfInstall
     }
     $object = QubitSetting::createNewSetting('premisAccessRightValues', serialize($premisAccessRightValues));
     $object->save();
+
+    $accessDisallowWarning = sfContext::getInstance()->i18n->__('Access to this record is restricted because it contains personal or confidential information. Please contact the Reference Archivist for more information on accessing this record.');
+    $accessConditionalWarning = sfContext::getInstance()->i18n->__('This record has not yet been reviewed for personal or confidential information. Please contact the Reference Archivist to request access and initiate an access review.');
+    foreach (QubitTaxonomy::getTermsById(QubitTaxonomy::RIGHT_BASIS_ID) as $item)
+    {
+      $setting = new QubitSetting;
+      $setting->name = "{$item->slug}_disallow";
+      $setting->scope = 'access_statement';
+      $setting->setValue($accessDisallowWarning, array('culture' => 'en'));
+      // TODO Set translations from xliff catalogue using sfI18N?
+      $setting->save();
+
+      $setting = new QubitSetting;
+      $setting->name = "{$item->slug}_conditional";
+      $setting->scope = 'access_statement';
+      $setting->setValue($accessConditionalWarning, array('culture' => 'en'));
+      // TODO Set translations from xliff catalogue using sfI18N?
+      $setting->save();
+    }
   }
 
   public static function populateSearchIndex()


### PR DESCRIPTION
Redmine ticket: https://projects.artefactual.com/issues/8887.
### Items
- [x] New form in setting/permissions and user interface (area PREMIS access statements)
- [x] Store settings individually in QubitSetting with i18n support
- [x] Update getWarning in showComponent.class.php
- [x] Migration script: delete access_disallow_warning and access_conditional_warnings settings
- [x] Migration script: populate new settings
- [x] Installer: populate new settings (defaults have to be provided, they must use i18n)
### Preview

![Preview](http://i.imgur.com/wLCX7Oz.png)
