### PR TITLE
Improve job worker prefix uniqueness, refs #9858

### DIFF
--- a/lib/model/QubitJob.php
+++ b/lib/model/QubitJob.php
@@ -317,9 +317,9 @@ class QubitJob extends BaseJob
    */
   public static function getJobPrefix()
   {
-    // Deliberately avoiding spaces, tabs, etc... see #9648.
-    $key = sprintf('title="%s"; url="%s"', addslashes(sfConfig::get('app_siteTitle')), addslashes(sfConfig::get('app_siteBaseUrl')));
-    return substr(md5($key), 0, 16).'-';
+    // Deliberately avoiding spaces, tabs, etc by using md5 hashing, see #9648.
+    $key = sfConfig::get('app_siteTitle').sfConfig::get('app_siteBaseUrl').sfConfig::get('sf_root_dir');
+    return md5($key).'-';
   }
 
   /**


### PR DESCRIPTION
Add root directory to add to the uniqueness of gearman job prefixes. I don't
think we need all the sprintf / addslashes in there previously either since
we're just producing an md5 hash in the end anyway.
