### PR TITLE
Delete keymap with info object delete, refs #10111

### DIFF
--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -318,9 +318,31 @@ class QubitInformationObject extends BaseInformationObject
       }
     }
 
+    // Delete any keymap entries
+    $this->removeKeymapEntries();
+
     QubitSearch::getInstance()->delete($this);
 
     parent::delete($connection);
+  }
+
+  /**
+   * Remove any corresponding keymap entries on delete of this object
+   *
+   */
+  private function removeKeymapEntries()
+  {
+    $criteria = new Criteria;
+    $criteria->add(QubitKeymap::TARGET_ID, $this->id);
+    $criteria->add(QubitKeymap::TARGET_NAME, 'information_object');
+
+    if ($objectKeymap = QubitKeymap::get($criteria))
+    {
+      foreach ($objectKeymap as $item)
+      {
+        $item->delete();
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Add code to QubitInformationObject to ensure that any associated keymap
records are deleted when the delete() method is called on an information
object.

New private function removeKeymapEntries() added and is called
from the delete() method of the information object.
