### PR TITLE
Hide upload stats when editing descs, refs #9275

### DIFF
--- a/apps/qubit/modules/repository/templates/_contextMenu.php
+++ b/apps/qubit/modules/repository/templates/_contextMenu.php
@@ -1,9 +1,9 @@
 <?php echo get_component('repository', 'logo') ?>
 
-<?php if (QubitAcl::check($resource, 'update')): ?>
-  <?php include_component('repository', 'uploadLimit', array('resource' => $resource)) ?>
-<?php endif; ?>
-
 <?php if ($resource->getRawValue() instanceof QubitRepository): ?>
+  <?php if (QubitAcl::check($resource, 'update')): ?>
+    <?php include_component('repository', 'uploadLimit', array('resource' => $resource)) ?>
+  <?php endif; ?>
+
   <?php include_component('repository', 'holdings', array('resource' => $resource)) ?>
 <?php endif; ?>


### PR DESCRIPTION
Hide repository upload statistics in context menu when we're not actually on a repository page.

These stats were previously appearing when editing archival descriptions, weren't useful, and led to timeout
issues when there were huge datasets.
