### PR TITLE
Enhance XML/EAD & CSV import matching, refs #9992

### DIFF
--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -1029,38 +1029,13 @@ class QubitXmlImport
       $results['matched'] = true;
     }
     // else check for an informationObject based on id, title, repo.
-    else if ($this->getMatchedInformationObject($currentObject->identifier, $currentObject->title, $currentObject->repository->authorizedFormOfName))
+    else if (null !== $objectId = QubitInformationObject::getByTitleIdentifierAndRepo($currentObject->identifier,
+             $currentObject->title, $currentObject->repository->authorizedFormOfName))
     {
       $results['matched'] = true;
     }
 
     return $results;
-  }
-
-  /**
-   * Try to match informationObject to an existing one in system.
-   */
-  private function getMatchedInformationObject ($identifier, $title, $repoName)
-  {
-    $sf_user = sfContext::getInstance()->user;
-    $currentCulture = $sf_user->getCulture();
-
-    // looking for exact match
-    $queryBool = new \Elastica\Query\BoolQuery;
-    $queryBool->addMust(new \Elastica\Query\MatchAll);
-    $queryBool->addMust(new \Elastica\Query\Term(array('identifier' => $identifier)));
-    $queryBool->addMust(new \Elastica\Query\Term(array(sprintf('i18n.%s.title.untouched', $currentCulture) => $title)));
-    $queryBool->addMust(new \Elastica\Query\Term(array(sprintf('repository.i18n.%s.authorizedFormOfName.untouched', $currentCulture) => $repoName)));
-
-    $query = new \Elastica\Query($queryBool);
-    $query->setLimit(1);
-    $resultSet = QubitSearch::getInstance()->index->getType('QubitInformationObject')->search($query);
-
-    // matching criteria matches a record exactly if > 0.
-    if (0 < $resultSet->count())
-    {
-      return true;
-    }
   }
 
   /**

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -2527,6 +2527,37 @@ class QubitInformationObject extends BaseInformationObject
     return QubitInformationObject::get($criteria, $options);
   }
 
+  /**
+   * Try to match informationObject to an existing one in system.
+   *
+   * @param string $identifier  informationObject identifier
+   * @param string $title       informationObject title
+   * @param string $repoName    repository authorizedFormOfName
+   *
+   * @return integer InfoObj id
+   */
+  public static function getByTitleIdentifierAndRepo ($identifier, $title, $repoName)
+  {
+    $sf_user = sfContext::getInstance()->user;
+    $currentCulture = $sf_user->getCulture();
+
+    // looking for exact match
+    $queryBool = new \Elastica\Query\BoolQuery;
+    $queryBool->addMust(new \Elastica\Query\MatchAll);
+    $queryBool->addMust(new \Elastica\Query\Term(array('identifier' => $identifier)));
+    $queryBool->addMust(new \Elastica\Query\Term(array(sprintf('i18n.%s.title.untouched', $currentCulture) => $title)));
+    $queryBool->addMust(new \Elastica\Query\Term(array(sprintf('repository.i18n.%s.authorizedFormOfName.untouched', $currentCulture) => $repoName)));
+
+    $query = new \Elastica\Query($queryBool);
+    $query->setLimit(1);
+    $resultSet = QubitSearch::getInstance()->index->getType('QubitInformationObject')->search($query);
+
+    if ($resultSet->count())
+    {
+      return $resultSet[0]->getId();
+    }
+  }
+
   /*****************************************************
    Publication Status
   *****************************************************/


### PR DESCRIPTION
Address several cleanup items for Issue 9992.

CSV importer:
- move keymap cleanup code into block where keymap is retrieved and checked.
  This is necessary to prevent accidental deleltion of keymap records.
- Consolidate two versions of 'getMatchedInformationObject' into one public
  static method in QubitInformationObject.php. Change CSV and XML/EAD import
  programs to use this method.
