### PR TITLE
Correct keymap matching EAD XML import, Refs #9992

### DIFF
--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -1076,7 +1076,7 @@ class QubitXmlImport
         }
 
         // If resource not found, try matching against keymap table.
-        if (!isset($matchResource) && $this->eadUrl && $importSchema == 'ead')
+        if (!isset($matchResource) && $this->eadUrl)
         {
           $criteria = new Criteria;
           $criteria->add(QubitKeymap::SOURCE_ID, $this->eadUrl);


### PR DESCRIPTION
Dropping clause '$importSchema == 'ead'' as it does not work ($importSchema
is not available in this function) and is redundant since eadUrl will only be
set when loading an EAD XML file.