### PR TITLE
CSV import using existing parent IDs, refs #10626

### DIFF
--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -624,9 +624,13 @@ EOF;
             {
               $parentId = $mapEntry->target_id;
             }
+            else if (null !== QubitInformationObject::getById($self->rowStatusVars['parentId']))
+            {
+              $parentId = $self->rowStatusVars['parentId'];
+            }
             else
             {
-              $error = sprintf('legacyId %s: could not find parentId %s in key_map table. Setting parent to root...',
+              $error = sprintf('legacyId %s: could not find parentId %s in key_map table or existing data. Setting parent to root...',
                                $self->rowStatusVars['legacyId'], $self->rowStatusVars['parentId']);
 
               print $self->logError($error);


### PR DESCRIPTION
Added logic to CSV information object import to, if a parent ID in a row
doesn't correspond to a keymap entry, check to see if the parent is present in
existing information object data.

This adds the ability to import children of information objects that have been
created by entry through the web UI (rather than only being able to import
children of information objects that have been created by importing data).