### PR TITLE
Specify csv transform script WebUI, refs #10138

### DIFF
--- a/apps/qubit/modules/object/actions/importAction.class.php
+++ b/apps/qubit/modules/object/actions/importAction.class.php
@@ -119,6 +119,7 @@ class ObjectImportAction extends sfAction
           case 'csv':
             $importer = new QubitCsvImport;
             $importer->indexDuringImport = ($request->getParameter('noindex') == 'on') ? false : true;
+            $importer->doCsvTransform = ($request->getParameter('doCsvTransform') == 'on') ? true : false;
             if (isset($this->getRoute()->resource)) $importer->setParent($this->getRoute()->resource);
             $importer->import($file['tmp_name'], $request->csvObjectType);
 

--- a/apps/qubit/modules/object/templates/importSelectSuccess.php
+++ b/apps/qubit/modules/object/templates/importSelectSuccess.php
@@ -66,6 +66,18 @@
           </label>
         </div>
 
+        <?php if ('csv' == $type && sfConfig::get('app_csv_transform_script_name')): ?>
+          <div class="form-item">
+            <label>
+              <input name="doCsvTransform" type="checkbox"/>
+              <?php echo __('Include transformation script') ?>
+              <div class="pull-right">
+                <?php echo __(sfConfig::get('app_csv_transform_script_name')) ?>
+              </div>
+            </label>
+          </div>
+        <?php endif; ?>
+
       </fieldset>
 
     </section>

--- a/config/app.yml
+++ b/config/app.yml
@@ -28,3 +28,7 @@ all:
 
   # htmlpurifier is used in static pages, disabled by default
   htmlpurifier_enabled: false
+
+  # Specify a CSV Transform script that can be automatically applied from
+  # the CSV Import Page in AtoM
+  # csv_transform_script_name: /full/path/to/transformscript


### PR DESCRIPTION
The CSV Import page in AtoM now allows a user to choose if they would like
to run a transformation script against the csv file being uploaded.

The transformation script to be run must be configured in config/app.yml by an
administrator prior to the user being able to see the checkbox on the CSV
Import page. If a transformation script is configured, the full path and
name of the transform script will also display opposite the checkbox on the
CSV Import page.

If the transformation script returns an exit code greater than zero, this
indicates a failure in the transform script and an exception will be thrown
and the csv import will not proceed.

The transform script must take 2 parameters:
1) The file to be transformed
2) The output file name that will contain the tranformed csv

The transform script must return a non-zero exit code to indicate an error
condition. An exit code of zero indicates success and will cause the csv
import to proceed. Any error messages must be output by the script to stdout
or stderr.
