### PR TITLE
Background file import error, refs #10137

### DIFF
--- a/apps/qubit/modules/object/actions/importSelectAction.class.php
+++ b/apps/qubit/modules/object/actions/importSelectAction.class.php
@@ -95,6 +95,13 @@ class ObjectImportSelectAction extends DefaultEditAction
     }
   }
 
+  /**
+   * Launch the file import background job and return.
+   *
+   * @param  $request data
+   *
+   * @return null
+   */
   protected function doBackgroundImport($request)
   {
     $file = $request->getFiles('file');
@@ -110,6 +117,17 @@ class ObjectImportSelectAction extends DefaultEditAction
     else
     {
       $importSelectRoute = array('module' => 'object', 'action' => 'importSelect', 'type' => $importType);
+    }
+
+    // Move uploaded file to new location to pass off to background arFileImportJob.
+    try
+    {
+      $file = Qubit::moveUploadFile($file);
+    }
+    catch (sfException $e)
+    {
+      $this->getUser()->setFlash('error', $e->getMessage());
+      $this->redirect($importSelectRoute);
     }
 
     // if we got here without a file upload, go to file selection
@@ -131,7 +149,7 @@ class ObjectImportSelectAction extends DefaultEditAction
                      'update' => $request->getParameter('updateType'),
                      'repositorySlug' => $request->getPostParameter('repos'),
                      'collectionSlug' => end(explode('/', $request->getPostParameter('collection'))),
-                     'file' => $request->getFiles('file'));
+                     'file' => $file);
 
     try
     {

--- a/lib/Qubit.class.php
+++ b/lib/Qubit.class.php
@@ -309,4 +309,41 @@ class Qubit
 
     return $default;
   }
+
+  /**
+   * Move the uploaded file to a stable location so it is available post-upload.
+   *
+   * @param  $file array
+   *
+   * @return modified $file array
+   */
+  public static function moveUploadFile($file)
+  {
+    // Create tmp dir if it doesn't exist already.
+    $tmpDir = sfConfig::get('sf_upload_dir').'/tmp';
+    if (!file_exists($tmpDir))
+    {
+      mkdir($tmpDir);
+      chmod($tmpDir, 0775);
+    }
+
+    // Get a unique file name (to avoid clashing file names).
+    do
+    {
+      $uniqueString = substr(md5(time().$file['name']), 0, 8);
+      $tmpFileName = "TMP$uniqueString";
+      $tmpFilePath = "$tmpDir/$tmpFileName";
+    }
+    while (file_exists($tmpFilePath));
+
+    // Move file to web/uploads/tmp directory.
+    if (!move_uploaded_file($file['tmp_name'], $tmpFilePath))
+    {
+      $errorMessage = $this->context->i18n->__('Unable to complete file import. File %1% could not be moved to %2%', array('%1%' => $file['name'], '%2%' => $tmpDir));
+      throw new sfException($errorMessage);
+    }
+
+    $file['tmp_name'] = $tmpFilePath;
+    return $file;
+  }
 }

--- a/lib/job/arFileImportJob.class.php
+++ b/lib/job/arFileImportJob.class.php
@@ -85,6 +85,13 @@ class arFileImportJob extends arBaseJob
       }
     }
 
+    // Try to remove tmp file from uploads/tmp.
+    if (unlink($parameters['file']['tmp_name']) === false)
+    {
+      // Issue warning if unable to delete but do not show job as failed because of this.
+      $this->error($this->i18n->__('Failed to delete temporary file %1 -- please check your folder permissions.', array('%1' => $parameters['file']['tmp_name'])));
+    }
+
     // Mark job as complete.
     $this->info($this->i18n->__('Import complete.'));
     $this->job->setStatusCompleted();


### PR DESCRIPTION
An issue was discovered in testing where the import file uploaded via
the WebUI was no longer available for the background import job once
it was launched.

This change moves the uploaded import file to the uploads/tmp
directory before launching the background job. Also added code to the
background job (arFileImportJob) to remove the temp file from
uploads/tmp after the file has been processed.
