### PR TITLE
Fix notes source culture, refs #9578

### DIFF
--- a/apps/qubit/modules/informationobject/actions/notesComponent.class.php
+++ b/apps/qubit/modules/informationobject/actions/notesComponent.class.php
@@ -211,9 +211,6 @@ class InformationObjectNotesComponent extends sfComponent
         if (is_null($this->note))
         {
           $this->resource->notes[] =  $this->note = new QubitNote;
-
-          // Notes should inherit the source culture from its descriptions
-          $this->note->sourceCulture = $this->resource->sourceCulture;
         }
 
         if (isset($item['type']))


### PR DESCRIPTION
Use current culture instead of source culture of the related
information object as it was creating notes without source
culture and notes that can't make culture fallback and can't
be translated
