### PR TITLE
Level of desc filter on export, Refs #10000

### DIFF
--- a/apps/qubit/modules/object/actions/exportAction.class.php
+++ b/apps/qubit/modules/object/actions/exportAction.class.php
@@ -84,7 +84,6 @@ class ObjectExportAction extends DefaultEditAction
 
     $options = array('params' => array('fromClipboard' => true,
                                        'slugs' => $this->context->user->getClipboard()->getAll()),
-                     'include-all-levels' => ('on' == $request->getParameter('includeAllLevels')) ? true : false,
                      'current-level-only' => ('on' == $request->getParameter('includeDescendants')) ? false : true,
                      'public' => ($request->getParameter('includeDrafts') == 'on') ? false : true,
                      'objectType' => $request->getParameter('objectType'),

--- a/apps/qubit/modules/object/templates/exportSuccess.php
+++ b/apps/qubit/modules/object/templates/exportSuccess.php
@@ -25,7 +25,7 @@
     <?php echo $form->renderHiddenFields() ?>
 
     <section id="content">
-      <div id="export-options" data-export-toggle="tooltip" data-export-title="<?php echo __('Export') ?>" data-export-alert-message="<?php echo __('Error: Must select a level of description or include all descendants.') ?>">
+      <div id="export-options" data-export-toggle="tooltip" data-export-title="<?php echo __('Export') ?>" data-export-alert-message="<?php echo __('Error: You must have at least one %1%Level of description%2% selected or choose %1%Include all levels of description%2% to proceed.', array('%1%' => '<strong>', '%2%' => '</strong>')) ?>">
       <fieldset class="collapsible">
 
         <legend><?php echo __('Export options') ?></legend>

--- a/js/exportOptions.js
+++ b/js/exportOptions.js
@@ -125,7 +125,7 @@
 
     onExportSubmit: function ()
     {
-      if (!this.$includeAllLevels.prop('checked') && '' == this.$levelSelect.val())
+      if (!this.$includeAllLevels.prop('checked') && null == this.$levelSelect.val())
       {
         event.preventDefault();
         this.showAlert();

--- a/lib/job/arInformationObjectCsvExportJob.php
+++ b/lib/job/arInformationObjectCsvExportJob.php
@@ -102,6 +102,8 @@ class arInformationObjectCsvExportJob extends arBaseJob
   {
     $itemsExported = 0;
     $public = isset($this->params['public']) && $this->params['public'];
+    $levels = isset($this->params['levels']) ? $this->params['levels'] : array();
+    $numLevels = count($levels);
 
     // Exporter will create a new file each 10,000 rows
     $writer = new csvInformationObjectExport($path, $this->archivalStandard, 10000);
@@ -124,8 +126,10 @@ class arInformationObjectCsvExportJob extends arBaseJob
       // If ElasticSearch document is stale (corresponding MySQL data deleted), ignore
       if ($resource !== null)
       {
-        // Don't export draft descriptions with public option
-        if ($public && $resource->getPublicationStatus()->statusId == QubitTerm::PUBLICATION_STATUS_DRAFT_ID)
+        // Don't export draft descriptions with public option.
+        // Don't export records if level of description is not in list of selected LODs.
+        if (($public && $resource->getPublicationStatus()->statusId == QubitTerm::PUBLICATION_STATUS_DRAFT_ID) ||
+          (0 < $numLevels && !array_key_exists($resource->levelOfDescriptionId, $levels)))
         {
           continue;
         }
@@ -139,8 +143,10 @@ class arInformationObjectCsvExportJob extends arBaseJob
 
           foreach($descendants as $descendant)
           {
-            // Don't export draft descendant descriptions with public option
-            if ($public && $descendant->getPublicationStatus()->statusId == QubitTerm::PUBLICATION_STATUS_DRAFT_ID)
+            // Don't export draft descendant descriptions with public option.
+            // Don't export records if level of description is not in list of selected LODs.
+            if (($public && $descendant->getPublicationStatus()->statusId == QubitTerm::PUBLICATION_STATUS_DRAFT_ID) ||
+              (0 < $numLevels && !array_key_exists($descendant->levelOfDescriptionId, $levels)))
             {
               continue;
             }


### PR DESCRIPTION
This change adds the ability for users to restrict a CSV or XML export to
specific Levels of Description when exporting from the WebUI.

The levels of description are passed to the CSV and XML export jobs in an
array. If the array is empty, it is assumed that all levels of description
will be exported.

I have refactored arXmlExportJob to remove code that was calling the CLI
export task directly. This background job is now modelled off
arInformationObjectCsvExportJob and queries Elasticsearch directly. It
leverages the static export functions from exportBulkBaseTask.

In addition, I have corrected a validation bug in exportOptions.js.