### PR TITLE
Modification of the method replaceLineBreak to find <lb/> tags nested…

### DIFF
--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -303,11 +303,14 @@ class QubitXmlImport
             continue;
           }
 
+
+          //A remettre avant push, Pas de changement de langue pour pouvoir tester plus facilement
+          /*
           if ($currentCulture !== $twoCharCode)
           {
             $this->errors[] = sfContext::getInstance()->i18n->__('EAD "langmaterial" is set to').': "'.$isocode.'" ('.format_language($twoCharCode, 'en').'). '.sfContext::getInstance()->i18n->__('Your XML document has been saved in this language and your user interface has just been switched to this language.');
           }
-          $sf_user->setCulture($twoCharCode);
+          $sf_user->setCulture($twoCharCode);*/
           // can only set to one language, so have to break once the first valid language is encountered
           break;
         }
@@ -810,6 +813,7 @@ class QubitXmlImport
   public static function replaceLineBreaks($node)
   {
     $nodeValue = '';
+    $fieldsArray = array('extent', 'physfacet', 'dimensions');
 
     foreach ($node->childNodes as $child)
     {
@@ -817,29 +821,25 @@ class QubitXmlImport
       {
         $nodeValue .= "\n";
       }
-      else
+      else if (in_array($child->tagName, $fieldsArray)) 
       {
-        if($child->tagName=='extent') 
+        foreach ($child->childNodes as $childNode)
         {
-          foreach ($child->childNodes as $childChild)
+          if ($childNode->nodeName == 'lb')
           {
-            if ($childChild->nodeName == 'lb')
-            {
-              $nodeValue .= "\n";
-            } 
-            else
-            {
-              $nodeValue .= preg_replace('/[\n\r\s]+/', ' ', $childChild->nodeValue);
-            }
+            $nodeValue .= "\n";
+          } 
+          else
+          {
+            $nodeValue .= preg_replace('/[\n\r\s]+/', ' ', $childNode->nodeValue);
           }
-        } else {
-
-          $nodeValue .= preg_replace('/[\n\r\s]+/', ' ', $child->nodeValue);
-
         }
+      } 
+      else 
+      {
+        $nodeValue .= preg_replace('/[\n\r\s]+/', ' ', $child->nodeValue);
       }
     }
-
     return $nodeValue;
   }
 

--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -819,7 +819,24 @@ class QubitXmlImport
       }
       else
       {
-        $nodeValue .= preg_replace('/[\n\r\s]+/', ' ', $child->nodeValue);
+        if($child->tagName=='extent') 
+        {
+          foreach ($child->childNodes as $childChild)
+          {
+            if ($childChild->nodeName == 'lb')
+            {
+              $nodeValue .= "\n";
+            } 
+            else
+            {
+              $nodeValue .= preg_replace('/[\n\r\s]+/', ' ', $childChild->nodeValue);
+            }
+          }
+        } else {
+
+          $nodeValue .= preg_replace('/[\n\r\s]+/', ' ', $child->nodeValue);
+
+        }
       }
     }
 

--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -304,14 +304,11 @@ class QubitXmlImport
           }
 
 
-          //A remettre avant push, Pas de changement de langue pour pouvoir tester plus facilement
-          /*
           if ($currentCulture !== $twoCharCode)
           {
             $this->errors[] = sfContext::getInstance()->i18n->__('EAD "langmaterial" is set to').': "'.$isocode.'" ('.format_language($twoCharCode, 'en').'). '.sfContext::getInstance()->i18n->__('Your XML document has been saved in this language and your user interface has just been switched to this language.');
           }
-          $sf_user->setCulture($twoCharCode);*/
-          // can only set to one language, so have to break once the first valid language is encountered
+          $sf_user->setCulture($twoCharCode);
           break;
         }
       }

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -1742,6 +1742,10 @@ class QubitInformationObject extends BaseInformationObject
       {
         $noteContent .= "\n";
       }
+      else if ($child->nodeName == 'language')
+      {
+        $noteContent .= ' '.trim($child->nodeValue);
+      }
     }
 
     // add language and script note, if so


### PR DESCRIPTION
```
… in <physdesc> tag

When importing a xml ead file all the <lb/> tags aren't read:
A <physdesc> tag may contain an <extent> tag that containt <lb/>. Before modifaction <lb/> was hidden inside <extent>.
```
