### PR TITLE
CSV/XML import matching option, refs #10054

### DIFF
--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -674,7 +674,6 @@ class QubitFlatfileImport
           }
           else
           {
-            // create new object
             $this->object = new $this->className;
           }
         }

--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -34,7 +34,8 @@ class QubitXmlImport
     $parent = null,
     $events = array(),
     $eadUrl = null,
-    $sourceName = null;
+    $sourceName = null,
+    $options = array();
 
   public function import($xmlFile, $options = array())
   {
@@ -43,6 +44,9 @@ class QubitXmlImport
 
     // save the file name for use in saving keymap record
     $this->sourceName = basename($xmlFile);
+
+    // save options so we can access from processMethods
+    $this->options = $options;
 
     // if we were unable to parse the XML file at all
     if (empty($importDOM->documentElement))
@@ -414,7 +418,7 @@ class QubitXmlImport
 
     $doSave = true;
     // if this is an information object in an XML EAD import, run the enhanced matching check.
-    if ($currentObject instanceof QubitInformationObject && $importSchema == 'ead')
+    if ($currentObject instanceof QubitInformationObject && $importSchema == 'ead' &&  $this->options['match'])
     {
       // run matching check - will return true or false
       $results = $this->handlePreSaveInformationObject($currentObject);

--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -418,7 +418,8 @@ class QubitXmlImport
 
     $doSave = true;
     // if this is an information object in an XML EAD import, run the enhanced matching check.
-    if ($currentObject instanceof QubitInformationObject && $importSchema == 'ead' &&  $this->options['match'])
+    if ($currentObject instanceof QubitInformationObject && $importSchema == 'ead'
+      && isset($this->options['match']) && $this->options['match'])
     {
       // run matching check - will return true or false
       $results = $this->handlePreSaveInformationObject($currentObject);

--- a/lib/task/import/csvImportBaseTask.class.php
+++ b/lib/task/import/csvImportBaseTask.class.php
@@ -77,6 +77,21 @@ abstract class csvImportBaseTask extends arBaseTask
         ."specify a source name (otherwise the filename will be used as a "
         . "source name).\n";
     }
+
+    // validate params that can be used in conjunction with --update='opt'
+    if ($options['update'])
+    {
+      // array of valid params
+      $validParams = array('match');
+
+      // if supplied param is not in $validParams, throw exception
+      if (!in_array(trim($options['update']), $validParams))
+      {
+        $msg = sprintf("Parameter \"%s\" is not valid for --update option.", $options['update']);
+        $msg .= sprintf(" Valid options are: %s", implode(", ", $validParams));
+        throw new sfException($msg);
+      }
+    }
   }
 
   /**

--- a/lib/task/import/csvImportBaseTask.class.php
+++ b/lib/task/import/csvImportBaseTask.class.php
@@ -87,7 +87,7 @@ abstract class csvImportBaseTask extends arBaseTask
       // if supplied param is not in $validParams, throw exception
       if (!in_array(trim($options['update']), $validParams))
       {
-        $msg = sprintf("Parameter \"%s\" is not valid for --update option.", $options['update']);
+        $msg = sprintf('Parameter "%s" is not valid for --update option.', $options['update']);
         $msg .= sprintf(" Valid options are: %s", implode(", ", $validParams));
         throw new sfException($msg);
       }

--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -75,8 +75,8 @@ EOF;
       new sfCommandOption(
         'update',
         null,
-        sfCommandOption::PARAMETER_NONE,
-        "Attempt to update if description has already been imported."
+        sfCommandOption::PARAMETER_OPTIONAL,
+        "Attempt to update if description has already been imported. Use update=\"match\" to update matched records only."
       ),
       new sfCommandOption(
         'skip-derivatives',
@@ -1073,6 +1073,27 @@ EOF;
 
     // Allow updating to be enabled via a CLI option
     $import->updateExisting = isset($options['update']);
+
+    // Are there params set on --update flag?
+    if ($options['update'])
+    {
+      // Parameters for --update are validated in csvImportBaseTask.class.php.
+      switch ($options['update'])
+      {
+        case 'match':
+          // Save match option. If update is ON, and match is set, only updating
+          // existing records - do not create new objects.
+          $import->matchExisting = true;
+        break;
+
+        default:
+          // Validation of params to --update in csvImportBaseTask.class.php.
+          throw new sfException('Update parameter "'
+            . $options['update']
+            .'" not handled: Correct --update parameter.');
+        break;
+      }
+    }
 
     // Convert content with | characters to a bulleted list
     $import->contentFilterLogic = function($text)

--- a/lib/task/import/importBulkTask.class.php
+++ b/lib/task/import/importBulkTask.class.php
@@ -34,6 +34,7 @@ class importBulkTask extends arBaseTask
       new sfCommandOption('schema', null, sfCommandOption::PARAMETER_OPTIONAL, 'Schema to use if importing a CSV file'),
       new sfCommandOption('output', null, sfCommandOption::PARAMETER_OPTIONAL, 'Filename to output results in CSV format'),
       new sfCommandOption('verbose', '-v', sfCommandOption::PARAMETER_NONE, 'Verbose output'),
+      new sfCommandOption('match', null, sfCommandOption::PARAMETER_NONE, 'Skip loading imported objects where no match is found'),
     ));
 
     $this->namespace        = 'import';


### PR DESCRIPTION
CSV Import:

Modified --update option to be able to take parameters to modify the update
logic. Adding further parameters for --update can leverage work done for this
task. Parameters will be specified as: --update="match". Parameters are
verified and an exception will be thrown if an unknown parameter is specified.

Added logic to implement 'match' parameter with --update option. When set,
Information Objects must match to a record in the database or they will be
skipped and a message will be logged in the console.
