### PR TITLE
slugify: check iconv error, refs #9855

### DIFF
--- a/lib/model/QubitSlug.php
+++ b/lib/model/QubitSlug.php
@@ -58,8 +58,12 @@ class QubitSlug extends BaseSlug
    */
   public static function slugify($slug, $dropArticles = true)
   {
-    // Handle exotic characters gracefully
-    $slug = iconv('utf-8', 'ascii//TRANSLIT', $slug);
+    // Handle exotic characters gracefully.
+    // TRANSLIT doesn't work in musl's iconv, see #9855.
+    if ((false !== $result = iconv('utf-8', 'ascii//TRANSLIT', $slug)) || (false !== $result = iconv('utf-8', 'ascii', $slug)))
+    {
+      $slug = $result;
+    }
 
     $slug = strtolower($slug);
 


### PR DESCRIPTION
Redmine: https://projects.artefactual.com/issues/9855

iconv() returns `FALSE` when there is a failure, which was happening
consistently in our Alpine-based Docker image as musl's iconv does not support
`//TRANSLIT`. This commit gives it a second shot without `//TRANSLIT`` or
ignore otherwise.
