### PR TITLE
Let editors edit accession PREMIS, refs #9419

### DIFF
--- a/apps/qubit/modules/right/templates/_relatedRights.php
+++ b/apps/qubit/modules/right/templates/_relatedRights.php
@@ -6,7 +6,7 @@
       array(
         'resource' => $right->object,
         'inherit' => $item != $resource ? $item : null,
-        'informationObject' => $resource)) ?>
+        'relatedObject' => $resource)) ?>
 
   <?php endforeach; ?>
 
@@ -17,7 +17,8 @@
     <?php echo get_partial('right/right',
       array(
         'resource' => $item->object,
-        'inherit' => 0 == count($resource->getRights()) ? $resource : null)) ?>
+        'inherit' => 0 == count($resource->getRights()) ? $resource : null,
+        'relatedObject' => $resource)) ?>
 
   <?php endforeach; ?>
 

--- a/apps/qubit/modules/right/templates/_right.php
+++ b/apps/qubit/modules/right/templates/_right.php
@@ -1,6 +1,6 @@
 <div class="field">
   <h3><?php echo __('Related right') ?></h3>
-  <?php if (QubitAcl::check($informationObject, 'update')): ?>
+  <?php if (QubitAcl::check($relatedObject, 'update')): ?>
     <a href="<?php echo url_for(array('module' => 'right', 'action' => 'edit', 'slug' => $resource->slug)) ?>">&nbsp;Edit</a> |
     <a href="<?php echo url_for(array('module' => 'right', 'action' => 'delete', 'slug' => $resource->slug)) ?>"  class="deleteRightBasis">Delete</a>
   <?php endif; ?>


### PR DESCRIPTION
Due to the rights partial being used by both information objects and accessions, one of the security checks that determines if the PREMIS edit button appears was only checking the permissions for the information object case.
