### PR TITLE
Fix public EAD XML export with drafts, refs #9254

### DIFF
--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
@@ -302,6 +302,13 @@
     <?php $nestedRgt = array() ?>
     <?php foreach ($resource->getDescendantsForExport($options) as $descendant): ?>
 
+      <?php // Close previous <c> tags when we pass the end of the child list ?>
+      <?php $rgt = $descendant->rgt ?>
+      <?php while (count($nestedRgt) > 0 && $rgt > $nestedRgt[count($nestedRgt) - 1]): ?>
+        <?php array_pop($nestedRgt); ?>
+        </c>
+      <?php endwhile; ?>
+
       <c <?php echo $ead->renderLOD($descendant, $eadLevels) ?>>
 
       <?php
@@ -453,14 +460,13 @@
         <?php array_push($nestedRgt, $descendant->rgt) ?>
       <?php endif; ?>
 
-      <?php // close <c> tag when we reach end of child list ?>
-      <?php $rgt = $descendant->rgt ?>
-      <?php while (count($nestedRgt) > 0 && $rgt + 1 == $nestedRgt[count($nestedRgt) - 1]): ?>
-        <?php $rgt = array_pop($nestedRgt); ?>
-        </c>
-      <?php endwhile; ?>
-
     <?php endforeach; ?>
+
+    <?php // Make sure all <c> tags are closed ?>
+    <?php while (count($nestedRgt) > 0): ?>
+      <?php array_pop($nestedRgt); ?>
+      </c>
+    <?php endwhile; ?>
 
   </dsc>
   <?php endif; ?>


### PR DESCRIPTION
We were relying in the last descendant to close the ancestors <c> tags
and, with the public option, that child may not be included in the
descendants to export. Closing the previous ancestors tags when
we are in the next sibling (rgt value bigger than the previous one) and
making sure all <c> tags are closed at the end allows us to have missing
descendants in the exported hierarchy.
