### PR TITLE
Elasticsearch: handle search exceptions, refs #9851

### DIFF
--- a/apps/qubit/modules/search/actions/errorAction.class.php
+++ b/apps/qubit/modules/search/actions/errorAction.class.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class SearchErrorAction extends sfAction
+{
+  public function execute($request)
+  {
+    $context = sfContext::getInstance();
+    $exception = $request->getParameter('exception');
+    $exceptionName = get_class($exception);
+
+    // Make sure that $this->reason does not disclose internal details as it
+    // is going to be shown to public users.
+
+    if ($exception instanceof Elastica\Exception\ResponseException)
+    {
+      $reasonParams = array('%1%' => sprintf('%s (%s)', $exceptionName, $exception->getElasticsearchException()->getExceptionName()));
+
+      $this->error = $exception->getResponse()->getError();
+    }
+    else
+    {
+      $reasonParams = array('%1%' => $exceptionName);
+
+      $this->error = $exception->getMessage();
+    }
+
+    // $this->reason is going to be logged and shown in the template
+    $this->reason = $context->i18n->__('Elasticsearch error: %1%', $reasonParams);
+
+    $message = sprintf("%s - %s", $this->reason, $this->error);
+    $this->logMessage($message, 'err');
+
+    // $this->error is going to be shown in the template only in debug mode
+    if (!$context->getConfiguration()->isDebug())
+    {
+      unset($this->error);
+    }
+  }
+}

--- a/apps/qubit/modules/search/templates/errorSuccess.php
+++ b/apps/qubit/modules/search/templates/errorSuccess.php
@@ -1,0 +1,20 @@
+<?php decorate_with('layout_1col.php') ?>
+
+<?php slot('title') ?>
+  <h1><?php echo __('Search error encountered') ?></h1>
+<?php end_slot() ?>
+
+<?php slot('content') ?>
+
+  <div class="messages error">
+    <div>
+      <strong><?php echo $reason ?></strong>
+      <?php if (!empty($error)): ?>
+        <pre><?php echo $error ?></pre>
+      <?php endif; ?>
+    </div>
+  </div>
+
+  <p><a href="javascript:history.go(-1)"><?php echo __('Back to previous page.') ?></a></p>
+
+<?php end_slot() ?>

--- a/lib/filter/QubitMeta.class.php
+++ b/lib/filter/QubitMeta.class.php
@@ -26,6 +26,22 @@ class QubitMeta extends sfFilter
     $context->response->addMeta('title', sfConfig::get('app_siteTitle'));
     $context->response->addMeta('description', sfConfig::get('app_siteDescription'));
 
-    $filterChain->execute();
+    try
+    {
+      $filterChain->execute();
+    }
+    catch (Exception $e)
+    {
+      $interfaces = class_implements($e, true);
+      if (in_array('Elastica\Exception\ExceptionInterface', $interfaces))
+      {
+        $context->getRequest()->setParameter('exception', $e);
+        $context->getController()->forward('search', 'error');
+
+        throw new sfStopException;
+      }
+
+      throw $e;
+    }
   }
 }


### PR DESCRIPTION
Handle Elastica exceptions gracefully. Redirect user to a custom error page
showing the exception name and if debug mode is enabled a more detailed error
message. The exceptions are also logged with level "err". The goal is to tell
the user that Elasticsearch is somehow involved in the error, which is a common
issue.

It reuses the QubitMeta filter so we don't add more levels in the stack.
