### PR TITLE
Fix regenerate derivatives by type. refs #9964

### DIFF
--- a/lib/task/digitalobject/digitalObjectRegenDerivativesTask.class.php
+++ b/lib/task/digitalobject/digitalObjectRegenDerivativesTask.class.php
@@ -174,9 +174,25 @@ EOF;
 
   public static function regenerateDerivatives(&$digitalObject, $type = null)
   {
+    // Determine usage ID for type
+    switch($type)
+    {
+      case "reference":
+        $usageId = QubitTerm::REFERENCE_ID;
+        break;
+
+      case "thumbnail":
+        $usageId = QubitTerm::THUMBNAIL_ID;
+        break;
+
+      default:
+        $usageId = QubitTerm::MASTER_ID;
+    }
+
     // Delete existing derivatives
     $criteria = new Criteria;
     $criteria->add(QubitDigitalObject::PARENT_ID, $digitalObject->id);
+    $criteria->add(QubitDigitalObject::USAGE_ID, $usageId);
 
     foreach(QubitDigitalObject::get($criteria) as $derivative)
     {
@@ -190,20 +206,6 @@ EOF;
       {
         $property->delete();
       }
-    }
-
-    switch($type)
-    {
-      case "reference":
-        $usageId = QubitTerm::REFERENCE_ID;
-        break;
-
-      case "thumbnail":
-        $usageId = QubitTerm::THUMBNAIL_ID;
-        break;
-
-      default:
-        $usageId = QubitTerm::MASTER_ID;
     }
 
     $digitalObject->createRepresentations($usageId, $conn);


### PR DESCRIPTION
When regenerating digital object derivatives, using the CLI task, and
specifying type all derivatives would be deleted. Fixed.
