### PR TITLE
WebUI CSV XML import filename keymap, refs #10175

### DIFF
--- a/apps/qubit/modules/object/actions/importAction.class.php
+++ b/apps/qubit/modules/object/actions/importAction.class.php
@@ -121,14 +121,14 @@ class ObjectImportAction extends sfAction
             $importer->indexDuringImport = ($request->getParameter('noindex') == 'on') ? false : true;
             $importer->doCsvTransform = ($request->getParameter('doCsvTransform') == 'on') ? true : false;
             if (isset($this->getRoute()->resource)) $importer->setParent($this->getRoute()->resource);
-            $importer->import($file['tmp_name'], $request->csvObjectType);
+            $importer->import($file['tmp_name'], $request->csvObjectType, $file['name']);
 
             break;
 
           case 'xml':
             $importer = new QubitXmlImport;
             if (isset($this->getRoute()->resource)) $importer->setParent($this->getRoute()->resource);
-            $importer->import($file['tmp_name'], array('strictXmlParsing' => false));
+            $importer->import($file['tmp_name'], array('strictXmlParsing' => false), $file['name']);
 
             break;
 

--- a/lib/QubitCsvImport.class.php
+++ b/lib/QubitCsvImport.class.php
@@ -35,8 +35,20 @@ class QubitCsvImport
   public $indexDuringImport = false;
   public $doCsvTransform = false;
 
-  public function import($csvFile, $type = null)
+  public function import($csvFile, $type = null, $csvOrigFileName = null)
   {
+    if (null === $csvOrigFileName)
+    {
+      // WebUI passes a temp file name in $csvFile. e.g. /tmp/phpLjBIBv
+      // If $csvOrigFileName is null, save $csvFile in keymap record
+      $csvOrigFileName = basename($csvFile);
+    }
+    else
+    {
+      // use the orig file name when creating keymap record
+      $csvOrigFileName = basename($csvOrigFileName);
+    }
+
     // perform the transformation, if requested and correctly configured
     if ($this->doCsvTransform)
     {
@@ -79,7 +91,7 @@ class QubitCsvImport
         escapeshellarg(sfConfig::get('sf_root_dir').DIRECTORY_SEPARATOR.'symfony'),
         escapeshellarg($taskClassName),
         $commandIndexFlag,
-        escapeshellarg($csvFile),  // --source-name should be original pre-transform file name. tmp file name: /tmp/phpLjBIBv ??
+        escapeshellarg($csvOrigFileName),
         escapeshellarg($this->parent->slug),
         escapeshellarg($transformedFile ? $transformedFile : $csvFile));
     }
@@ -90,7 +102,7 @@ class QubitCsvImport
         escapeshellarg(sfConfig::get('sf_root_dir').DIRECTORY_SEPARATOR.'symfony'),
         escapeshellarg($taskClassName),
         $commandIndexFlag,
-        escapeshellarg($csvFile),   // --source-name should be original pre-transform file name. tmp file name: /tmp/phpLjBIBv ??
+        escapeshellarg($csvOrigFileName),
         escapeshellarg($transformedFile ? $transformedFile : $csvFile));
     }
 

--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -37,13 +37,22 @@ class QubitXmlImport
     $sourceName = null,
     $options = array();
 
-  public function import($xmlFile, $options = array())
+  public function import($xmlFile, $options = array(), $xmlOrigFileName = null)
   {
     // load the XML document into a DOMXML object
     $importDOM = $this->loadXML($xmlFile, $options);
 
-    // save the file name for use in saving keymap record
-    $this->sourceName = basename($xmlFile);
+    if (null === $xmlOrigFileName)
+    {
+      // WebUI passes a temp file name in $xmlFile. e.g. /tmp/phpLjBIBv
+      // If $xmlOrigFileName is null, save $xmlFile in keymap record
+      $this->sourceName = basename($xmlFile);
+    }
+    else
+    {
+      // use the original file name when creating keymap record
+      $this->sourceName = basename($xmlOrigFileName);
+    }
 
     // save options so we can access from processMethods
     $this->options = $options;


### PR DESCRIPTION
CSV and XML files uploaded via the WebUI generate keymap table records when
uploaded. Keymap records are used for matching import records to records in
the database.

Currently uploaded files are assigned a randomly generated temporary file
name and these were being assigned to the keymap record on import. This has
been changed such that the original file name is now being assigned to the
keymap record. This will ensure that matching logic based on the keymap
table will work correctly when loading update files.
