### PR TITLE
Handle Propel exception in filter, refs #9533

### DIFF
--- a/lib/filter/QubitTransactionFilter.class.php
+++ b/lib/filter/QubitTransactionFilter.class.php
@@ -34,31 +34,37 @@ class QubitTransactionFilter extends sfFilter
 
   public function execute($filterChain)
   {
-    self::getConnection();
-    self::$connection->beginTransaction();
+    try
+    {
+      $conn = self::getConnection();
+      $conn->beginTransaction();
+    }
+    catch (PropelException $e)
+    {
+    }
 
     try
     {
       $filterChain->execute();
 
-      if (isset(self::$connection))
+      if (isset($conn))
       {
-        self::$connection->commit();
+        $conn->commit();
       }
     }
     catch (Exception $e)
     {
-      if (isset(self::$connection))
+      if (isset($conn))
       {
         // Whitelist of exceptions which commit instead of rollback the
         // transaction
         if ($e instanceof sfStopException)
         {
-          self::$connection->commit();
+          $conn->commit();
         }
         else
         {
-          self::$connection->rollBack();
+          $conn->rollBack();
         }
       }
 


### PR DESCRIPTION
We need to handle the possibility of Propel not delivering a connection where
there is none available, e.g. in the AtoM installer before the database is
configured (missing `config/config.php`). There might be other scenarios where
this is possible too and we want to handle it gracefully.
