### PR TITLE
Fix browse pagination limits, refs #9595

### DIFF
--- a/apps/qubit/modules/actor/actions/browseAction.class.php
+++ b/apps/qubit/modules/actor/actions/browseAction.class.php
@@ -112,7 +112,7 @@ class ActorBrowseAction extends DefaultBrowseAction
 
     $this->pager = new QubitSearchPager($resultSet);
     $this->pager->setPage($request->page ? $request->page : 1);
-    $this->pager->setMaxPerPage($request->limit);
+    $this->pager->setMaxPerPage($this->limit);
     $this->pager->init();
 
     $this->populateFacets($resultSet);

--- a/apps/qubit/modules/digitalobject/actions/browseAction.class.php
+++ b/apps/qubit/modules/digitalobject/actions/browseAction.class.php
@@ -56,9 +56,6 @@ class DigitalObjectBrowseAction extends DefaultBrowseAction
 
   public function execute($request)
   {
-    // Force number of hits per page
-    $request->limit = 30;
-
     parent::execute($request);
 
     // Create query object
@@ -105,7 +102,7 @@ class DigitalObjectBrowseAction extends DefaultBrowseAction
     // Pager results
     $this->pager = new QubitSearchPager($resultSet);
     $this->pager->setPage($request->page ? $request->page : 1);
-    $this->pager->setMaxPerPage($request->limit);
+    $this->pager->setMaxPerPage($this->limit);
     $this->pager->init();
 
     $this->populateFacets($resultSet);

--- a/apps/qubit/modules/repository/actions/browseAction.class.php
+++ b/apps/qubit/modules/repository/actions/browseAction.class.php
@@ -165,7 +165,7 @@ class RepositoryBrowseAction extends DefaultBrowseAction
 
     $this->pager = new QubitSearchPager($resultSet);
     $this->pager->setPage($request->page ? $request->page : 1);
-    $this->pager->setMaxPerPage($request->limit);
+    $this->pager->setMaxPerPage($this->limit);
     $this->pager->init();
 
     $this->populateFacets($resultSet);


### PR DESCRIPTION
Repository and actor browse pages weren't detecting when they need
to paginate properly. They are now fixed. Digital object browse
was hardcoded to 30 results per page, now it will go off the admin
setting instead.
