### PR TITLE
Option: use DB for CSV import match, refs #10624

### DIFF
--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -107,6 +107,12 @@ EOF;
         null,
         sfCommandOption::PARAMETER_NONE,
         'Skip the deletion of existing digital objects and their derivatives when using --update with "match-and-update".'
+      ),
+      new sfCommandOption(
+        'match-using-database',
+        null,
+        sfCommandOption::PARAMETER_NONE,
+        'Detect matches without relying on the ElasticSearch index.'
       )
     ));
   }
@@ -458,6 +464,8 @@ EOF;
         'creationDatesEnd'   => '|',
         'creationDateNotes'  => '|'
       ),
+
+      'matchUsingDatabase' => $options['match-using-database'],
 
       'updatePreparationLogic' => function(&$self)
       {


### PR DESCRIPTION
Redmine: https://projects.artefactual.com/issues/10624

Added option, to CSV import CLI tool, to use the database, rather than the
ElasticSearch index, when using import modes that check if the row matches
existing data.

I added this as I'm working on an import where I am importing on top of an
existing database and it takes a long time to index the existing data so I
don't want to have to do that before indexing just so the matching will work.