### PR TITLE
Improve ES search for archival descriptions, #10082

### DIFF
--- a/apps/qubit/modules/actor/actions/browseAction.class.php
+++ b/apps/qubit/modules/actor/actions/browseAction.class.php
@@ -74,7 +74,7 @@ class ActorBrowseAction extends DefaultBrowseAction
     {
       $queryText = new \Elastica\Query\QueryString($request->subquery);
       $queryText->setDefaultOperator('OR');
-      arElasticSearchPluginUtil::setAllFields($queryText, 'actor');
+      arElasticSearchPluginUtil::setFields($queryText, 'actor');
 
       $this->search->queryBool->addMust($queryText);
     }

--- a/apps/qubit/modules/informationobject/actions/browseAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/browseAction.class.php
@@ -520,12 +520,17 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
     // Sort
     switch ($request->sort)
     {
+      // Sort by highest ES score
+      case 'relevance':
+        $this->search->query->addSort(array('_score' => 'desc'));
+
+        break;
+
       case 'identifier':
         $this->search->query->addSort(array('referenceCode.untouched' => 'asc'));
 
         break;
 
-      // I don't think that this is going to scale, but let's leave it for now
       case 'alphabetic':
         $field = sprintf('i18n.%s.title.untouched', $this->selectedCulture);
         $this->search->query->addSort(array($field => 'asc'));

--- a/apps/qubit/modules/informationobject/templates/browseSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/browseSuccess.php
@@ -305,6 +305,7 @@
         'options' => array(
           'lastUpdated' => __('Most recent'),
           'alphabetic'  => __('Alphabetic'),
+          'relevance'   => __('Relevance'),
           'identifier'  => __('Reference code'),
           'startDate'   => __('Start date'),
           'endDate'     => __('End date')))) ?>

--- a/apps/qubit/modules/repository/actions/browseAction.class.php
+++ b/apps/qubit/modules/repository/actions/browseAction.class.php
@@ -102,7 +102,7 @@ class RepositoryBrowseAction extends DefaultBrowseAction
     {
       $queryText = new \Elastica\Query\QueryString($request->subquery);
       $queryText->setDefaultOperator('OR');
-      arElasticSearchPluginUtil::setAllFields($queryText, 'repository');
+      arElasticSearchPluginUtil::setFields($queryText, 'repository');
 
       $this->search->queryBool->addMust($queryText);
     }

--- a/apps/qubit/modules/search/actions/indexAction.class.php
+++ b/apps/qubit/modules/search/actions/indexAction.class.php
@@ -29,7 +29,7 @@ class SearchIndexAction extends DefaultBrowseAction
     parent::execute($request);
 
     $queryText = new \Elastica\Query\QueryString($request->query);
-    $queryText->setDefaultOperator('OR');
+    $queryText->setDefaultOperator('AND');
     arElasticSearchPluginUtil::setFields($queryText, 'informationObject');
 
     $this->search->queryBool->addMust($queryText);

--- a/apps/qubit/modules/search/actions/indexAction.class.php
+++ b/apps/qubit/modules/search/actions/indexAction.class.php
@@ -30,7 +30,7 @@ class SearchIndexAction extends DefaultBrowseAction
 
     $queryText = new \Elastica\Query\QueryString($request->query);
     $queryText->setDefaultOperator('OR');
-    arElasticSearchPluginUtil::setAllFields($queryText, 'informationObject');
+    arElasticSearchPluginUtil::setFields($queryText, 'informationObject');
 
     $this->search->queryBool->addMust($queryText);
 

--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -371,6 +371,20 @@ mapping:
       timestamp: true
       autocompleteFields: [title]
       rawFields:  [title]
+      # Select which foreign type i18n fields we'll include when searching _all
+      i18nIncludeInAll:
+        - repository.authorizedFormOfName
+        - names.authorizedFormOfName
+        - names.otherNames.name
+        - names.parallelNames.name
+        - names.standardizedNames.name
+        - creators.authorizedFormOfName
+        - creators.otherNames.name
+        - creators.parallelNames.name
+        - creators.standardizedNames.name
+        - subjects.name
+        - places.name
+        - genres.name
     _partial_foreign_types:
       part_of:
         _i18nFields: [title]

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchMapping.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchMapping.class.php
@@ -93,8 +93,6 @@ class arElasticSearchMapping
       $this->fixYamlShorthands();
 
       $this->excludeNestedOnlyTypes();
-
-      $this->cleanYamlShorthands();
     }
   }
 
@@ -175,9 +173,16 @@ class arElasticSearchMapping
   }
 
   /**
-   * Clean YAML shorthands recursively
+   * Clean YAML shorthands recursively.
+   *
+   * We have some special YAML properties in mapping.yml that we only use internally
+   * to indicate foreign types, special attributes, etc. This method will remove those
+   * from the mappings array, which is necessary since when we generate our ES schema
+   * we don't want to send those special properties in the mapping.
+   *
+   * @param array mapping  A reference to our ES YAML mappings
    */
-  protected function cleanYamlShorthands(&$mapping = null)
+  public function cleanYamlShorthands(&$mapping = null)
   {
     // If no parameter is passed, $this->mapping will be used
     if (null === $mapping)
@@ -229,7 +234,7 @@ class arElasticSearchMapping
           $languages = QubitSetting::getByScope('i18n_languages');
           if (1 > count($languages))
           {
-            throw new sfException('The database settings don\'t content any language.');
+            throw new sfException('No i18n_languages in database settings.');
           }
 
           $this->setIfNotSet($typeProperties['properties'], 'sourceCulture', array('type' => 'string', 'index' => 'not_analyzed', 'include_in_all' => false));

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPlugin.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPlugin.class.php
@@ -169,7 +169,9 @@ class arElasticSearchPlugin extends QubitSearchEngine
       // Load mappings
       if (null === $this->mappings)
       {
-        $this->mappings = self::loadMappings();
+        $mappings = self::loadMappings();
+        $mappings->cleanYamlShorthands(); // Remove _attributes, _foreign_types, etc.
+        $this->mappings = $mappings->asArray();
       }
 
       // Iterate over types (actor, information_object, ...)
@@ -211,8 +213,7 @@ class arElasticSearchPlugin extends QubitSearchEngine
     // Load first mapping.yml file found
     $esMapping = new arElasticSearchMapping;
     $esMapping->loadYAML(array_shift($files));
-
-    return $esMapping->asArray();
+    return $esMapping;
   }
 
   /**

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginQuery.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginQuery.class.php
@@ -408,7 +408,7 @@ class arElasticSearchPluginQuery
         $queryField = new \Elastica\Query\QueryString($query);
         $queryField->setDefaultOperator('OR');
         $except = array('findingAid.transcript');
-        arElasticSearchPluginUtil::setAllFields($queryField, 'informationObject', $except);
+        arElasticSearchPluginUtil::setFields($queryField, 'informationObject', $except);
 
         break;
 
@@ -416,7 +416,7 @@ class arElasticSearchPluginQuery
       default:
         $queryField = new \Elastica\Query\QueryString($query);
         $queryField->setDefaultOperator('OR');
-        arElasticSearchPluginUtil::setAllFields($queryField, 'informationObject');
+        arElasticSearchPluginUtil::setFields($queryField, 'informationObject');
 
         break;
     }

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginQuery.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginQuery.class.php
@@ -307,28 +307,28 @@ class arElasticSearchPluginQuery
       case 'identifier':
         $queryField = new \Elastica\Query\QueryString($query);
         $queryField->setDefaultField('identifier');
-        $queryField->setDefaultOperator('OR');
+        $queryField->setDefaultOperator('AND');
 
         break;
 
       case 'referenceCode':
         $queryField = new \Elastica\Query\QueryString($query);
         $queryField->setDefaultField('referenceCode');
-        $queryField->setDefaultOperator('OR');
+        $queryField->setDefaultOperator('AND');
 
         break;
 
       case 'title':
         $queryField = new \Elastica\Query\QueryString($query);
         $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.title'));
-        $queryField->setDefaultOperator('OR');
+        $queryField->setDefaultOperator('AND');
 
         break;
 
       case 'scopeAndContent':
         $queryField = new \Elastica\Query\QueryString($query);
         $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.scopeAndContent'));
-        $queryField->setDefaultOperator('OR');
+        $queryField->setDefaultOperator('AND');
 
         break;
 
@@ -342,7 +342,7 @@ class arElasticSearchPluginQuery
         {
           $queryField = new \Elastica\Query\QueryString($query);
           $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.archivalHistory'));
-          $queryField->setDefaultOperator('OR');
+          $queryField->setDefaultOperator('AND');
         }
 
         break;
@@ -350,28 +350,28 @@ class arElasticSearchPluginQuery
       case 'extentAndMedium':
         $queryField = new \Elastica\Query\QueryString($query);
         $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.extentAndMedium'));
-        $queryField->setDefaultOperator('OR');
+        $queryField->setDefaultOperator('AND');
 
         break;
 
       case 'genre':
         $queryField = new \Elastica\Query\QueryString($query);
         $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('genres.i18n.%s.name'));
-        $queryField->setDefaultOperator('OR');
+        $queryField->setDefaultOperator('AND');
 
         break;
 
       case 'subject':
         $queryField = new \Elastica\Query\QueryString($query);
         $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('subjects.i18n.%s.name'));
-        $queryField->setDefaultOperator('OR');
+        $queryField->setDefaultOperator('AND');
 
         break;
 
       case 'name':
         $queryField = new \Elastica\Query\QueryString($query);
         $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('names.i18n.%s.authorizedFormOfName'));
-        $queryField->setDefaultOperator('OR');
+        $queryField->setDefaultOperator('AND');
 
         break;
 
@@ -380,12 +380,12 @@ class arElasticSearchPluginQuery
 
         $queryPlaceTermName = new \Elastica\Query\QueryString($query);
         $queryPlaceTermName->setFields(arElasticSearchPluginUtil::getI18nFieldNames('places.i18n.%s.name'));
-        $queryPlaceTermName->setDefaultOperator('OR');
+        $queryPlaceTermName->setDefaultOperator('AND');
         $queryField->addShould($queryPlaceTermName);
 
         $queryPlaceTermUseFor = new \Elastica\Query\QueryString($query);
         $queryPlaceTermUseFor->setFields(arElasticSearchPluginUtil::getI18nFieldNames('places.useFor.i18n.%s.name'));
-        $queryPlaceTermUseFor->setDefaultOperator('OR');
+        $queryPlaceTermUseFor->setDefaultOperator('AND');
         $queryField->addShould($queryPlaceTermUseFor);
 
         break;
@@ -393,20 +393,20 @@ class arElasticSearchPluginQuery
       case 'findingAidTranscript':
         $queryField = new \Elastica\Query\QueryString($query);
         $queryField->setDefaultField('findingAid.transcript');
-        $queryField->setDefaultOperator('OR');
+        $queryField->setDefaultOperator('AND');
 
         break;
 
       case 'digitalObjectTranscript':
         $queryField = new \Elastica\Query\QueryString($query);
         $queryField->setDefaultField('transcript');
-        $queryField->setDefaultOperator('OR');
+        $queryField->setDefaultOperator('AND');
 
         break;
 
       case 'allExceptFindingAidTranscript':
         $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setDefaultOperator('OR');
+        $queryField->setDefaultOperator('AND');
         $except = array('findingAid.transcript');
         arElasticSearchPluginUtil::setFields($queryField, 'informationObject', $except);
 
@@ -415,7 +415,7 @@ class arElasticSearchPluginQuery
       case '_all':
       default:
         $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setDefaultOperator('OR');
+        $queryField->setDefaultOperator('AND');
         arElasticSearchPluginUtil::setFields($queryField, 'informationObject');
 
         break;

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
@@ -460,48 +460,6 @@ class arElasticSearchPluginUtil
   }
 
   /**
-   * Add boost values to various fields.
-   *
-   * @param array &$fields  An array of the fields to be modified with their boost values added.
-   * @param array $i18nfields  Specifies which i18n fields to boost, and which boost value to use.
-   *                           The array is in the form of 'fieldName' => (int)boostNumber
-   *
-   * @param array $nonI18nFields  Same as above, except for non-i18n string fields.
-   */
-  public static function addBoostValuesToFields(&$fields, $i18nFields, $nonI18nFields)
-  {
-    // Expand all the i18n fields into their various cultures, add boost values
-    $i18nBoostFields = arElasticSearchPluginUtil::getI18nFieldNames(
-      array_keys($i18nFields),
-      $cultures,
-      $i18nFields
-    );
-
-    foreach ($fields as &$field)
-    {
-      foreach ($i18nBoostFields as $i18nBoostField)
-      {
-        // Match boost field against current field, add boost if match found.
-        // i.e.: i18n.en.title will turn into i18n.en.title^10
-        if (0 === strpos($i18nBoostField, $field))
-        {
-          $field = $i18nBoostField;
-        }
-      }
-
-      foreach ($nonI18nFields as $nonI18nBoostField => $boost)
-      {
-        $nonI18nBoostField = $nonI18nBoostField.'^'.$boost;
-
-        if (0 === strpos($nonI18nBoostField, $field))
-        {
-          $field = $nonI18nBoostField;
-        }
-      }
-    }
-  }
-
-  /**
    * Expands i18n field names into various specified cultures, with the option to add boosting.
    *
    * @param array $fields  Which fields to expand. For example, 'i18n.%s.title' will expand to 'i18n.en.title',

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
@@ -459,6 +459,15 @@ class arElasticSearchPluginUtil
     return $fields;
   }
 
+  /**
+   * Add boost values to various fields.
+   *
+   * @param array &$fields  An array of the fields to be modified with their boost values added.
+   * @param array $i18nfields  Specifies which i18n fields to boost, and which boost value to use.
+   *                           The array is in the form of 'fieldName' => (int)boostNumber
+   *
+   * @param array $nonI18nFields  Same as above, except for non-i18n string fields.
+   */
   public static function addBoostValuesToFields(&$fields, $i18nFields, $nonI18nFields)
   {
     // Expand all the i18n fields into their various cultures, add boost values
@@ -492,6 +501,17 @@ class arElasticSearchPluginUtil
     }
   }
 
+  /**
+   * Expands i18n field names into various specified cultures, with the option to add boosting.
+   *
+   * @param array $fields  Which fields to expand. For example, 'i18n.%s.title' will expand to 'i18n.en.title',
+   *                       'i18n.fr.title', 'i18n.es.title', etc.
+   *
+   * @param array $cultures  An array specifying which cultures to expand to. If not specified, we look up which
+   *                         cultures are active in AtoM and go off that.
+   *
+   * @param array $boost  An array specifying filedName => (int)boostValue to add boost values onto the fields.
+   */
   public static function getI18nFieldNames($fields, $cultures = null, $boost = array())
   {
     // Get all available cultures if $cultures isn't set

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
@@ -113,6 +113,6 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
       'identifier' => 5,
     );
 
-    arElasticSearchPluginUtil::addBoostValuesToFields($fields, $i18nBoostFields, $nonI18nBoostFields);
+    arElasticSearchModelBase::addBoostValuesToFields($fields, $i18nBoostFields, $nonI18nBoostFields);
   }
 }

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
@@ -91,4 +91,22 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
 
     return true;
   }
+
+  public static function setBoostValues(&$fields, $cultures)
+  {
+    $i18nBoostFields = array(
+      'i18n.%s.title' => 10,
+      'subjects.i18n.%s.name' => 5,
+      'creators.i18n.%s.authorizedFormOfName' => 8,
+      'names.i18n.%s.authorizedFormOfName' => 3,
+      'places.i18n.%s.name' => 3,
+      'i18n.%s.scopeAndContent' => 5,
+    );
+
+    $nonI18nBoostFields = array(
+      'identifier' => 5,
+    );
+
+    arElasticSearchPluginUtil::addBoostValuesToFields($fields, $i18nBoostFields, $nonI18nBoostFields);
+  }
 }

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
@@ -92,6 +92,12 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
     return true;
   }
 
+  /**
+   * Set boost values for various information object fields.
+   *
+   * @param array &$fields  A reference to our array of fields we're adding boost values to.
+   * @param array $cultures  An array specifying which cultures the i18n fields cover.
+   */
   public static function setBoostValues(&$fields, $cultures)
   {
     $i18nBoostFields = array(

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
@@ -97,7 +97,7 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
     $i18nBoostFields = array(
       'i18n.%s.title' => 10,
       'subjects.i18n.%s.name' => 5,
-      'creators.i18n.%s.authorizedFormOfName' => 8,
+      'creators.i18n.%s.authorizedFormOfName' => 6,
       'names.i18n.%s.authorizedFormOfName' => 3,
       'places.i18n.%s.name' => 3,
       'i18n.%s.scopeAndContent' => 5,

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchModelBase.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchModelBase.class.php
@@ -126,4 +126,46 @@ abstract class arElasticSearchModelBase
   {
     return true;
   }
+
+  /**
+   * Add boost values to various fields.
+   *
+   * @param array &$fields  An array of the fields to be modified with their boost values added.
+   * @param array $i18nfields  Specifies which i18n fields to boost, and which boost value to use.
+   *                           The array is in the form of 'fieldName' => (int)boostNumber
+   *
+   * @param array $nonI18nFields  Same as above, except for non-i18n string fields.
+   */
+  public static function addBoostValuesToFields(&$fields, $i18nFields, $nonI18nFields)
+  {
+    // Expand all the i18n fields into their various cultures, add boost values
+    $i18nBoostFields = arElasticSearchPluginUtil::getI18nFieldNames(
+      array_keys($i18nFields),
+      $cultures,
+      $i18nFields
+    );
+
+    foreach ($fields as &$field)
+    {
+      foreach ($i18nBoostFields as $i18nBoostField)
+      {
+        // Match boost field against current field, add boost if match found.
+        // i.e.: i18n.en.title will turn into i18n.en.title^10
+        if (0 === strpos($i18nBoostField, $field))
+        {
+          $field = $i18nBoostField;
+        }
+      }
+
+      foreach ($nonI18nFields as $nonI18nBoostField => $boost)
+      {
+        $nonI18nBoostField = $nonI18nBoostField.'^'.$boost;
+
+        if (0 === strpos($nonI18nBoostField, $field))
+        {
+          $field = $nonI18nBoostField;
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
The following PR attempts to accomplish 3 things:
1. Narrow down how many fields in nested, foreign types inside information object we search over. Now we only search for things like repository name (but not history), creator name (but not history), etc. This will ensure we don't accidentally get weird search results just because a keyword was in a creator's biog history or things like that.
2. Add weighting to search fields when searching, so certain fields yield higher scores when returning from queries. Also added a 'sort by relevance' option so we can take advantage of this way of searching.
3. Change the default search operator from OR to AND. This will result in more concise results.
