### PR TITLE
Enable ACL checks on export, Refs #10000

### DIFF
--- a/apps/qubit/config/settings.yml.tmpl
+++ b/apps/qubit/config/settings.yml.tmpl
@@ -11,6 +11,10 @@ cli:
   .settings:
     logging_enabled:        true
 
+worker:
+  .settings:
+    logging_enabled:        true
+
 dev:
   .settings:
     error_reporting:        <?php echo (E_ALL | E_STRICT)."\n" ?>

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -672,7 +672,6 @@ class QubitInformationObject extends BaseInformationObject
   public function getDescendantsForExport($options = array())
   {
     $descendants = array();
-    $fromClipboard = isset($options['params']['fromClipboard']) ? true : false;
     $levels = isset($options['levels']) ? $options['levels'] : array();
     $numLevels = count($levels);
 
@@ -680,8 +679,8 @@ class QubitInformationObject extends BaseInformationObject
     {
       $addCondition = true;
 
-      // If we're not in a CLI or BG job enviroment, check ACL
-      if (!is_using_cli() || $fromClipboard)
+      // If we're not in a CLI enviroment, check ACL
+      if ('cli' != sfContext::getInstance()->getConfiguration()->getEnvironment())
       {
         $addCondition = QubitAcl::check($child, 'read');
       }

--- a/lib/task/jobs/jobWorkerTask.class.php
+++ b/lib/task/jobs/jobWorkerTask.class.php
@@ -29,7 +29,7 @@ class jobWorkerTask extends arBaseTask
   {
     $this->addOptions(array(
       new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
-      new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
+      new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'worker'),
       new sfCommandOption('types', null, sfCommandOption::PARAMETER_REQUIRED, 'Type of jobs to perform (check config/gearman.yml for details)', ''),
       new sfCommandOption('abilities', null, sfCommandOption::PARAMETER_REQUIRED, 'A comma separated string indicating which jobs this worker can do.', '')
     ));

--- a/plugins/qbAclPlugin/lib/QubitAcl.class.php
+++ b/plugins/qbAclPlugin/lib/QubitAcl.class.php
@@ -74,6 +74,18 @@ class QubitAcl
   }
 
   /**
+   * Each request is completely unique in PHP however our workers run in a loop
+   * where state is held across jobs. This class was built as a singleton so we
+   * need this extra method to void the instance when needed when running ACL
+   * checks from a worker process.
+   *
+   */
+  public static function destruct()
+  {
+    self::$_instance = null;
+  }
+
+  /**
    * Test user access to the given resource
    *
    * Note: Current sf_user is assumed, but can be overridden with


### PR DESCRIPTION
Historically, ACL checks are disabled for CLI tasks. This applied also to
asynchronous background jobs. CSV and XML export background jobs launched
from the Clipboard required ACL checks to be run. This change allows a
background job to conditionally enable ACL checks.

arBaseJob has two new methods that activate ACL checks when called. This is
optional for each background job so as not to impact existing functionality.
Currently, the only two background jobs that call these methods to activate
ACL checks are arInformationObjectExportJob and arXmlExportJob.