### PR TITLE
Add clipboard icons on Desc Update, refs #10007

### DIFF
--- a/apps/qubit/modules/search/actions/descriptionUpdatesAction.class.php
+++ b/apps/qubit/modules/search/actions/descriptionUpdatesAction.class.php
@@ -114,6 +114,8 @@ class SearchDescriptionUpdatesAction extends sfAction
       $this->addField($name);
     }
 
+    $this->response->addJavaScript('clipboardToggleAll');
+
     $defaults = array(
       'className' => 'QubitInformationObject',
       'dateStart' => date('Y-m-d', strtotime('-1 month')),

--- a/apps/qubit/modules/search/templates/descriptionUpdatesSuccess.php
+++ b/apps/qubit/modules/search/templates/descriptionUpdatesSuccess.php
@@ -41,7 +41,7 @@
 
 <?php slot('content') ?>
 
-  <table class="table table-bordered sticky-enabled">
+  <table class="table table-bordered sticky-enabled" id="clipboardButtonNode">
     <thead>
       <tr>
         <th><?php echo __($nameColumnDisplay); ?></th>
@@ -54,6 +54,13 @@
           <th style="width: 110px"><?php echo __('Updated'); ?></th>
         <?php else: ?>
           <th style="width: 110px"><?php echo __('Created'); ?></th>
+        <?php endif; ?>
+        <?php if ('QubitInformationObject' == $className || 'QubitActor' == $className || 'QubitRepository' == $className): ?>
+          <th style="width: 110px">
+            <a href="#" class="all">All</a>
+            <div class="separator" style="display: inline;">/</div>
+            <a href="#" class="none">None</a>
+          </th>
         <?php endif; ?>
       </tr>
     </thead><tbody>
@@ -108,6 +115,12 @@
               <?php echo $result->updatedAt ?>
             <?php else: ?>
               <?php echo $result->createdAt ?>
+            <?php endif; ?>
+          </td>
+
+          <td>
+            <?php if ('QubitInformationObject' == $className || 'QubitActor' == $className || 'QubitRepository' == $className): ?>
+              <?php echo get_component('informationobject', 'clipboardButton', array('slug' => $result->slug, 'wide' => true)) ?>
             <?php endif; ?>
           </td>
 

--- a/js/clipboardToggleAll.js
+++ b/js/clipboardToggleAll.js
@@ -1,0 +1,41 @@
+(function ($)
+  {
+    // Toggle buttons
+    var clickClipButton = function (node, selectAll) {
+      var $button = $(node);
+
+      // We only want to click the button when needed
+      if (selectAll === $button.hasClass('added'))
+      {
+        return;
+      }
+
+      $button.click();
+    };
+
+    // Convenience wrapper in jQuery
+    $.fn.clickClipButton = function(clicked) {
+      this.each(function () {
+        clickClipButton.apply(null, [this, clicked]);
+      });
+    };
+
+    // get all affected clipboard buttons and select all or none based on
+    // item clicked.
+    $(document).ready(function() {
+
+      var $area = $('#clipboardButtonNode');
+      var $buttons = $area.find('button');
+
+      $area.find('.all').on('click', function (event) {
+        event.preventDefault();
+        $buttons.clickClipButton(true);
+      });
+
+      $area.find('.none').on('click', function (event) {
+        event.preventDefault();
+        $buttons.clickClipButton(false);
+      });
+    });
+  }
+)(jQuery);


### PR DESCRIPTION
Added a new column to the Description Updates page for archival descriptions,
authority records, and repository records. This new column will include the
clipboard clip icon, so users can add descriptions recently added or updated
directly to the clipboard.

Added ability to bulk add all or remove all items to/from the clipboard.
'All / None' links are located in the column header for the clipboard button
column.
