### PR TITLE
renderDate leading zeroes on day, Refs #10641

### DIFF
--- a/lib/Qubit.class.php
+++ b/lib/Qubit.class.php
@@ -39,8 +39,11 @@ class Qubit
   // support zero day or zero month
   public static function renderDate($value)
   {
-    // Natural number
-    $natural = '([1-9]\d*)';
+    // Natural number - This will not strip leading zeroes.
+    // Note that this will NOT add leading zeroes if they are not present.
+    // e.g. 2016-12-08 will be displayed as 2016-12-08
+    //      2016-12-8 will be displayed as 2016-12-8
+    $natural = '(0*[1-9]\d*)';
 
     // Zero and separator, trim leading zeros
     $zero = '0*(0[-\/])';
@@ -48,12 +51,11 @@ class Qubit
     // Trim trailing separator and zero
     $trim = '[-\/]0+';
 
-    // Trim leading zeros from year, month, and day, and trailing zero day and
-    // month
+    // Trim trailing zero day and month
     $pattern = "/0*(\d+)(?:([-\/])$natural(?:([-\/])$natural
-          |$trim)
-        |([-\/])$zero$natural
-        |$trim$trim)/x";
+      |$trim)
+      |([-\/])$zero$natural
+      |$trim$trim)/x";
 
     $replacement = '$1$2$3$4$5$6$7$8';
 

--- a/test/unit/qubitTest.php
+++ b/test/unit/qubitTest.php
@@ -34,7 +34,7 @@ class sfWebRequestStub
 $configuration = ProjectConfiguration::getApplicationConfiguration('qubit', 'test', true);
 sfContext::createInstance($configuration)->request = new sfWebRequestStub;
 
-$t = new lime_test(2, new lime_output_color);
+$t = new lime_test(19, new lime_output_color);
 
 sfContext::getInstance()->request->pathInfoPrefix = '/aaa/bbb';
 
@@ -45,3 +45,38 @@ sfContext::getInstance()->request->pathInfoPrefix = null;
 
 $t->is(Qubit::pathInfo('/aaa/bbb/ccc/ddd'), '/aaa/bbb/ccc/ddd',
   '"::pathInfo()" without prefix');
+
+
+/*
+ * Qubit::renderDate
+ */
+
+$tests = array(
+  # GIVEN - EXPECTED
+  array('1992-00-00', '1992'),
+  array('1992-12-00', '1992-12'),
+  array('1992-08-00', '1992-08'),
+  array('1992-8-00', '1992-8'),
+  array('1992-8-0', '1992-8'),
+
+  array('1992-01-02', '1992-01-02'),
+  array('1992-01-01', '1992-01-01'),
+  array('1992-6-9', '1992-6-9'),
+  array('1992-06-9', '1992-06-9'),
+  array('1992-6-09', '1992-6-09'),
+  array('1992-08-12', '1992-08-12'),
+  array('1992-6-16', '1992-6-16'),
+  array('1992-06-16', '1992-06-16'),
+
+  array('1992-12-12', '1992-12-12'),
+  array('1992-12-6', '1992-12-6'),
+  array('1992-12-06', '1992-12-06'),
+  array('1992-12-16', '1992-12-16'),
+);
+
+foreach ($tests as $item)
+{
+  list($given, $expected) = $item;
+
+  $t->is(Qubit::renderDate($given), $expected, "renderDate() renders date $given as $expected");
+}


### PR DESCRIPTION
This change addresses an issue with date formatting where if the day had a
leading zero it would be formatted incorrectly when displayed on the screen.
e.g. 2016-12-03 would display as 2016-123

Note that this issue would only occur when the month was a two digit month as
in the example above.

This corrects the issue and forces single digit month and date to display
with a leading zero. Including the '0*' within the parentheses
will force any leading zero to be part of the replacement string sub-
pattern.
e.g. 2016-6-9 will display as 2016-06-09
     2016-12-6 will display as 2016-12-06