### PR TITLE
Dev/issue 9602

### DIFF
--- a/lib/task/export/exportBulkBaseTask.class.php
+++ b/lib/task/export/exportBulkBaseTask.class.php
@@ -90,12 +90,14 @@ abstract class exportBulkBaseTask extends sfBaseTask
   {
     $appRoot = sfConfig::get('sf_root_dir');
 
-    include($appRoot .'/plugins/sfEadPlugin/lib/sfEadPlugin.class.php');
-    include($appRoot .'/vendor/symfony/lib/helper/UrlHelper.php');
-    include($appRoot .'/vendor/symfony/lib/helper/I18NHelper.php');
-    include($appRoot .'/vendor/FreeBeerIso639Map.php');
-    include($appRoot .'/vendor/symfony/lib/helper/EscapingHelper.php');
-    include($appRoot .'/lib/helper/QubitHelper.php');
+    include $appRoot.'/plugins/sfEadPlugin/lib/sfEadPlugin.class.php';
+    include $appRoot.'/plugins/sfModsPlugin/lib/sfModsPlugin.class.php';
+    include $appRoot.'/plugins/sfEacPlugin/lib/sfEacPlugin.class.php';
+    include $appRoot.'/vendor/symfony/lib/helper/UrlHelper.php';
+    include $appRoot.'/vendor/symfony/lib/helper/I18NHelper.php';
+    include $appRoot.'/vendor/FreeBeerIso639Map.php';
+    include $appRoot.'/vendor/symfony/lib/helper/EscapingHelper.php';
+    include $appRoot.'/lib/helper/QubitHelper.php';
   }
 
   public static function captureResourceExportTemplateOutput($resource, $format, $options)

--- a/lib/task/export/exportBulkBaseTask.class.php
+++ b/lib/task/export/exportBulkBaseTask.class.php
@@ -88,7 +88,7 @@ abstract class exportBulkBaseTask extends sfBaseTask
 
   public static function includeXmlExportClassesAndHelpers()
   {
-    $appRoot = dirname(__FILE__) .'/../../..';
+    $appRoot = sfConfig::get('sf_root_dir');
 
     include($appRoot .'/plugins/sfEadPlugin/lib/sfEadPlugin.class.php');
     include($appRoot .'/vendor/symfony/lib/helper/UrlHelper.php');


### PR DESCRIPTION
Include EAC and MODS plugins for export:bulk. Previously they weren't included and when the user wanted to export these, it'd fail.
