### PR TITLE
OAI Unavailable Metadata Error, refs #10279

### DIFF
--- a/plugins/arOaiPlugin/modules/arOaiPlugin/actions/indexAction.class.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/actions/indexAction.class.php
@@ -125,7 +125,7 @@ class arOaiPluginIndexAction extends sfAction
       $metadataPrefix = $this->request->metadataPrefix;
       if ($metadataPrefix != '' AND $metadataPrefix != 'oai_dc')
       {
-        $request->setParameter('errorCode', 'badVerb');
+        $request->setParameter('errorCode', 'cannotDisseminateFormat');
         $request->setParameter('errorMsg', 'The metadata format identified by the value given for the metadataPrefix argument is not supported by the item or by the repository.');
 
         $this->forward('arOaiPlugin', 'error');


### PR DESCRIPTION
AtoM was returning a 'badVerb' error code when an unknown metadata
prefix was requested. According to OAI-PMH, AtoM should return a
'cannotDisseminateFormat' response when the verb itself is valid but
the format requested is not.

This change corrects the response when this occurs - response will now
be cannotDisseminateFormat.
