### PR TITLE
Export dates of existence in EAC, refs #9755

### DIFF
--- a/plugins/sfEacPlugin/lib/sfEacPlugin.class.php
+++ b/plugins/sfEacPlugin/lib/sfEacPlugin.class.php
@@ -256,10 +256,9 @@ class sfEacPlugin implements ArrayAccess
         return;
 
       case 'existDates':
-
         // TODO <date/>, <dateRange/>, <dateSet/>, <descriptiveNote/>, simple
         // natural language parsing?
-        if (isset($this->resource->datesOfExistence))
+        if ($this->resource->datesOfExistence)
         {
           return '<date>'.esc_specialchars($this->resource->datesOfExistence).'</date>';
         }

--- a/plugins/sfEacPlugin/modules/sfEacPlugin/templates/indexSuccess.xml.php
+++ b/plugins/sfEacPlugin/modules/sfEacPlugin/templates/indexSuccess.xml.php
@@ -127,7 +127,7 @@
 
     <?php if ($eac->hasDescriptionElements($resource)): ?>
       <description>
-        <?php if (isset($eac->existDates) && $eac->existDates): ?>
+        <?php if ($eac->existDates): ?>
           <existDates><?php echo $eac->existDates ?></existDates>
         <?php endif; ?>
 


### PR DESCRIPTION
There was a regression where the dates of existence for an actor wasn't exporting in EAC anymore.
This was caused by trying to use isset() to test a property that isn't normal but instead uses
__get and __set magic, but the __isset magic wasn't defined.
