### PR TITLE
Fix Archives Canada search issue. refs #9141

### DIFF
--- a/plugins/arArchivesCanadaPlugin/modules/search/templates/_box.php
+++ b/plugins/arArchivesCanadaPlugin/modules/search/templates/_box.php
@@ -2,6 +2,8 @@
 
   <form action="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse')) ?>" data-autocomplete="<?php echo url_for(array('module' => 'search', 'action' => 'autocomplete')) ?>">
 
+    <input type="hidden" name="topLod" value="0"/>
+
     <div class="input-append">
 
       <?php if (isset($repository)): ?>


### PR DESCRIPTION
Basic search, in Archives Canada theme, was returning only results from the
top level. Fixed it so it includes children.
