### PR TITLE
Fix print preview, refs #8970

### DIFF
--- a/apps/qubit/modules/default/templates/_printPreviewBar.php
+++ b/apps/qubit/modules/default/templates/_printPreviewBar.php
@@ -1,6 +1,6 @@
 <?php if ('print' == $sf_request->getParameter('media')): ?>
   <div id="preview-message">
     <?php echo __('Print preview') ?>
-    <?php echo link_to(__('Close'), array($resource, 'module' => 'informationobject')) ?>
+    <?php echo link_to(__('Close'), array_diff($sf_data->getRaw('sf_request')->getParameterHolder()->getAll(), array('media' => 'print'))) ?>
   </div>
 <?php endif; ?>

--- a/apps/qubit/modules/default/templates/_printPreviewButton.php
+++ b/apps/qubit/modules/default/templates/_printPreviewButton.php
@@ -1,0 +1,4 @@
+<a <?php echo isset($class) ? 'class="'. $class . '"' : '' ?> href="<?php echo url_for(array_merge($sf_data->getRaw('sf_request')->getParameterHolder()->getAll(), array('media' => 'print'))) ?>">
+  <i class="icon-print"></i>
+  <?php echo __('Print preview') ?>
+</a>

--- a/apps/qubit/modules/informationobject/actions/indexAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/indexAction.class.php
@@ -122,11 +122,6 @@ class InformationObjectIndexAction extends sfAction
       $this->getResponse()->addJavascript('/vendor/jstree/jstree.min.js', 'last');
     }
 
-    if ('print' == $request->getGetParameter('media', 'screen'))
-    {
-      $this->getResponse()->addStylesheet('print-preview', 'last');
-    }
-
     $scopeAndContent = $this->resource->getScopeAndContent(array('cultureFallback' => true));
     if (!empty($scopeAndContent))
     {

--- a/apps/qubit/modules/informationobject/config/view.yml
+++ b/apps/qubit/modules/informationobject/config/view.yml
@@ -47,15 +47,15 @@ multiFileUploadSuccess:
 
 storageLocationsSuccess:
   stylesheets:
-    print-preview: { media: screen, position: last }
+    print-reports: { media: screen, position: last }
 
 fileListSuccess:
   stylesheets:
-    print-preview: { media: screen, position: last }
+    print-reports: { media: screen, position: last }
 
 itemListSuccess:
   stylesheets:
-    print-preview: { media: screen, position: last }
+    print-reports: { media: screen, position: last }
 
 renameSuccess:
   javascripts:

--- a/apps/qubit/modules/physicalobject/config/view.yml
+++ b/apps/qubit/modules/physicalobject/config/view.yml
@@ -1,6 +1,6 @@
 boxListSuccess:
   stylesheets:
-    print-preview: { media: screen, position: last }
+    print-reports: { media: screen, position: last }
   javascripts:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/jquery.once.js:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/tableheader:

--- a/apps/qubit/modules/search/actions/indexAction.class.php
+++ b/apps/qubit/modules/search/actions/indexAction.class.php
@@ -159,11 +159,6 @@ class SearchIndexAction extends DefaultBrowseAction
   {
     parent::execute($request);
 
-    if ('print' == $request->getGetParameter('media'))
-    {
-      $this->getResponse()->addStylesheet('print-preview', 'last');
-    }
-
     // Print noResults template if query is empty
     if (empty($request->query))
     {

--- a/apps/qubit/modules/search/templates/advancedSuccess.php
+++ b/apps/qubit/modules/search/templates/advancedSuccess.php
@@ -64,12 +64,7 @@
 <?php end_slot() ?>
 
 <?php slot('title') ?>
-  <?php if ('print' == $sf_request->getParameter('media')): ?>
-    <div id="preview-message">
-      <?php echo __('Print preview') ?>
-      <?php echo link_to('Close', array_diff($sf_data->getRaw('sf_request')->getParameterHolder()->getAll(), array('media' => 'print'))) ?>
-    </div>
-  <?php endif; ?>
+  <?php echo get_partial('default/printPreviewBar') ?>
 
   <h1><?php echo __('Advanced search') ?></h1>
 <?php end_slot() ?>
@@ -78,10 +73,7 @@
   <section id="action-icons">
     <ul>
       <li>
-        <a href="<?php echo url_for(array_merge($sf_data->getRaw('sf_request')->getParameterHolder()->getAll(), array('media' => 'print'))) ?>">
-          <i class="icon-print"></i>
-          <?php echo __('Print') ?>
-        </a>
+        <?php echo get_partial('default/printPreviewButton') ?>
       </li>
       <?php if (isset($pager) && $pager->hasResults() && $sf_user->isAuthenticated()): ?>
       <li>

--- a/apps/qubit/modules/user/actions/clipboardAction.class.php
+++ b/apps/qubit/modules/user/actions/clipboardAction.class.php
@@ -29,6 +29,11 @@ class UserClipboardAction extends DefaultBrowseAction
 
   public function execute($request)
   {
+    if ('print' == $request->getGetParameter('media'))
+    {
+      $this->getResponse()->addStylesheet('print-preview', 'last');
+    }
+
     $slugs = $this->context->user->getClipboard()->getAll();
 
     if (count($slugs) == 0)

--- a/apps/qubit/modules/user/templates/clipboardSuccess.php
+++ b/apps/qubit/modules/user/templates/clipboardSuccess.php
@@ -1,6 +1,8 @@
 <?php decorate_with('layout_1col') ?>
 
 <?php slot('title') ?>
+  <?php echo get_partial('default/printPreviewBar') ?>
+
   <div class="multiline-header">
     <?php echo image_tag('/images/icons-large/icon-archival.png', array('alt' => '')) ?>
     <h1 aria-describedby="results-label"><?php echo __('Showing %1% results', array('%1%' => $pager->getNbResults())) ?></h1>
@@ -10,10 +12,7 @@
 
 <?php slot('before-content') ?>
   <section class="header-options">
-    <a class="clipboard-print" href="<?php echo url_for(array_merge($sf_data->getRaw('sf_request')->getParameterHolder()->getAll(), array('media' => 'print'))) ?>">
-      <i class="icon-print"></i>
-      <?php echo __('Print') ?>
-    </a>
+    <?php echo get_partial('default/printPreviewButton', array('class' => 'clipboard-print')) ?>
 
     <?php echo get_partial('default/sortPicker',
       array(

--- a/css/print-ie.css
+++ b/css/print-ie.css
@@ -1,7 +1,0 @@
-.field > h3
-{
-  /* Reset */
-
-  margin: 0;
-  padding: 2px 4px;
-}

--- a/css/print-preview.css
+++ b/css/print-preview.css
@@ -1,26 +1,2 @@
-@import "print.css";
-
-#print-date
-{
-  display: none;
-}
-
-#preview-message
-{
-  background: #eee;
-  display: block;
-  padding: 5px;
-  text-align: center;
-  border-right: 1px solid #ccc;
-  border-bottom: 1px solid #ccc;
-}
-
-#preview-message a
-{
-  float: right;
-}
-
-#sfWebDebug
-{
-  display: block;
-}
+/* Minified CSS version of arDominionPlugin print.less */
+@media all{#update-check,header,#site-slogan,#sidebar,#context-menu,section.actions,footer,#sfWebDebug,button.clipboard,a.clipboard-print{display:none;} a[href]:after{content:none !important;} .container,.container .row>.span9,#main-column,#main-column .row>.span7{width:100%;margin:0;padding:0;} .row{margin-left:0;} body{padding-left:0;padding-right:0;} #content{border:none;box-shadow:none;} #coverflow{padding-top:0 !important;}#coverflow #imageflow,#coverflow #imageflow_images{height:auto !important;} #coverflow img{position:relative !important;display:inline-block !important;visibility:visible !important;margin:5px !important;left:0 !important;top:0 !important;opacity:1 !important;height:auto !important;width:auto !important;} #coverflow #imageflow_caption,#coverflow #imageflow_navigation,#coverflow .result-count{display:none;} #fullwidth-treeview-row{height:auto !important;} #content .field>h3{padding:0;margin:0;margin-top:2px;}}

--- a/css/print-reports.css
+++ b/css/print-reports.css
@@ -460,3 +460,28 @@ table.item-list img
   float: left;
   margin: 2px 4px;
 }
+
+#print-date
+{
+  display: none;
+}
+
+#preview-message
+{
+  background: #eee;
+  display: block;
+  padding: 5px;
+  text-align: center;
+  border-right: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
+}
+
+#preview-message a
+{
+  float: right;
+}
+
+#sfWebDebug
+{
+  display: block;
+}

--- a/plugins/arDacsPlugin/modules/arDacsPlugin/templates/indexSuccess.php
+++ b/plugins/arDacsPlugin/modules/arDacsPlugin/templates/indexSuccess.php
@@ -8,8 +8,6 @@
 
   <h1><?php echo render_title($dacs) ?></h1>
 
-  <?php echo get_partial('informationobject/printPreviewBar', array('resource' => $resource)) ?>
-
   <?php if (isset($errorSchema)): ?>
     <div class="messages error">
       <ul>

--- a/plugins/arDominionPlugin/css/less/print.less
+++ b/plugins/arDominionPlugin/css/less/print.less
@@ -9,7 +9,9 @@
   #context-menu,
   section.actions,
   footer,
-  #sfWebDebug
+  #sfWebDebug,
+  button.clipboard,
+  a.clipboard-print
   {
     display: none;
   }
@@ -82,6 +84,12 @@
     padding: 0;
     margin: 0;
     margin-top: 2px;
+  }
+
+  /* This must not be added to the minified CSS version in 'css/print-preview.css' */
+
+  #preview-message {
+    display: none;
   }
 
 }

--- a/plugins/arDominionPlugin/css/less/scaffolding.less
+++ b/plugins/arDominionPlugin/css/less/scaffolding.less
@@ -1756,3 +1756,17 @@ body.login #content {
   border: 1px dashed #FFD700;
 }
 
+// Print preview bar
+
+#preview-message {
+  background: #eee;
+  display: block;
+  padding: 5px;
+  text-align: center;
+  border-right: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
+
+  a {
+    float: right;
+  }
+}

--- a/plugins/arDominionPlugin/css/main.less
+++ b/plugins/arDominionPlugin/css/main.less
@@ -58,7 +58,6 @@
 @import "less/header.less";
 @import "less/treeview.less";
 @import "less/popovers.less";
-@import "less/print.less";
 @import "less/description.less";
 @import "less/import.less";
 @import "less/forms.less";
@@ -66,6 +65,9 @@
 @import "less/legacy.less";
 @import "less/jobs.less";
 @import "less/bootstrap-mod.less";
+
+// Print rules last
+@import "less/print.less";
 
 // TODO
 // Merge css/* (including classic)

--- a/plugins/sfDcPlugin/modules/sfDcPlugin/templates/indexSuccess.php
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/templates/indexSuccess.php
@@ -8,8 +8,6 @@
 
   <h1><?php echo render_title($dc) ?></h1>
 
-  <?php echo get_partial('informationobject/printPreviewBar', array('resource' => $resource)) ?>
-
   <?php if (isset($errorSchema)): ?>
     <div class="messages error">
       <ul>

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/indexSuccess.php
@@ -8,8 +8,6 @@
 
   <h1><?php echo render_title($isad) ?></h1>
 
-  <?php echo get_partial('informationobject/printPreviewBar', array('resource' => $resource)) ?>
-
   <?php if (isset($errorSchema)): ?>
     <div class="messages error">
       <ul>

--- a/plugins/sfModsPlugin/modules/sfModsPlugin/templates/indexSuccess.php
+++ b/plugins/sfModsPlugin/modules/sfModsPlugin/templates/indexSuccess.php
@@ -8,8 +8,6 @@
 
   <h1><?php echo render_title($mods) ?></h1>
 
-  <?php echo get_partial('informationobject/printPreviewBar', array('resource' => $resource)) ?>
-
   <?php if (isset($errorSchema)): ?>
     <div class="messages error">
       <ul>

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
@@ -8,8 +8,6 @@
 
   <h1><?php echo render_title($rad) ?></h1>
 
-  <?php echo get_partial('informationobject/printPreviewBar', array('resource' => $resource)) ?>
-
   <?php if (isset($errorSchema)): ?>
     <div class="messages error">
       <ul>


### PR DESCRIPTION
- Move old print-preview rules to css/print-reports.css
- Create print-preview.css with the new rules added in arDominionPlugin
- Use print-reports.css in report pages
- Remove print-preview.css add and print preview bar in pages
  without print preview button
- Move to a partial and rename to 'Print preview' the print button
- Move print preview bar to a partial, hide it in real print view
  and style it in arDominionPlugin
