### PR TITLE
Change UI labels to adhere to ISAAR-CPF ref #9632

### DIFF
--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/actions/indexAction.class.php
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/actions/indexAction.class.php
@@ -57,7 +57,7 @@ class sfIsaarPluginIndexAction extends ActorIndexAction
 
       $validatorSchema->descriptionIdentifier = new sfValidatorString(array(
         'required' => true), array(
-        'required' => $this->context->i18n->__('%1%Description identifier%2% - This is a %3%mandatory%4% element.', array('%1%' => '<a href="http://ica-atom.org/doc/RS-2#5.4.1">', '%2%' => '</a>', '%3%' => '<a href="http://ica-atom.org/doc/RS-2#4.7">', '%4%' => '</a>'))));
+        'required' => $this->context->i18n->__('%1%Authority record identifier%2% - This is a %3%mandatory%4% element.', array('%1%' => '<a href="http://ica-atom.org/doc/RS-2#5.4.1">', '%2%' => '</a>', '%3%' => '<a href="http://ica-atom.org/doc/RS-2#4.7">', '%4%' => '</a>'))));
       $values['descriptionIdentifier'] = $this->resource->descriptionIdentifier;
 
       $validatorSchema->entityType = new sfValidatorString(array(

--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/editSuccess.php
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/editSuccess.php
@@ -106,7 +106,7 @@
 
         <?php echo render_field($form->descriptionIdentifier
           ->help(__('"Record a unique authority record identifier in accordance with local and/or national conventions. If the authority record is to be used internationally, record the country code of the country in which the authority record was created in accordance with the latest version of ISO 3166 Codes for the representation of names of countries. Where the creator of the authority record is an international organization, give the organizational identifier in place of the country code." (ISAAR 5.4.1)'))
-          ->label(__('Description identifier').' <span class="form-required" title="'.__('This is a mandatory element.').'">*</span>'), $resource) ?>
+          ->label(__('Authority record identifier').' <span class="form-required" title="'.__('This is a mandatory element.').'">*</span>'), $resource) ?>
 
         <?php echo render_field($form->institutionResponsibleIdentifier
           ->help(__('"Record the full authorized form of name(s) of the agency(ies) responsible for creating, modifying or disseminating the authority record or, alternatively, record a code for the agency in accordance with the national or international agency code standard. Include reference to any systems of identification used to identify the institutions (e.g. ISO 15511)." (ISAAR 5.4.2)'))

--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/indexSuccess.php
@@ -163,7 +163,7 @@
 
   <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Control area').'</h2>', array($resource, 'module' => 'actor', 'action' => 'edit'), array('anchor' => 'controlArea', 'title' => __('Edit control area'))) ?>
 
-  <?php echo render_show(__('Description identifier'), render_value($resource->descriptionIdentifier)) ?>
+  <?php echo render_show(__('Authority record identifier'), render_value($resource->descriptionIdentifier)) ?>
 
   <?php echo render_show(__('Institution identifier'), render_value($resource->getInstitutionResponsibleIdentifier(array('cultureFallback' => true)))) ?>
 


### PR DESCRIPTION
Previously in the UI the authority record identifier was labelled "description identifier"
since that's what we call it in the database. This changes the labels to say
"authority record identifier" in the UI.
