### PR TITLE
Update autocompleteSuccess.php

### DIFF
--- a/apps/qubit/modules/search/templates/autocompleteSuccess.php
+++ b/apps/qubit/modules/search/templates/autocompleteSuccess.php
@@ -13,7 +13,7 @@
         </li>
       <?php endforeach; ?>
       <?php if ($descriptions->getTotalHits() > 3): ?>
-        <li class="showall"><?php echo link_to(__('all matching descriptions'), array('module' => 'search', 'action' => 'index') + $sf_data->getRaw('sf_request')->getParameterHolder()->getAll()) ?></li>
+        <li class="showall"><?php echo link_to(__('all matching descriptions'), array('module' => 'informationobject', 'action' => 'browse', 'topLod' => '0') + $sf_data->getRaw('sf_request')->getParameterHolder()->getAll()) ?></li>
       <?php endif; ?>
     </ul>
   </section>


### PR DESCRIPTION
In AtoM 2.3, the search was changed "from search?query=Dalhousie&repos=" to "informationobject/browse?topLod=0&query=Dalhousie&repos=". The autocomplete drop down for "all matching descriptions" was not updated to match the changes. If a user selects it, they will be shown encoded json instead of a valid AtoM search page.
