### PR TITLE
Speed up PDF page counting, refs #10062

### DIFF
--- a/apps/qubit/modules/settings/actions/digitalObjectDerivativesAction.class.php
+++ b/apps/qubit/modules/settings/actions/digitalObjectDerivativesAction.class.php
@@ -69,6 +69,8 @@ class SettingsDigitalObjectDerivativesAction extends DefaultEditAction
   {
     parent::execute($request);
 
+    $this->pdfinfoAvailable = sfImageMagickAdapter::pdfinfoToolAvailable();
+
     if ($request->isMethod('post'))
     {
       $this->form->bind($request->getPostParameters());

--- a/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php
+++ b/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php
@@ -22,20 +22,28 @@
 
         <legend><?php echo __('%1% derivatives settings', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))) ?></legend>
 
-        <?php echo $form->pdfPageNumber
-          ->label(__('PDF page number for image derivative'))
-          ->help(__('If the page number does not exist, the derivative will be generated from the previous closest one.'))
-          ->renderRow() ?>
+        <?php if ($pdfinfoAvailable): ?>
+          <?php echo $form->pdfPageNumber
+            ->label(__('PDF page number for image derivative'))
+            ->help(__('If the page number does not exist, the derivative will be generated from the previous closest one.'))
+            ->renderRow() ?>
+        <?php else: ?>
+          <div class="messages error">
+            <?php echo __('The pdfinfo tool is required to use this functionality. Please contact your system administrator.') ?>
+          </div>
+        <?php endif; ?>
 
       </fieldset>
 
     </div>
 
-    <section class="actions">
-      <ul>
-        <li><input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Save') ?>"/></li>
-      </ul>
-    </section>
+    <?php if ($pdfinfoAvailable): ?>
+      <section class="actions">
+        <ul>
+          <li><input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Save') ?>"/></li>
+        </ul>
+      </section>
+    <?php endif; ?>
 
   </form>
 

--- a/plugins/sfThumbnailPlugin/lib/sfImageMagickAdapter.class.php
+++ b/plugins/sfThumbnailPlugin/lib/sfImageMagickAdapter.class.php
@@ -380,6 +380,14 @@ class sfImageMagickAdapter
    */
   private function getCount($image)
   {
+    $extension = pathinfo($image, PATHINFO_EXTENSION);
+
+    // If processing a PDF, attempt to use pdfinfo as it's faster
+    if (strtolower($extension) == 'pdf')
+    {
+      return sfImageMagickAdapter::getPdfPageCount($image);
+    }
+
     $command = $this->magickCommands['identify'].' -format %n '.escapeshellarg($image);
     exec($command, $stdout, $retval);
     if ($retval === 1)
@@ -388,6 +396,43 @@ class sfImageMagickAdapter
     }
 
     return intval(@$stdout[0]);
+  }
+
+  public static function pdfinfoToolAvailable()
+  {
+    return !empty(shell_exec('which pdfinfo'));
+  }
+
+  public static function getPdfPageCount($filename)
+  {
+    // Default to 1 if pdfinfo not installed
+    if (!sfImageMagickAdapter::pdfinfoToolAvailable())
+    {
+      return 1;
+    }
+
+    return sfImageMagickAdapter::getPdfinfoPageCount($filename);
+  }
+
+  public static function getPdfinfoPageCount($filename)
+  {
+    exec('pdfinfo '. escapeshellarg($filename), $stdout, $retval);
+
+    if ($retval === 1)
+    {
+      throw new Exception('PDF could not be analyzed.');
+    }
+
+    // Parse page number from output
+    foreach ($stdout as $line)
+    {
+      if (preg_match('/Pages:\s*(\d+)/i', $line, $matches) === 1)
+      {
+        return intval($matches[1]);
+      }
+    }
+
+    throw new Exception('PDF analysis incomplete.');
   }
 
   private function getExtract($image, array $options = array())


### PR DESCRIPTION
Redmine: https://projects.artefactual.com/issues/10062

Use pdfinfo, if available, to determine how many pages of content a PDF has. If pdfinfo isn't installed then the option to create thumbnails from pages, other than the front page, gets disabled.
