### PR TITLE
Fix pagination in term index page, refs #10426

### DIFF
--- a/apps/qubit/modules/term/actions/indexAction.class.php
+++ b/apps/qubit/modules/term/actions/indexAction.class.php
@@ -295,7 +295,7 @@ EOF;
         // Page results
         $this->pager = new QubitSearchPager($resultSet);
         $this->pager->setPage($request->page ? $request->page : 1);
-        $this->pager->setMaxPerPage($request->limit);
+        $this->pager->setMaxPerPage($this->limit);
         $this->pager->init();
 
         $this->populateFacets($resultSet);


### PR DESCRIPTION
In terms where the related information objects are shown (places, subjects
and genres) a default limit is needed to make the pager work properly
