### PR TITLE
Ensure entity type exports in EAC, refs #9828

### DIFF
--- a/plugins/sfEacPlugin/modules/sfEacPlugin/templates/indexSuccessBody.xml.php
+++ b/plugins/sfEacPlugin/modules/sfEacPlugin/templates/indexSuccessBody.xml.php
@@ -70,7 +70,7 @@
         <entityId><?php echo esc_specialchars($resource->corporateBodyIdentifiers) ?></entityId>
       <?php endif; ?>
 
-      <?php if (!empty($eac->entityType)): ?>
+      <?php if ($eac->entityType): ?>
         <entityType><?php echo $eac->entityType ?></entityType>
       <?php endif; ?>
 


### PR DESCRIPTION
Due to us using __get magic, calling empty() on ->entityType wasn't the correct
way to check for its presence.
