### PR TITLE
Create always keymap on IO CSV import, refs #10144

### DIFF
--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -2191,7 +2191,8 @@ class QubitFlatfileImport
   public static function fetchKeymapEntryBySourceAndTargetName($sourceId, $sourceName, $targetName)
   {
     $query = "SELECT target_id, id FROM keymap
-      WHERE source_id=? AND source_name=? AND target_name=?";
+      WHERE source_id=? AND source_name=? AND target_name=?
+      ORDER BY id DESC";
 
     $statement = QubitFlatfileImport::sqlQuery(
       $query,

--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -653,24 +653,13 @@ EOF;
           throw new sfException('Information object save failed');
         }
 
-        $targetClass = 'information_object';
-
-        $keymap = $self->fetchKeymapEntryBySourceAndTargetName(
-          $self->rowStatusVars['legacyId'],
-          $self->getStatus('sourceName'),
-          $targetClass
-        );
-
-        if (!$keymap)
-        {
-          // Add keymap entry
-          $keymap = new QubitKeymap;
-          $keymap->sourceId   = $self->rowStatusVars['legacyId'];
-          $keymap->sourceName = $self->getStatus('sourceName');
-          $keymap->targetId   = $self->object->id;
-          $keymap->targetName = $targetClass;
-          $keymap->save();
-        }
+        // Add keymap entry
+        $keymap = new QubitKeymap;
+        $keymap->sourceId   = $self->rowStatusVars['legacyId'];
+        $keymap->sourceName = $self->getStatus('sourceName');
+        $keymap->targetId   = $self->object->id;
+        $keymap->targetName = 'information_object';
+        $keymap->save();
 
         // Inherit repository instead of duplicating the association to it if applicable
         if ($self->object->canInheritRepository($self->object->repositoryId))


### PR DESCRIPTION
When importing files with the same name and legacy ids if a new entry is not
created in the keymap table it will always get the resource from the previous
file. Make sure to get the last entry while checking.