### PR TITLE
Escaping issues, refs #8522

### DIFF
--- a/js/treeView.js
+++ b/js/treeView.js
@@ -240,7 +240,7 @@
         }
 
         // Pass function so the placement is computed every time
-        $li.popover({ placement: function(popover, element) {
+        $li.popover({ html: true, placement: function(popover, element) {
             return ($(window).innerWidth() - $(element).offset().left < 550) ? 'left' : 'right';
           }});
 

--- a/plugins/arDacsPlugin/modules/arDacsPlugin/templates/editSuccess.php
+++ b/plugins/arDacsPlugin/modules/arDacsPlugin/templates/editSuccess.php
@@ -81,7 +81,12 @@
           <input class="list" type="hidden" value="<?php echo url_for(array('module' => 'actor', 'action' => 'autocomplete')) ?>"/>
         </div>
 
-        <?php echo get_partial('informationobject/childLevels', array('help' => __('<strong>Identifier</strong><br />Provide a unique identifier for the materials being described in accordance with the institution’s administrative control system.<br /><strong>Level of description</strong><br />Record the level of this unit of description.<br /><strong>Title</strong><br />In the absence of a meaningful formal title, compose a brief title that uniquely identifies the material.<br /><strong>Date</strong><br />Record a date of creation.'))) ?>
+        <?php // Take note of escaping strategy, then turn it off so help HTML won't be escaped
+              $escapingStrategy = sfConfig::get('sf_escaping_strategy');
+              sfConfig::set('sf_escaping_strategy', false); ?>
+        <?php echo get_partial('informationobject/childLevels', array('help' => __('<strong>Identifier</strong><br />Provide a unique identifier for the materials being described in accordance with the institution’s administrative control system.<br /><strong>Level of description</strong><br />Record the level of this unit of description.<br /><strong>Title</strong><br />In the absence of a meaningful formal title, compose a brief title that uniquely identifies the material.<br /><strong>Date</strong><br />Record a date of creation.')), ESC_RAW) ?>
+        <?php // Restore escaping strategy
+              sfConfig::set('sf_escaping_strategy', $escapingStrategy); ?>
 
       </fieldset> <!-- /#identityArea -->
 


### PR DESCRIPTION
Fixed a couple of escaping issues:
- treeview popovers were being unneccesarily escaped
- help text in the DACS editing form was being escaped

The fix for the DACS editing escaping is a bit unelegant, involving adding PHP to the template to disable escaping while rendering the field with the problem help text. Unfortunately, when I tried to disable escaping in the action as a whole I'd run into an exception:

{sfException} Unknown record property "rawValue" on "QubitInformationObject"
