### PR TITLE
Description update clipboard tooltip, Refs #10007

### DIFF
--- a/js/clipboardToggleAll.js
+++ b/js/clipboardToggleAll.js
@@ -18,7 +18,7 @@
         // put them in a queue and execute sequentially.
         function getToggleFn(button) {
           return function() {
-            return clipboard.toggle(true, { 'target': button })
+            return clipboard.toggle(false, { 'target': button })
           }
         }
 


### PR DESCRIPTION
This change corrects an issue reported during QA where clipboard button
tooltips on the Description Updates page do not always match what state the
button is actually in.

The cause of this issue is that the toggling of tooltips is not implemented
on the wide clipboard button component. Since the button text matches the
tooltip text exactly, the tooltip is redundant. An example of this is on
the information object detail page - the clipboard button can be seen without
tooltips.

I have removed the tooltip from the clipboard buttons on the Description
Updates page to correct the issue and make it behave identically to the same
button elsewhere in AtoM.
