### PR TITLE
Fix ACL check adding terms, refs #8988

### DIFF
--- a/apps/qubit/modules/term/actions/editAction.class.php
+++ b/apps/qubit/modules/term/actions/editAction.class.php
@@ -87,7 +87,19 @@ class TermEditAction extends DefaultEditAction
     else
     {
       // Check authorization
-      if (!QubitAcl::check(QubitTerm::getRoot(), 'create'))
+      if (isset($this->request->taxonomy))
+      {
+        $params = $this->context->routing->parse(Qubit::pathInfo($this->request->taxonomy));
+        $taxonomy = $params['_sf_route']->resource;
+
+        $authorized = QubitAcl::check($taxonomy, 'createTerm');
+      }
+      else
+      {
+        $authorized = QubitAcl::check(QubitTerm::getRoot(), 'create');
+      }
+
+      if (!$authorized)
       {
         QubitAcl::forwardUnauthorized();
       }


### PR DESCRIPTION
When a term is being created in a specific taxonomy,
the ACL check needs to be done against the taxonomy,
to allow custom permissions per taxonomy.
