### PR TITLE
Prevent term duplication in CSV import, refs #9459

### DIFF
--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -1135,7 +1135,13 @@ class QubitFlatfileImport
     // Add relation with place
     if (isset($options['place']))
     {
-      $placeTerm = $this->createOrFetchTerm(QubitTaxonomy::PLACE_ID, $options['place']);
+      $culture = 'en';
+      if (isset($options['culture']))
+      {
+        $culture = $options['culture'];
+      }
+
+      $placeTerm = $this->createOrFetchTerm(QubitTaxonomy::PLACE_ID, $options['place'], $culture);
       $this->createObjectTermRelation($event->id, $placeTerm->id);
     }
 
@@ -1346,10 +1352,12 @@ class QubitFlatfileImport
   {
     $query = "SELECT t.id FROM term t LEFT JOIN term_i18n ti ON t.id=ti.id \r
       WHERE t.taxonomy_id=? AND ti.name=? AND ti.culture=?";
+
     $statement = QubitFlatfileImport::sqlQuery(
       $query,
       array($taxonomyId, $name, $culture)
     );
+
     $result = $statement->fetch(PDO::FETCH_OBJ);
     if ($result)
     {

--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -1516,28 +1516,21 @@ class QubitFlatfileImport
   }
 
   /**
-   * Get the terms in a taxonomy, optionally specifying culture
+   * Get the terms in a taxonomy using sql query
    *
    * @param integer $taxonomyId  taxonomy ID
-   * @param string $culture  culture code (defaulting to English)
    *
-   * @return array  array of term IDs and their respective names
+   * @return array  objects resultset
    */
-  public static function getTaxonomyTerms($taxonomyId, $culture = 'en')
+  public static function getTaxonomyTerms($taxonomyId)
   {
-    $terms = array();
-
-    $query = "SELECT * FROM term t \r
-      LEFT JOIN term_i18n ti ON t.id=ti.id AND ti.culture=? \r
+    $query = "SELECT t.id, ti.culture, ti.name FROM term t
+      LEFT JOIN term_i18n ti ON t.id=ti.id
       WHERE taxonomy_id=?";
-    $statement = QubitFlatfileImport::sqlQuery($query, array($culture, $taxonomyId));
 
-    while($term = $statement->fetch(PDO::FETCH_OBJ))
-    {
-      $terms[$term->id] = $term;
-    }
+    $statement = QubitFlatfileImport::sqlQuery($query, array($taxonomyId));
 
-    return $terms;
+    return $statement->fetchAll(PDO::FETCH_OBJ);
   }
 
   /**
@@ -1555,9 +1548,9 @@ class QubitFlatfileImport
     foreach ($taxonomies as $taxonomyId => $varName)
     {
       $taxonomyTerms[$varName] = array();
-      foreach (QubitFlatfileImport::getTaxonomyTerms($taxonomyId) as $termId => $term)
+      foreach (QubitFlatfileImport::getTaxonomyTerms($taxonomyId) as $term)
       {
-        $taxonomyTerms[$varName][$termId] = $term->name;
+        $taxonomyTerms[$varName][$term->culture][$term->id] = $term->name;
       }
     }
 

--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -1541,39 +1541,6 @@ class QubitFlatfileImport
   }
 
   /**
-   * Get a term's ID using its name, optionally specifying culture
-   *
-   * @param integer $taxonomyId  taxonomy ID
-   * @param string $termName  term name
-   * @param string $culture  culture code (defaulting to English)
-   *
-   * @return integer/boolean  term ID/false
-   */
-  public function getTaxonomyTermIdUsingName($taxonomyId, $termName, $culture = 'en')
-  {
-    global $cachedTaxonomyTerms;
-
-    $cachedTaxonomyTerms = (isset($cachedTaxonomyTerms))
-      ? $cachedTaxonomyTerms
-      : array();
-
-    $cachedTaxonomyTerms[$culture] = (isset($cachedTaxonomyTerms[$culture]))
-      ? $cachedTaxonomyTerms[$culture]
-      : array();
-
-    if (!isset($cachedTaxonomyTerms[$culture][$taxonomyId]))
-    {
-      $cachedTaxonomyTerms[$culture][$taxonomyId] = array();
-      foreach (QubitFlatfileImport::getTaxonomyTerms($taxonomyId, $culture) as $term)
-      {
-        $cachedTaxonomyTerms[$culture][$taxonomyId][$term->id] = $term->name;
-      }
-    }
-
-    return array_search($termName, $cachedTaxonomyTerms[$culture][$taxonomyId]);
-  }
-
-  /**
    * Load terms from one or more taxonomies and use the terms to populate one
    * or more array elements.
    *

--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -573,33 +573,33 @@ class QubitXmlImport
 
               // Load taxonomies into variables to avoid use of magic numbers
               $termData = QubitFlatfileImport::loadTermsFromTaxonomies(array(
-                QubitTaxonomy::NOTE_TYPE_ID                => 'noteTypes',
-                QubitTaxonomy::RAD_NOTE_ID                 => 'radNoteTypes',
-                QubitTaxonomy::RAD_TITLE_NOTE_ID           => 'titleNoteTypes',
-                QubitTaxonomy::DACS_NOTE_ID               => 'dacsSpecializedNotesTypes'
+                QubitTaxonomy::NOTE_TYPE_ID      => 'noteTypes',
+                QubitTaxonomy::RAD_NOTE_ID       => 'radNoteTypes',
+                QubitTaxonomy::RAD_TITLE_NOTE_ID => 'titleNoteTypes',
+                QubitTaxonomy::DACS_NOTE_ID      => 'dacsSpecializedNotesTypes'
               ));
 
-              $titleVariationNoteTypeId            = array_search('Variations in title', $termData['titleNoteTypes']);
-              $titleAttributionsNoteTypeId         = array_search('Attributions and conjectures', $termData['titleNoteTypes']);
-              $titleContinuationNoteTypeId         = array_search('Continuation of title', $termData['titleNoteTypes']);
-              $titleStatRepNoteTypeId              = array_search('Statements of responsibility', $termData['titleNoteTypes']);
-              $titleParallelNoteTypeId             = array_search('Parallel titles and other title information', $termData['titleNoteTypes']);
-              $titleSourceNoteTypeId               = array_search('Source of title proper', $termData['titleNoteTypes']);
-              $alphaNumericaDesignationsNoteTypeId = array_search('Alpha-numeric designations', $termData['radNoteTypes']);
-              $physDescNoteTypeId                  = array_search('Physical description', $termData['radNoteTypes']);
-              $editionNoteTypeId                   = array_search('Edition', $termData['radNoteTypes']);
-              $conservationNoteTypeId              = array_search('Conservation', $termData['radNoteTypes']);
+              $titleVariationNoteTypeId            = array_search('Variations in title', $termData['titleNoteTypes']['en']);
+              $titleAttributionsNoteTypeId         = array_search('Attributions and conjectures', $termData['titleNoteTypes']['en']);
+              $titleContinuationNoteTypeId         = array_search('Continuation of title', $termData['titleNoteTypes']['en']);
+              $titleStatRepNoteTypeId              = array_search('Statements of responsibility', $termData['titleNoteTypes']['en']);
+              $titleParallelNoteTypeId             = array_search('Parallel titles and other title information', $termData['titleNoteTypes']['en']);
+              $titleSourceNoteTypeId               = array_search('Source of title proper', $termData['titleNoteTypes']['en']);
+              $alphaNumericaDesignationsNoteTypeId = array_search('Alpha-numeric designations', $termData['radNoteTypes']['en']);
+              $physDescNoteTypeId                  = array_search('Physical description', $termData['radNoteTypes']['en']);
+              $editionNoteTypeId                   = array_search('Edition', $termData['radNoteTypes']['en']);
+              $conservationNoteTypeId              = array_search('Conservation', $termData['radNoteTypes']['en']);
 
-              $pubSeriesNoteTypeId                 = array_search("Publisher's series", $termData['radNoteTypes']);
-              $rightsNoteTypeId                    = array_search("Rights", $termData['radNoteTypes']);
-              $materialNoteTypeId                  = array_search("Accompanying material", $termData['radNoteTypes']);
-              $generalNoteTypeId                   = array_search("General note", $termData['radNoteTypes']);
+              $pubSeriesNoteTypeId                 = array_search("Publisher's series", $termData['radNoteTypes']['en']);
+              $rightsNoteTypeId                    = array_search("Rights", $termData['radNoteTypes']['en']);
+              $materialNoteTypeId                  = array_search("Accompanying material", $termData['radNoteTypes']['en']);
+              $generalNoteTypeId                   = array_search("General note", $termData['radNoteTypes']['en']);
 
-              $dacsAlphaNumericaDesignationsNoteTypeId  = array_search('Alphanumeric designations', $termData['dacsSpecializedNotesTypes']);
-              $dacsCitationNoteTypeId            = array_search("Citation", $termData['dacsSpecializedNotesTypes']);
-              $dacsConservationNoteTypeId        = array_search("Conservation", $termData['dacsSpecializedNotesTypes']);
-              $dacsProcessingInformationNoteTypeId   = array_search("Processing information", $termData['dacsSpecializedNotesTypes']);
-              $dacsVariantTitleInformationNoteTypeId   = array_search("Variant title information", $termData['dacsSpecializedNotesTypes']);
+              $dacsAlphaNumericaDesignationsNoteTypeId  = array_search('Alphanumeric designations', $termData['dacsSpecializedNotesTypes']['en']);
+              $dacsCitationNoteTypeId            = array_search("Citation", $termData['dacsSpecializedNotesTypes']['en']);
+              $dacsConservationNoteTypeId        = array_search("Conservation", $termData['dacsSpecializedNotesTypes']['en']);
+              $dacsProcessingInformationNoteTypeId   = array_search("Processing information", $termData['dacsSpecializedNotesTypes']['en']);
+              $dacsVariantTitleInformationNoteTypeId   = array_search("Variant title information", $termData['dacsSpecializedNotesTypes']['en']);
 
               // invoke the object and method defined in the schema map
               $obj = call_user_func_array(array( & $currentObject, $methodMap['Method']), $parameters);

--- a/lib/flatfile/QubitFlatfileExport.class.php
+++ b/lib/flatfile/QubitFlatfileExport.class.php
@@ -252,12 +252,14 @@ class QubitFlatfileExport
   {
     $terms = array();
 
-    foreach (QubitFlatfileImport::getTaxonomyTerms($taxonomyId) as $termId => $term)
+    foreach (QubitFlatfileImport::getTaxonomyTerms($taxonomyId) as $term)
     {
-      $terms[$termId] = $term->name;
+      $terms[$term->culture][$term->id] = $term->name;
     }
 
-    return $terms;
+    // QubitFlatfileImport::getTaxonomyTerms has changed to allow a better
+    // culture matching on import. On export we're still only using english terms
+    return $terms['en'];
   }
 
 

--- a/lib/task/import/csvAccessionImportTask.class.php
+++ b/lib/task/import/csvAccessionImportTask.class.php
@@ -310,7 +310,7 @@ EOF;
         'resourceTypeId',
         'resource type',
         $data,
-        $self->getStatus('resourceTypes')
+        $self->status['resourceTypes'][$self->columnValue('culture')]
       );
     });
 
@@ -321,7 +321,7 @@ EOF;
         'acquisitionTypeId',
         'acquisition type',
         $data,
-        $self->getStatus('acquisitionTypes')
+        $self->status['acquisitionTypes'][$self->columnValue('culture')]
       );
     });
 
@@ -332,7 +332,7 @@ EOF;
         'processingStatusId',
         'processing status',
         $data,
-        $self->getStatus('processingStatus')
+        $self->status['processingStatus'][$self->columnValue('culture')]
       );
     });
 
@@ -343,7 +343,7 @@ EOF;
         'processingPriorityId',
         'processing priority',
         $data,
-        $self->getStatus('processingPriority')
+        $self->status['processingPriority'][$self->columnValue('culture')]
       );
     });
 

--- a/lib/task/import/csvAuthorityRecordImportTask.class.php
+++ b/lib/task/import/csvAuthorityRecordImportTask.class.php
@@ -212,7 +212,7 @@ EOF;
       // Import columns that can be added as QubitNote objects
       'noteMap' => array(
         'maintenanceNotes' => array(
-          'typeId' => array_search('Maintenance note', $termData['noteTypes'])
+          'typeId' => array_search('Maintenance note', $termData['noteTypes']['en'])
         )
       ),
 
@@ -245,7 +245,7 @@ EOF;
               'type of entity',
               $self->rowStatusVars['typeOfEntity'],
               array(),
-              $self->getStatus('actorTypes')
+              $self->status['actorTypes'][$self->columnValue('culture')]
             );
           }
 
@@ -258,7 +258,7 @@ EOF;
               'status',
               $self->rowStatusVars['status'],
               array(),
-              $self->getStatus('descriptionStatusTypes')
+              $self->status['descriptionStatusTypes'][$self->columnValue('culture')]
             );
           }
 
@@ -271,7 +271,7 @@ EOF;
               'level of detail',
               $self->rowStatusVars['levelOfDetail'],
               array(),
-              $self->getStatus('detailLevelTypes')
+              $self->status['detailLevelTypes'][$self->columnValue('culture')]
             );
           }
         }
@@ -405,7 +405,7 @@ EOF;
             // Determine type ID of relationship type
             $relationTypeId = array_search(
               $self->rowStatusVars['category'],
-              $self->status['actorRelationTypes']
+              $self->status['actorRelationTypes'][$self->columnValue('culture')]
             );
 
             if (!$relationTypeId)

--- a/lib/task/import/csvEventImportTask.class.php
+++ b/lib/task/import/csvEventImportTask.class.php
@@ -178,7 +178,7 @@ EOF;
             $type = $self->columnValue($self->status['relationTypeColumn']);
             print 'Relate '. $subjectId .' to '. $objectId .' as '. $type .".\n";
 
-            $typeId = array_search($type, $self->status['eventTypes']);
+            $typeId = array_search($type, $self->status['eventTypes'][$self->columnValue('culture')]);
 
             if (!$typeId)
             {

--- a/lib/task/import/csvEventImportTask.class.php
+++ b/lib/task/import/csvEventImportTask.class.php
@@ -183,9 +183,10 @@ EOF;
             if (!$typeId)
             {
               print "Term does not exist... adding.\n";
-              $term = QubitFlatfileImport::createOrFetchTerm(
+              $term = QubitFlatfileImport::createTerm(
                 QubitTaxonomy::EVENT_TYPE_ID,
-                $type
+                $type,
+                $self->columnValue('culture')
               );
               $typeId = $term->id;
               $self->status['eventTypes'][$typeId] = $type;

--- a/lib/task/import/csvImportBaseTask.class.php
+++ b/lib/task/import/csvImportBaseTask.class.php
@@ -195,11 +195,14 @@ abstract class csvImportBaseTask extends arBaseTask
       else
       {
         // Get or add term if event type is set
-        $typeTerm = $import->createOrFetchTerm(QubitTaxonomy::EVENT_TYPE_ID, $eventData['type']);
+        $typeTerm = $import->createOrFetchTerm(QubitTaxonomy::EVENT_TYPE_ID, $eventData['type'], $import->columnValue('culture'));
         $eventTypeId = $typeTerm->id;
 
         unset($eventData['type']);
       }
+
+      // Add row culture to fetch place term in event creation/update
+      $eventData['culture'] = $import->columnValue('culture');
 
       $event = $import->createOrUpdateEvent($eventTypeId, $eventData);
     }

--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -282,70 +282,70 @@ EOF;
       // Import columns that can be added as QubitNote objects
       'noteMap' => array(
         'languageNote' => array(
-          'typeId' => array_search('Language note', $termData['noteTypes'])
+          'typeId' => array_search('Language note', $termData['noteTypes']['en'])
         ),
         'publicationNote' => array(
-          'typeId' => array_search('Publication note', $termData['noteTypes'])
+          'typeId' => array_search('Publication note', $termData['noteTypes']['en'])
         ),
         'generalNote' => array(
-          'typeId' => array_search('General note', $termData['noteTypes'])
+          'typeId' => array_search('General note', $termData['noteTypes']['en'])
         ),
         'archivistNote' => array(
-          'typeId' => array_search("Archivist's note", $termData['noteTypes'])
+          'typeId' => array_search("Archivist's note", $termData['noteTypes']['en'])
         ),
         'radNoteCast' => array(
-          'typeId' => array_search('Cast note', $termData['radNoteTypes'])
+          'typeId' => array_search('Cast note', $termData['radNoteTypes']['en'])
         ),
         'radNoteCredits' => array(
-          'typeId' => array_search('Credits note', $termData['radNoteTypes'])
+          'typeId' => array_search('Credits note', $termData['radNoteTypes']['en'])
         ),
         'radNoteSignaturesInscriptions' => array(
-          'typeId' => array_search('Signatures note', $termData['radNoteTypes'])
+          'typeId' => array_search('Signatures note', $termData['radNoteTypes']['en'])
         ),
         'radNoteConservation' => array(
-          'typeId' => array_search('Conservation', $termData['radNoteTypes'])
+          'typeId' => array_search('Conservation', $termData['radNoteTypes']['en'])
         ),
         'radNoteGeneral' => array(
-          'typeId' => array_search('General note', $termData['noteTypes'])
+          'typeId' => array_search('General note', $termData['noteTypes']['en'])
         ),
         'radNotePhysicalDescription' => array(
-          'typeId' => array_search('Physical description', $termData['radNoteTypes'])
+          'typeId' => array_search('Physical description', $termData['radNoteTypes']['en'])
         ),
         'radNotePublishersSeries' => array(
-          'typeId' => array_search("Publisher's series", $termData['radNoteTypes'])
+          'typeId' => array_search("Publisher's series", $termData['radNoteTypes']['en'])
         ),
         'radNoteRights' => array(
-          'typeId' => array_search('Rights', $termData['radNoteTypes'])
+          'typeId' => array_search('Rights', $termData['radNoteTypes']['en'])
         ),
         'radNoteAccompanyingMaterial' => array(
-          'typeId' => array_search('Accompanying material', $termData['radNoteTypes'])
+          'typeId' => array_search('Accompanying material', $termData['radNoteTypes']['en'])
         ),
         'radNoteAlphaNumericDesignation' => array(
-          'typeId' => array_search('Alpha-numeric designations', $termData['radNoteTypes'])
+          'typeId' => array_search('Alpha-numeric designations', $termData['radNoteTypes']['en'])
         ),
         'radNoteEdition' => array(
-          'typeId' => array_search('Edition', $termData['radNoteTypes'])
+          'typeId' => array_search('Edition', $termData['radNoteTypes']['en'])
         ),
         'radTitleStatementOfResponsibilityNote' => array(
-          'typeId' => array_search('Statements of responsibility', $termData['titleNoteTypes'])
+          'typeId' => array_search('Statements of responsibility', $termData['titleNoteTypes']['en'])
         ),
         'radTitleParallelTitles' => array(
-          'typeId' => array_search('Parallel titles and other title information', $termData['titleNoteTypes'])
+          'typeId' => array_search('Parallel titles and other title information', $termData['titleNoteTypes']['en'])
         ),
         'radTitleSourceOfTitleProper' => array(
-          'typeId' => array_search('Source of title proper', $termData['titleNoteTypes'])
+          'typeId' => array_search('Source of title proper', $termData['titleNoteTypes']['en'])
         ),
         'radTitleVariationsInTitle' => array(
-          'typeId' => array_search('Variations in title', $termData['titleNoteTypes'])
+          'typeId' => array_search('Variations in title', $termData['titleNoteTypes']['en'])
         ),
         'radTitleAttributionsAndConjectures' => array(
-          'typeId' => array_search('Attributions and conjectures', $termData['titleNoteTypes'])
+          'typeId' => array_search('Attributions and conjectures', $termData['titleNoteTypes']['en'])
         ),
         'radTitleContinues' => array(
-          'typeId' => array_search('Continuation of title', $termData['titleNoteTypes'])
+          'typeId' => array_search('Continuation of title', $termData['titleNoteTypes']['en'])
         ),
         'radTitleNoteContinuationOfTitle' => array(
-          'typeId' => array_search('Continuation of title', $termData['titleNoteTypes'])
+          'typeId' => array_search('Continuation of title', $termData['titleNoteTypes']['en'])
         )
       ),
 
@@ -441,17 +441,15 @@ EOF;
         {
           $levelOfDetail = trim($self->rowStatusVars['levelOfDetail']);
 
-          $levelOfDetailTermId = array_search_case_insensitive($levelOfDetail, $self->status['levelOfDetailTypes']);
+          $levelOfDetailTermId = array_search_case_insensitive($levelOfDetail, $self->status['levelOfDetailTypes'][$self->columnValue('culture')]);
           if ($levelOfDetailTermId === false)
           {
             print "\nTerm $levelOfDetail not found in description details level taxonomy, creating it...\n";
 
-            $culture = isset($self->object->culture) ? $self->object->culture : 'en';
-
             $newTerm = QubitFlatfileImport::createTerm(
               QubitTaxonomy::DESCRIPTION_DETAIL_LEVEL_ID,
               $levelOfDetail,
-              $culture
+              $self->columnValue('culture')
             );
 
             $levelOfDetailTermId = $newTerm->id;
@@ -493,7 +491,7 @@ EOF;
         if (isset($self->rowStatusVars['descriptionStatus']) && 0 < strlen($self->rowStatusVars['descriptionStatus']))
         {
           $descStatus = trim($self->rowStatusVars['descriptionStatus']);
-          $statusTermId = array_search_case_insensitive($descStatus, $self->status['descriptionStatusTypes']);
+          $statusTermId = array_search_case_insensitive($descStatus, $self->status['descriptionStatusTypes'][$self->columnValue('culture')]);
 
           if (false !== $statusTermId)
           {
@@ -516,7 +514,7 @@ EOF;
         {
           $pubStatusTermId = array_search_case_insensitive(
             $self->rowStatusVars['publicationStatus'],
-            $self->status['pubStatusTypes']
+            $self->status['pubStatusTypes'][$self->columnValue('culture')]
           );
 
           if (!$pubStatusTermId)
@@ -647,7 +645,7 @@ EOF;
               $type = 'Box';
             }
 
-            $physicalObjectTypeId = array_search_case_insensitive($type, $self->getStatus('physicalObjectTypes'));
+            $physicalObjectTypeId = array_search_case_insensitive($type, $self->status['physicalObjectTypes'][$self->columnValue('culture')]);
 
             // Create new physical object type if not found
             if ($physicalObjectTypeId === false)
@@ -1017,7 +1015,7 @@ EOF;
         foreach ($data as $value)
         {
           $value = trim($value);
-          $materialTypeId = array_search_case_insensitive($value, $self->getStatus('materialTypes'));
+          $materialTypeId = array_search_case_insensitive($value, $self->status['materialTypes'][$self->columnValue('culture')]);
 
           if ($materialTypeId !== false)
           {

--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -501,8 +501,7 @@ EOF;
           {
             print "\nTerm $descStatus not found in description status taxonomy, creating it...\n";
 
-            $culture = isset($self->object->culture) ? $self->object->culture : 'en';
-            $newTerm = QubitFlatfileImport::createTerm(QubitTaxonomy::DESCRIPTION_STATUS_ID, $descStatus, $culture);
+            $newTerm = QubitFlatfileImport::createTerm(QubitTaxonomy::DESCRIPTION_STATUS_ID, $descStatus, $self->columnValue('culture'));
             $self->status['descriptionStatusTypes'] = refreshTaxonomyTerms(QubitTaxonomy::DESCRIPTION_STATUS_ID);
 
             $self->object->descriptionStatusId = $newTerm->id;
@@ -652,8 +651,7 @@ EOF;
             {
               print "\nTerm $type not found in physical object type taxonomy, creating it...\n";
 
-              $culture = isset($self->object->culture) ? $self->object->culture : 'en';
-              $newTerm = QubitFlatfileImport::createTerm(QubitTaxonomy::PHYSICAL_OBJECT_TYPE_ID, $type, $culture);
+              $newTerm = QubitFlatfileImport::createTerm(QubitTaxonomy::PHYSICAL_OBJECT_TYPE_ID, $type, $self->columnValue('culture'));
               $self->status['physicalObjectTypes'] = refreshTaxonomyTerms(QubitTaxonomy::PHYSICAL_OBJECT_TYPE_ID);
 
               $physicalObjectTypeId = $newTerm->id;
@@ -1025,8 +1023,7 @@ EOF;
           {
             print "\nTerm $value not found in material type taxonomy, creating it...\n";
 
-            $culture = isset($self->object->culture) ? $self->object->culture : 'en';
-            $newTerm = QubitFlatfileImport::createTerm(QubitTaxonomy::MATERIAL_TYPE_ID, $value, $culture);
+            $newTerm = QubitFlatfileImport::createTerm(QubitTaxonomy::MATERIAL_TYPE_ID, $value, $self->columnValue('culture'));
             $self->status['materialTypes'] = refreshTaxonomyTerms(QubitTaxonomy::MATERIAL_TYPE_ID);
 
             $self->rowStatusVars['radGeneralMaterialDesignation'][] = $newTerm->id;

--- a/lib/task/import/csvRepositoryImportTask.class.php
+++ b/lib/task/import/csvRepositoryImportTask.class.php
@@ -68,15 +68,6 @@ EOF;
     $databaseManager = new sfDatabaseManager($this->configuration);
     $conn = $databaseManager->getDatabase('propel')->getConnection();
 
-    // Load taxonomies into variables to avoid use of magic numbers
-    $termData = QubitFlatfileImport::loadTermsFromTaxonomies(array(
-      QubitTaxonomy::NOTE_TYPE_ID                => 'noteTypes',
-      QubitTaxonomy::ACTOR_ENTITY_TYPE_ID        => 'actorTypes',
-      QubitTaxonomy::ACTOR_RELATION_TYPE_ID      => 'actorRelationTypes',
-      QubitTaxonomy::DESCRIPTION_STATUS_ID       => 'descriptionStatusTypes',
-      QubitTaxonomy::DESCRIPTION_DETAIL_LEVEL_ID => 'detailLevelTypes'
-    ));
-
     // Define import
     $import = new QubitFlatfileImport(array(
       // Pass context
@@ -94,7 +85,7 @@ EOF;
       // the status array is a place to put data that should be accessible
       // from closure logic using the getStatus method
       'status' => array(
-        'options'                => $options
+        'options' => $options
       ),
 
       // Import columns that map directory to QubitRepository properties

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
@@ -117,10 +117,9 @@
   <?php
   // Load taxonomies into variables to avoid use of magic numbers
   $termData = QubitFlatfileImport::loadTermsFromTaxonomies(array(
-    QubitTaxonomy::NOTE_TYPE_ID                => 'noteTypes',
-    QubitTaxonomy::RAD_NOTE_ID                 => 'radNoteTypes',
-    QubitTaxonomy::RAD_TITLE_NOTE_ID      => 'titleNoteTypes',
-    QubitTaxonomy::DACS_NOTE_ID               => 'dacsSpecializedNotesTypes'
+    QubitTaxonomy::RAD_NOTE_ID       => 'radNoteTypes',
+    QubitTaxonomy::RAD_TITLE_NOTE_ID => 'titleNoteTypes',
+    QubitTaxonomy::DACS_NOTE_ID      => 'dacsSpecializedNoteTypes'
   ));
 
   $radTitleNotes = array(
@@ -134,7 +133,7 @@
 
   foreach ($radTitleNotes as $name => $xmlType)
   {
-    $noteTypeId = array_search($name, $termData['titleNoteTypes']);
+    $noteTypeId = array_search($name, $termData['titleNoteTypes']['en']);
 
     if (0 < count($notes = $resource->getNotesByType(array('noteTypeId' => $noteTypeId)))):
       foreach ($notes as $note): ?>
@@ -155,7 +154,7 @@
 
   foreach($radNotes as $name => $xmlType)
   {
-    $noteTypeId = array_search($name, $termData['radNoteTypes']);
+    $noteTypeId = array_search($name, $termData['radNoteTypes']['en']);
 
     if (0 < count($notes = $resource->getNotesByType(array('noteTypeId' => $noteTypeId)))):
       foreach ($notes as $note): ?>
@@ -165,16 +164,16 @@
   }
 
   $dacsSpecializedNotes = array(
-    'Conservation'       => 'dacsConservation',
-    'Citation'                => 'dacsCitation',
+    'Conservation'              => 'dacsConservation',
+    'Citation'                  => 'dacsCitation',
     'Alphanumeric designations' => 'dacsAlphanumericDesignation',
-    'Variant title information'               => 'dacsVariantTitleInformation',
-    'Processing information'      => 'dacsProcessingInformation'
+    'Variant title information' => 'dacsVariantTitleInformation',
+    'Processing information'    => 'dacsProcessingInformation'
   );
 
   foreach ($dacsSpecializedNotes as $name => $xmlType)
   {
-    $noteTypeId = array_search($name, $termData['dacsSpecializedNotesTypes']);
+    $noteTypeId = array_search($name, $termData['dacsSpecializedNoteTypes']['en']);
 
     if (0 < count($notes = $resource->getNotesByType(array('noteTypeId' => $noteTypeId)))):
       foreach ($notes as $note): ?>
@@ -445,7 +444,7 @@
       <?php endif; ?>
 
       <?php foreach($radNotes as $name => $xmlType): ?>
-          <?php $noteTypeId = array_search($name, $termData['radNoteTypes']); ?>
+          <?php $noteTypeId = array_search($name, $termData['radNoteTypes']['en']); ?>
 
           <?php if (0 < count($notes = $descendant->getNotesByType(array('noteTypeId' => $noteTypeId)))): ?>
             <?php foreach ($notes as $note): ?>


### PR DESCRIPTION
- Include all cultures in term id-> name mapping created for import/export
- Use current CSV row culture to search for matches in the new mapping
- Use current CSV row culture to fetch and create terms
