### PR TITLE
Transactions process improvements, refs #9533

### DIFF
--- a/lib/filter/QubitTransactionFilter.class.php
+++ b/lib/filter/QubitTransactionFilter.class.php
@@ -27,7 +27,6 @@ class QubitTransactionFilter extends sfFilter
     if (!isset(self::$connection))
     {
       self::$connection = Propel::getConnection();
-      self::$connection->beginTransaction();
     }
 
     return self::$connection;
@@ -36,6 +35,7 @@ class QubitTransactionFilter extends sfFilter
   public function execute($filterChain)
   {
     self::getConnection();
+    self::$connection->beginTransaction();
 
     try
     {

--- a/lib/model/map/ObjectTableMap.php
+++ b/lib/model/map/ObjectTableMap.php
@@ -49,6 +49,7 @@ class ObjectTableMap extends TableMap {
 	 */
 	public function buildRelations()
 	{
+    $this->addRelation('aclPermission', 'aclPermission', RelationMap::ONE_TO_MANY, array('id' => 'object_id', ), 'CASCADE', null);
     $this->addRelation('accessLog', 'accessLog', RelationMap::ONE_TO_MANY, array('id' => 'object_id', ), 'CASCADE', null);
     $this->addRelation('actor', 'actor', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('aipRelatedByid', 'aip', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
@@ -75,7 +76,6 @@ class ObjectTableMap extends TableMap {
     $this->addRelation('status', 'status', RelationMap::ONE_TO_MANY, array('id' => 'object_id', ), 'CASCADE', null);
     $this->addRelation('taxonomy', 'taxonomy', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('term', 'term', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
-    $this->addRelation('aclPermission', 'aclPermission', RelationMap::ONE_TO_MANY, array('id' => 'object_id', ), 'CASCADE', null);
     $this->addRelation('accession', 'accession', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('deaccession', 'deaccession', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
 	} // buildRelations()

--- a/lib/model/map/UserTableMap.php
+++ b/lib/model/map/UserTableMap.php
@@ -51,10 +51,10 @@ class UserTableMap extends TableMap {
 	public function buildRelations()
 	{
     $this->addRelation('actor', 'actor', RelationMap::MANY_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
-    $this->addRelation('job', 'job', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'SET NULL', null);
-    $this->addRelation('note', 'note', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), null, null);
     $this->addRelation('aclPermission', 'aclPermission', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'CASCADE', null);
     $this->addRelation('aclUserGroup', 'aclUserGroup', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'CASCADE', null);
+    $this->addRelation('job', 'job', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'SET NULL', null);
+    $this->addRelation('note', 'note', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), null, null);
 	} // buildRelations()
 
 } // UserTableMap

--- a/lib/model/om/BaseAccessLog.php
+++ b/lib/model/om/BaseAccessLog.php
@@ -92,7 +92,7 @@ abstract class BaseAccessLog implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAccessLog::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -412,7 +412,7 @@ abstract class BaseAccessLog implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAccessLog::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -464,7 +464,7 @@ abstract class BaseAccessLog implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAccessLog::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseActor.php
+++ b/lib/model/om/BaseActor.php
@@ -655,7 +655,7 @@ unset($this->values['lft']);
 unset($this->values['rgt']);
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitActor::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     if (!isset($this->lft) || !isset($this->rgt))
@@ -750,7 +750,7 @@ unset($this->values['rgt']);
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitActor::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $delta = $this->rgt - $this->lft + 1;

--- a/lib/model/om/BaseActorI18n.php
+++ b/lib/model/om/BaseActorI18n.php
@@ -118,7 +118,7 @@ abstract class BaseActorI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitActorI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -439,7 +439,7 @@ abstract class BaseActorI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitActorI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -491,7 +491,7 @@ abstract class BaseActorI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitActorI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseContactInformation.php
+++ b/lib/model/om/BaseContactInformation.php
@@ -120,7 +120,7 @@ abstract class BaseContactInformation implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitContactInformation::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -512,7 +512,7 @@ abstract class BaseContactInformation implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitContactInformation::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -564,7 +564,7 @@ abstract class BaseContactInformation implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitContactInformation::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseContactInformationI18n.php
+++ b/lib/model/om/BaseContactInformationI18n.php
@@ -100,7 +100,7 @@ abstract class BaseContactInformationI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitContactInformationI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -421,7 +421,7 @@ abstract class BaseContactInformationI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitContactInformationI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -473,7 +473,7 @@ abstract class BaseContactInformationI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitContactInformationI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseEventI18n.php
+++ b/lib/model/om/BaseEventI18n.php
@@ -98,7 +98,7 @@ abstract class BaseEventI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitEventI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -419,7 +419,7 @@ abstract class BaseEventI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitEventI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -471,7 +471,7 @@ abstract class BaseEventI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitEventI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseFunctionI18n.php
+++ b/lib/model/om/BaseFunctionI18n.php
@@ -112,7 +112,7 @@ abstract class BaseFunctionI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitFunctionI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -433,7 +433,7 @@ abstract class BaseFunctionI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitFunctionI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -485,7 +485,7 @@ abstract class BaseFunctionI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitFunctionI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseGrantedRight.php
+++ b/lib/model/om/BaseGrantedRight.php
@@ -102,7 +102,7 @@ abstract class BaseGrantedRight implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitGrantedRight::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -422,7 +422,7 @@ abstract class BaseGrantedRight implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitGrantedRight::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -474,7 +474,7 @@ abstract class BaseGrantedRight implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitGrantedRight::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseInformationObject.php
+++ b/lib/model/om/BaseInformationObject.php
@@ -600,7 +600,7 @@ unset($this->values['lft']);
 unset($this->values['rgt']);
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitInformationObject::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     if (!isset($this->lft) || !isset($this->rgt))
@@ -695,7 +695,7 @@ unset($this->values['rgt']);
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitInformationObject::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $delta = $this->rgt - $this->lft + 1;

--- a/lib/model/om/BaseInformationObjectI18n.php
+++ b/lib/model/om/BaseInformationObjectI18n.php
@@ -134,7 +134,7 @@ abstract class BaseInformationObjectI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitInformationObjectI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -455,7 +455,7 @@ abstract class BaseInformationObjectI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitInformationObjectI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -507,7 +507,7 @@ abstract class BaseInformationObjectI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitInformationObjectI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseKeymap.php
+++ b/lib/model/om/BaseKeymap.php
@@ -98,7 +98,7 @@ abstract class BaseKeymap implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitKeymap::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -418,7 +418,7 @@ abstract class BaseKeymap implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitKeymap::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -470,7 +470,7 @@ abstract class BaseKeymap implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitKeymap::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseMenu.php
+++ b/lib/model/om/BaseMenu.php
@@ -106,7 +106,7 @@ abstract class BaseMenu implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitMenu::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -589,7 +589,7 @@ abstract class BaseMenu implements ArrayAccess
 
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitMenu::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -668,7 +668,7 @@ abstract class BaseMenu implements ArrayAccess
 
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitMenu::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -845,7 +845,7 @@ unset($this->values['lft']);
 unset($this->values['rgt']);
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitMenu::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     if (!isset($this->lft) || !isset($this->rgt))
@@ -940,7 +940,7 @@ unset($this->values['rgt']);
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitMenu::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $delta = $this->rgt - $this->lft + 1;

--- a/lib/model/om/BaseMenuI18n.php
+++ b/lib/model/om/BaseMenuI18n.php
@@ -96,7 +96,7 @@ abstract class BaseMenuI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitMenuI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -417,7 +417,7 @@ abstract class BaseMenuI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitMenuI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -469,7 +469,7 @@ abstract class BaseMenuI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitMenuI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseNote.php
+++ b/lib/model/om/BaseNote.php
@@ -100,7 +100,7 @@ abstract class BaseNote implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitNote::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -492,7 +492,7 @@ abstract class BaseNote implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitNote::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -544,7 +544,7 @@ abstract class BaseNote implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitNote::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseNoteI18n.php
+++ b/lib/model/om/BaseNoteI18n.php
@@ -94,7 +94,7 @@ abstract class BaseNoteI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitNoteI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -415,7 +415,7 @@ abstract class BaseNoteI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitNoteI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -467,7 +467,7 @@ abstract class BaseNoteI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitNoteI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseOaiHarvest.php
+++ b/lib/model/om/BaseOaiHarvest.php
@@ -106,7 +106,7 @@ abstract class BaseOaiHarvest implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitOaiHarvest::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -426,7 +426,7 @@ abstract class BaseOaiHarvest implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitOaiHarvest::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -478,7 +478,7 @@ abstract class BaseOaiHarvest implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitOaiHarvest::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseOaiRepository.php
+++ b/lib/model/om/BaseOaiRepository.php
@@ -102,7 +102,7 @@ abstract class BaseOaiRepository implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitOaiRepository::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -444,7 +444,7 @@ abstract class BaseOaiRepository implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitOaiRepository::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -496,7 +496,7 @@ abstract class BaseOaiRepository implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitOaiRepository::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseObject.php
+++ b/lib/model/om/BaseObject.php
@@ -96,7 +96,7 @@ abstract class BaseObject implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitObject::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -185,6 +185,11 @@ abstract class BaseObject implements ArrayAccess
       }
     }
 
+    if ('aclPermissions' == $name)
+    {
+      return true;
+    }
+
     if ('accessLogs' == $name)
     {
       return true;
@@ -245,11 +250,6 @@ abstract class BaseObject implements ArrayAccess
       return true;
     }
 
-    if ('aclPermissions' == $name)
-    {
-      return true;
-    }
-
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
@@ -289,6 +289,23 @@ abstract class BaseObject implements ArrayAccess
 
         $offset++;
       }
+    }
+
+    if ('aclPermissions' == $name)
+    {
+      if (!isset($this->refFkValues['aclPermissions']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['aclPermissions'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['aclPermissions'] = self::getaclPermissionsById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['aclPermissions'];
     }
 
     if ('accessLogs' == $name)
@@ -495,23 +512,6 @@ abstract class BaseObject implements ArrayAccess
       return $this->refFkValues['statuss'];
     }
 
-    if ('aclPermissions' == $name)
-    {
-      if (!isset($this->refFkValues['aclPermissions']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['aclPermissions'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['aclPermissions'] = self::getaclPermissionsById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['aclPermissions'];
-    }
-
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
@@ -704,7 +704,7 @@ abstract class BaseObject implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitObject::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -756,7 +756,7 @@ abstract class BaseObject implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitObject::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -837,6 +837,26 @@ abstract class BaseObject implements ArrayAccess
 	{
 		$this->setid($key);
 	}
+
+  public static function addaclPermissionsCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitAclPermission::OBJECT_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getaclPermissionsById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addaclPermissionsCriteriaById($criteria, $id);
+
+    return QubitAclPermission::get($criteria, $options);
+  }
+
+  public function addaclPermissionsCriteria(Criteria $criteria)
+  {
+    return self::addaclPermissionsCriteriaById($criteria, $this->id);
+  }
 
   public static function addaccessLogsCriteriaById(Criteria $criteria, $id)
   {
@@ -1076,26 +1096,6 @@ abstract class BaseObject implements ArrayAccess
   public function addstatussCriteria(Criteria $criteria)
   {
     return self::addstatussCriteriaById($criteria, $this->id);
-  }
-
-  public static function addaclPermissionsCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitAclPermission::OBJECT_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getaclPermissionsById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::addaclPermissionsCriteriaById($criteria, $id);
-
-    return QubitAclPermission::get($criteria, $options);
-  }
-
-  public function addaclPermissionsCriteria(Criteria $criteria)
-  {
-    return self::addaclPermissionsCriteriaById($criteria, $this->id);
   }
 
   public function __call($name, $args)

--- a/lib/model/om/BaseOtherName.php
+++ b/lib/model/om/BaseOtherName.php
@@ -100,7 +100,7 @@ abstract class BaseOtherName implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitOtherName::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -492,7 +492,7 @@ abstract class BaseOtherName implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitOtherName::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -544,7 +544,7 @@ abstract class BaseOtherName implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitOtherName::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseOtherNameI18n.php
+++ b/lib/model/om/BaseOtherNameI18n.php
@@ -98,7 +98,7 @@ abstract class BaseOtherNameI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitOtherNameI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -419,7 +419,7 @@ abstract class BaseOtherNameI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitOtherNameI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -471,7 +471,7 @@ abstract class BaseOtherNameI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitOtherNameI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BasePhysicalObject.php
+++ b/lib/model/om/BasePhysicalObject.php
@@ -505,7 +505,7 @@ unset($this->values['lft']);
 unset($this->values['rgt']);
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitPhysicalObject::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     if (!isset($this->lft) || !isset($this->rgt))
@@ -600,7 +600,7 @@ unset($this->values['rgt']);
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitPhysicalObject::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $delta = $this->rgt - $this->lft + 1;

--- a/lib/model/om/BasePhysicalObjectI18n.php
+++ b/lib/model/om/BasePhysicalObjectI18n.php
@@ -98,7 +98,7 @@ abstract class BasePhysicalObjectI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitPhysicalObjectI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -419,7 +419,7 @@ abstract class BasePhysicalObjectI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitPhysicalObjectI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -471,7 +471,7 @@ abstract class BasePhysicalObjectI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitPhysicalObjectI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseProperty.php
+++ b/lib/model/om/BaseProperty.php
@@ -98,7 +98,7 @@ abstract class BaseProperty implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitProperty::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -490,7 +490,7 @@ abstract class BaseProperty implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitProperty::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -542,7 +542,7 @@ abstract class BaseProperty implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitProperty::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BasePropertyI18n.php
+++ b/lib/model/om/BasePropertyI18n.php
@@ -94,7 +94,7 @@ abstract class BasePropertyI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitPropertyI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -415,7 +415,7 @@ abstract class BasePropertyI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitPropertyI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -467,7 +467,7 @@ abstract class BasePropertyI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitPropertyI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseRelationI18n.php
+++ b/lib/model/om/BaseRelationI18n.php
@@ -96,7 +96,7 @@ abstract class BaseRelationI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitRelationI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -417,7 +417,7 @@ abstract class BaseRelationI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitRelationI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -469,7 +469,7 @@ abstract class BaseRelationI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitRelationI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseRepositoryI18n.php
+++ b/lib/model/om/BaseRepositoryI18n.php
@@ -122,7 +122,7 @@ abstract class BaseRepositoryI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitRepositoryI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -443,7 +443,7 @@ abstract class BaseRepositoryI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitRepositoryI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -495,7 +495,7 @@ abstract class BaseRepositoryI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitRepositoryI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseRightsI18n.php
+++ b/lib/model/om/BaseRightsI18n.php
@@ -110,7 +110,7 @@ abstract class BaseRightsI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitRightsI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -431,7 +431,7 @@ abstract class BaseRightsI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitRightsI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -483,7 +483,7 @@ abstract class BaseRightsI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitRightsI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseSetting.php
+++ b/lib/model/om/BaseSetting.php
@@ -100,7 +100,7 @@ abstract class BaseSetting implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitSetting::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -492,7 +492,7 @@ abstract class BaseSetting implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitSetting::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -544,7 +544,7 @@ abstract class BaseSetting implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitSetting::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseSettingI18n.php
+++ b/lib/model/om/BaseSettingI18n.php
@@ -94,7 +94,7 @@ abstract class BaseSettingI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitSettingI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -415,7 +415,7 @@ abstract class BaseSettingI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitSettingI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -467,7 +467,7 @@ abstract class BaseSettingI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitSettingI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseSlug.php
+++ b/lib/model/om/BaseSlug.php
@@ -94,7 +94,7 @@ abstract class BaseSlug implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitSlug::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -414,7 +414,7 @@ abstract class BaseSlug implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitSlug::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -466,7 +466,7 @@ abstract class BaseSlug implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitSlug::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseStaticPageI18n.php
+++ b/lib/model/om/BaseStaticPageI18n.php
@@ -96,7 +96,7 @@ abstract class BaseStaticPageI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitStaticPageI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -417,7 +417,7 @@ abstract class BaseStaticPageI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitStaticPageI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -469,7 +469,7 @@ abstract class BaseStaticPageI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitStaticPageI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseStatus.php
+++ b/lib/model/om/BaseStatus.php
@@ -96,7 +96,7 @@ abstract class BaseStatus implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitStatus::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -416,7 +416,7 @@ abstract class BaseStatus implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitStatus::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -468,7 +468,7 @@ abstract class BaseStatus implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitStatus::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseTaxonomy.php
+++ b/lib/model/om/BaseTaxonomy.php
@@ -540,7 +540,7 @@ unset($this->values['lft']);
 unset($this->values['rgt']);
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitTaxonomy::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     if (!isset($this->lft) || !isset($this->rgt))
@@ -635,7 +635,7 @@ unset($this->values['rgt']);
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitTaxonomy::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $delta = $this->rgt - $this->lft + 1;

--- a/lib/model/om/BaseTaxonomyI18n.php
+++ b/lib/model/om/BaseTaxonomyI18n.php
@@ -96,7 +96,7 @@ abstract class BaseTaxonomyI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitTaxonomyI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -417,7 +417,7 @@ abstract class BaseTaxonomyI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitTaxonomyI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -469,7 +469,7 @@ abstract class BaseTaxonomyI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitTaxonomyI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseTerm.php
+++ b/lib/model/om/BaseTerm.php
@@ -1893,7 +1893,7 @@ unset($this->values['lft']);
 unset($this->values['rgt']);
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitTerm::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     if (!isset($this->lft) || !isset($this->rgt))
@@ -1988,7 +1988,7 @@ unset($this->values['rgt']);
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitTerm::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $delta = $this->rgt - $this->lft + 1;

--- a/lib/model/om/BaseTermI18n.php
+++ b/lib/model/om/BaseTermI18n.php
@@ -94,7 +94,7 @@ abstract class BaseTermI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitTermI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -415,7 +415,7 @@ abstract class BaseTermI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitTermI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -467,7 +467,7 @@ abstract class BaseTermI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitTermI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/lib/model/om/BaseUser.php
+++ b/lib/model/om/BaseUser.php
@@ -84,22 +84,22 @@ abstract class BaseUser extends QubitActor implements ArrayAccess
     {
     }
 
-    if ('jobs' == $name)
-    {
-      return true;
-    }
-
-    if ('notes' == $name)
-    {
-      return true;
-    }
-
     if ('aclPermissions' == $name)
     {
       return true;
     }
 
     if ('aclUserGroups' == $name)
+    {
+      return true;
+    }
+
+    if ('jobs' == $name)
+    {
+      return true;
+    }
+
+    if ('notes' == $name)
     {
       return true;
     }
@@ -123,40 +123,6 @@ abstract class BaseUser extends QubitActor implements ArrayAccess
     }
     catch (sfException $e)
     {
-    }
-
-    if ('jobs' == $name)
-    {
-      if (!isset($this->refFkValues['jobs']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['jobs'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['jobs'] = self::getjobsById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['jobs'];
-    }
-
-    if ('notes' == $name)
-    {
-      if (!isset($this->refFkValues['notes']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['notes'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['notes'] = self::getnotesById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['notes'];
     }
 
     if ('aclPermissions' == $name)
@@ -193,47 +159,41 @@ abstract class BaseUser extends QubitActor implements ArrayAccess
       return $this->refFkValues['aclUserGroups'];
     }
 
+    if ('jobs' == $name)
+    {
+      if (!isset($this->refFkValues['jobs']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['jobs'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['jobs'] = self::getjobsById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['jobs'];
+    }
+
+    if ('notes' == $name)
+    {
+      if (!isset($this->refFkValues['notes']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['notes'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['notes'] = self::getnotesById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['notes'];
+    }
+
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
-  }
-
-  public static function addjobsCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitJob::USER_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getjobsById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::addjobsCriteriaById($criteria, $id);
-
-    return QubitJob::get($criteria, $options);
-  }
-
-  public function addjobsCriteria(Criteria $criteria)
-  {
-    return self::addjobsCriteriaById($criteria, $this->id);
-  }
-
-  public static function addnotesCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitNote::USER_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getnotesById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::addnotesCriteriaById($criteria, $id);
-
-    return QubitNote::get($criteria, $options);
-  }
-
-  public function addnotesCriteria(Criteria $criteria)
-  {
-    return self::addnotesCriteriaById($criteria, $this->id);
   }
 
   public static function addaclPermissionsCriteriaById(Criteria $criteria, $id)
@@ -274,5 +234,45 @@ abstract class BaseUser extends QubitActor implements ArrayAccess
   public function addaclUserGroupsCriteria(Criteria $criteria)
   {
     return self::addaclUserGroupsCriteriaById($criteria, $this->id);
+  }
+
+  public static function addjobsCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitJob::USER_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getjobsById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addjobsCriteriaById($criteria, $id);
+
+    return QubitJob::get($criteria, $options);
+  }
+
+  public function addjobsCriteria(Criteria $criteria)
+  {
+    return self::addjobsCriteriaById($criteria, $this->id);
+  }
+
+  public static function addnotesCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitNote::USER_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getnotesById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addnotesCriteriaById($criteria, $id);
+
+    return QubitNote::get($criteria, $options);
+  }
+
+  public function addnotesCriteria(Criteria $criteria)
+  {
+    return self::addnotesCriteriaById($criteria, $this->id);
   }
 }

--- a/lib/propel/builder/QubitObjectBuilder.php
+++ b/lib/propel/builder/QubitObjectBuilder.php
@@ -558,7 +558,7 @@ script;
   {
     if (!isset(\$connection))
     {
-      \$connection = QubitTransactionFilter::getConnection({$this->getPeerClassName()}::DATABASE_NAME);
+      \$connection = Propel::getConnection();
     }
 
     \$affectedRows = 0;
@@ -1500,7 +1500,7 @@ script;
 
     if (!isset(\$connection))
     {
-      \$connection = QubitTransactionFilter::getConnection({$this->getPeerClassName()}::DATABASE_NAME);
+      \$connection = Propel::getConnection();
     }
 
     \$offset = 0;
@@ -1619,7 +1619,7 @@ script;
 
     if (!isset(\$connection))
     {
-      \$connection = QubitTransactionFilter::getConnection({$this->getPeerClassName()}::DATABASE_NAME);
+      \$connection = Propel::getConnection();
     }
 
     \$offset = 0;
@@ -1961,7 +1961,7 @@ unset(\$this->values['{$this->getColumnVarName($this->nestedSetLeftColumn)}']);
 unset(\$this->values['{$this->getColumnVarName($this->nestedSetRightColumn)}']);
     if (!isset(\$connection))
     {
-      \$connection = QubitTransactionFilter::getConnection({$this->getPeerClassName()}::DATABASE_NAME);
+      \$connection = Propel::getConnection();
     }
 
     if (!isset(\$this->{$this->getColumnVarName($this->nestedSetLeftColumn)}) || !isset(\$this->{$this->getColumnVarName($this->nestedSetRightColumn)}))
@@ -2063,7 +2063,7 @@ script;
   {
     if (!isset(\$connection))
     {
-      \$connection = QubitTransactionFilter::getConnection({$this->getPeerClassName()}::DATABASE_NAME);
+      \$connection = Propel::getConnection();
     }
 
     \$delta = \$this->{$this->getColumnVarName($this->nestedSetRightColumn)} - \$this->{$this->getColumnVarName($this->nestedSetLeftColumn)} + 1;

--- a/plugins/qbAclPlugin/lib/model/om/BaseAclGroup.php
+++ b/plugins/qbAclPlugin/lib/model/om/BaseAclGroup.php
@@ -102,7 +102,7 @@ abstract class BaseAclGroup implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAclGroup::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -629,7 +629,7 @@ abstract class BaseAclGroup implements ArrayAccess
 
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAclGroup::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -708,7 +708,7 @@ abstract class BaseAclGroup implements ArrayAccess
 
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAclGroup::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -925,7 +925,7 @@ unset($this->values['lft']);
 unset($this->values['rgt']);
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAclGroup::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     if (!isset($this->lft) || !isset($this->rgt))
@@ -1020,7 +1020,7 @@ unset($this->values['rgt']);
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAclGroup::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $delta = $this->rgt - $this->lft + 1;

--- a/plugins/qbAclPlugin/lib/model/om/BaseAclGroupI18n.php
+++ b/plugins/qbAclPlugin/lib/model/om/BaseAclGroupI18n.php
@@ -96,7 +96,7 @@ abstract class BaseAclGroupI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAclGroupI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -417,7 +417,7 @@ abstract class BaseAclGroupI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAclGroupI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -469,7 +469,7 @@ abstract class BaseAclGroupI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAclGroupI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/plugins/qbAclPlugin/lib/model/om/BaseAclPermission.php
+++ b/plugins/qbAclPlugin/lib/model/om/BaseAclPermission.php
@@ -108,7 +108,7 @@ abstract class BaseAclPermission implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAclPermission::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -428,7 +428,7 @@ abstract class BaseAclPermission implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAclPermission::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -480,7 +480,7 @@ abstract class BaseAclPermission implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAclPermission::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/plugins/qbAclPlugin/lib/model/om/BaseAclUserGroup.php
+++ b/plugins/qbAclPlugin/lib/model/om/BaseAclUserGroup.php
@@ -94,7 +94,7 @@ abstract class BaseAclUserGroup implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAclUserGroup::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -414,7 +414,7 @@ abstract class BaseAclUserGroup implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAclUserGroup::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -466,7 +466,7 @@ abstract class BaseAclUserGroup implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAclUserGroup::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/plugins/qtAccessionPlugin/lib/model/om/BaseAccessionI18n.php
+++ b/plugins/qtAccessionPlugin/lib/model/om/BaseAccessionI18n.php
@@ -110,7 +110,7 @@ abstract class BaseAccessionI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAccessionI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -431,7 +431,7 @@ abstract class BaseAccessionI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAccessionI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -483,7 +483,7 @@ abstract class BaseAccessionI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitAccessionI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;

--- a/plugins/qtAccessionPlugin/lib/model/om/BaseDeaccessionI18n.php
+++ b/plugins/qtAccessionPlugin/lib/model/om/BaseDeaccessionI18n.php
@@ -98,7 +98,7 @@ abstract class BaseDeaccessionI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitDeaccessionI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $affectedRows = 0;
@@ -419,7 +419,7 @@ abstract class BaseDeaccessionI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitDeaccessionI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;
@@ -471,7 +471,7 @@ abstract class BaseDeaccessionI18n implements ArrayAccess
   {
     if (!isset($connection))
     {
-      $connection = QubitTransactionFilter::getConnection(QubitDeaccessionI18n::DATABASE_NAME);
+      $connection = Propel::getConnection();
     }
 
     $offset = 0;


### PR DESCRIPTION
- Only use transactions in QubitTransactionFilter in HTTP requests.
- Commit current database transaction and start a new one before we
  dispatch the task to gearmand so the resources modified are persisted
  before the assigned worker starts processing the task.
- Use Propel to get the connection in model classes.
