### PR TITLE
Improve actor matching on IO import, refs #10506

### DIFF
--- a/lib/model/QubitActor.php
+++ b/lib/model/QubitActor.php
@@ -441,7 +441,7 @@ class QubitActor extends BaseActor
 
   /**
    * Search for an actor by the AUTHORIZED_FORM_OF_NAME i18n column. Optionally
-   * limit search to a specific culture.
+   * limit search to a specific culture, history or maintaining repository
    *
    * @param string $name search string
    * @param array $options optional parameters
@@ -456,6 +456,18 @@ class QubitActor extends BaseActor
     if (isset($options['culture']))
     {
       $criteria->addAnd(QubitActorI18n::CULTURE, $options['culture']);
+    }
+
+    if (isset($options['history']))
+    {
+      $criteria->addAnd(QubitActorI18n::HISTORY, $options['history']);
+    }
+
+    if (isset($options['repositoryId']))
+    {
+      $criteria->addJoin(QubitActor::ID, QubitRelation::OBJECT_ID);
+      $criteria->add(QubitRelation::TYPE_ID, QubitTerm::MAINTAINING_REPOSITORY_RELATION_ID);
+      $criteria->add(QubitRelation::SUBJECT_ID, $options['repositoryId']);
     }
 
     return QubitActor::getOne($criteria, $options);

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -1597,6 +1597,17 @@ class QubitInformationObject extends BaseInformationObject
       $actor = QubitActor::getByAuthorizedFormOfName($name);
     }
 
+    // When the history option is populated and we
+    // already have a match with a different history
+    if ($actor && !empty($options['history']) && $actor->history !== $options['history'])
+    {
+      // Try to get a full match in name and history or create a new one.
+      // Only the delete and replace option from IO import could reach
+      // this point so there is no need to check by maintaining repository
+      // and update the actor history.
+      $actor = QubitActor::getByAuthorizedFormOfName($name, array('history' => $options['history']));
+    }
+
     // If there isn't a match create a new actor
     if (!$actor)
     {

--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -832,7 +832,7 @@ EOF;
                 $actorOptions['repositoryId'] = $repo->id;
               }
 
-              $actor = $self->createOrFetchActor($name, $actorOptions);
+              $actor = $self->createOrFetchAndUpdateActorForIo($name, $actorOptions);
               $self->createRelation($self->object->id, $actor->id, QubitTerm::NAME_ACCESS_POINT_ID);
             }
 


### PR DESCRIPTION
Fetch or create a QubitActor record based on the actor name, the
imported IO repository and the update options. Update the actor
history in matches from the same repository when using the match
and update option. For a full description, check:

https://projects.artefactual.com/issues/10506