### PR TITLE
Metadata-only digital objects, refs #9969

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/imageflowComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/imageflowComponent.class.php
@@ -57,21 +57,29 @@ class DigitalObjectImageflowComponent extends sfComponent
 
     foreach (QubitDigitalObject::get($criteria) as $item)
     {
-      // ensure the user has permissions to see a thumbnail
-      if (!QubitAcl::check($item->informationObject, 'readThumbnail') ||
-          !QubitGrantedRight::checkPremis($item->informationObject->id, 'readThumb'))
+      if ($item->usageId == QubitTerm::OFFLINE_ID)
       {
-        $thumbnail = QubitDigitalObject::getGenericRepresentation($item->mimeType);
+        $thumbnail = QubitDigitalObject::getGenericRepresentation($item->mimeType, QubitTerm::THUMBNAIL_ID);
         $thumbnail->setParent($item);
       }
       else
       {
-        $thumbnail = $item->getRepresentationByUsage(QubitTerm::THUMBNAIL_ID);
-
-        if (!$thumbnail)
+        // Ensure the user has permissions to see a thumbnail
+        if (!QubitAcl::check($item->informationObject, 'readThumbnail') ||
+            !QubitGrantedRight::checkPremis($item->informationObject->id, 'readThumb'))
         {
-          $thumbnail = QubitDigitalObject::getGenericRepresentation($item->mimeType, QubitTerm::THUMBNAIL_ID);
+          $thumbnail = QubitDigitalObject::getGenericRepresentation($item->mimeType);
           $thumbnail->setParent($item);
+        }
+        else
+        {
+          $thumbnail = $item->getRepresentationByUsage(QubitTerm::THUMBNAIL_ID);
+
+          if (!$thumbnail)
+          {
+            $thumbnail = QubitDigitalObject::getGenericRepresentation($item->mimeType, QubitTerm::THUMBNAIL_ID);
+            $thumbnail->setParent($item);
+          }
         }
       }
 

--- a/apps/qubit/modules/digitalobject/templates/_metadata.php
+++ b/apps/qubit/modules/digitalobject/templates/_metadata.php
@@ -37,6 +37,10 @@
   <?php if ($sf_user->isAuthenticated()): ?>
     <?php echo render_show(__('Object UUID'), $resource->informationObject->objectUUID, array('fieldLabel' => 'objectUUID')) ?>
     <?php echo render_show(__('AIP UUID'), $resource->informationObject->aipUUID, array('fieldLabel' => 'aipUUID')) ?>
+    <?php echo render_show(__('Format name'), $resource->informationObject->formatName, array('fieldLabel' => 'formatName')) ?>
+    <?php echo render_show(__('Format version'), $resource->informationObject->formatVersion, array('fieldLabel' => 'formatVersion')) ?>
+    <?php echo render_show(__('Format registry key'), $resource->informationObject->formatRegistryKey, array('fieldLabel' => 'formatRegistryKey')) ?>
+    <?php echo render_show(__('Format registry name'), $resource->informationObject->formatRegistryName, array('fieldLabel' => 'formatRegistryName')) ?>
   <?php endif; ?>
 
 </section>

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 140
+    value: 142
   milestone:
     name: milestone
     editable: 0

--- a/data/fixtures/taxonomyTerms.yml
+++ b/data/fixtures/taxonomyTerms.yml
@@ -2147,6 +2147,13 @@ QubitTerm:
       sv: 'Extern URI'
       vi: 'URI ngoài'
       zh: 外部URI
+  QubitTerm_digital_object_usage_offline:
+    taxonomy_id: QubitTaxonomy_17
+    parent_id: QubitTerm_110
+    id: 186
+    source_culture: en
+    name:
+      en: 'Offline'
   QubitTerm_137:
     taxonomy_id: QubitTaxonomy_17
     parent_id: QubitTerm_110

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -1243,14 +1243,17 @@ class QubitDigitalObject extends BaseDigitalObject
       $child->delete();
     }
 
-    // Delete digital asset
-    if (file_exists($this->getAbsolutePath()))
+    if ($this->usageId !== QubitTerm::OFFLINE_ID)
     {
-      unlink($this->getAbsolutePath());
-    }
+      // Delete digital asset
+      if (file_exists($this->getAbsolutePath()))
+      {
+        unlink($this->getAbsolutePath());
+      }
 
-    // Prune asset directory, if empty
-    self::pruneEmptyDirs(sfConfig::get('sf_web_dir').$this->path);
+      // Prune asset directory, if empty
+      self::pruneEmptyDirs(sfConfig::get('sf_web_dir').$this->path);
+    }
 
     foreach (QubitRelation::getBySubjectOrObjectId($this->id) as $item)
     {
@@ -1577,9 +1580,12 @@ class QubitDigitalObject extends BaseDigitalObject
    */
   public function getPublicPath()
   {
-    if ($this->usageId == QubitTerm::EXTERNAL_URI_ID) {
+    if ($this->usageId == QubitTerm::EXTERNAL_URI_ID)
+    {
       return $this->getPath();
-    } else {
+    }
+    else
+    {
       return public_path($this->getFullPath(), true);
     }
   }

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -65,6 +65,10 @@ class QubitInformationObject extends BaseInformationObject
 
     switch ($name)
     {
+      case 'formatName':
+      case 'formatVersion':
+      case 'formatRegistryKey':
+      case 'formatRegistryName':
       case 'objectUUID':
       case 'aipUUID':
 
@@ -1217,6 +1221,10 @@ class QubitInformationObject extends BaseInformationObject
       if (QubitTerm::EXTERNAL_URI_ID == $do->usageId)
       {
         return $path;
+      }
+      else if (QubitTerm::OFFLINE_ID === $do->usageId)
+      {
+        throw new sfException('getDigitalObjectPublicUrl() is not available for offline digital objects');
       }
       else
       {
@@ -2908,20 +2916,26 @@ class QubitInformationObject extends BaseInformationObject
       return;
     }
 
-    $isText = in_array($this->digitalObjects[0]->mediaTypeId, array(QubitTerm::TEXT_ID));
+    $digitalObject = $this->digitalObjects[0];
+    if (QubitTerm::OFFLINE_ID === $digitalObject->usageId)
+    {
+      throw new sfException('getDigitalObjectLink() is not available for offline digital objects');
+    }
+
+    $isText = in_array($digitalObject->mediaTypeId, array(QubitTerm::TEXT_ID));
     $hasReadMaster = QubitAcl::check($this, 'readMaster');
 
     if (QubitGrantedRight::checkPremis($this->id, 'readMaster') && ($hasReadMaster || $isText))
     {
-      if (QubitTerm::EXTERNAL_URI_ID == $this->digitalObjects[0]->usageId)
+      if (QubitTerm::EXTERNAL_URI_ID == $digitalObject->usageId)
       {
-        return $this->digitalObjects[0]->path;
+        return $digitalObject->path;
       }
       else
       {
         $request = sfContext::getInstance()->getRequest();
         return $request->getUriPrefix().$request->getRelativeUrlRoot().
-          $this->digitalObjects[0]->getFullPath();
+          $digitalObject->getFullPath();
       }
     }
   }

--- a/lib/model/QubitTerm.php
+++ b/lib/model/QubitTerm.php
@@ -122,7 +122,7 @@ class QubitTerm extends BaseTerm
     // ISAAR standardized form name
     STANDARDIZED_FORM_OF_NAME_ID = 165,
 
-    // External URI
+    // Digital object usage taxonomy (addition)
     EXTERNAL_URI_ID = 166,
 
     // Relation types
@@ -160,7 +160,10 @@ class QubitTerm extends BaseTerm
     // Job statuses
     JOB_STATUS_IN_PROGRESS_ID = 183,
     JOB_STATUS_COMPLETED_ID = 184,
-    JOB_STATUS_ERROR_ID = 185;
+    JOB_STATUS_ERROR_ID = 185,
+
+    // Digital object usage taxonomy (addition)
+    OFFLINE_ID = 186;
 
 
   public static function isProtected($id)

--- a/lib/task/digitalobject/digitalObjectDeleteTask.class.php
+++ b/lib/task/digitalobject/digitalObjectDeleteTask.class.php
@@ -107,7 +107,7 @@ EOF;
 
   private function deleteDigitalObject($digitalObject)
   {
-    if ($digitalObject->usageId == QubitTerm::EXTERNAL_URI_ID)
+    if ($digitalObject->usageId == QubitTerm::EXTERNAL_URI_ID || $digitalObject->usageId == QubitTerm::OFFLINE_ID)
     {
       return;
     }

--- a/lib/task/digitalobject/digitalObjectRegenDerivativesTask.class.php
+++ b/lib/task/digitalobject/digitalObjectRegenDerivativesTask.class.php
@@ -95,6 +95,8 @@ EOF;
       $query .= ' AND do.id IN (' . implode(', ', $ids) . ')';
     }
 
+    $query .= ' AND do.usage_id != '.QubitTerm::OFFLINE_ID;
+
     // Final confirmation
     if (!$options['force'])
     {
@@ -102,7 +104,7 @@ EOF;
 
       if ($options['slug'])
       {
-        $confirm[] = 'Continuing will regenerate the dervivatives for ALL descendants of';
+        $confirm[] = 'Continuing will regenerate the derivatives for ALL descendants of';
         $confirm[] = '"'.$options['slug'].'"';
       }
       else

--- a/lib/task/migrate/migrations/arMigration0142.class.php
+++ b/lib/task/migrate/migrations/arMigration0142.class.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add new term to digital object usages taxonomy
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0142
+{
+  const
+    VERSION = 142, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  public function up($configuration)
+  {
+    // Create new term for protected controlled vocabulary (digital object usages)
+    QubitMigrate::bumpTerm(QubitTerm::OFFLINE_ID, $configuration);
+    $term = new QubitTerm;
+    $term->id = QubitTerm::OFFLINE_ID;
+    $term->parentId = QubitTerm::ROOT_ID;
+    $term->taxonomyId = QubitTaxonomy::DIGITAL_OBJECT_USAGE_ID;
+    $term->name = 'Offline';
+    $term->culture = 'en';
+    $term->save();
+
+    return true;
+  }
+}

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
@@ -117,6 +117,7 @@ class arElasticSearchInformationObjectPdo
          pubstat.status_id as publication_status_id,
          do.id as digital_object_id,
          do.media_type_id as media_type_id,
+         do.usage_id as usage_id,
          do.name as filename
        FROM '.QubitInformationObject::TABLE_NAME.' io
        JOIN '.QubitObject::TABLE_NAME.' obj
@@ -1144,6 +1145,13 @@ class arElasticSearchInformationObjectPdo
     foreach ($this->getMaterialTypeId() as $item)
     {
       $serialized['materialTypeId'][] = $item->id;
+    }
+
+    // Make sure that media_type_id gets a value in case that one was not
+    // assigned, which seems to be a possibility when using the offline usage.
+    if (null === $this->media_type_id && $this->usage_id == QubitTerm::OFFLINE_ID)
+    {
+      $this->media_type_id = QubitTerm::OTHER_ID;
     }
 
     // Media

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_about.xml.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_about.xml.php
@@ -2,6 +2,9 @@
         <about>
           <feed xmlns="http://www.w3.org/2005/Atom">
             <?php foreach ($record->digitalObjects as $digitalObject): ?>
+              <?php if ($digitalObject->usageId == QubitTerm::OFFLINE_ID) ?>
+                <?php continue; ?>
+              <?php endif; ?>
               <?php if ($digitalObject->usageId == QubitTerm::MASTER_ID && QubitAcl::check($record, 'readMaster')): ?>
                 <?php $digitalObjectUrl = (string)QubitSetting::getByName('siteBaseUrl') . $digitalObject->path . $digitalObject->name ?>
                 <?php echo include_partial('getRecordAtomFeedEntry', array('object' => $digitalObject, 'url' => $digitalObjectUrl, 'usage' => 'master')) ?>

--- a/plugins/arRestApiPlugin/modules/api/actions/informationobjectsReadAction.class.php
+++ b/plugins/arRestApiPlugin/modules/api/actions/informationobjectsReadAction.class.php
@@ -439,19 +439,22 @@ class ApiInformationObjectsReadAction extends QubitApiAction
         {
           $this->addItemToArray($doData, 'url', $digitalObject->getFullPath());
         }
-        else
+        else if (QubitTerm::OFFLINE_ID != $digitalObject->usageId)
         {
           $this->addItemToArray($doData, 'url', $this->siteBaseUrl . $digitalObject->getFullPath());
         }
 
-        if (null !== $reference = $digitalObject->getRepresentationByUsage(QubitTerm::REFERENCE_ID))
+        if (QubitTerm::OFFLINE_ID != $digitalObject->usageId)
         {
-          $this->addItemToArray($doData, 'reference_url', $this->siteBaseUrl . $reference->getFullPath());
-        }
+          if (null !== $reference = $digitalObject->getRepresentationByUsage(QubitTerm::REFERENCE_ID))
+          {
+            $this->addItemToArray($doData, 'reference_url', $this->siteBaseUrl . $reference->getFullPath());
+          }
 
-        if (null !== $thumbnail = $digitalObject->getRepresentationByUsage(QubitTerm::THUMBNAIL_ID))
-        {
-          $this->addItemToArray($doData, 'thumbnail_url', $this->siteBaseUrl . $thumbnail->getFullPath());
+          if (null !== $thumbnail = $digitalObject->getRepresentationByUsage(QubitTerm::THUMBNAIL_ID))
+          {
+            $this->addItemToArray($doData, 'thumbnail_url', $this->siteBaseUrl . $thumbnail->getFullPath());
+          }
         }
       }
 

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
@@ -181,10 +181,12 @@
   <?php endif; ?>
 
   <?php if (null !== $digitalObject = $$resourceVar->digitalObjects[0]): ?>
-    <?php if (QubitAcl::check($$resourceVar, 'readMaster') && 0 < strlen($url = QubitTerm::EXTERNAL_URI_ID == $digitalObject->usageId ? $digitalObject->getPath() : $ead->getAssetPath($digitalObject))): ?>
-      <dao linktype="simple" href="<?php echo $url ?>" role="master" actuate="onrequest" show="embed"/>
-    <?php elseif (null !== $digitalObject->reference && QubitAcl::check($$resourceVar, 'readReference') && 0 < strlen($url = $ead->getAssetPath($digitalObject, true))): ?>
-      <dao linktype="simple" href="<?php echo $url ?>" role="reference" actuate="onrequest" show="embed"/>
+    <?php if (QubitTerm::OFFLINE_ID != $digitalObject->usageId): ?>
+      <?php if (QubitAcl::check($$resourceVar, 'readMaster') && 0 < strlen($url = QubitTerm::EXTERNAL_URI_ID == $digitalObject->usageId ? $digitalObject->getPath() : $ead->getAssetPath($digitalObject))): ?>
+        <dao linktype="simple" href="<?php echo $url ?>" role="master" actuate="onrequest" show="embed"/>
+      <?php elseif (null !== $digitalObject->reference && QubitAcl::check($$resourceVar, 'readReference') && 0 < strlen($url = $ead->getAssetPath($digitalObject, true))): ?>
+        <dao linktype="simple" href="<?php echo $url ?>" role="reference" actuate="onrequest" show="embed"/>
+      <?php endif; ?>
     <?php endif; ?>
   <?php endif; ?>
 


### PR DESCRIPTION
Redmine: https://projects.artefactual.com/issues/9969

Archivematica is incorporating a new type of DIP upload known as "metadata only" where the actual objects are not uploaded but its metadata. This pull request makes the necessary changes in AtoM to accommodate this new type of upload by introducing a new type of digital object where `usage` is `offline` (along with `master`, `representative` and `thumbnail`).

The HTTP API has also been updated to accept some extra fields that are relevant in this upload: format name, format version, format registry key and format registry name.
