### PR TITLE
Fixed issue with search result display. refs #9351

### DIFF
--- a/apps/qubit/modules/search/templates/_searchResult.php
+++ b/apps/qubit/modules/search/templates/_searchResult.php
@@ -71,7 +71,7 @@
     </ul>
 
     <?php if (null !== $scopeAndContent = get_search_i18n($doc, 'scopeAndContent', array('culture' => $culture))): ?>
-      <p><?php echo truncate_text($scopeAndContent, 250) ?></p>
+      <p><?php echo truncate_text(strip_tags(render_value($scopeAndContent)), 250) ?></p>
     <?php endif; ?>
 
     <?php if (isset($doc['creators']) && null !== $creationDetails = get_search_creation_details($doc, $culture)): ?>


### PR DESCRIPTION
Fixed issue with our custom link tags (like `"Google":http://google.ca`) displaying, without being converted
to links, in search results. Fixed by converting to HTML then stripping HTML tags to convert to text. Conversion to text was done so the text in the results could be easily truncated (given I couldn't find decent code to truncate HTML without edge cases).
