### PR TITLE
Fixed issues with rename page. refs #8759

### DIFF
--- a/apps/qubit/modules/informationobject/actions/renameAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/renameAction.class.php
@@ -110,7 +110,7 @@ class InformationObjectRenameAction extends DefaultEditAction
       // Attempt to change slug if submitted slug's different than current slug
       if ($postedSlug != $slug->slug)
       {
-        $slug->slug = InformationObjectSlugPreviewAction::determineAvailableSlug($postedSlug);
+        $slug->slug = InformationObjectSlugPreviewAction::determineAvailableSlug($postedSlug, $this->resource->id);
         $slug->save();
       }
     }

--- a/apps/qubit/modules/informationobject/config/view.yml
+++ b/apps/qubit/modules/informationobject/config/view.yml
@@ -62,5 +62,7 @@ renameSuccess:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/collapse:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/form:
     /vendor/yui/container/container-min:
+    /vendor/yui/connection/connection-min:
+    repositoryHoldings:
     description:
     rename:

--- a/apps/qubit/modules/informationobject/templates/renameSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/renameSuccess.php
@@ -14,6 +14,25 @@
 
 <?php slot('content') ?>
 
+  <div class="modal hide" id="rename-slug-warning">
+    <div class="modal-header">
+      <a class="close" data-dismiss="modal">×</a>
+      <h3><?php echo __('Slug in use') ?></h3>
+    </div>
+
+    <div class="modal-body">
+      <?php echo __('A slug based on this title already exists so a number has been added to pad the slug.') ?>
+    </div>
+
+    <div class="modal-footer">
+      <section class="actions">
+        <ul>
+          <li><a href="#" id="renameModalCancel" class="c-btn c-btn-submit" data-dismiss="modal"><?php echo __('Close') ?></a></li>
+        </ul>
+      </section>
+    </div>
+  </div>
+
   <?php echo $form->renderFormTag(url_for(array('module' => 'informationobject', 'action' => 'rename', 'slug' => $resource->slug)), array('id' => 'rename-form')) ?>
 
     <?php echo $form->renderHiddenFields() ?>
@@ -33,12 +52,16 @@
           ->label(__('Title'))
           ->help(__('Editing the description title will automatically update the slug field if the "Update slug" checkbox is selected - you can still edit it after.'))) ?>
 
+        <p><?php echo __('Original title') ?>: <em><?php echo $resource->title ?></em></p>
+
         <div class="rename-form-field-toggle"><input id="rename_enable_slug" type="checkbox" checked="checked" /> <?php echo __('Update slug') ?></div>
         <br />
 
         <?php echo render_field($form->slug
           ->label(__('Slug'))
           ->help(__('Do not use any special characters or spaces in the slug - only lower case alphanumeric characters (a-z, 0-9) and dashes (-) will be saved. Other characters will be stripped out or replaced. Editing the slug will not automatically update the other fields.')), $resource) ?>
+
+        <p><?php echo __('Original slug') ?>: <em><?php echo $resource->slug ?></em></p>
 
         <?php if (count($resource->digitalObjects) > 0): ?>
 
@@ -48,6 +71,8 @@
           <?php echo render_field($form->filename
           ->label(__('Filename'))
           ->help(__('Do not use any special characters or spaces in the filename - only lower case alphanumeric characters (a-z, 0-9) and dashes (-) will be saved. Other characters will be stripped out or replaced. Editing the filename will not automatically update the other fields.')), $resource) ?>
+
+          <p><?php echo __('Original filename') ?>: <em><?php echo $resource->digitalObjects[0]->name ?></em></p>
 
         <?php endif; ?>
 

--- a/apps/qubit/templates/_alerts.php
+++ b/apps/qubit/templates/_alerts.php
@@ -1,12 +1,12 @@
 <?php if ($sf_user->hasFlash('notice')): ?>
-  <div class="alert">
+  <div id="notice-alerts" class="alert">
     <button type="button" class="close" data-dismiss="alert">&times;</button>
     <?php echo $sf_user->getFlash('notice', ESC_RAW) ?>
   </div>
 <?php endif; ?>
 
 <?php if ($sf_user->hasFlash('error')): ?>
-  <div class="alert alert-error">
+  <div id="error-alerts" class="alert alert-error">
     <button type="button" class="close" data-dismiss="alert">&times;</button>
     <?php echo $sf_user->getFlash('error', ESC_RAW) ?>
   </div>

--- a/js/fullWidthTreeView.js
+++ b/js/fullWidthTreeView.js
@@ -83,6 +83,9 @@
     // Bind click events to nodes to load the informationobject's page and insert the current page
     $("#fullwidth-treeview").bind("select_node.jstree", function(evt, data)
     {
+      // Remove any alerts
+      $('#notice-alerts.alert,#error-alerts.alert').remove();
+
       // Open node if possible
       data.instance.open_node(data.node);
 

--- a/js/rename.js
+++ b/js/rename.js
@@ -1,9 +1,9 @@
 (function ($) {
 
   var fields = ['title', 'slug', 'filename'];
-  var asyncOpInProgress = false;
+  var asyncOpCounter = 0;
 
-  // Fetch a slug preview for a given title
+  // Convert text (can be a title or slug text) to an available slug
   function fetchSlugPreview(title, callback)
   {
     // Assemble slug preview URL
@@ -31,7 +31,9 @@
     $('#rename-form input:text:visible:first').focus();
 
     // Create references to selectors
-    var $renameForm = $('#rename-form');
+    var $renameForm             = $('#rename-form');
+    var $renameFormSubmit       = $('#rename-form-submit');
+    var $slugExistsWarningModal = $('#rename-slug-warning');
 
     var $fields          = {};
     var $fieldCheckboxes = {};
@@ -42,8 +44,6 @@
       $fieldCheckboxes[field] = $('#rename_enable_' + field);
     }
 
-    $renameFormSubmit = $('#rename-form-submit');
-
     // Cycle through fields and disable them if their corresponding checkbox isn't checked
     function enableFields() {
       for (var index in fields) {
@@ -52,25 +52,29 @@
       }
     }
 
-    function updateSlugPreview() {
+    // Update slug field by getting a slug preview based on the title
+    function updateSlugUsingTitle() {
       // Only update slug preview if the slug field's enabled
       if ($fieldCheckboxes['slug'].is(':checked')) {
-        fetchSlugPreview($fields['title'].val(), function(err, slug, adjusted) {
-          if (err) {
-            alert('Error fetching slug preview.');
-          } else {
-            if (adjusted) {
-              $('#rename-slug-warning').modal('show');
-            }
-            $fields['slug'].val(slug);
-          }
-        });
+        fetchSlugPreview($fields['title'].val(), fetchSlugPreviewCallback);
+      }
+    }
+
+    // Callback to handle slug preview results
+    function fetchSlugPreviewCallback(err, slug, adjusted) {
+      if (err) {
+        alert('Error fetching slug preview.');
+      } else {
+        if (adjusted) {
+          $slugExistsWarningModal.modal('show');
+        }
+        $fields['slug'].val(slug);
       }
     }
 
     // When no AJAX requests are pending, submit form data
     function trySubmit() {
-      if (asyncOpInProgress) {
+      if (asyncOpCounter > 0) {
         setTimeout(trySubmit, 1000);
       } else {
         $renameForm.submit();
@@ -84,18 +88,23 @@
     $renameForm.on('keypress', function (e) {
       if (e.keyCode == 13) {
         e.preventDefault();
-        updateSlugPreview();
+
+        // If user pressing enter from title field, update slug if enabled
+        if ($fields['title'].is(':focus')) {
+          updateSlugUsingTitle();
+        }
+
         trySubmit();
       }
     });
 
-    // Keep track of whether async requests are in progress
+    // Keep track of how many async requests are in progress
     $renameForm.ajaxStart(function() {
-      asyncOpInProgress = true;
+      asyncOpCounter++;
     });
 
     $renameForm.ajaxStop(function() {
-      asyncOpInProgress = false;
+      asyncOpCounter--;
     });
 
     // Enable/disable fields when checkboxes clicked
@@ -110,7 +119,12 @@
 
     // If title changes, update slug
     $fields['title'].change(function() {
-      updateSlugPreview();
+      updateSlugUsingTitle();
+    });
+
+    // If slug changes, check availability
+    $fields['slug'].change(function() {
+      fetchSlugPreview($fields['slug'].val(), fetchSlugPreviewCallback);
     });
   });
 

--- a/js/rename.js
+++ b/js/rename.js
@@ -17,7 +17,7 @@
       'type': 'GET',
       'cache': false,
       'success': function(results) {
-        callback(false, results['slug']);
+        callback(false, results['slug'], results['adjusted']);
       },
       'error': function() {
         callback(true);
@@ -53,13 +53,19 @@
     }
 
     function updateSlugPreview() {
-      fetchSlugPreview($fields['title'].val(), function(err, slug) {
-        if (err) {
-          alert('Error fetching slug preview.');
-        } else {
-          $fields['slug'].val(slug);
-        }
-      });
+      // Only update slug preview if the slug field's enabled
+      if ($fieldCheckboxes['slug'].is(':checked')) {
+        fetchSlugPreview($fields['title'].val(), function(err, slug, adjusted) {
+          if (err) {
+            alert('Error fetching slug preview.');
+          } else {
+            if (adjusted) {
+              $('#rename-slug-warning').modal('show');
+            }
+            $fields['slug'].val(slug);
+          }
+        });
+      }
     }
 
     // When no AJAX requests are pending, submit form data

--- a/js/rename.js
+++ b/js/rename.js
@@ -13,11 +13,11 @@
 
     $.ajax({
       'url': slugPreviewUrl,
-      'data': {'title': title},
+      'data': {'text': title},
       'type': 'GET',
       'cache': false,
       'success': function(results) {
-        callback(false, results['slug'], results['adjusted']);
+        callback(false, results['slug'], results['padded']);
       },
       'error': function() {
         callback(true);
@@ -61,11 +61,11 @@
     }
 
     // Callback to handle slug preview results
-    function fetchSlugPreviewCallback(err, slug, adjusted) {
+    function fetchSlugPreviewCallback(err, slug, padded) {
       if (err) {
         alert('Error fetching slug preview.');
       } else {
-        if (adjusted) {
+        if (padded) {
           $slugExistsWarningModal.modal('show');
         }
         $fields['slug'].val(slug);

--- a/js/rename.js
+++ b/js/rename.js
@@ -122,7 +122,8 @@
       updateSlugUsingTitle();
     });
 
-    // If slug changes, check availability
+    // If slug changes, sanitize it and indicate if it has already been used
+    // by another resource
     $fields['slug'].change(function() {
       fetchSlugPreview($fields['slug'].val(), fetchSlugPreviewCallback);
     });


### PR DESCRIPTION
Fixed a number of issues with the rename page:
- Added alert if new slug is already used
- Prevent the slug field from being auto-updated if disabled
- Added availability checking to slug field
- Fix issue with repository quota setting in sidebar
- Fixed issue with background AJAX operation bookkeeping
