### PR TITLE
Fix OAI calls to getUpdatedRecords. refs #9889

### DIFF
--- a/plugins/arOaiPlugin/lib/arOaiPluginComponent.class.php
+++ b/plugins/arOaiPlugin/lib/arOaiPluginComponent.class.php
@@ -112,7 +112,7 @@ abstract class arOaiPluginComponent extends sfComponent
       'from'   => $this->from,
       'until'  => $this->until,
       'cursor' => $this->cursor,
-      'offset' => QubitSetting::getByName('resumption_token_limit')->__toString(),
+      'limit' => QubitSetting::getByName('resumption_token_limit')->__toString(),
       'oaiSet' => $oaiSet);
 
     // Get the records according to the limit dates and collection


### PR DESCRIPTION
In OAI calls to getUpdatedRecords, the query result offset is being set to
what should be the limit. This results in no results or the wrong results being show.
