### PR TITLE
Remove blank "Use for" list items, refs #8244

### DIFF
--- a/apps/qubit/modules/term/actions/editAction.class.php
+++ b/apps/qubit/modules/term/actions/editAction.class.php
@@ -294,7 +294,7 @@ class TermEditAction extends DefaultEditAction
 
         foreach ($this[$field->getName()] as $item)
         {
-          if (isset($value[$item->id]))
+          if (!empty($value[$item->id]))
           {
             $item->content = $value[$item->id];
             unset($filtered[$item->id]);
@@ -307,6 +307,11 @@ class TermEditAction extends DefaultEditAction
 
         foreach ($filtered as $item)
         {
+          if (!$item)
+          {
+            continue;
+          }
+
           $note = new QubitNote;
           $note->content = $item;
           switch ($field->getName())
@@ -496,7 +501,7 @@ class TermEditAction extends DefaultEditAction
 
         foreach ($this->useFor as $item)
         {
-          if (isset($value[$item->id]))
+          if (!empty($value[$item->id]))
           {
             $item->name = $value[$item->id];
             unset($filtered[$item->id]);
@@ -509,6 +514,11 @@ class TermEditAction extends DefaultEditAction
 
         foreach ($filtered as $item)
         {
+          if (!$item)
+          {
+            continue;
+          }
+
           $otherName = new QubitOtherName;
           $otherName->name = $item;
           $otherName->typeId = QubitTerm::ALTERNATIVE_LABEL_ID;


### PR DESCRIPTION
Also fixed this same issue for a couple other fields that had it. This is a similar
fix to #8243
