### PR TITLE
Update pub. status via job scheduler, refs #9304

### DIFF
--- a/apps/qubit/modules/informationobject/actions/updatePublicationStatusAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/updatePublicationStatusAction.class.php
@@ -74,10 +74,6 @@ class InformationObjectUpdatePublicationStatusAction extends DefaultEditAction
         $this->form->setWidget('updateDescendants', new sfWidgetFormInputCheckbox);
 
         break;
-
-      default:
-
-        return parent::addField($name);
     }
   }
 

--- a/apps/qubit/modules/informationobject/actions/updatePublicationStatusAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/updatePublicationStatusAction.class.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class InformationObjectUpdatePublicationStatusAction extends DefaultEditAction
+{
+  // Arrays not allowed in class constants
+  public static
+    $NAMES = array(
+      'publicationStatus',
+      'updateDescendants');
+
+  protected function earlyExecute()
+  {
+    $this->resource = $this->getRoute()->resource;
+
+    // Check that object exists and that it is not the root
+    if (!isset($this->resource) || !isset($this->resource->parent))
+    {
+      $this->forward404();
+    }
+
+    // Check user authorization
+    if (!QubitAcl::check($this->resource, 'publish'))
+    {
+      QubitAcl::forwardUnauthorized();
+    }
+  }
+
+  protected function addField($name)
+  {
+    switch ($name)
+    {
+      case 'publicationStatus':
+        $publicationStatus = $this->resource->getStatus(array('typeId' => QubitTerm::STATUS_TYPE_PUBLICATION_ID));
+        if (isset($publicationStatus))
+        {
+          $this->form->setDefault('publicationStatus', $publicationStatus->statusId);
+        }
+        else
+        {
+          $this->form->setDefault('publicationStatus', sfConfig::get('app_defaultPubStatus'));
+        }
+
+        $this->form->setValidator('publicationStatus', new sfValidatorString);
+
+        $choices = array();
+        foreach (QubitTaxonomy::getTermsById(QubitTaxonomy::PUBLICATION_STATUS_ID) as $item)
+        {
+          $choices[$item->id] = $item;
+        }
+
+        $this->form->setWidget('publicationStatus', new sfWidgetFormSelect(array('choices' => $choices)));
+
+        break;
+
+      case 'updateDescendants':
+        $this->form->setValidator('updateDescendants', new sfValidatorBoolean);
+        $this->form->setWidget('updateDescendants', new sfWidgetFormInputCheckbox);
+
+        break;
+
+      default:
+
+        return parent::addField($name);
+    }
+  }
+
+  public function execute($request)
+  {
+    parent::execute($request);
+
+    if ($this->request->getMethod() == 'POST')
+    {
+      $this->form->bind($request->getPostParameters());
+
+      if ($this->form->isValid())
+      { 
+        // Update resource synchronously
+        $publicationStatusId = $this->form->getValue('publicationStatus');
+        $this->resource->setPublicationStatus($publicationStatusId);
+        $this->resource->save();
+        
+        // Update descendants using job scheduler
+        if (filter_var($this->form->getValue('updateDescendants'), FILTER_VALIDATE_BOOLEAN))
+        {
+          $options = array('resourceId' => $this->resource->id, 'publicationStatusId' => $publicationStatusId);
+          QubitJob::runJob('arUpdatePublicationStatusJob', $options);
+      
+          // Let user know descendants update has started
+          $i18n = $this->context->i18n;
+          $this->context->getConfiguration()->loadHelpers(array('Url'));
+          $jobsUrl = url_for(array('module' => 'jobs', 'action' => 'browse'));
+          $message = $i18n->__('Your description has been updated. Lower level descriptions are being updated now – check the <a href="%1">job scheduler page</a> for status and details.', array('%1' => $jobsUrl));
+          $this->getUser()->setFlash('notice', $message);
+        }
+
+        $this->redirect(array($this->resource, 'module' => 'informationobject'));
+      }
+    }
+  }
+}

--- a/apps/qubit/modules/informationobject/config/view.yml
+++ b/apps/qubit/modules/informationobject/config/view.yml
@@ -72,3 +72,11 @@ renameSuccess:
     repositoryHoldings:
     description:
     rename:
+
+updatePublicationStatusSuccess:
+  javascripts:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/collapse:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/form:
+    /vendor/yui/container/container-min:
+    /vendor/yui/connection/connection-min:
+    repositoryHoldings:

--- a/apps/qubit/modules/informationobject/templates/_actions.php
+++ b/apps/qubit/modules/informationobject/templates/_actions.php
@@ -30,6 +30,10 @@
 
               <li><?php echo link_to(__('Rename'), array($resource, 'module' => 'informationobject', 'action' => 'rename')) ?></li>
 
+              <?php if (QubitAcl::check($resource, 'publish')): ?>
+                <li><?php echo link_to(__('Update publication status'), array($resource, 'module' => 'informationobject', 'action' => 'updatePublicationStatus')) ?></li>
+              <?php endif; ?>
+
               <li class="divider"></li>
 
               <li><?php echo link_to(__('Link physical storage'), array($resource, 'module' => 'informationobject', 'action' => 'editPhysicalObjects')) ?></li>

--- a/apps/qubit/modules/informationobject/templates/_adminInfo.php
+++ b/apps/qubit/modules/informationobject/templates/_adminInfo.php
@@ -6,8 +6,6 @@
 
     <div class="span4">
 
-      <?php echo $form->publicationStatus->label(__('Publication status'))->renderRow() ?>
-
       <div class="field">
         <h3><?php echo __('Source language') ?></h3>
         <div>

--- a/apps/qubit/modules/informationobject/templates/updatePublicationStatusSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/updatePublicationStatusSuccess.php
@@ -1,0 +1,46 @@
+<?php decorate_with('layout_2col.php') ?>
+
+<?php slot('sidebar') ?>
+
+  <?php include_component('repository', 'contextMenu') ?>
+
+<?php end_slot() ?>
+
+<?php slot('title') ?>
+
+  <h1><?php echo $resource->title ?></h1>
+
+<?php end_slot() ?>
+
+<?php slot('content') ?>
+
+  <?php echo $form->renderFormTag(url_for(array($resource, 'module' => 'informationobject', 'action' => 'updatePublicationStatus'))) ?>
+
+    <?php echo $form->renderHiddenFields() ?>
+
+    <div id="content">
+
+      <fieldset class="collapsible">
+
+        <legend><?php echo __('Update publication status') ?></legend>
+
+        <?php echo $form->publicationStatus->label(__('Publication status'))->renderRow() ?>
+        
+        <?php if ($resource->rgt - $resource->lft > 1): ?>
+          <?php echo $form->updateDescendants->label(__('Update descendants'))->renderRow() ?>
+        <?php endif; ?>
+        
+      </fieldset>
+
+    </div>
+
+    <section class="actions">
+      <ul>
+        <li><input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Update') ?>"/></li>
+        <li><?php echo link_to(__('Cancel'), array($resource, 'module' => 'informationobject'), array('class' => 'c-btn')) ?></li>
+      </ul>
+    </section>
+
+  </form>
+
+<?php end_slot() ?>

--- a/config/gearman.yml
+++ b/config/gearman.yml
@@ -11,3 +11,5 @@ all:
       - arInformationObjectCsvExportJob
     sword:
       - qtSwordPluginWorker
+    publication_status:
+      - arUpdatePublicationStatusJob

--- a/lib/job/arBaseJob.class.php
+++ b/lib/job/arBaseJob.class.php
@@ -60,6 +60,7 @@ class arBaseJob extends Net_Gearman_Job_Common
     {
       $this->createJobsDownloadsDirectory();
       $this->runJob($parameters);
+      $this->info('Job finished.');
     }
     catch (Exception $e)
     {

--- a/lib/job/arGenerateFindingAidJob.class.php
+++ b/lib/job/arGenerateFindingAidJob.class.php
@@ -127,8 +127,6 @@ class arGenerateFindingAidJob extends arBaseJob
     $this->job->setStatusCompleted();
     $this->job->save();
 
-    $this->info('Job finished.');
-
     return true;
   }
 

--- a/lib/job/arUpdatePublicationStatusJob.class.php
+++ b/lib/job/arUpdatePublicationStatusJob.class.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Updates the publication status to the descendants of an information object
+ *
+ * @package    symfony
+ * @subpackage jobs
+ */
+
+class arUpdatePublicationStatusJob extends arBaseJob
+{
+  /**
+   * @see arBaseJob::$requiredParameters
+   */
+  protected $extraRequiredParameters = array('resourceId', 'publicationStatusId');
+
+  public function runJob($parameters)
+  {
+    $i18n = sfContext::getInstance()->i18n;
+
+    if (null === $resource = QubitInformationObject::getById($parameters['resourceId']))
+    {
+      $this->error($i18n->__('Invalid description id: %1', array('%1' => $parameters['resourceId'])));
+
+      return false;
+    }
+
+    if (null === $publicationStatus = QubitTerm::getById($parameters['publicationStatusId']))
+    {
+      $this->error($i18n->__('Invalid publication status id: %1', array('%1' => $parameters['publicationStatusId'])));
+
+      return false;
+    }
+
+    $message = $i18n->__('Updating publication status to the descendants of "%1" to "%2".', array('%1' => $resource->title, '%2' => $publicationStatus->name));
+    $this->job->addNoteText($message);
+    $this->info($message);
+
+    $descriptionsUpdated = 0;
+    foreach ($resource->descendants as $descendant)
+    {
+      $descendant->setPublicationStatus($publicationStatus->id);
+      $descendant->save();
+
+      $descriptionsUpdated++;
+    }
+
+    $message = $i18n->__('%1 descriptions updated.', array('%1' => $descriptionsUpdated));
+    $this->job->addNoteText($message);
+    $this->info($message);
+
+    $this->job->setStatusCompleted();
+    $this->job->save();
+
+    $this->info('Job finished.');
+
+    return true;
+  }
+}

--- a/lib/job/arUpdatePublicationStatusJob.class.php
+++ b/lib/job/arUpdatePublicationStatusJob.class.php
@@ -69,8 +69,6 @@ class arUpdatePublicationStatusJob extends arBaseJob
     $this->job->setStatusCompleted();
     $this->job->save();
 
-    $this->info('Job finished.');
-
     return true;
   }
 }

--- a/plugins/arDacsPlugin/modules/arDacsPlugin/actions/editAction.class.php
+++ b/plugins/arDacsPlugin/modules/arDacsPlugin/actions/editAction.class.php
@@ -50,7 +50,6 @@ class arDacsPluginEditAction extends InformationObjectEditAction
       'script',
       'sources',
       'subjectAccessPoints',
-      'publicationStatus',
       'displayStandard',
       'displayStandardUpdateDescendants',
       'title',

--- a/plugins/sfDcPlugin/modules/sfDcPlugin/actions/editAction.class.php
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/actions/editAction.class.php
@@ -41,7 +41,6 @@ class sfDcPluginEditAction extends InformationObjectEditAction
       'subjectAccessPoints',
       'title',
       'type',
-      'publicationStatus',
       'displayStandard',
       'displayStandardUpdateDescendants');
 

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/actions/editAction.class.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/actions/editAction.class.php
@@ -65,7 +65,6 @@ class sfIsadPluginEditAction extends InformationObjectEditAction
       'sources',
       'subjectAccessPoints',
       'descriptionStatus',
-      'publicationStatus',
       'displayStandard',
       'displayStandardUpdateDescendants',
       'title');

--- a/plugins/sfModsPlugin/modules/sfModsPlugin/actions/editAction.class.php
+++ b/plugins/sfModsPlugin/modules/sfModsPlugin/actions/editAction.class.php
@@ -40,7 +40,6 @@ class sfModsPluginEditAction extends InformationObjectEditAction
       'type',
       'repository',
       'scopeAndContent',
-      'publicationStatus',
       'displayStandard',
       'displayStandardUpdateDescendants');
 

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/actions/editAction.class.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/actions/editAction.class.php
@@ -82,7 +82,6 @@ class sfRadPluginEditAction extends InformationObjectEditAction
       'titleStatementOfResponsibility',
       'titleProperOfPublishersSeries',
       'type',
-      'publicationStatus',
       'displayStandard',
       'displayStandardUpdateDescendants');
 


### PR DESCRIPTION
- Remove pub. status field from IO edit forms
- Use default pub. status setting on IO creation
- Add update pub. status link in IO actions more dropdown,
  only added for user with publish permissions over the IO
- Add form action and template, only accessible for users
  with publish permission
- Update current resource synchronously
- Update descendants (if required) using job scheduler
- Create arUpdatePublicationStatusJob and add it to the worker
