### PR TITLE
Add maintaining repository relation, refs #8642

### DIFF
--- a/apps/qubit/modules/actor/actions/browseAction.class.php
+++ b/apps/qubit/modules/actor/actions/browseAction.class.php
@@ -40,6 +40,10 @@ class ActorBrowseAction extends DefaultBrowseAction
       'types' =>
         array('type' => 'term',
               'field' => 'entityTypeId',
+              'size' => 10),
+      'maintainingRepository' =>
+        array('type' => 'term',
+              'field' => 'maintainingRepositoryId',
               'size' => 10));
 
   protected function populateFacet($name, $ids)
@@ -53,6 +57,17 @@ class ActorBrowseAction extends DefaultBrowseAction
         foreach (QubitTerm::get($criteria) as $item)
         {
           $this->types[$item->id] = $item->getName(array('cultureFallback' => true));
+        }
+
+        break;
+
+      case 'maintainingRepository':
+        $criteria = new Criteria;
+        $criteria->add(QubitActor::ID, array_keys($ids), Criteria::IN);
+
+        foreach (QubitActor::get($criteria) as $item)
+        {
+          $this->types[$item->id] = $item->getAuthorizedFormOfName(array('cultureFallback' => true));
         }
 
         break;

--- a/apps/qubit/modules/actor/actions/editAction.class.php
+++ b/apps/qubit/modules/actor/actions/editAction.class.php
@@ -118,6 +118,20 @@ class ActorEditAction extends DefaultEditAction
 
         break;
 
+      case 'maintainingRepository':
+        $choices = array();
+        if (null !== $repo = $this->resource->getMaintainingRepository())
+        {
+          $repoRoute = $this->context->routing->generate(null, array($repo, 'module' => 'repository'));
+          $choices[$repoRoute] = $repo;
+          $this->form->setDefault('maintainingRepository', $repoRoute);
+        }
+
+        $this->form->setValidator('maintainingRepository', new sfValidatorString);
+        $this->form->setWidget('maintainingRepository', new sfWidgetFormSelect(array('choices' => $choices)));
+
+        break;
+
       default:
 
         return parent::addField($name);
@@ -161,6 +175,16 @@ class ActorEditAction extends DefaultEditAction
         {
           $params = $this->context->routing->parse(Qubit::pathInfo($value));
           $this->resource->entityType = $params['_sf_route']->resource;
+        }
+
+        break;
+
+      case 'maintainingRepository':
+        $value = $this->form->getValue('maintainingRepository');
+        if (isset($value))
+        {
+          $params = $this->context->routing->parse(Qubit::pathInfo($value));
+          $this->resource->setMaintainingRepository($params['_sf_route']->resource);
         }
 
         break;

--- a/apps/qubit/modules/actor/templates/browseSuccess.php
+++ b/apps/qubit/modules/actor/templates/browseSuccess.php
@@ -38,6 +38,13 @@
         'pager' => $pager,
         'filters' => $search->filters)) ?>
 
+      <?php echo get_partial('search/facet', array(
+        'target' => '#facet-maintainingrepository',
+        'label' => __('Maintained by'),
+        'facet' => 'maintainingRepository',
+        'pager' => $pager,
+        'filters' => $search->filters)) ?>
+
     </div>
 
   </section>

--- a/apps/qubit/modules/repository/actions/maintainedActorsAction.class.php
+++ b/apps/qubit/modules/repository/actions/maintainedActorsAction.class.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *names.id
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class RepositoryMaintainedActorsAction extends sfAction
+{
+  public function execute($request)
+  {
+    $this->response->setHttpHeader('Content-Type', 'application/json; charset=utf-8');
+
+    if ((empty($request->repositoryId) || !ctype_digit($request->repositoryId))
+      || (empty($request->page) || !ctype_digit($request->page)))
+    {
+      $this->forward404();
+    }
+
+    $limit = sfConfig::get('app_hits_per_page', 10);
+    $culture = $this->context->user->getCulture();
+
+    $resultSet = self::getActors($request->repositoryId, $request->page, $limit);
+
+    $pager = new QubitSearchPager($resultSet);
+    $pager->setMaxPerPage($limit);
+    $pager->setPage($request->page);
+    $pager->init();
+
+    sfContext::getInstance()->getConfiguration()->loadHelpers(array('Qubit', 'Url'));
+
+    $results = array();
+    foreach ($pager->getResults() as $item)
+    {
+      $doc = $item->getData();
+      $results[] = array(
+        'url' => url_for(array('module' => 'actor', 'slug' => $doc['slug'])),
+        'title' => get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false, 'culture' => $culture, 'cultureFallback' => true))
+      );
+    }
+
+    $data = array(
+      'results'     => $results,
+      'start'       => $pager->getFirstIndice(),
+      'end'         => $pager->getLastIndice(),
+      'currentPage' => $pager->getPage(),
+      'lastPage'    => $pager->getLastPage()
+    );
+
+    return $this->renderText(json_encode($data));
+  }
+
+  public static function getActors($repositoryId, $page, $limit)
+  {
+    $query = new \Elastica\Query;
+    $queryTerm = new \Elastica\Query\Term(array('maintainingRepositoryId' => $repositoryId));
+    $query->setQuery($queryTerm);
+
+    $query->setLimit($limit);
+    $query->setFrom($limit * ($page - 1));
+
+    $field = sprintf('i18n.%s.authorizedFormOfName.untouched', sfContext::getInstance()->user->getCulture());
+    $query->setSort(array($field => array('order' => 'asc', 'ignore_unmapped' => true)));
+
+    $resultSet = QubitSearch::getInstance()->index->getType('QubitActor')->search($query);
+
+    return $resultSet;
+  }
+}

--- a/apps/qubit/modules/repository/actions/maintainedActorsComponent.class.php
+++ b/apps/qubit/modules/repository/actions/maintainedActorsComponent.class.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Repository maintained actors component
+ *
+ * @package AccesstoMemory
+ * @subpackage repository
+ */
+class RepositoryMaintainedActorsComponent extends sfComponent
+{
+  public function execute($request)
+  {
+    sfContext::getInstance()->getConfiguration()->loadHelpers(array('Url'));
+
+    $page = 1;
+    $limit = sfConfig::get('app_hits_per_page', 10);
+
+    $resultSet = RepositoryMaintainedActorsAction::getActors($this->resource->id, $page, $limit);
+    if ($resultSet->getTotalHits() == 0)
+    {
+      return sfView::NONE;
+    }
+
+    $pager = new QubitSearchPager($resultSet);
+    $pager->setPage($page);
+    $pager->setMaxPerPage($limit);
+    $pager->init();
+
+    $this->list = array(
+      'label' => $this->context->i18n->__('Maintainer of'),
+      'pager' => $pager,
+      'dataUrl' => url_for(array('module' => 'repository', 'action' => 'maintainedActors', 'repositoryId' => $this->resource->id)),
+      'moreUrl' => url_for(array('module' => 'actor', 'action' => 'browse', 'maintainingRepository' => $this->resource->id)));
+  }
+}

--- a/apps/qubit/modules/repository/templates/_maintainedActors.php
+++ b/apps/qubit/modules/repository/templates/_maintainedActors.php
@@ -1,0 +1,26 @@
+<section class="sidebar-paginated-list list-menu"
+  data-total-pages="<?php echo $list['pager']->getLastPage() ?>"
+  data-url="<?php echo $list['dataUrl'] ?>">
+
+  <h3>
+    <?php echo $list['label'] ?>
+    <?php echo image_tag('loading.small.gif', array('class' => 'hidden', 'id' => 'spinner', 'alt' => __('Loading ...'))) ?>
+  </h3>
+
+  <div class="more">
+    <a href="<?php echo $list['moreUrl'] ?>">
+      <i class="fa fa-search"></i>
+      <?php echo __('Browse %1% results', array('%1%' => $list['pager']->getNbResults())) ?>
+    </a>
+  </div>
+
+  <ul>
+    <?php foreach ($list['pager']->getResults() as $hit): ?>
+      <?php $doc = $hit->getData() ?>
+      <li><?php echo link_to(get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false)), array('module' => 'actor', 'slug' => $doc['slug'])) ?></li>
+    <?php endforeach; ?>
+  </ul>
+
+  <?php echo get_partial('default/sidebarPager', array('pager' => $list['pager'])) ?>
+
+</section>

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 144
+    value: 145
   milestone:
     name: milestone
     editable: 0

--- a/data/fixtures/taxonomyTerms.yml
+++ b/data/fixtures/taxonomyTerms.yml
@@ -2421,6 +2421,13 @@ QubitTerm:
       th: วัตถุทางกายภาพ
       vi: 'có đối tượng vật lý'
       zh: 有物理藏品
+  QubitTerm_maintaining_repository_relation:
+    taxonomy_id: QubitTaxonomy_19
+    parent_id: QubitTerm_110
+    id: 187
+    source_culture: en
+    name:
+      en: 'Maintaining repository'
   QubitTerm_180:
     taxonomy_id: QubitTaxonomy_7
     parent_id: QubitTerm_110

--- a/lib/model/QubitActor.php
+++ b/lib/model/QubitActor.php
@@ -466,4 +466,36 @@ class QubitActor extends BaseActor
 
     return QubitInformationObject::get($criteria);
   }
+
+  public function getMaintainingRepository()
+  {
+    $criteria = new Criteria;
+    $criteria->add(QubitRelation::OBJECT_ID, $this->id);
+    $criteria->add(QubitRelation::TYPE_ID, QubitTerm::MAINTAINING_REPOSITORY_RELATION_ID);
+
+    if (null !== $relation = QubitRelation::getOne($criteria))
+    {
+      return $relation->subject;
+    }
+  }
+
+  public function setMaintainingRepository($repository)
+  {
+    $criteria = new Criteria;
+    $criteria->add(QubitRelation::OBJECT_ID, $this->id);
+    $criteria->add(QubitRelation::TYPE_ID, QubitTerm::MAINTAINING_REPOSITORY_RELATION_ID);
+
+    if (null === $relation = QubitRelation::getOne($criteria))
+    {
+      $relation = new QubitRelation;
+      $relation->typeId = QubitTerm::MAINTAINING_REPOSITORY_RELATION_ID;
+      $relation->subjectId = $repository->id;
+      $this->relationsRelatedByobjectId[] = $relation;
+    }
+    else
+    {
+      $relation->subjectId = $repository->id;
+      $relation->save();
+    }
+  }
 }

--- a/lib/model/QubitTerm.php
+++ b/lib/model/QubitTerm.php
@@ -163,7 +163,10 @@ class QubitTerm extends BaseTerm
     JOB_STATUS_ERROR_ID = 185,
 
     // Digital object usage taxonomy (addition)
-    OFFLINE_ID = 186;
+    OFFLINE_ID = 186,
+
+    // Relation type taxonomy
+    MAINTAINING_REPOSITORY_RELATION_ID = 187;
 
 
   public static function isProtected($id)

--- a/lib/task/migrate/migrations/arMigration0145.class.php
+++ b/lib/task/migrate/migrations/arMigration0145.class.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add maintaining repository relation type term
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0145
+{
+  const
+    VERSION = 145, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  public function up($configuration)
+  {
+    QubitMigrate::bumpTerm(QubitTerm::MAINTAINING_REPOSITORY_RELATION_ID, $configuration);
+    $term = new QubitTerm;
+    $term->id = QubitTerm::MAINTAINING_REPOSITORY_RELATION_ID;
+    $term->parentId = QubitTerm::ROOT_ID;
+    $term->taxonomyId = QubitTaxonomy::RELATION_TYPE_ID;
+    $term->sourceCulture = 'en';
+    $term->setName('Maintaining repository', array('culture' => 'en'));
+    $term->save();
+
+    return true;
+  }
+}

--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -339,6 +339,7 @@ mapping:
       description_identifier: { type:string, index: not_analyzed }
       corporate_body_identifiers: { type: string, index: not_analyzed }
       entity_type_id: { type: integer, index: not_analyzed, include_in_all: false }
+      maintaining_repository_id: { type: integer, index: not_analyzed, include_in_all: false }
 
   accession:
     _attributes:

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchActorPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchActorPdo.class.php
@@ -127,6 +127,25 @@ class arElasticSearchActorPdo
     return $this;
   }
 
+  protected function getMaintainingRepositoryId()
+  {
+    if (!isset(self::$statements['maintainingRepository']))
+    {
+      $sql  = 'SELECT rel.subject_id';
+      $sql .= ' FROM '.QubitRelation::TABLE_NAME.' rel';
+      $sql .= ' WHERE rel.object_id = :object_id';
+      $sql .= '   AND rel.type_id = :type_id';
+
+      self::$statements['maintainingRepository'] = self::$conn->prepare($sql);
+    }
+
+    self::$statements['maintainingRepository']->execute(array(
+      ':object_id' => $this->id,
+      ':type_id' => QubitTerm::MAINTAINING_REPOSITORY_RELATION_ID));
+
+    return self::$statements['maintainingRepository']->fetchColumn();
+  }
+
   public function serialize()
   {
     $serialized = array();
@@ -155,6 +174,11 @@ class arElasticSearchActorPdo
     foreach (QubitPdo::fetchAll($sql, array($this->id, QubitTerm::STANDARDIZED_FORM_OF_NAME_ID)) as $item)
     {
       $serialized['standardizedNames'][] = arElasticSearchOtherName::serialize($item);
+    }
+
+    if (false !== $maintainingRepositoryId = $this->getMaintainingRepositoryId())
+    {
+      $serialized['maintainingRepositoryId'] = (integer)$maintainingRepositoryId;
     }
 
     $serialized['createdAt'] = arElasticSearchPluginUtil::convertDate($this->created_at);

--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/actions/editAction.class.php
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/actions/editAction.class.php
@@ -43,6 +43,7 @@ class sfIsaarPluginEditAction extends ActorEditAction
       'internalStructures',
       'language',
       'legalStatus',
+      'maintainingRepository',
       'maintenanceNotes',
       'mandates',
       'otherName',

--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/editSuccess.php
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/editSuccess.php
@@ -108,6 +108,16 @@
           ->help(__('"Record a unique authority record identifier in accordance with local and/or national conventions. If the authority record is to be used internationally, record the country code of the country in which the authority record was created in accordance with the latest version of ISO 3166 Codes for the representation of names of countries. Where the creator of the authority record is an international organization, give the organizational identifier in place of the country code." (ISAAR 5.4.1)'))
           ->label(__('Authority record identifier').' <span class="form-required" title="'.__('This is a mandatory element.').'">*</span>'), $resource) ?>
 
+        <div class="form-item">
+          <?php echo $form->maintainingRepository->label(__('Maintaining repository'))->renderLabel() ?>
+          <?php echo $form->maintainingRepository->render(array('class' => 'form-autocomplete')) ?>
+          <input class="add" type="hidden" data-link-existing="true" value="<?php echo url_for(array('module' => 'repository', 'action' => 'add')) ?> #authorizedFormOfName"/>
+          <input class="list" type="hidden" value="<?php echo url_for(array('module' => 'repository', 'action' => 'autocomplete')) ?>"/>
+          <?php echo $form->maintainingRepository
+            ->help(__('"Record the full authorized form of name(s) of the agency(ies) responsible for creating, modifying or disseminating the authority record or, alternatively, record a code for the agency in accordance with the national or international agency code standard. Include reference to any systems of identification used to identify the institutions (e.g. ISO 15511)." (ISAAR 5.4.2)'))
+            ->renderHelp(); ?>
+        </div>
+
         <?php echo render_field($form->institutionResponsibleIdentifier
           ->help(__('"Record the full authorized form of name(s) of the agency(ies) responsible for creating, modifying or disseminating the authority record or, alternatively, record a code for the agency in accordance with the national or international agency code standard. Include reference to any systems of identification used to identify the institutions (e.g. ISO 15511)." (ISAAR 5.4.2)'))
           ->label(__('Institution identifier')), $resource) ?>

--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/indexSuccess.php
@@ -166,7 +166,7 @@
   <?php echo render_show(__('Authority record identifier'), render_value($resource->descriptionIdentifier)) ?>
 
   <?php if (null !== $repository = $resource->getMaintainingRepository()): ?>
-    <?php echo render_show(__('Maintaining repository'), link_to(render_title($repository), array($repository, 'module' => 'repository'))) ?>
+    <?php echo render_show(__('Maintained by'), link_to(render_title($repository), array($repository, 'module' => 'repository'))) ?>
   <?php endif; ?>
 
   <?php echo render_show(__('Institution identifier'), render_value($resource->getInstitutionResponsibleIdentifier(array('cultureFallback' => true)))) ?>

--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/indexSuccess.php
@@ -165,6 +165,10 @@
 
   <?php echo render_show(__('Authority record identifier'), render_value($resource->descriptionIdentifier)) ?>
 
+  <?php if (null !== $repository = $resource->getMaintainingRepository()): ?>
+    <?php echo render_show(__('Maintaining repository'), link_to(render_title($repository), array($repository, 'module' => 'repository'))) ?>
+  <?php endif; ?>
+
   <?php echo render_show(__('Institution identifier'), render_value($resource->getInstitutionResponsibleIdentifier(array('cultureFallback' => true)))) ?>
 
   <?php echo render_show(__('Rules and/or conventions used'), render_value($resource->getRules(array('cultureFallback' => true)))) ?>

--- a/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
@@ -2,6 +2,7 @@
 
 <?php slot('sidebar') ?>
   <?php include_component('repository', 'contextMenu') ?>
+  <?php include_component('repository', 'maintainedActors', array('resource' => $resource)) ?>
 <?php end_slot() ?>
 
 <?php slot('google_analytics') ?>


### PR DESCRIPTION
Create a new relation between actors and repositories to indicate the
institution maintaining an authority record.
- Create relation type (migration and fixtures)
- Add autocomplete field in actor edit page
- Display relation in actor index page
- Add maintaining repo id to actors in ES
- Add facet to actors browse page
- Add paginated list in repositories index page
