### PR TITLE
Rights label wording change, refs #9919

### DIFF
--- a/apps/qubit/modules/right/actions/editAction.class.php
+++ b/apps/qubit/modules/right/actions/editAction.class.php
@@ -74,6 +74,10 @@ class RightEditAction extends sfAction
         $this->form->setValidator($name, new sfValidatorString);
         $this->form->setWidget($name, $this->dateWidget());
         $this->form->setDefault($name, $this->right[$name]);
+        if ($name == 'copyrightStatusDate')
+        {
+          $this->form->getWidgetSchema()->{$name}->setLabel($this->context->i18n->__('Copyright status determination date'));
+        }
 
         break;
 

--- a/apps/qubit/modules/right/templates/_right.php
+++ b/apps/qubit/modules/right/templates/_right.php
@@ -32,7 +32,7 @@
 
       <?php echo render_show(__('Copyright status'), render_value($resource->copyrightStatus)) ?>
 
-      <?php echo render_show(__('Copyright status date'), render_value($resource->copyrightStatusDate)) ?>
+      <?php echo render_show(__('Copyright status determination date'), render_value($resource->copyrightStatusDate)) ?>
 
       <?php echo render_show(__('Copyright jurisdiction'), render_value(format_country($resource->copyrightJurisdiction))) ?>
 


### PR DESCRIPTION
Redmine: https://projects.artefactual.com/issues/9919

Change the "Copyright status date" label to "Copyright status determination date" for edit and display.
