### PR TITLE
Prevent trying to save deleted digi objs #10272

### DIFF
--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -1264,10 +1264,23 @@ class QubitDigitalObject extends BaseDigitalObject
     if (!empty($this->informationObjectId))
     {
       QubitSearch::getInstance()->update($this->getInformationObject());
+      $this->deleteFromAssociatedInformationObject();
     }
 
     // Delete self
     parent::delete($connection);
+  }
+
+  /**
+   * If we have an associated information object, ensure this digital object is cleared
+   * from its digitalObjects property.
+   */
+  private function deleteFromAssociatedInformationObject()
+  {
+    if ((null !== $io = $this->getInformationObject()) && isset($io->refFkValues['digitalObjects']))
+    {
+      unset($io->refFkValues['digitalObjects']);
+    }
   }
 
   /**
@@ -2068,7 +2081,7 @@ class QubitDigitalObject extends BaseDigitalObject
       {
         $pages = sfImageMagickAdapter::getPdfinfoPageCount($filename);
       }
-      else 
+      else
       {
         $command = 'identify '. $filename;
         exec($command, $output, $status);


### PR DESCRIPTION
When we call delete on a digital object here: https://github.com/artefactual/atom/blob/qa/2.4.x/lib/task/import/csvImportTask.class.php#L486

Sometimes when we do a subsequent call to the associated information object's save(), it hasn't removed that digital object instance from the information object's ->digitalObjects magic property, so it throws the error "this object has already been deleted". This PR creates a helper function to manually clear that property when needed.

I tried tracking down exactly why this was happening (and only sometimes--sometime it'd work fine) to no avail. If anyone has any ideas for a more elegant solution or insights into what the problem might have been, I'm open to suggestions. :)
