### PR TITLE
Fix OAI Identify response

### DIFF
--- a/apps/qubit/modules/settings/actions/oaiAction.class.php
+++ b/apps/qubit/modules/settings/actions/oaiAction.class.php
@@ -25,6 +25,7 @@
  * @author     Peter Van Garderen <peter@artefactual.com>
  * @author     Jack Bates <jack@nottheoilrig.com>
  * @author     David Juhasz <david@artefactual.com>
+ * @author     Damian Bauder <drbauder@ucalgary.ca>
  */
 
 class SettingsOaiAction extends sfAction

--- a/apps/qubit/modules/settings/actions/oaiAction.class.php
+++ b/apps/qubit/modules/settings/actions/oaiAction.class.php
@@ -70,7 +70,7 @@ class SettingsOaiAction extends sfAction
     $oaiRepositoryCode = QubitSetting::getByName('oai_repository_code');
     $oaiAdminEmails = QubitSetting::getByName('oai_admin_emails');
     $oaiRepositoryIdentifier = QubitOai::getRepositoryIdentifier();
-    $sampleOaiIdentifier = QubitOai::getSampleIdentifier();
+    $sampleOaiIdentifier = QubitOai::getOaiSampleIdentifier();
     $resumptionTokenLimit = QubitSetting::getByName('resumption_token_limit');
     $oaiAdditionalSetsEnabled = QubitSetting::getByName('oai_additional_sets_enabled');
 

--- a/lib/QubitOai.class.php
+++ b/lib/QubitOai.class.php
@@ -24,6 +24,7 @@
  * @subpackage lib
  * @author     Mathieu Fortin Library and Archives Canada <mathieu.fortin@lac-bac.gc.ca>
  * @author     Peter Van Garderen <peter@artefactual.com>
+ * @author     Damian Bauder <drbauder@ucalgary.ca>
  */
 
 class QubitOai

--- a/lib/QubitOai.class.php
+++ b/lib/QubitOai.class.php
@@ -277,24 +277,31 @@ class QubitOai
     }
     return false;
   }
+  
+  public static function getOaiNamespaceIdentifier()
+  {
+	$oaiNamespaceIdentifier = sfContext::getInstance()->request->getHost();
+    
+    return $oaiNamespaceIdentifier; 
+  }
 
   public static function getRepositoryIdentifier()
   {
     $repositoryIdentifier = sfContext::getInstance()->request->getHost();
     if ($repositoryCode = sfConfig::get('app_oai_oai_repository_code'))
     {
-      $repositoryIdentifier .= ':'.$repositoryCode;
+      $repositoryIdentifier .= ':' . $repositoryCode;
     }
 
     return $repositoryIdentifier;
   }
 
-  public static function getSampleIdentifier()
+  public static function getOaiSampleIdentifier()
   {
-    $sampleIdentifier = sfContext::getInstance()->request->getHost().':';
+    $sampleIdentifier = 'oai:' . QubitOai::getOaiNamespaceIdentifier();
     if ($repositoryCode = sfConfig::get('app_oai_oai_repository_code'))
     {
-      $sampleIdentifier .= $repositoryCode;
+      $sampleIdentifier .=  ':' . $repositoryCode;
     }
     $sampleIdentifier .= '_100002';
 

--- a/lib/QubitOai.class.php
+++ b/lib/QubitOai.class.php
@@ -281,14 +281,22 @@ class QubitOai
   
   public static function getOaiNamespaceIdentifier()
   {
-     $oaiNamespaceIdentifier = sfContext::getInstance()->request->getHost();
+     $oaiNamespaceIdentifier = QubitSetting::getByName('siteBaseUrl')->getValue(array('cultureFallback' => true));
+     
+     // If parse_url() successfully returns a host, use it; otherwise, use
+     // siteBaseUrl unmodified.
+     if ($urlHost = parse_url($oaiNamespaceIdentifier, PHP_URL_HOST))
+     {
+       $oaiNamespaceIdentifier = $urlHost;
+     };
     
     return $oaiNamespaceIdentifier; 
   }
 
   public static function getRepositoryIdentifier()
   {
-    $repositoryIdentifier = sfContext::getInstance()->request->getHost();
+    $repositoryIdentifier = QubitOai::getOaiNamespaceIdentifier();
+    
     if ($repositoryCode = sfConfig::get('app_oai_oai_repository_code'))
     {
       $repositoryIdentifier .= ':'.$repositoryCode;
@@ -299,12 +307,7 @@ class QubitOai
 
   public static function getOaiSampleIdentifier()
   {
-    $sampleIdentifier = 'oai:'.QubitOai::getOaiNamespaceIdentifier();
-    if ($repositoryCode = sfConfig::get('app_oai_oai_repository_code'))
-    {
-      $sampleIdentifier .=  ':'.$repositoryCode;
-    }
-    $sampleIdentifier .= '_100002';
+    $sampleIdentifier = 'oai:'.QubitOai::getRepositoryIdentifier().'_100002';
 
     return $sampleIdentifier;
   }

--- a/lib/QubitOai.class.php
+++ b/lib/QubitOai.class.php
@@ -281,7 +281,7 @@ class QubitOai
   
   public static function getOaiNamespaceIdentifier()
   {
-	$oaiNamespaceIdentifier = sfContext::getInstance()->request->getHost();
+     $oaiNamespaceIdentifier = sfContext::getInstance()->request->getHost();
     
     return $oaiNamespaceIdentifier; 
   }
@@ -291,7 +291,7 @@ class QubitOai
     $repositoryIdentifier = sfContext::getInstance()->request->getHost();
     if ($repositoryCode = sfConfig::get('app_oai_oai_repository_code'))
     {
-      $repositoryIdentifier .= ':' . $repositoryCode;
+      $repositoryIdentifier .= ':'.$repositoryCode;
     }
 
     return $repositoryIdentifier;
@@ -299,10 +299,10 @@ class QubitOai
 
   public static function getOaiSampleIdentifier()
   {
-    $sampleIdentifier = 'oai:' . QubitOai::getOaiNamespaceIdentifier();
+    $sampleIdentifier = 'oai:'.QubitOai::getOaiNamespaceIdentifier();
     if ($repositoryCode = sfConfig::get('app_oai_oai_repository_code'))
     {
-      $sampleIdentifier .=  ':' . $repositoryCode;
+      $sampleIdentifier .=  ':'.$repositoryCode;
     }
     $sampleIdentifier .= '_100002';
 

--- a/lib/QubitOai.class.php
+++ b/lib/QubitOai.class.php
@@ -171,7 +171,7 @@ class QubitOai
     
     // If the scheme is missing from a URL, parse_url() mistakenly interprets the host as the path.
     // Prepend a dummy scheme and re-parse, if this is the case.
-    if ($parsedURL['scheme'] == null)
+    if (!isset($parsedURL['scheme']))
     {
       $parsedURL = parse_url('http://'.$URL);
     }

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_identify.xml.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_identify.xml.php
@@ -12,9 +12,9 @@
     <description>
       <oai-identifier xmlns="http://www.openarchives.org/OAI/2.0/oai-identifier" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai-identifier http://www.openarchives.org/OAI/2.0/oai-identifier.xsd">
         <scheme>oai</scheme>
-        <repositoryIdentifier><?php echo QubitOai::getRepositoryIdentifier() ?></repositoryIdentifier>
+        <repositoryIdentifier><?php echo QubitOai::getOaiNamespaceIdentifier() ?></repositoryIdentifier>
         <delimiter>:</delimiter>
-        <sampleIdentifier><?php echo QubitOai::getSampleIdentifier() ?></sampleIdentifier>
+        <sampleIdentifier><?php echo QubitOai::getOaiSampleIdentifier() ?></sampleIdentifier>
       </oai-identifier>
     </description>
   </Identify>


### PR DESCRIPTION
Redmine: https://projects.artefactual.com/issues/9395

I noticed that the XML returned by the OAI Identify response does not validate. Validation would fail because of the format of the repositoryIdentifer and sampleIdentifier elements. This patch fixes the output of those elements and ensures validation succeeds.

This is my first pull request here, so any and all feedback is welcome.

Refer to the following:
- http://www.openarchives.org/OAI/2.0/openarchivesprotocol.htm#Identify, for information on the Identify response
- http://www.openarchives.org/OAI/2.0/guidelines.htm, section 3.1, for information on the description container
- http://www.openarchives.org/OAI/2.0/guidelines-oai-identifier.htm, for specifics on the oai-identifier format
