### PR TITLE
Add end date sorting to description browse #9953

### DIFF
--- a/apps/qubit/modules/informationobject/actions/browseAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/browseAction.class.php
@@ -532,8 +532,13 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
 
         break;
 
-      case 'date':
+      case 'startDate':
         $this->search->query->setSort(array('dates.startDate' => 'asc'));
+
+        break;
+
+      case 'endDate':
+        $this->search->query->setSort(array('dates.endDate' => 'desc'));
 
         break;
 

--- a/apps/qubit/modules/informationobject/templates/browseSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/browseSuccess.php
@@ -301,7 +301,8 @@
           'lastUpdated' => __('Most recent'),
           'alphabetic'  => __('Alphabetic'),
           'identifier'  => __('Reference code'),
-          'date'        => __('Date')))) ?>
+          'startDate'   => __('Start date'),
+          'endDate'     => __('End date')))) ?>
     </section>
 
     <div id="content">


### PR DESCRIPTION
No other sortPickers being used in AtoM use the 'date' sort type as far as I
can tell, so removing the 'date' case and just renaming it to startDate in
apps/qubit/modules/informationobject/actions/browseAction.class.php should
be okay.
