### PR TITLE
Exclude draft for description export, Refs #10006

### DIFF
--- a/lib/flatfile/csvInformationObjectExport.class.php
+++ b/lib/flatfile/csvInformationObjectExport.class.php
@@ -41,6 +41,8 @@ class csvInformationObjectExport extends QubitFlatfileExport
   protected $eventTypeTerms          = array();
   protected $physicalObjectTypes     = array();
 
+  protected $options = array();
+
   /*
    * Information object-specific property setting based on configuration data
    *
@@ -52,6 +54,16 @@ class csvInformationObjectExport extends QubitFlatfileExport
     $this->commonNoteMap = $config['note']['common'];
     $this->radNoteMap    = $config['note']['rad'];
     $this->titleNoteMap  = $config['note']['title'];
+  }
+
+  /*
+   * Store export parameters for use.
+   *
+   * @return void
+   */
+  public function setOptions($options = array())
+  {
+    $this->options = $options;
   }
 
   /*
@@ -80,7 +92,7 @@ class csvInformationObjectExport extends QubitFlatfileExport
     $this->setEventColumns();
 
     // Set physical object columns if CLI being used or user has permission
-    if (check_field_visibility('app_element_visibility_physical_storage'))
+    if (check_field_visibility('app_element_visibility_physical_storage', $this->options))
     {
       $this->setPhysicalObjectColumns();
     }


### PR DESCRIPTION
This change introduces bahaviour similar to the CLI export '--public' option
for the new WebUI clipboard export features.

On the export form there is a new checkbox for both CSV and XML export
labelled 'Include draft records'.

When unchecked, any draft records will be excluded from the export selections.

Similarly, like the existing CLI public option, if physical storage locations
are hidden via Visible elements, they will be excluded during the export as
well.

For CSV export the columns physicalObjectName, physicalObjectLocation, and
physicalObjectType will be empty. For XML export, the 'physloc' and
'container' nodes will be omitted.