### PR TITLE
CSV import: issue importing digital objects

### DIFF
--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -1011,7 +1011,7 @@ EOF;
         // only remove the DO if the checksums differ.  If they are removed
         // because the checksums are different, the following code will
         // recreate them from the CSV file.
-        if ($uri = $self->rowStatusVars['digitalObjectURI']
+        if (($uri = $self->rowStatusVars['digitalObjectURI'])
           && null === $self->object->getDigitalObject())
         {
           $do = new QubitDigitalObject;
@@ -1040,7 +1040,7 @@ EOF;
             $this->log($e->getMessage(), sfLogger::ERR);
           }
         }
-        else if ($path = $self->rowStatusVars['digitalObjectPath']
+        else if (($path = $self->rowStatusVars['digitalObjectPath'])
           && null === $self->object->getDigitalObject())
         {
           $do = new QubitDigitalObject;


### PR DESCRIPTION
An issue was introduced in 9995/6 where digital object
URLs could not be imported: doing so would produce the
error "could not resolve host" in the console. This
change resolves this issue.

Assignment of the url from the CSV file was not
working correctly. This same issue would have
affected loading from path as well.
