### PR TITLE
Keep transcript renaming DO filename, refs #9983

### DIFF
--- a/apps/qubit/modules/informationobject/actions/renameAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/renameAction.class.php
@@ -140,7 +140,7 @@ class InformationObjectRenameAction extends DefaultEditAction
       rename($oldFilePath, $newFilePath);
       chmod($newFilePath, 0644);
 
-      // Regeneraate derivatives
+      // Regenerate derivatives
       digitalObjectRegenDerivativesTask::regenerateDerivatives($digitalObject, array('keepTranscript' => true));
 
       // Change name in database

--- a/apps/qubit/modules/informationobject/actions/renameAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/renameAction.class.php
@@ -140,12 +140,12 @@ class InformationObjectRenameAction extends DefaultEditAction
       rename($oldFilePath, $newFilePath);
       chmod($newFilePath, 0644);
 
+      // Regeneraate derivatives
+      digitalObjectRegenDerivativesTask::regenerateDerivatives($digitalObject, array('keepTranscript' => true));
+
       // Change name in database
       $digitalObject->name = $filename;
       $digitalObject->save();
-
-      // Regeneraate derivatives
-      digitalObjectRegenDerivativesTask::regenerateDerivatives($digitalObject);
     }
 
     $this->resource->save();

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -911,24 +911,6 @@ class QubitInformationObject extends BaseInformationObject
   }
 
   /**
-   * Get first matching related property by name (optionally scope).
-   * Return an empty QubitProperty object if a matching one doesn't exist.
-   *
-   * @param string $name
-   * @param array $options
-   * @return QubitProperty
-   */
-  public function getPropertyByName($name, $options = array())
-  {
-    if (null === $property = QubitProperty::getOneByObjectIdAndName($this->id, $name, $options))
-    {
-      $property = new QubitProperty;
-    }
-
-    return $property;
-  }
-
-  /**
    * Save a related property and create a new property if a matching one doesn't
    * already exist.
    *

--- a/lib/model/QubitObject.php
+++ b/lib/model/QubitObject.php
@@ -364,4 +364,26 @@ class QubitObject extends BaseObject implements Zend_Acl_Resource_Interface
   {
     return QubitRelation::getRelationsBySubjectId($this->id, array('typeId' => QubitTerm::RIGHT_ID));
   }
+
+  /********************
+       Properties
+  *********************/
+
+  /**
+   * Get first matching related property by name (optionally scope).
+   * Return an empty QubitProperty object if a matching one doesn't exist.
+   *
+   * @param string $name
+   * @param array $options
+   * @return QubitProperty
+   */
+  public function getPropertyByName($name, $options = array())
+  {
+    if (null === $property = QubitProperty::getOneByObjectIdAndName($this->id, $name, $options))
+    {
+      $property = new QubitProperty;
+    }
+
+    return $property;
+  }
 }

--- a/lib/task/digitalobject/digitalObjectRegenDerivativesTask.class.php
+++ b/lib/task/digitalobject/digitalObjectRegenDerivativesTask.class.php
@@ -182,16 +182,13 @@ EOF;
       $derivative->delete();
     }
 
-    // Delete existing transcripts if 'keepTranscript' option is not sent or it's false
+    // Delete existing transcript if 'keepTranscript' option is not sent or it's false,
+    // we need to keep it to avoid an error trying to save a deleted property when this
+    // method is called from IO rename action
     if (!isset($options['keepTranscript']) || !$options['keepTranscript'])
     {
-      foreach ($digitalObject->propertys as $property)
-      {
-        if ('transcript' == $property->name)
-        {
-          $property->delete();
-        }
-      }
+      $transcriptProperty = $digitalObject->getPropertyByName('transcript');
+      $transcriptProperty->delete();
     }
 
     $digitalObject->createRepresentations(QubitTerm::MASTER_ID, $conn);

--- a/lib/task/digitalobject/digitalObjectRegenDerivativesTask.class.php
+++ b/lib/task/digitalobject/digitalObjectRegenDerivativesTask.class.php
@@ -171,7 +171,7 @@ EOF;
     $this->logSection('digital object', 'Done!');
   }
 
-  public static function regenerateDerivatives(&$digitalObject)
+  public static function regenerateDerivatives(&$digitalObject, $options = array())
   {
     // Delete existing derivatives
     $criteria = new Criteria;
@@ -182,12 +182,15 @@ EOF;
       $derivative->delete();
     }
 
-    // Delete existing transcripts
-    foreach ($digitalObject->propertys as $property)
+    // Delete existing transcripts if 'keepTranscript' option is not sent or it's false
+    if (!isset($options['keepTranscript']) || !$options['keepTranscript'])
     {
-      if ('transcript' == $property->name)
+      foreach ($digitalObject->propertys as $property)
       {
-        $property->delete();
+        if ('transcript' == $property->name)
+        {
+          $property->delete();
+        }
       }
     }
 


### PR DESCRIPTION
It's needed to avoid an error trying to save a deleted property when the
method is called from IO rename action.
- Send 'keepTranscript' option to regenerateDerivatives
- Regenerate derivates before saving DO to reflect all changes
