### PR TITLE
Import changes, refs #10472, #10016 and #10017

### DIFF
--- a/apps/qubit/modules/actor/actions/deleteAction.class.php
+++ b/apps/qubit/modules/actor/actions/deleteAction.class.php
@@ -39,25 +39,6 @@ class ActorDeleteAction extends sfAction
 
     if ($request->isMethod('delete'))
     {
-      foreach ($this->resource->events as $item)
-      {
-        if (isset($item->object) && isset($item->type))
-        {
-          unset($item->actor);
-
-          $item->save();
-        }
-        else
-        {
-          $item->delete();
-        }
-      }
-
-      foreach (QubitRelation::getBySubjectOrObjectId($this->resource->id) as $relation)
-      {
-        $relation->delete();
-      }
-
       $this->resource->delete();
 
       $this->redirect(array('module' => 'actor', 'action' => 'browse'));

--- a/apps/qubit/modules/object/actions/importSelectAction.class.php
+++ b/apps/qubit/modules/object/actions/importSelectAction.class.php
@@ -95,6 +95,30 @@ class ObjectImportSelectAction extends DefaultEditAction
     }
   }
 
+  protected function processField($field)
+  {
+    switch ($field->getName())
+    {
+      case 'repos':
+        $this->repositorySlug = $this->request->getPostParameter('repos');
+
+        break;
+
+      case 'collection':
+        $url = $this->request->getPostParameter('collection');
+        if (!empty($url))
+        {
+          $parts = explode('/', $url);
+          $this->collectionSlug = end($parts);
+        }
+
+        break;
+
+      default:
+        return parent::processField($field);
+    }
+  }
+
   /**
    * Launch the file import background job and return.
    *
@@ -147,8 +171,8 @@ class ObjectImportSelectAction extends DefaultEditAction
                      // experienced problems when the extension was omitted
                      'importType' => $importType,
                      'update' => $request->getParameter('updateType'),
-                     'repositorySlug' => $request->getPostParameter('repos'),
-                     'collectionSlug' => end(explode('/', $request->getPostParameter('collection'))),
+                     'repositorySlug' => $this->repositorySlug,
+                     'collectionSlug' => $this->collectionSlug,
                      'file' => $file);
 
     try

--- a/apps/qubit/modules/object/templates/importSelectSuccess.php
+++ b/apps/qubit/modules/object/templates/importSelectSuccess.php
@@ -45,6 +45,7 @@
               <option value="accession"><?php echo sfConfig::get('app_ui_label_accession', __('Accession')) ?></option>
               <option value="authorityRecord"><?php echo sfConfig::get('app_ui_label_actor') ?></option>
               <option value="event"><?php echo sfConfig::get('app_ui_label_event', __('Event')) ?></option>
+              <option value="repository"><?php echo sfConfig::get('app_ui_label_repository', __('Repository')) ?></option>
             </select>
           </div>
         <?php endif; ?>

--- a/apps/qubit/modules/object/templates/importSelectSuccess.php
+++ b/apps/qubit/modules/object/templates/importSelectSuccess.php
@@ -100,7 +100,7 @@
                 </label>
 
                 <div class="criteria">
-                  <div class="filter-row">
+                  <div class="filter-row repos-limit">
                     <div class="filter">
                       <?php echo $form->repos
                         ->label(__('Limit matches to:'))
@@ -108,7 +108,7 @@
                     </div>
                   </div>
 
-                  <div class="filter-row">
+                  <div class="filter-row collection-limit">
                     <div class="filter">
                       <?php echo $form->collection
                         ->label(__('Top-level description'))

--- a/apps/qubit/modules/repository/actions/deleteAction.class.php
+++ b/apps/qubit/modules/repository/actions/deleteAction.class.php
@@ -39,32 +39,6 @@ class RepositoryDeleteAction extends sfAction
 
     if ($request->isMethod('delete'))
     {
-      foreach ($this->resource->informationObjects as $item)
-      {
-        unset($item->repository);
-
-        $item->save();
-      }
-
-      foreach ($this->resource->events as $item)
-      {
-        if (isset($item->object) && isset($item->type))
-        {
-          unset($item->actor);
-
-          $item->save();
-        }
-        else
-        {
-          $item->delete();
-        }
-      }
-
-      foreach (QubitRelation::getBySubjectOrObjectId($this->resource->id) as $item)
-      {
-        $item->delete();
-      }
-
       $this->resource->delete();
 
       $this->redirect(array('module' => 'repository', 'action' => 'browse'));

--- a/js/checkReposFilter.js
+++ b/js/checkReposFilter.js
@@ -21,6 +21,9 @@
       this.$updateBlock = this.$element.find('div[id="updateBlock"]');
       this.$noIndexBlock = this.$element.find('div[id="noIndex"]');
 
+      this.$repoLimitBlock = this.$element.find('div.repos-limit');
+      this.$collectionLimitBlock = this.$element.find('div.collection-limit');
+
       this.init();
       this.listen();
     };
@@ -89,8 +92,7 @@
       {
         this.$reposFilter.removeAttr('disabled');
         this.$skipMatched.attr('checked', false);
-        this.$importAsNewPanel.hide();
-        this.$matchingPanel.show();
+        this.updateMatchingPanel();
       }
     },
 
@@ -101,7 +103,9 @@
         case 'informationObject':
         case 'authorityRecord':
         case 'ead':
+        case 'repository':
           // Show updateBlock for these objectTypes.
+          this.updateMatchingPanel();
           this.$updateBlock.show();
           break;
 
@@ -112,6 +116,39 @@
           // Do NOT show updateBlock for these objectTypes.
           this.$updateBlock.hide();
           break;
+      }
+    },
+
+    updateMatchingPanel: function ()
+    {
+      if (this.$updateTypeSelect.val() == 'import-as-new')
+      {
+        this.resetMatchingBlock();
+      }
+      else
+      {
+        switch (this.$objectTypeSelect.val())
+        {
+          case 'authorityRecord':
+            this.$collectionFilter.val('');
+            this.$repoLimitBlock.show();
+            this.$collectionLimitBlock.hide();
+            break;
+
+          case 'repository':
+            this.$reposFilter.val('');
+            this.$collectionFilter.val('');
+            this.$repoLimitBlock.hide();
+            this.$collectionLimitBlock.hide();
+            break;
+
+          default:
+            this.$repoLimitBlock.show();
+            this.$collectionLimitBlock.show();
+        }
+
+        this.$importAsNewPanel.hide();
+        this.$matchingPanel.show();
       }
     },
 

--- a/lib/QubitCsvImport.class.php
+++ b/lib/QubitCsvImport.class.php
@@ -83,6 +83,11 @@ class QubitCsvImport
 
         break;
 
+      case 'repository':
+        $taskClassName = 'csv:repository-import';
+
+        break;
+
       case 'informationObject':
       default:
         $taskClassName = 'csv:import';

--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -688,20 +688,13 @@ class QubitFlatfileImport
   {
     switch ($this->className)
     {
-      case 'QubitRepository':
-        if ($this->status['options']['merge-existing'] == 1)
-        {
-          $this->object = $this->createOrFetchRepository($this->columnValue('authorizedFormOfName'));
-          return false;
-        }
-
-        break;
-
       case 'QubitInformationObject':
         return $this->handleInformationObjectRow();
+
+      default:
+        $this->object = new $this->className;
     }
 
-    $this->object = new $this->className;
     return false;
   }
 

--- a/lib/model/QubitActor.php
+++ b/lib/model/QubitActor.php
@@ -169,6 +169,25 @@ class QubitActor extends BaseActor
 
   public function delete($connection = null)
   {
+    foreach ($this->events as $item)
+    {
+      if (isset($item->object) && isset($item->type))
+      {
+        unset($item->actor);
+
+        $item->save();
+      }
+      else
+      {
+        $item->delete();
+      }
+    }
+
+    foreach (QubitRelation::getBySubjectOrObjectId($this->id) as $relation)
+    {
+      $relation->delete();
+    }
+
     if (!($this instanceOf QubitRightsHolder || $this instanceOf QubitDonor))
     {
       QubitSearch::getInstance()->delete($this);

--- a/lib/model/QubitRepository.php
+++ b/lib/model/QubitRepository.php
@@ -151,7 +151,14 @@ class QubitRepository extends BaseRepository
     // Remove adv. search repository options from cache
     QubitCache::getInstance()->removePattern('advanced-search:list-of-repositories:*');
 
-    // Elasticsearch document is deleted in QubitActor
+    foreach ($this->informationObjects as $item)
+    {
+      unset($item->repository);
+
+      $item->save();
+    }
+
+    // Events, relations and the Elasticsearch document are deleted in QubitActor
     parent::delete($connection);
   }
 

--- a/lib/task/import/csvAuthorityRecordImportTask.class.php
+++ b/lib/task/import/csvAuthorityRecordImportTask.class.php
@@ -362,6 +362,9 @@ EOF;
     // Allow search indexing to be enabled via a CLI option
     $import->searchIndexingDisabled = ($options['index']) ? false : true;
 
+    // Set update, limit and skip options
+    $import->setUpdateOptions($options);
+
     $import->csv($fh, $skipRows);
     $actorNames = $import->getStatus('actorNames');
 

--- a/lib/task/import/csvAuthorityRecordImportTask.class.php
+++ b/lib/task/import/csvAuthorityRecordImportTask.class.php
@@ -64,6 +64,30 @@ EOF;
         null,
         sfCommandOption::PARAMETER_NONE,
         "Index for search during import."
+      ),
+      new sfCommandOption(
+        'update',
+        null,
+        sfCommandOption::PARAMETER_REQUIRED,
+        'Attempt to update if an actor already exists. Valid option values are "match-and-update" and "delete-and-replace".'
+      ),
+      new sfCommandOption(
+        'skip-matched',
+        null,
+        sfCommandOption::PARAMETER_NONE,
+        'When importing records without --update, use this option to skip creating new records when an existing one matches.'
+      ),
+      new sfCommandOption(
+        'skip-unmatched',
+        null,
+        sfCommandOption::PARAMETER_NONE,
+        "When importing records with --update, skip creating new records if no existing records match."
+      ),
+      new sfCommandOption(
+        'limit',
+        null,
+        sfCommandOption::PARAMETER_REQUIRED,
+        'Limit --update matching to under a specified maintaining repository via slug.'
       )
     ));
   }

--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -1098,36 +1098,9 @@ EOF;
 
     // Allow search indexing to be enabled via a CLI option
     $import->searchIndexingDisabled = ($options['index']) ? false : true;
-    if ($options['limit'])
-    {
-      $import->limitToId = getIdCorrespondingToSlug($options['limit']);
-    }
 
-    // Are there params set on --update flag?
-    if ($options['update'])
-    {
-      // Parameters for --update are validated in csvImportBaseTask.class.php.
-      switch ($options['update'])
-      {
-        case 'delete-and-replace':
-          // Delete any matching records, and re-import them (attach to existing entities if possible).
-          $import->deleteAndReplace = true;
-          break;
-
-        case 'match-and-update':
-          // Save match option. If update is ON, and match is set, only updating
-          // existing records - do not create new objects.
-          $import->matchAndUpdate = true;
-          break;
-
-        default:
-          // This should never happen due to parent::validateOptions()
-          throw new sfException('Update parameter "'.$options['update'].'" not handled: Correct --update parameter.');
-      }
-    }
-
-    $import->skipMatched = $options['skip-matched'];
-    $import->skipUnmatched = $options['skip-unmatched'];
+    // Set update, limit and skip options
+    $import->setUpdateOptions($options);
 
     // Convert content with | characters to a bulleted list
     $import->contentFilterLogic = function($text)
@@ -1185,24 +1158,6 @@ EOF;
 function array_search_case_insensitive($search, $array)
 {
   return array_search(strtolower($search), array_map('strtolower', $array));
-}
-
-function getIdCorrespondingToSlug($slug)
-{
-  $query = "SELECT object_id FROM slug WHERE slug=?";
-
-  $statement = QubitFlatfileImport::sqlQuery($query, array($slug));
-
-  $result = $statement->fetch(PDO::FETCH_OBJ);
-
-  if ($result)
-  {
-    return $result->object_id;
-  }
-  else
-  {
-    throw new sfException('Could not find information object matching slug "'. $slug .'"');
-  }
 }
 
 function setAlternativeIdentifiers($io, $altIds, $altIdLabels)

--- a/lib/task/import/csvRepositoryImportTask.class.php
+++ b/lib/task/import/csvRepositoryImportTask.class.php
@@ -87,6 +87,8 @@ EOF;
    */
   public function execute($arguments = array(), $options = array())
   {
+    parent::execute($arguments, $options);
+
     $this->validateOptions($options);
 
     $this->logSection("Importing repository objects from CSV to AtoM");
@@ -188,6 +190,9 @@ EOF;
 
     // Allow search indexing to be enabled via a CLI option
     $import->searchIndexingDisabled = ($options['index']) ? false : true;
+
+    // Set update, limit and skip options
+    $import->setUpdateOptions($options);
 
     $import->csv($fh, $skipRows);
     $this->logSection("Imported repositories successfully!");

--- a/lib/task/import/csvRepositoryImportTask.class.php
+++ b/lib/task/import/csvRepositoryImportTask.class.php
@@ -42,11 +42,44 @@ EOF;
   {
     parent::configure();
 
-    $this->addOptions(array(new sfCommandOption('merge-existing', null, sfCommandOption::PARAMETER_OPTIONAL,
-      "Don't create a new repository if there's already one with the same authorizedFormOfName in the db.")));
-
-    $this->addOptions(array(new sfCommandOption('upload-limit', null, sfCommandOption::PARAMETER_OPTIONAL,
-      "Set the upload limit for repositories getting imported (default: disable uploads)")));
+    $this->addOptions(array(
+      new sfCommandOption(
+        'source-name',
+        null,
+        sfCommandOption::PARAMETER_OPTIONAL,
+        'Source name to use when inserting keymap entries.'
+      ),
+      new sfCommandOption(
+        'index',
+        null,
+        sfCommandOption::PARAMETER_NONE,
+        "Index for search during import."
+      ),
+      new sfCommandOption(
+        'update',
+        null,
+        sfCommandOption::PARAMETER_REQUIRED,
+        'Attempt to update if repository has already been imported. Valid option values are "match-and-update" & "delete-and-replace".'
+      ),
+      new sfCommandOption(
+        'skip-matched',
+        null,
+        sfCommandOption::PARAMETER_NONE,
+        'When importing records without --update, use this option to skip creating new records when an existing one matches.'
+      ),
+      new sfCommandOption(
+        'skip-unmatched',
+        null,
+        sfCommandOption::PARAMETER_NONE,
+        "When importing records with --update, skip creating new records if no existing records match."
+      ),
+      new sfCommandOption(
+        'upload-limit',
+        null,
+        sfCommandOption::PARAMETER_OPTIONAL,
+        "Set the upload limit for repositories getting imported (default: disable uploads)")
+      )
+    );
   }
 
   /**
@@ -152,6 +185,9 @@ EOF;
         $note->save();
       }
     ));
+
+    // Allow search indexing to be enabled via a CLI option
+    $import->searchIndexingDisabled = ($options['index']) ? false : true;
 
     $import->csv($fh, $skipRows);
     $this->logSection("Imported repositories successfully!");


### PR DESCRIPTION
- Add repository CSV import via UI, refs #10472:
  - Add repository option to CSV import form
  - Fix CSV import form submission
  - Remove merge-existing option and allow update and other options
  - Disable/enable search index based on option
- Add update options to repo CSV import, refs #10017:
  - Display update fields based on import object type
  - Set update options in QubitFlatfileImport
  - Use update options on repository CSV import
- Update options for actor CSV import, refs #10016:
  - Add new update, skip and limit options to the actor CSV import task
  - Merge actor and repo update logic in the same function
  - Fix delete method for actors and repositories