### PR TITLE
Fix genre term creation issue, refs #9300

### DIFF
--- a/plugins/arDacsPlugin/modules/arDacsPlugin/templates/editSuccess.php
+++ b/plugins/arDacsPlugin/modules/arDacsPlugin/templates/editSuccess.php
@@ -253,7 +253,7 @@
             ->renderLabel() ?>
           <?php echo $form->genreAccessPoints->render(array('class' => 'form-autocomplete')) ?>
           <?php if (QubitAcl::check(QubitActor::getRoot(), 'create')): ?>
-            <input class="add" type="hidden" data-link-existing="true" value="<?php echo url_for(array('module' => 'actor', 'action' => 'add')) ?>"/>
+            <input class="add" type="hidden" data-link-existing="true" value="<?php echo url_for(array('module' => 'term', 'action' => 'add', 'taxonomy' => url_for(array(QubitTaxonomy::getById(QubitTaxonomy::GENRE_ID), 'module' => 'taxonomy')))) ?> #name"/>
           <?php endif; ?>
           <input class="list" type="hidden" value="<?php echo url_for(array('module' => 'term', 'action' => 'autocomplete', 'taxonomy' => url_for(array(QubitTaxonomy::getById(QubitTaxonomy::GENRE_ID), 'module' => 'taxonomy')))) ?>"/>
         </div>

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/editSuccess.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/editSuccess.php
@@ -229,7 +229,7 @@
             ->renderLabel() ?>
           <?php echo $form->genreAccessPoints->render(array('class' => 'form-autocomplete')) ?>
           <?php if (QubitAcl::check(QubitActor::getRoot(), 'create')): ?>
-            <input class="add" type="hidden" data-link-existing="true" value="<?php echo url_for(array('module' => 'actor', 'action' => 'add')) ?>"/>
+            <input class="add" type="hidden" data-link-existing="true" value="<?php echo url_for(array('module' => 'term', 'action' => 'add', 'taxonomy' => url_for(array(QubitTaxonomy::getById(QubitTaxonomy::GENRE_ID), 'module' => 'taxonomy')))) ?> #name"/>
           <?php endif; ?>
           <input class="list" type="hidden" value="<?php echo url_for(array('module' => 'term', 'action' => 'autocomplete', 'taxonomy' => url_for(array(QubitTaxonomy::getById(QubitTaxonomy::GENRE_ID), 'module' => 'taxonomy')))) ?>"/>
         </div>


### PR DESCRIPTION
Redmine ticket: https://projects.artefactual.com/issues/9300

When editing an archival description in either ISAD or DACS, adding a new genre form term in the access
points section would cause a JS error and prevent the user from saving the record changes.
