### PR TITLE
Move LOD check to Criteria to improve efficiency

### DIFF
--- a/apps/qubit/modules/informationobject/actions/fileListAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/fileListAction.class.php
@@ -114,6 +114,7 @@ class InformationObjectFileListAction extends sfAction
     $criteria = new Criteria;
     $criteria->add(QubitInformationObject::LFT, $this->resource->lft, Criteria::GREATER_EQUAL);
     $criteria->add(QubitInformationObject::RGT, $this->resource->rgt, Criteria::LESS_EQUAL);
+    $criteria->add(QubitInformationObject::LEVEL_OF_DESCRIPTION_ID, $lod->id);
     $criteria->addAscendingOrderByColumn(QubitInformationObject::LFT);
 
     // Filter drafts
@@ -125,23 +126,20 @@ class InformationObjectFileListAction extends sfAction
 
     foreach($informationObjects as $item)
     {
-      if ($lod->id == $item->levelOfDescriptionId)
-      {
-        $creationDates = self::getCreationDates($item);
-        $parentTitle = QubitInformationObject::getStandardsBasedInstance($item->parent)->__toString();
+      $creationDates = self::getCreationDates($item);
+      $parentTitle = QubitInformationObject::getStandardsBasedInstance($item->parent)->__toString();
 
-        $this->results[$parentTitle][] = array(
-          'resource' => $item,
-          'referenceCode' => QubitInformationObject::getStandardsBasedInstance($item)->referenceCode,
-          'title' => $item->getTitle(array('cultureFallback' => true)),
-          'dates' => (isset($creationDates)) ? Qubit::renderDateStartEnd($creationDates->getDate(array('cultureFallback' => true)), $creationDates->startDate, $creationDates->endDate) : '&nbsp;',
-          'startDate' => (isset($creationDates)) ? $creationDates->startDate : null,
-          'accessConditions' => $item->getAccessConditions(array('cultureFallback' => true)),
-          'locations' => self::getLocationString($item)
-        );
+      $this->results[$parentTitle][] = array(
+        'resource' => $item,
+        'referenceCode' => QubitInformationObject::getStandardsBasedInstance($item)->referenceCode,
+        'title' => $item->getTitle(array('cultureFallback' => true)),
+        'dates' => (isset($creationDates)) ? Qubit::renderDateStartEnd($creationDates->getDate(array('cultureFallback' => true)), $creationDates->startDate, $creationDates->endDate) : '&nbsp;',
+        'startDate' => (isset($creationDates)) ? $creationDates->startDate : null,
+        'accessConditions' => $item->getAccessConditions(array('cultureFallback' => true)),
+        'locations' => self::getLocationString($item)
+      );
 
-        $this->resultCount++;
-      }
+      $this->resultCount++;
     }
 
     // Sort items by selected criteria
@@ -149,7 +147,7 @@ class InformationObjectFileListAction extends sfAction
     foreach ($this->results as $key => &$items)
     {
       uasort($items, function($a, $b) use ($sortBy) {
-         return strnatcasecmp($a[$sortBy], $b[$sortBy]); 
+         return strnatcasecmp($a[$sortBy], $b[$sortBy]);
       });
     }
   }


### PR DESCRIPTION
Since the "File List Report" is only checking information objects with a level of description of "file", we can safely move that LOD check to the Criteria of the query. 

Previously, the Criteria was broad enough to include all item level descriptions as well if they were children of the Files. This created performance issues in certain circumstances (several files but having thousands of child, item level descriptions).

We'll want to move these reports to use the job scheduler and combine the duplicate code between the item/list action files in the future.
(see: ./apps/qubit/modules/informationobject/actions/fileListAction.class.php vs. ./apps/qubit/modules/informationobject/actions/itemListAction.class.php)
