### PR TITLE
Fix adv. search form validation, refs #9718

### DIFF
--- a/apps/qubit/modules/informationobject/templates/browseSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/browseSuccess.php
@@ -1,4 +1,9 @@
-<?php decorate_with('layout_2col') ?>
+<?php if (isset($pager) && $pager->hasResults()): ?>
+  <?php decorate_with('layout_2col') ?>
+<?php else: ?>
+  <?php decorate_with('layout_1col') ?>
+<?php endif; ?>
+
 <?php use_helper('Date') ?>
 
 <?php slot('title') ?>
@@ -6,7 +11,13 @@
 
   <div class="multiline-header">
     <?php echo image_tag('/images/icons-large/icon-archival.png', array('alt' => '')) ?>
-    <h1 aria-describedby="results-label"><?php echo __('Showing %1% results', array('%1%' => $pager->getNbResults())) ?></h1>
+    <h1 aria-describedby="results-label">
+      <?php if (isset($pager) && $pager->hasResults()): ?>
+        <?php echo __('Showing %1% results', array('%1%' => $pager->getNbResults())) ?>
+      <?php else: ?>
+        <?php echo __('No results found') ?>
+      <?php endif; ?>
+    </h1>
     <span class="sub" id="results-label"><?php echo sfConfig::get('app_ui_label_informationobject') ?></span>
   </div>
 <?php end_slot() ?>
@@ -17,96 +28,102 @@
   </div>
 <?php endif; ?>
 
-<?php slot('sidebar') ?>
-  <section id="facets">
+<?php if (isset($pager) && $pager->hasResults()): ?>
 
-    <div class="visible-phone facets-header">
-      <a class="x-btn btn-wide">
-        <i class="icon-filter"></i>
-        <?php echo __('Filters') ?>
-      </a>
-    </div>
+  <?php slot('sidebar') ?>
 
-    <div class="content">
+    <section id="facets">
 
-      <h2><?php echo sfConfig::get('app_ui_label_facetstitle') ?></h2>
+      <div class="visible-phone facets-header">
+        <a class="x-btn btn-wide">
+          <i class="icon-filter"></i>
+          <?php echo __('Filters') ?>
+        </a>
+      </div>
 
-      <?php echo get_partial('search/facetLanguage', array(
-        'target' => '#facet-languages',
-        'label' => __('Language'),
-        'facet' => 'languages',
-        'pager' => $pager,
-        'filters' => $search->filters)) ?>
+      <div class="content">
 
-      <?php echo get_partial('search/facet', array(
-        'target' => '#facet-collection',
-        'label' => __('Part of'),
-        'facet' => 'collection',
-        'pager' => $pager,
-        'filters' => $search->filters)) ?>
+        <h2><?php echo sfConfig::get('app_ui_label_facetstitle') ?></h2>
 
-      <?php if (sfConfig::get('app_multi_repository')): ?>
-        <?php echo get_partial('search/facet', array(
-          'target' => '#facet-repository',
-          'label' => sfConfig::get('app_ui_label_repository'),
-          'facet' => 'repos',
+        <?php echo get_partial('search/facetLanguage', array(
+          'target' => '#facet-languages',
+          'label' => __('Language'),
+          'facet' => 'languages',
           'pager' => $pager,
           'filters' => $search->filters)) ?>
-      <?php endif; ?>
 
-      <?php echo get_partial('search/facet', array(
-        'target' => '#facet-names',
-        'label' => sfConfig::get('app_ui_label_creator'),
-        'facet' => 'creators',
-        'pager' => $pager,
-        'filters' => $search->filters)) ?>
+        <?php echo get_partial('search/facet', array(
+          'target' => '#facet-collection',
+          'label' => __('Part of'),
+          'facet' => 'collection',
+          'pager' => $pager,
+          'filters' => $search->filters)) ?>
 
-      <?php echo get_partial('search/facet', array(
-        'target' => '#facet-names',
-        'label' => sfConfig::get('app_ui_label_name'),
-        'facet' => 'names',
-        'pager' => $pager,
-        'filters' => $search->filters)) ?>
+        <?php if (sfConfig::get('app_multi_repository')): ?>
+          <?php echo get_partial('search/facet', array(
+            'target' => '#facet-repository',
+            'label' => sfConfig::get('app_ui_label_repository'),
+            'facet' => 'repos',
+            'pager' => $pager,
+            'filters' => $search->filters)) ?>
+        <?php endif; ?>
 
-      <?php echo get_partial('search/facet', array(
-        'target' => '#facet-places',
-        'label' => sfConfig::get('app_ui_label_place'),
-        'facet' => 'places',
-        'pager' => $pager,
-        'filters' => $search->filters)) ?>
+        <?php echo get_partial('search/facet', array(
+          'target' => '#facet-names',
+          'label' => sfConfig::get('app_ui_label_creator'),
+          'facet' => 'creators',
+          'pager' => $pager,
+          'filters' => $search->filters)) ?>
 
-      <?php echo get_partial('search/facet', array(
-        'target' => '#facet-subjects',
-        'label' => sfConfig::get('app_ui_label_subject'),
-        'facet' => 'subjects',
-        'pager' => $pager,
-        'filters' => $search->filters)) ?>
+        <?php echo get_partial('search/facet', array(
+          'target' => '#facet-names',
+          'label' => sfConfig::get('app_ui_label_name'),
+          'facet' => 'names',
+          'pager' => $pager,
+          'filters' => $search->filters)) ?>
 
-      <?php echo get_partial('search/facet', array(
-        'target' => '#facet-genres',
-        'label' => sfConfig::get('app_ui_label_genre'),
-        'facet' => 'genres',
-        'pager' => $pager,
-        'filters' => $search->filters)) ?>
+        <?php echo get_partial('search/facet', array(
+          'target' => '#facet-places',
+          'label' => sfConfig::get('app_ui_label_place'),
+          'facet' => 'places',
+          'pager' => $pager,
+          'filters' => $search->filters)) ?>
 
-      <?php echo get_partial('search/facet', array(
-        'target' => '#facet-levelOfDescription',
-        'label' => __('Level of description'),
-        'facet' => 'levels',
-        'pager' => $pager,
-        'filters' => $search->filters)) ?>
+        <?php echo get_partial('search/facet', array(
+          'target' => '#facet-subjects',
+          'label' => sfConfig::get('app_ui_label_subject'),
+          'facet' => 'subjects',
+          'pager' => $pager,
+          'filters' => $search->filters)) ?>
 
-      <?php echo get_partial('search/facet', array(
-        'target' => '#facet-mediaTypes',
-        'label' => sfConfig::get('app_ui_label_mediatype'),
-        'facet' => 'mediatypes',
-        'pager' => $pager,
-        'filters' => $search->filters)) ?>
+        <?php echo get_partial('search/facet', array(
+          'target' => '#facet-genres',
+          'label' => sfConfig::get('app_ui_label_genre'),
+          'facet' => 'genres',
+          'pager' => $pager,
+          'filters' => $search->filters)) ?>
 
-    </div>
+        <?php echo get_partial('search/facet', array(
+          'target' => '#facet-levelOfDescription',
+          'label' => __('Level of description'),
+          'facet' => 'levels',
+          'pager' => $pager,
+          'filters' => $search->filters)) ?>
 
-  </section>
-<?php end_slot() ?>
+        <?php echo get_partial('search/facet', array(
+          'target' => '#facet-mediaTypes',
+          'label' => sfConfig::get('app_ui_label_mediatype'),
+          'facet' => 'mediatypes',
+          'pager' => $pager,
+          'filters' => $search->filters)) ?>
+
+      </div>
+
+    </section>
+
+  <?php end_slot() ?>
+
+<?php endif; ?>
 
 <?php slot('before-content') ?>
 
@@ -258,27 +275,27 @@
     'rangeType'    => $rangeType,
     'hiddenFields' => $hiddenFields)) ?>
 
-  <section class="browse-options">
-    <?php echo get_partial('default/printPreviewButton') ?>
+  <?php if (isset($pager) && $pager->hasResults()): ?>
 
-    <?php if (isset($pager) && $pager->hasResults() && $sf_user->isAuthenticated()): ?>
-      <a href="<?php echo url_for(array_merge($sf_data->getRaw('sf_request')->getParameterHolder()->getAll(), array('module' => 'informationobject', 'action' => 'exportCsv'))) ?>">
-        <i class="icon-upload-alt"></i>
-        <?php echo __('Export CSV') ?>
-      </a>
-    <?php endif; ?>
+    <section class="browse-options">
+      <?php echo get_partial('default/printPreviewButton') ?>
 
-    <?php echo get_partial('default/sortPicker', array(
-      'options' => array(
-        'lastUpdated' => __('Most recent'),
-        'alphabetic'  => __('Alphabetic'),
-        'identifier'  => __('Reference code'),
-        'date'        => __('Date')))) ?>
-  </section>
+      <?php if ($sf_user->isAuthenticated()): ?>
+        <a href="<?php echo url_for(array_merge($sf_data->getRaw('sf_request')->getParameterHolder()->getAll(), array('module' => 'informationobject', 'action' => 'exportCsv'))) ?>">
+          <i class="icon-upload-alt"></i>
+          <?php echo __('Export CSV') ?>
+        </a>
+      <?php endif; ?>
 
-  <div id="content">
+      <?php echo get_partial('default/sortPicker', array(
+        'options' => array(
+          'lastUpdated' => __('Most recent'),
+          'alphabetic'  => __('Alphabetic'),
+          'identifier'  => __('Reference code'),
+          'date'        => __('Date')))) ?>
+    </section>
 
-    <?php if (isset($pager)): ?>
+    <div id="content">
 
       <?php if (!isset($sf_request->onlyMedia) && isset($pager->facets['digitalobjects']) && 0 < $pager->facets['digitalobjects']['count']): ?>
         <div class="search-result media-summary">
@@ -306,12 +323,14 @@
         </section>
       <?php endif; ?>
 
-    <?php endif; ?>
+    </div>
 
-  </div>
+  <?php endif; ?>
 
 <?php end_slot() ?>
 
-<?php slot('after-content') ?>
-  <?php echo get_partial('default/pager', array('pager' => $pager)) ?>
-<?php end_slot() ?>
+<?php if (isset($pager)): ?>
+  <?php slot('after-content') ?>
+    <?php echo get_partial('default/pager', array('pager' => $pager)) ?>
+  <?php end_slot() ?>
+<?php endif; ?>


### PR DESCRIPTION
- Validate form after query creation but before execution to keep the
  boolean query and other params.
- Stop populating the LOD filter with the facet data as there may be
  no facet data after the form validation fails.
- Check results pager in the template to remove unnecessary sections.
