### PR TITLE
Fix migration issue. refs #8598

### DIFF
--- a/lib/task/migrate/migrations/arMigration0130.class.php
+++ b/lib/task/migrate/migrations/arMigration0130.class.php
@@ -36,10 +36,13 @@ class arMigration0130
    */
   public function up($configuration)
   {
-    // Add extra column, information_object.display_standard_id
-    QubitMigrate::addColumn(
-      QubitJob::TABLE_NAME,
-      'download_path TEXT');
+    if (false === QubitPdo::fetchOne("SHOW COLUMNS IN ". QubitJob::TABLE_NAME." LIKE ?", array('download_path')))
+    {
+      // Add extra column, job.download_path, if it doesn't already exist
+      QubitMigrate::addColumn(
+        QubitJob::TABLE_NAME,
+        'download_path TEXT');
+    }
 
     return true;
   }


### PR DESCRIPTION
Migration 130 is redundant in isolated cases (for reasons not yet determined).
Add logic to prevent migration from being applied if it's not needed.
