### PR TITLE
CSV import missing fields in php7, Refs #10633

### DIFF
--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -1121,13 +1121,13 @@ EOF;
       return (substr_count($text, '|')) ? '* '. str_replace("|", "\n* ", $text) : $text;
     };
 
-    $import->addColumnHandler('levelOfDescription', function(&$self, $data)
+    $import->addColumnHandler('levelOfDescription', function($self, $data)
     {
       $self->object->setLevelOfDescriptionByName($data);
     });
 
     // Map value to taxonomy term name and take note of taxonomy term's ID
-    $import->addColumnHandler('radGeneralMaterialDesignation', function(&$self, $data)
+    $import->addColumnHandler('radGeneralMaterialDesignation', function($self, $data)
     {
       if ($data)
       {


### PR DESCRIPTION
This change corrects an issue discovered when running AtoM under PHP 7.x.

Under PHP 7.x, the CSV import from the command line would not import all
fields from the CSV. This fix has been tested with PHP 5.5.9 and does
not have any side effects.