### PR TITLE
Add basic support for Docker + Compose, refs #9406

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.gitignore

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,55 @@
+FROM php:7-fpm-alpine
+
+ENV FOP_HOME /usr/share/fop-2.1
+
+RUN set -xe \
+		&& apk add --no-cache --virtual .phpext-builddeps \
+			gettext-dev \
+			libmcrypt-dev \
+			libxslt-dev \
+			zlib-dev \
+			libmemcached-dev \
+		&& docker-php-ext-install \
+			gettext \
+			mbstring \
+			mcrypt \
+			mysqli \
+			opcache \
+			pdo_mysql \
+			sockets \
+			xsl \
+			zip \
+		# https://bugs.php.net/bug.php?id=70751
+		&& curl -Ls https://github.com/websupport-sk/pecl-memcache/archive/NON_BLOCKING_IO_php7.tar.gz | tar xz -C / \
+		&& cd /pecl-memcache-NON_BLOCKING_IO_php7 \
+		&& phpize && ./configure && make && make install \
+		&& docker-php-ext-enable memcache \
+		&& rm -rf /pecl-memcache-NON_BLOCKING_IO_php7 \
+		&& apk add --virtual .phpext-rundeps \
+			gettext \
+			libmcrypt \
+			libxslt \
+			libmemcached-libs \
+		&& apk del .phpext-builddeps
+
+RUN set -xe \
+		&& apk add --no-cache --virtual .atom-deps \
+			openjdk8-jre-base \
+			# ffmpeg \ (libva package problem, temporary disabled)
+			imagemagick \
+			ghostscript \
+			poppler-utils \
+			nodejs \
+			make \
+			bash \
+		&& npm install -g "less@<2.0.0" \
+		&& curl -Ls https://archive.apache.org/dist/xmlgraphics/fop/binaries/fop-2.1-bin.tar.gz | tar xz -C /usr/share \
+		&& ln -sf /usr/share/fop-2.1/fop /usr/local/bin/fop
+
+COPY / /atom/src
+RUN make -C /atom/src/plugins/arDominionPlugin \
+	&& make -C /atom/src/plugins/arArchivesCanadaPlugin
+
+WORKDIR /atom/src
+ENTRYPOINT ["/atom/src/docker/entrypoint.sh"]
+CMD ["fpm"]

--- a/docker/bootstrap.php
+++ b/docker/bootstrap.php
@@ -1,0 +1,297 @@
+<?php
+
+define('_ATOM_DIR', '/atom/src');
+define('_ETC_DIR', '/usr/local/etc');
+
+
+function getenv_default($name, $default)
+{
+  $value = getenv($name);
+
+  if (false === $value)
+  {
+    return $default;
+  }
+
+  return $value;
+}
+
+
+function getenv_or_fail($name)
+{
+  $value = getenv($name);
+
+  if (false === $value)
+  {
+    echo "Environment variable ${name} is not defined!";
+    exit(1);
+  }
+
+  return $value;
+}
+
+function get_host_and_port($value, $default_port)
+{
+  $parts = explode(':', $value);
+
+  if (count($parts) == 1)
+  {
+    $parts[1] = $default_port;
+  }
+
+  return array('host' => $parts[0], 'port' => $parts[1]);
+}
+
+
+$CONFIG = array(
+  'atom.development_mode'   => filter_var(getenv_default('ATOM_DEVELOPMENT_MODE', false), FILTER_VALIDATE_BOOLEAN),
+  'atom.elasticsearch_host' => getenv_or_fail('ATOM_ELASTICSEARCH_HOST'),
+  'atom.memcached_host'     => getenv_or_fail('ATOM_MEMCACHED_HOST'),
+  'atom.gearmand_host'      => getenv_or_fail('ATOM_GEARMAND_HOST'),
+  'atom.mysql_dsn'          => getenv_or_fail('ATOM_MYSQL_DSN'),
+  'atom.mysql_username'     => getenv_or_fail('ATOM_MYSQL_USERNAME'),
+  'atom.mysql_password'     => getenv_or_fail('ATOM_MYSQL_PASSWORD'),
+  'php.max_execution_time'  => getenv_default('ATOM_PHP_MAX_EXECUTION_TIME', '120'),
+  'php.max_input_time'      => getenv_default('ATOM_PHP_MAX_INPUT_TIME', '120'),
+  'php.memory_limit'        => getenv_default('ATOM_PHP_MEMORY_LIMIT', '512M'),
+  'php.post_max_size'       => getenv_default('ATOM_PHP_POST_MAX_SIZE', '72M'),
+  'php.upload_max_filesize' => getenv_default('ATOM_PHP_UPLOAD_MAX_FILESIZE', '64M'),
+  'php.max_file_uploads'    => getenv_default('ATOM_PHP_MAX_FILE_UPLOADS', '20'),
+  'php.date.timezone'       => getenv_default('ATOM_PHP_DATE_TIMEZONE', 'America/Vancouver')
+);
+
+
+#
+# /apps/qubit/config/settings.yml
+#
+
+copy(_ATOM_DIR.'/apps/qubit/config/settings.yml.tmpl', _ATOM_DIR.'/apps/qubit/config/settings.yml');
+
+
+#
+# /config/propel.ini
+#
+
+@unlink(_ATOM_DIR.'/config/propel.ini');
+touch(_ATOM_DIR.'/config/propel.ini');
+
+
+#
+# /apps/qubit/config/gearman.yml
+#
+
+$gearman_yml = <<<EOT
+all:
+  servers:
+    default: ${CONFIG['atom.gearmand_host']}
+EOT;
+
+@unlink(_ATOM_DIR.'/apps/qubit/config/gearman.yml');
+file_put_contents(_ATOM_DIR.'/apps/qubit/config/gearman.yml', $gearman_yml);
+
+
+#
+# /apps/qubit/config/app.yml
+#
+
+$parts = get_host_and_port($CONFIG['atom.memcached_host'], 11211);
+$app_yml = <<<EOT
+all:
+  upload_limit: -1
+  download_timeout: 10
+  cache_engine: sfMemcacheCache
+  cache_engine_param:
+    host: ${parts['host']}
+    port: ${parts['port']}
+    prefix: atom
+    storeCacheInfo: true
+    persistent: true
+  read_only: false
+  htmlpurifier_enabled: false
+EOT;
+
+@unlink(_ATOM_DIR.'/apps/qubit/config/app.yml');
+file_put_contents(_ATOM_DIR.'/apps/qubit/config/app.yml', $app_yml);
+
+
+#
+# /apps/qubit/config/factories.yml
+#
+
+$parts = get_host_and_port($CONFIG['atom.memcached_host'], 11211);
+$factories_yml = <<<EOT
+prod:
+  storage:
+    class: QubitCacheSessionStorage
+    param:
+      session_name: symfony
+      session_cookie_httponly: true
+      session_cookie_secure: true
+      cache:
+        class: sfMemcacheCache
+        param:
+          host: memcached
+          port: 11211
+          prefix: atom
+          storeCacheInfo: true
+          persistent: true
+
+dev:
+  storage:
+    class: QubitCacheSessionStorage
+    param:
+      session_name: symfony
+      session_cookie_httponly: true
+      session_cookie_secure: true
+      cache:
+        class: sfMemcacheCache
+        param:
+          host: memcached
+          port: 11211
+          prefix: atom
+          storeCacheInfo: true
+          persistent: true
+
+EOT;
+
+@unlink(_ATOM_DIR.'/apps/qubit/config/factories.yml');
+file_put_contents(_ATOM_DIR.'/apps/qubit/config/factories.yml', $factories_yml);
+
+
+#
+# /config/search.yml
+#
+
+$parts = get_host_and_port($CONFIG['atom.elasticsearch_host'], 9200);
+$search_yml = <<<EOT
+all:
+  server:
+    host: ${parts['host']}
+    post: ${parts['port']}
+
+EOT;
+
+@unlink(_ATOM_DIR.'/config/search.yml');
+file_put_contents(_ATOM_DIR.'/config/search.yml', $search_yml);
+
+
+#
+# /config/config.php
+#
+
+$mysql_config = array(
+  'all' => array(
+    'propel' => array(
+      'class' => 'sfPropelDatabase',
+      'param' => array(
+        'encoding' => 'utf8',
+        'persistent' => true,
+        'pooling' => true,
+        'dsn' => $CONFIG['atom.mysql_dsn'],
+        'username' => $CONFIG['atom.mysql_username'],
+        'password' => $CONFIG['atom.mysql_password'],
+      ),
+    ),
+  ),
+  'dev' => array(
+    'propel' => array(
+      'param' => array(
+        'classname' => 'DebugPDO',
+        'debug' => array(
+          'realmemoryusage' => true,
+          'details' => array(
+            'time' => array('enabled' => true,),
+            'slow' => array('enabled' => true, 'threshold' => 0.1,),
+            'mem' => array('enabled' => true,),
+            'mempeak' => array ('enabled' => true,),
+            'memdelta' => array ('enabled' => true,),
+          ),
+        ),
+      ),
+    ),
+  ),
+  'test' => array(
+    'propel' => array(
+      'param' => array(
+        'classname' => 'DebugPDO',
+      ),
+    ),
+  ),
+);
+
+$config_php = "<?php\n\nreturn ".var_export($mysql_config, 1).";\n\n?>\n";
+
+@unlink(_ATOM_DIR.'/config/config.php');
+file_put_contents(_ATOM_DIR.'/config/config.php', $config_php);
+
+
+#
+# php ini
+#
+
+$php_ini = <<<EOT
+[PHP]
+output_buffering = 4096
+expose_php = off
+log_errors = on
+error_reporting = E_ALL
+display_errors = stderr
+display_startup_errors = on
+max_execution_time = ${CONFIG['php.max_execution_time']}
+max_input_time = ${CONFIG['php.max_input_time']}
+memory_limit = ${CONFIG['php.memory_limit']}
+log_errors = on
+post_max_size = ${CONFIG['php.post_max_size']}
+default_charset = UTF-8
+cgi.fix_pathinfo = off
+upload_max_filesize = ${CONFIG['php.upload_max_filesize']}
+max_file_uploads = ${CONFIG['php.max_file_uploads']}
+date.timezone = ${CONFIG['php.date.timezone']}
+session.use_only_cookies = off
+opcache.fast_shutdown = on
+opcache.max_accelerated_files = 10000
+opcache.validate_timestamps = off
+
+EOT;
+
+if ($CONFIG['atom.development_mode'])
+{
+  $php_ini .= <<<EOT
+\n
+# Development-specific configuration
+expose_php = on
+opcache.validate_timestamps = on
+
+EOT;
+}
+
+@unlink(_ETC_DIR.'/php/php.ini');
+file_put_contents(_ETC_DIR.'/php/php.ini', $php_ini);
+
+
+#
+# fpm ini
+#
+
+$fpm_ini = <<<EOT
+[global]
+error_log = /proc/self/fd/2
+daemonize = no
+
+[atom]
+access.log = /proc/self/fd/2
+clear_env = no
+catch_workers_output = yes
+user = root
+group = root
+listen = [::]:9000
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+
+EOT;
+
+@unlink(_ETC_DIR.'/php-fpm.d/atom.conf');
+file_put_contents(_ETC_DIR.'/php-fpm.d/atom.conf', $fpm_ini);

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,0 +1,113 @@
+---
+version: "2"
+
+volumes:
+
+  elasticsearch_data:
+    driver: local
+
+  percona_data:
+    driver: local
+
+  atom_uploads:
+    driver: local
+
+  atom_downloads:
+    driver: local
+
+services:
+
+  elasticsearch:
+    image: "elasticsearch:1.7"
+    # chown only seems to be solving a problem only happeing with osx+boot2docker and vboxsf
+    command: "bash -c 'chown -R elasticsearch:elasticsearch /elasticsearch-data && elasticsearch -Des.network.host=0.0.0.0 -Des.path.data=/elasticsearch-data'"
+    volumes:
+      - "elasticsearch_data:/elasticsearch-data:rw"
+    expose:
+      - "9200"
+      - "9300"
+
+  percona:
+    image: "percona:5.7"
+    environment:
+      - "MYSQL_ROOT_PASSWORD=my-secret-pw"
+      - "MYSQL_DATABASE=atom"
+      - "MYSQL_USER=atom"
+      - "MYSQL_PASSWORD=atom_12345"
+    volumes:
+      - "percona_data:/var/lib/mysql:rw"
+      - "./etc/mysql/conf.d/:/etc/mysql/conf.d:ro"
+    expose:
+      - "3306"
+
+  memcached:
+    image: "memcached"
+    command: "-p 11211 -m 128 -u memcache"
+    expose:
+      - "11211"
+
+  gearmand:
+    image: "sevein/gearmand"
+    command: "--queue-type=libmemcached --libmemcached-servers=memcached:11211 --listen=0.0.0.0 --port=4730 --log-file=stderr"
+    expose:
+      - "4730"
+    links:
+      - "memcached"
+
+  atom:
+    build:
+      context: "../"
+      dockerfile: "./docker/Dockerfile"
+    command: "fpm"
+    links:
+      - "gearmand"
+      - "memcached"
+      - "percona"
+      - "elasticsearch"
+    volumes:
+      - "../:/atom/src:rw"
+      - "atom_uploads:/atom/src/uploads:rw"
+      - "atom_downloads:/atom/src/downloads:rw"
+    environment:
+      - "ATOM_DEVELOPMENT_MODE=on"
+      - "ATOM_ELASTICSEARCH_HOST=elasticsearch"
+      - "ATOM_MEMCACHED_HOST=memcached"
+      - "ATOM_GEARMAND_HOST=gearmand"
+      - "ATOM_MYSQL_DSN=mysql:host=percona;port=3306;dbname=atom;charset=utf8"
+      - "ATOM_MYSQL_USERNAME=atom"
+      - "ATOM_MYSQL_PASSWORD=atom_12345"
+
+  atom_worker:
+    build:
+      context: "../"
+      dockerfile: "./docker/Dockerfile"
+    command: "worker"
+    links:
+      - "gearmand"
+      - "memcached"
+      - "percona"
+      - "elasticsearch"
+    volumes:
+      - "../:/atom/src:rw"
+      - "atom_uploads:/atom/src/uploads:rw"
+      - "atom_downloads:/atom/src/downloads:rw"
+    environment:
+      - "ATOM_DEVELOPMENT_MODE=on"
+      - "ATOM_ELASTICSEARCH_HOST=elasticsearch"
+      - "ATOM_MEMCACHED_HOST=memcached"
+      - "ATOM_GEARMAND_HOST=gearmand"
+      - "ATOM_MYSQL_DSN=mysql:host=percona;port=3306;dbname=atom;charset=utf8"
+      - "ATOM_MYSQL_USERNAME=atom"
+      - "ATOM_MYSQL_PASSWORD=atom_12345"
+
+  nginx:
+    image: "nginx:latest"
+    links:
+      - "atom"
+    ports:
+      - "8000:80"
+    volumes:
+      - "../:/atom/src:ro"
+      - "./etc/nginx/prod.conf:/etc/nginx/nginx.conf:ro"
+      - "atom_uploads:/atom/src/uploads:ro"
+      - "atom_downloads:/atom/src/downloads:ro"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+# set -o xtrace
+
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+__file="${__dir}/$(basename "${BASH_SOURCE[0]}")"
+__atom_root="/atom/src"
+
+
+# Clean-ups
+rm -rf /usr/local/etc/php-fpm.d/*
+rm -rf ${__atom_root}/cache/*
+
+# Populate configuration files
+php ${__dir}/bootstrap.php $@
+status=$?
+if [ $status -ne 0 ]; then
+    echo "bootstrap.php failed!"
+    exit $status
+fi
+
+
+case $1 in
+    '')
+        echo "Usage: (convenience shortcuts)"
+        echo "  ./entrypoint.sh worker      Execute worker."
+        echo "  ./entrypoint.sh fpm         Execute php-fpm."
+        echo ""
+        echo "You can also pass other commands:"
+        echo "  ./entrypoint.sh bash"
+        echo "  ./entrypoint.sh uptime"
+        echo "  ./entrypoint.sh ls -l /"
+        exit 0
+        ;;
+    'worker')
+        php ${__dir}/../symfony jobs:worker
+        exit 0
+        ;;
+    'fpm')
+        trap 'kill -INT $PID' TERM INT
+        php-fpm --allow-to-run-as-root &
+        PID=$!
+        wait $PID
+        trap - TERM INT
+        wait $PID
+        exit $?
+        ;;
+esac
+
+exec "${@}"

--- a/docker/etc/mysql/conf.d/encoding.cnf
+++ b/docker/etc/mysql/conf.d/encoding.cnf
@@ -1,0 +1,6 @@
+[mysqld]
+init_connect="SET collation_connection = utf8_unicode_ci"
+init_connect="SET NAMES utf8"
+character-set-server=utf8
+collation-server=utf8_unicode_ci
+skip-character-set-client-handshake

--- a/docker/etc/mysql/conf.d/sql_mode.cnf
+++ b/docker/etc/mysql/conf.d/sql_mode.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+; STRICT_TRANS_TABLES disabled on purpose (culture length bug in AtoM and other potential issues?)
+sql-mode="ONLY_FULL_GROUP_BY,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"

--- a/docker/etc/nginx/prod.conf
+++ b/docker/etc/nginx/prod.conf
@@ -1,0 +1,69 @@
+user nginx;
+worker_processes 1;
+
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+  log_format main '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
+  access_log /var/log/nginx/access.log main;
+  sendfile on;
+  keepalive_timeout 65;
+  gzip on;
+
+  upstream atom {
+    server atom_1:9000;
+  }
+
+  server {
+    listen 80;
+    root /atom/src;
+    server_name _;
+    client_max_body_size 72M;
+    location / {
+      try_files $uri /index.php?$args;
+    }
+    location ~ /\. {
+      deny all;
+      return 404;
+    }
+    location ~* (\.yml|\.ini|\.tmpl)$ {
+      deny all;
+      return 404;
+    }
+    location ~* /(?:uploads|files)/.*\.php$ {
+      deny all;
+      return 404;
+    }
+    location ~* /uploads/r/(.*)/conf/ { }
+    location ~* ^/uploads/r/(.*)$ {
+      include /etc/nginx/fastcgi_params;
+      set $index /index.php;
+      fastcgi_param SCRIPT_FILENAME $document_root$index;
+      fastcgi_param SCRIPT_NAME $index;
+      fastcgi_pass atom;
+    }
+    location ~ ^/private/(.*)$ {
+      internal;
+      alias /atom/src/$1;
+    }
+    location ~ ^/(index|qubit_dev)\.php(/|$) {
+      include /etc/nginx/fastcgi_params;
+      fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+      fastcgi_split_path_info ^(.+\.php)(/.*)$;
+      fastcgi_pass atom;
+    }
+    location ~* \.php$ {
+      deny all;
+      return 404;
+    }
+
+  }
+}


### PR DESCRIPTION
Redmine: https://projects.artefactual.com/issues/9406
### Usage

You need a Docker host (Engine) or a cluster (Swarm) and Docker Compose in order to orchestrate all the containers.

Docker Machine can assist you to easily deploy Docker hosts locally or using virtual machines or even remotely (cloud or bare-metal). There is also a bundle with all the tools included available for Windows and OSX users: [Docker Toolbox](https://www.docker.com/products/overview#/docker_toolbox).

Our default environment is described in `docker-compose.dev.yml`, which is meant to be used by developers. Production environments can differ significantly in the way they are composed based on your resources. We may provide some examples in the future, but that's not in the scope of this pull request.

Once the dependencies are installed, check out the repository and run:

``` shell
$ cd docker/
$ docker-compose -f docker-compose.dev.yml up -d
$ docker-compose -f docker-compose.dev.yml exec atom php symfony tools:purge --demo
$ docker-compose -f docker-compose.dev.yml exec atom make -C /atom/src/plugins/arDominionPlugin
$ docker-compose -f docker-compose.dev.yml restart atom_worker
```
### Environment variables

When you start the `artefactual/atom` image, you can adjust a number of settings passing environment variables on the `docker run` command line or via the Docker Compose file.

| Name | Default |
| --- | --- |
| `ATOM_DEVELOPMENT_MODE` | `Off` |
| `ATOM_ELASTICSEARCH_HOST` | Not provided |
| `ATOM_MEMCACHED_HOST` | Not provided |
| `ATOM_GEARMAND_HOST` | Not provided |
| `ATOM_MYSQL_DSN` | Not provided |
| `ATOM_MYSQL_USERNAME` | Not provided |
| `ATOM_MYSQL_PASSWORD` | Not provided |
| `ATOM_PHP_MAX_EXECUTION_TIME` | `120` |
| `ATOM_PHP_MAX_INPUT_TIME` | `120` |
| `ATOM_PHP_MEMORY_LIMIT` | `512M` |
| `ATOM_PHP_POST_MAX_SIZE` | `72M` |
| `ATOM_PHP_UPLOAD_MAX_FILESIZE` | `64M` |
| `ATOM_PHP_MAX_FILE_UPLOADS` | `20` |
| `ATOM_PHP_DATE_TIMEZONE` | `America/Vancouver` |
