### PR TITLE
Fix QubitTransactionFilter, refs #9401

### DIFF
--- a/lib/filter/QubitTransactionFilter.class.php
+++ b/lib/filter/QubitTransactionFilter.class.php
@@ -27,7 +27,7 @@ class QubitTransactionFilter extends sfFilter
     if (!isset(self::$connection))
     {
       self::$connection = Propel::getConnection();
-      // self::$connection->beginTransaction();
+      self::$connection->beginTransaction();
     }
 
     return self::$connection;
@@ -35,6 +35,8 @@ class QubitTransactionFilter extends sfFilter
 
   public function execute($filterChain)
   {
+    self::getConnection();
+
     try
     {
       $filterChain->execute();

--- a/lib/model/QubitActor.php
+++ b/lib/model/QubitActor.php
@@ -147,28 +147,14 @@ class QubitActor extends BaseActor
       // Update search index for related info object
       $event->indexOnSave = true;
       $event->actor = $this;
-
-      try
-      {
-        $event->save();
-      }
-      catch (PropelException $e)
-      {
-      }
+      $event->save();
     }
 
     // Save related contact information objects
     foreach ($this->contactInformations as $item)
     {
       $item->actor = $this;
-
-      try
-      {
-        $item->save();
-      }
-      catch (PropelException $e)
-      {
-      }
+      $item->save();
     }
 
     // Repositories are updated in the save function for QubitRepository class

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -210,14 +210,7 @@ class QubitInformationObject extends BaseInformationObject
     {
       // TODO Needed if $this is new, should be transparent
       $item->parent = $this;
-
-      try
-      {
-        $item->save($connection);
-      }
-      catch (PropelException $e)
-      {
-      }
+      $item->save($connection);
     }
 
     // Save updated related events (update search index after updating all
@@ -228,14 +221,7 @@ class QubitInformationObject extends BaseInformationObject
 
       // TODO Needed if $this is new, should be transparent
       $item->object = $this;
-
-      try
-      {
-        $item->save($connection);
-      }
-      catch (PropelException $e)
-      {
-      }
+      $item->save($connection);
     }
 
     // Save new digital objects
@@ -246,14 +232,7 @@ class QubitInformationObject extends BaseInformationObject
 
       // TODO Needed if $this is new, should be transparent
       $item->informationObject = $this;
-
-      try
-      {
-        $item->save($connection);
-      }
-      catch (PropelException $e)
-      {
-      }
+      $item->save($connection);
 
       break; // Save only one digital object per information object
     }

--- a/lib/model/QubitObject.php
+++ b/lib/model/QubitObject.php
@@ -103,14 +103,7 @@ class QubitObject extends BaseObject implements Zend_Acl_Resource_Interface
     {
       $relation->indexOnSave = false;
       $relation->object = $this;
-
-      try
-      {
-        $relation->save();
-      }
-      catch (PropelException $e)
-      {
-      }
+      $relation->save();
     }
 
     // Save updated notes
@@ -118,14 +111,7 @@ class QubitObject extends BaseObject implements Zend_Acl_Resource_Interface
     {
       $note->indexOnSave = false;
       $note->object = $this;
-
-      try
-      {
-        $note->save();
-      }
-      catch (PropelException $e)
-      {
-      }
+      $note->save();
     }
 
     // Save updated properties
@@ -133,14 +119,7 @@ class QubitObject extends BaseObject implements Zend_Acl_Resource_Interface
     {
       $property->indexOnSave = false;
       $property->object = $this;
-
-      try
-      {
-        $property->save();
-      }
-      catch (PropelException $e)
-      {
-      }
+      $property->save();
     }
 
     // Save updated object relations
@@ -148,14 +127,7 @@ class QubitObject extends BaseObject implements Zend_Acl_Resource_Interface
     {
       $relation->indexOnSave = false;
       $relation->object = $this;
-
-      try
-      {
-        $relation->save();
-      }
-      catch (PropelException $e)
-      {
-      }
+      $relation->save();
     }
 
     // Save updated subject relations
@@ -163,28 +135,14 @@ class QubitObject extends BaseObject implements Zend_Acl_Resource_Interface
     {
       $relation->indexOnSave = false;
       $relation->subject = $this;
-
-      try
-      {
-        $relation->save();
-      }
-      catch (PropelException $e)
-      {
-      }
+      $relation->save();
     }
 
     // Save updated other namnes
     foreach ($this->otherNames as $otherName)
     {
       $otherName->object = $this;
-
-      try
-      {
-        $otherName->save();
-      }
-      catch (PropelException $e)
-      {
-      }
+      $otherName->save();
     }
 
     return $this;

--- a/lib/model/QubitRights.php
+++ b/lib/model/QubitRights.php
@@ -89,14 +89,7 @@ class QubitRights extends BaseRights
     {
       $grantedRight->indexOnSave = false;
       $grantedRight->rights = $this;
-
-      try
-      {
-        $grantedRight->save();
-      }
-      catch (PropelException $e)
-      {
-      }
+      $grantedRight->save();
     }
   }
 

--- a/lib/model/QubitTerm.php
+++ b/lib/model/QubitTerm.php
@@ -262,14 +262,7 @@ class QubitTerm extends BaseTerm
     {
       $child->indexOnSave = false;
       $child->parentId = $this->id;
-
-      try
-      {
-        $child->save();
-      }
-      catch (PropelException $e)
-      {
-      }
+      $child->save();
     }
   }
 

--- a/lib/model/QubitUser.php
+++ b/lib/model/QubitUser.php
@@ -34,27 +34,13 @@ class QubitUser extends BaseUser
     foreach ($this->aclUserGroups as $aclUserGroup)
     {
       $aclUserGroup->user = $this;
-
-      try
-      {
-        $aclUserGroup->save();
-      }
-      catch (PropelException $e)
-      {
-      }
+      $aclUserGroup->save();
     }
 
     foreach ($this->aclPermissions as $aclPermission)
     {
       $aclPermission->user = $this;
-
-      try
-      {
-        $aclPermission->save();
-      }
-      catch (PropelException $e)
-      {
-      }
+      $aclPermission->save();
     }
 
     return $this;

--- a/plugins/qbAclPlugin/lib/model/QubitAclGroup.php
+++ b/plugins/qbAclPlugin/lib/model/QubitAclGroup.php
@@ -55,14 +55,7 @@ class QubitAclGroup extends BaseAclGroup implements Zend_Acl_Role_Interface
     foreach ($this->aclPermissions as $aclPermission)
     {
       $aclPermission->group = $this;
-
-      try
-      {
-        $aclPermission->save($connection);
-      }
-      catch (PropelException $e)
-      {
-      }
+      $aclPermission->save($connection);
     }
 
     return $this;

--- a/plugins/qtAccessionPlugin/lib/model/QubitAccession.php
+++ b/plugins/qtAccessionPlugin/lib/model/QubitAccession.php
@@ -51,14 +51,7 @@ class QubitAccession extends BaseAccession
 
       // TODO Needed if $this is new, should be transparent
       $item->object = $this;
-
-      try
-      {
-        $item->save($connection);
-      }
-      catch (PropelException $e)
-      {
-      }
+      $item->save($connection);
     }
 
     QubitSearch::getInstance()->update($this);


### PR DESCRIPTION
This fix will wrap almost the entire request process and the related Propel
connection in the same transaction. The changes in the database will be
rolled back in case of a fatal error, exception or timeout in the process,
or they will be committed in successful requests at the end of the process.
PropelPDO class takes care to prevent errors due to already in progress
transactions, so other calls to beginTransaction, commit and rollback
functions in the same request will be ignored.

Remove PropelException catches in save methods that avoid the rollback.
