### PR TITLE
Postpone apiKey property save(), refs #10139

### DIFF
--- a/apps/qubit/modules/user/actions/editAction.class.php
+++ b/apps/qubit/modules/user/actions/editAction.class.php
@@ -284,16 +284,23 @@ class UserEditAction extends DefaultEditAction
         {
           case 'generate':
             // Create user OAI-PMH key property if it doesn't exist
-            if (null == $apiKey)
+            if (null === $apiKey)
             {
               $apiKey = new QubitProperty;
-              $apiKey->objectId = $this->resource->id;
               $apiKey->name = sfInflector::camelize($name);
             }
 
             // Generate new OAI-PMH API key
             $apiKey->value = bin2hex(openssl_random_pseudo_bytes(8));
-            $apiKey->save();
+
+            if (!isset($apiKey->id))
+            {
+              $this->resource->propertys[] = $apiKey;
+            }
+            else
+            {
+              $apiKey->save();
+            }
 
             break;
 


### PR DESCRIPTION
We can't save a QubitProperty if its foreign key has not been populated yet.
The solution is to associate the object to the "propertys" magic member and
QubitObject will take care of it and postpone the call to save() when it's
ready.
