### PR TITLE
Geolocation improvements, refs #10330

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/metadataComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/metadataComponent.class.php
@@ -40,5 +40,16 @@ class DigitalObjectMetadataComponent extends sfComponent
     {
       $this->denyFileNameByPremis = true;
     }
+
+    // Provide Google Maps API key to template
+    $this->googleMapsApiKey = sfConfig::get('app_google_maps_api_key');
+
+    // Provide latitude to template
+    $latitudeProperty = $this->infoObj->digitalObjects[0]->getPropertyByName('latitude');
+    $this->latitude = $latitudeProperty->value;
+
+    // Provide longitude to template
+    $longitudeProperty = $this->infoObj->digitalObjects[0]->getPropertyByName('longitude');
+    $this->longitude = $longitudeProperty->value;
   }
 }

--- a/apps/qubit/modules/digitalobject/templates/_metadata.php
+++ b/apps/qubit/modules/digitalobject/templates/_metadata.php
@@ -22,6 +22,11 @@
     <?php endif; ?>
   <?php endif; ?>
 
+  <?php if (check_field_visibility('app_element_visibility_digital_object_geolocation')): ?>
+    <?php echo render_show(__('Latitude'), $latitude, array('fieldLabel' => 'latitude')) ?>
+    <?php echo render_show(__('Longitude'), $longitude, array('fieldLabel' => 'longitude')) ?>
+  <?php endif; ?>
+
   <?php if (check_field_visibility('app_element_visibility_digital_object_media_type')): ?>
     <?php echo render_show(__('Media type'), $resource->mediaType, array('fieldLabel' => 'mediaType')) ?>
   <?php endif; ?>

--- a/apps/qubit/modules/digitalobject/templates/_metadata.php
+++ b/apps/qubit/modules/digitalobject/templates/_metadata.php
@@ -4,6 +4,10 @@
 
   <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('%1% metadata', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))).'</h2>', array($resource, 'module' => 'digitalobject', 'action' => 'edit'), array('title' => __('Edit %1%', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))))) ?>
 
+  <?php if (sfConfig::get('app_toggleDigitalObjectMap') && is_numeric($latitude) && is_numeric($longitude) && $googleMapsApiKey): ?>
+    <div id="front-map" class="simple-map" data-key="<?php echo $googleMapsApiKey ?>" data-latitude="<?php echo $latitude ?>" data-longitude="<?php echo $longitude ?>"></div>
+  <?php endif; ?>
+
   <?php if (!QubitAcl::check($resource->informationObject, 'readReference')): ?>
     <?php echo render_show(__('Access'), __('Restricted')) ?>
   <?php endif; ?>

--- a/apps/qubit/modules/digitalobject/templates/editSuccess.php
+++ b/apps/qubit/modules/digitalobject/templates/editSuccess.php
@@ -39,6 +39,10 @@
             ->renderRow() ?>
         <?php endif; ?>
 
+        <?php echo $form->latitude->label('Latitude')->renderRow(); ?>
+
+        <?php echo $form->longitude->label('Longitude')->renderRow(); ?>
+
       </fieldset>
 
       <?php foreach ($representations as $usageId => $representation): ?>

--- a/apps/qubit/modules/settings/actions/globalAction.class.php
+++ b/apps/qubit/modules/settings/actions/globalAction.class.php
@@ -91,6 +91,7 @@ class SettingsGlobalAction extends sfAction
     $showTooltips = QubitSetting::getByName('show_tooltips');
     $defaultPubStatus = QubitSetting::getByName('defaultPubStatus');
     $swordDepositDir = QubitSetting::getByName('sword_deposit_dir');
+    $googleMapsApiKey = QubitSetting::getByName('google_maps_api_key');
     $slugTypeInformationObject = QubitSetting::getByName('slug_basis_informationobject');
 
 
@@ -117,7 +118,8 @@ class SettingsGlobalAction extends sfAction
       'slug_basis_informationobject' => (isset($slugTypeInformationObject)) ? intval($slugTypeInformationObject->getValue(array('sourceCulture'=>true))) : QubitSlug::SLUG_BASIS_TITLE,
       'show_tooltips' => (isset($showTooltips)) ? intval($showTooltips->getValue(array('sourceCulture'=>true))) : 1,
       'defaultPubStatus' => (isset($defaultPubStatus)) ? $defaultPubStatus->getValue(array('sourceCulture'=>true)) : QubitTerm::PUBLICATION_STATUS_DRAFT_ID,
-      'sword_deposit_dir' => (isset($swordDepositDir)) ? $swordDepositDir->getValue(array('sourceCulture'=>true)) : null
+      'sword_deposit_dir' => (isset($swordDepositDir)) ? $swordDepositDir->getValue(array('sourceCulture'=>true)) : null,
+      'google_maps_api_key' => (isset($googleMapsApiKey)) ? $googleMapsApiKey->getValue(array('sourceCulture'=>true)) : null
     ));
   }
 
@@ -361,6 +363,20 @@ class SettingsGlobalAction extends sfAction
 
       // Force sourceCulture update to prevent discrepency in settings between cultures
       $setting->setValue($swordDepositDir, array('sourceCulture' => true));
+      $setting->save();
+    }
+
+    // Google Maps Javascript API key
+    if (null !== $googleMapsApiKey = $thisForm->getValue('google_maps_api_key'))
+    {
+      if (null === $setting = QubitSetting::getByName('google_maps_api_key'))
+      {
+        $setting = new QubitSetting;
+        $setting->name = 'google_maps_api_key';
+      }
+
+      // Force sourceCulture update to prevent discrepency in settings between cultures
+      $setting->setValue($googleMapsApiKey, array('sourceCulture' => true));
       $setting->save();
     }
 

--- a/apps/qubit/modules/settings/actions/pageElementsAction.class.php
+++ b/apps/qubit/modules/settings/actions/pageElementsAction.class.php
@@ -36,6 +36,7 @@ class SettingsPageElementsAction extends sfAction
       'toggleTitle',
       'toggleLanguageMenu',
       'toggleIoSlider',
+      'toggleDigitalObjectMap',
       'toggleCopyrightFilter',
       'toggleMaterialFilter'
     );
@@ -45,9 +46,25 @@ class SettingsPageElementsAction extends sfAction
     $settings = array();
     $this->form = new sfForm;
 
+    // Take note if a Google Maps API key has been set
+    $googleMapsApiKeySetting = QubitSetting::getByName('google_maps_api_key');
+    $this->googleMapsApiKeySet = !empty($googleMapsApiKeySetting->value);
+
+    // Take note of whether digital object map is enabled
+    $toggleDigitalObjectMapSetting = QubitSetting::getByName('toggleDigitalObjectMap');
+
     foreach ($this::$NAMES as $name)
     {
-      $this->form->setWidget($name, new sfWidgetFormInputCheckbox);
+      // Disable checkbox to show digital object maps if it's not currently enabled and no Google Maps API key is defined
+      if ($name == 'toggleDigitalObjectMap' && empty($toggleDigitalObjectMapSetting->value) && empty($googleMapsApiKeySetting->value))
+      {
+        $this->form->setWidget($name, new sfWidgetFormInputCheckbox(array(), array('class' => 'disabled', 'disabled' => true)));
+      }
+      else
+      {
+        $this->form->setWidget($name, new sfWidgetFormInputCheckbox);
+      }
+
       $this->form->setValidator($name, new sfValidatorBoolean);
 
       if (null !== $settings[$name] = QubitSetting::getByName($name))

--- a/apps/qubit/modules/settings/templates/pageElementsSuccess.php
+++ b/apps/qubit/modules/settings/templates/pageElementsSuccess.php
@@ -50,6 +50,18 @@
             <td><?php echo $form->toggleIoSlider ?></td>
           </tr>
           <tr>
+            <td>
+              <?php echo $form->toggleDigitalObjectMap->label('Digital object map')->renderLabel() ?>
+              <?php if (!$googleMapsApiKeySet): ?>
+                <div class="description">
+                  <?php $securitySettingsLinkHtml = link_to(__('Security'), array('module' => 'settings', 'action' => 'security')) ?>
+                  <?php echo __('This feature will not work until a Google Maps API key is specified on the %1% settings page.', array('%1%' => $securitySettingsLinkHtml)) ?>
+                </div>
+              <?php endif; ?>
+            </td>
+            <td><?php echo $form->toggleDigitalObjectMap ?></td>
+          </tr>
+          <tr>
             <td><?php echo $form->toggleCopyrightFilter->label('Copyright status filter')->renderLabel() ?></td>
             <td><?php echo $form->toggleCopyrightFilter ?></td>
           </tr>

--- a/apps/qubit/modules/settings/templates/visibleElementsSuccess.php
+++ b/apps/qubit/modules/settings/templates/visibleElementsSuccess.php
@@ -136,6 +136,7 @@
         <?php foreach (array(
           'digital_object_url' => __('URL'),
           'digital_object_file_name' => __('File name'),
+          'digital_object_geolocation' => __('Latitude and longitude'),
           'digital_object_media_type' => __('Media type'),
           'digital_object_mime_type' => __('MIME type'),
           'digital_object_file_size' => __('File size'),

--- a/config/app.yml
+++ b/config/app.yml
@@ -20,9 +20,6 @@ all:
   # by and environment variable called "ATOM_READ_ONLY"
   read_only: false
 
-  # Used in the repo template
-  # google_maps_api_key: ...
-
   # Google Analitycs
   # google_analytics_api_key: ...
 

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -912,6 +912,10 @@ QubitSetting:
     name: digital_object_file_name
     scope: element_visibility
     value: 1
+  Qubit_Settings_visibleElements_digitalObjectGeolocation:
+    name: digital_object_geolocation
+    scope: element_visibility
+    value: 1
   Qubit_Settings_visibleElements_digitalObjectMediaType:
     name: digital_object_media_type
     scope: element_visibility

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 145
+    value: 146
   milestone:
     name: milestone
     editable: 0

--- a/lib/form/SettingsGlobalForm.class.php
+++ b/lib/form/SettingsGlobalForm.class.php
@@ -61,7 +61,8 @@ class SettingsGlobalForm extends sfForm
       'show_tooltips' => new sfWidgetFormSelectRadio(array('choices' => array(1 => 'yes', 0 => 'no')), array('class' => 'radio')),
       'slug_basis_informationobject' => $this->getSlugBasisInformationObjectWidget(),
       'defaultPubStatus' => new sfWidgetFormSelectRadio(array('choices' => array(QubitTerm::PUBLICATION_STATUS_DRAFT_ID => $this->i18n->__('Draft'), QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID => $this->i18n->__('Published'))), array('class' => 'radio')),
-      'sword_deposit_dir' => new sfWidgetFormInput
+      'sword_deposit_dir' => new sfWidgetFormInput,
+      'google_maps_api_key' => new sfWidgetFormInput
     ));
 
     // Add labels
@@ -90,7 +91,8 @@ class SettingsGlobalForm extends sfForm
       'sword_deposit_dir' => $this->i18n->__('SWORD deposit directory'),
       'require_ssl_admin' => $this->i18n->__('Require SSL for all administrator funcionality'),
       'slug_basis_informationobject' => $this->i18n->__('Generate description permalinks from'),
-      'require_strong_passwords' => $this->i18n->__('Require strong passwords')
+      'require_strong_passwords' => $this->i18n->__('Require strong passwords'),
+      'google_maps_api_key' => $this->i18n->__('Google Maps Javascript API key (for displaying dynamic maps)')
     ));
 
     // Add helper text
@@ -166,6 +168,7 @@ class SettingsGlobalForm extends sfForm
     $this->validatorSchema['show_tooltips'] = new sfValidatorInteger(array('required' => false));
     $this->validatorSchema['defaultPubStatus'] = new sfValidatorChoice(array('choices' => array(QubitTerm::PUBLICATION_STATUS_DRAFT_ID, QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID)));
     $this->validatorSchema['sword_deposit_dir'] = new sfValidatorString(array('required' => false));
+    $this->validatorSchema['google_maps_api_key'] = new sfValidatorString(array('required' => false));
 
     // Set decorator
     $decorator = new QubitWidgetFormSchemaFormatterList($this->widgetSchema);

--- a/lib/task/migrate/migrations/arMigration0146.class.php
+++ b/lib/task/migrate/migrations/arMigration0146.class.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add ability to set whether digital object geolocation shown
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0146
+{
+  const
+    VERSION = 146, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  /**
+   * Upgrade
+   *
+   * @return bool True if the upgrade succeeded, False otherwise
+   */
+  public function up($configuration)
+  {
+    if (null === QubitSetting::getByName('digital_object_geolocation'))
+    {
+      $setting = new QubitSetting;
+      $setting->setName('digital_object_geolocation');
+      $setting->setScope('element_visibility');
+      $setting->setValue('1');
+      $setting->save();
+    }
+
+    return true;
+  }
+}

--- a/plugins/arDominionPlugin/css/less/bootstrap-mod.less
+++ b/plugins/arDominionPlugin/css/less/bootstrap-mod.less
@@ -32,3 +32,8 @@
 .app-alert {
   margin-top: 1em
 }
+
+// Darken links within info alerts so they look different than text
+.alert-info > a {
+  color: #32127a
+}

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/indexSuccess.php
@@ -326,7 +326,7 @@
 <?php if (0 < count($resource->digitalObjects)): ?>
 
   <div class="digitalObjectMetadata">
-    <?php echo get_partial('digitalobject/metadata', array('resource' => $resource->digitalObjects[0])) ?>
+    <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjects[0], 'infoObj' => $resource)) ?>
   </div>
 
   <div class="digitalObjectRights">

--- a/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
@@ -73,8 +73,8 @@
 
 <?php end_slot() ?>
 
-<?php if (isset($latitude) && isset($longitude) && null !== $key = sfConfig::get('app_google_maps_api_key')): ?>
-  <div id="front-map" class="simple-map" data-key="<?php echo $key ?>" data-latitude="<?php echo $latitude ?>" data-longitude="<?php echo $longitude ?>"></div>
+<?php if (isset($latitude) && isset($longitude) && $mapApiKey = sfConfig::get('app_google_maps_api_key')): ?>
+  <div id="front-map" class="simple-map" data-key="<?php echo $mapApiKey ?>" data-latitude="<?php echo $latitude ?>" data-longitude="<?php echo $longitude ?>"></div>
 <?php endif; ?>
 
 <section id="identifyArea">

--- a/plugins/sfModsPlugin/modules/sfModsPlugin/templates/indexSuccess.php
+++ b/plugins/sfModsPlugin/modules/sfModsPlugin/templates/indexSuccess.php
@@ -137,7 +137,7 @@
 
 <?php if (0 < count($resource->digitalObjects)): ?>
 
-  <?php echo get_partial('digitalobject/metadata', array('resource' => $resource->digitalObjects[0])) ?>
+  <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjects[0], 'infoObj' => $resource)) ?>
 
   <?php echo get_partial('digitalobject/rights', array('resource' => $resource->digitalObjects[0])) ?>
 

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
@@ -394,7 +394,7 @@
 
 <?php if (0 < count($resource->digitalObjects)): ?>
   <div class="digitalObjectMetadata">
-    <?php echo get_partial('digitalobject/metadata', array('resource' => $resource->digitalObjects[0])) ?>
+    <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjects[0], 'infoObj' => $resource)) ?>
   </div>
   <div class="digitalObjectRights">
     <?php echo get_partial('digitalobject/rights', array('resource' => $resource->digitalObjects[0])) ?>


### PR DESCRIPTION
Redmine: https://projects.artefactual.com/issues/10330

Added ability to specify latitude/longitude of digital object and show resulting map on description pages:
- Add ability for admins to toggle display of digital object map on default page elements page
- Add ability to specify latitude/longitude when editing digital object metadata

AtoM tweaks/fixes related to feature:
- Change Google Maps API setting from config file var to DB setting
- Fix issue with use of get_partial instead of get_component when displaying digital object metadata
- Darken links within info alerts
