### PR TITLE
CSV import accession mapping, Refs #10602

### DIFF
--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -869,20 +869,26 @@ EOF;
             // If no entry found, create accession and entry
             if (!$accessionMapEntry)
             {
-              print "\nCreating accession # ". $accessionNumber ."\n";
+              $criteria = new Criteria;
+              $criteria->add(QubitAccession::IDENTIFIER, $accessionNumber);
 
-              // Create new accession
-              $accession = new QubitAccession;
-              $accession->identifier = $accessionNumber;
-              $accession->save();
+              if (null === $accession = QubitAccession::getone($criteria))
+              {
+                print "\nCreating accession # ". $accessionNumber ."\n";
 
-              // Create keymap entry for accession
-              $keymap = new QubitKeymap;
-              $keymap->sourceId   = $accessionNumber;
-              $keymap->sourceName = $self->getStatus('sourceName');
-              $keymap->targetId   = $accession->id;
-              $keymap->targetName = 'accession';
-              $keymap->save();
+                // Create new accession
+                $accession = new QubitAccession;
+                $accession->identifier = $accessionNumber;
+                $accession->save();
+
+                // Create keymap entry for accession
+                $keymap = new QubitKeymap;
+                $keymap->sourceId   = $accessionNumber;
+                $keymap->sourceName = $self->getStatus('sourceName');
+                $keymap->targetId   = $accession->id;
+                $keymap->targetName = 'accession';
+                $keymap->save();
+              }
 
               $accessionId = $accession->id;
             }


### PR DESCRIPTION
This change addresses an error that can show up during CSV import when the
column 'accessionNumber' is included in the CSV import file.

Previously, the import program would attempt to find the accession identifier
in the keymap table, and if that failed it would create a new accession
record with that identifier. In the case where the keymap record could not be
found, but the accession record already existed, an error would display and
the import would halt.

I have changed the logic so that the import will try to find a corresponding
keymap record to use and if that fails, it will try to directly find an
accession record in the database. If keymap search is successful, that
accession record will be used. If the secondary lookup against the database
is successful, then that accession record will be used. If both keymap and
direct lookup fail, a new accession record will be created.