### PR TITLE
Fix browse digital object link, refs #9949

### DIFF
--- a/data/fixtures/menus.yml
+++ b/data/fixtures/menus.yml
@@ -1700,7 +1700,7 @@ QubitMenu:
       th: วัตถุดิจิตอล
       vi: 'Tượng kỹ thuật số'
       zh: 数字对象
-    path: informationobject/browse?view=card&onlyMedia=1
+    path: informationobject/browse?view=card&onlyMedia=1&topLod=0
   QubitMenu_mainmenu_admin_visibleElements:
     parent_id: QubitMenu_mainmenu_admin
     source_culture: en

--- a/lib/task/migrate/migrations/arMigration0141.class.php
+++ b/lib/task/migrate/migrations/arMigration0141.class.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Change browse digital object link so it shows non-top level descriptions'
+ * digital objects too.
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0141
+{
+  const
+    VERSION = 141, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  public function up($configuration)
+  {
+    if (null !== $menu = QubitMenu::getByName('browseDigitalObjects'))
+    {
+      $menu->path = 'informationobject/browse?view=card&onlyMedia=1&topLod=0';
+      $menu->save();
+    }
+    else
+    {
+      throw new sfException('Unable to retrieve setting "browseDigitalObjects" from database');
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
Previously, clicking browse digital object would only show digital objects
that belong to top level descriptions by default. Now the link will show
all digital objects regardless of the level of description by default.
