### PR TITLE
Clipboard: call toggle sequentially, refs #10007

### DIFF
--- a/apps/qubit/modules/search/actions/descriptionUpdatesAction.class.php
+++ b/apps/qubit/modules/search/actions/descriptionUpdatesAction.class.php
@@ -114,7 +114,7 @@ class SearchDescriptionUpdatesAction extends sfAction
       $this->addField($name);
     }
 
-    $this->response->addJavaScript('clipboardToggleAll');
+    $this->response->addJavaScript('clipboardToggleAll', 'last');
 
     $defaults = array(
       'className' => 'QubitInformationObject',

--- a/js/clipboard.js
+++ b/js/clipboard.js
@@ -34,16 +34,20 @@
     },
     toggle: function (reloadTooltip, event)
     {
-      event.preventDefault();
+      if (typeof event.preventDefault === 'function')
+      {
+        event.preventDefault();
+      }
 
       var $button = $(event.target);
-      
+
       if (reloadTooltip)
       {
         $button.tooltip('hide');
       }
 
-      $.ajax({
+      // Return deferred object
+      return $.ajax({
         url: $button.data('clipboard-url'),
         data: { slug: $button.data('clipboard-slug') },
         context: this,

--- a/js/clipboardToggleAll.js
+++ b/js/clipboardToggleAll.js
@@ -1,40 +1,48 @@
 (function ($)
   {
-    // Toggle buttons
-    var clickClipButton = function (node, selectAll) {
-      var $button = $(node);
-
-      // We only want to click the button when needed
-      if (selectAll === $button.hasClass('added'))
+    $(document).ready(function() {
+      // Access to clipboard functionality
+      var clipboard = $('#clipboard-menu').data('clipboard');
+      if (typeof clipboard === 'undefined')
       {
         return;
       }
 
-      $button.click();
-    };
-
-    // Convenience wrapper in jQuery
-    $.fn.clickClipButton = function(clicked) {
-      this.each(function () {
-        clickClipButton.apply(null, [this, clicked]);
-      });
-    };
-
-    // get all affected clipboard buttons and select all or none based on
-    // item clicked.
-    $(document).ready(function() {
-
       var $area = $('#clipboardButtonNode');
       var $buttons = $area.find('button');
 
-      $area.find('.all').on('click', function (event) {
+      $area.find('.all, .none').on('click', function (event) {
         event.preventDefault();
-        $buttons.clickClipButton(true);
-      });
 
-      $area.find('.none').on('click', function (event) {
-        event.preventDefault();
-        $buttons.clickClipButton(false);
+        // Generator of toggle function returning deferred objects so we can
+        // put them in a queue and execute sequentially.
+        function getToggleFn(button) {
+          return function() {
+            return clipboard.toggle(true, { 'target': button })
+          }
+        }
+
+        // Are we selecting or unselecting all?
+        var select = $(this).hasClass('all');
+
+        // Our queue of toggle functions
+        var queue = [];
+        $buttons.each(function(index) {
+          var $button = $buttons.eq(index);
+
+          if (select === $button.hasClass('added'))
+          {
+            return;
+          }
+
+          queue.push(getToggleFn($button.get()))
+        });
+
+        // Execute functions sequentially
+        var d = $.Deferred().resolve();
+        while (queue.length > 0) {
+          d = d.then(queue.shift());
+        }
       });
     });
   }


### PR DESCRIPTION
QubitClipboard doesn't avoid concurrent access to the storage. This is a workaround implemented on the client forcing sequential access.
