### PR TITLE
Ensure Mime property set early, Refs #10675

### DIFF
--- a/plugins/sfThumbnailPlugin/lib/sfImageMagickAdapter.class.php
+++ b/plugins/sfThumbnailPlugin/lib/sfImageMagickAdapter.class.php
@@ -181,6 +181,9 @@ class sfImageMagickAdapter
     $imgData = @getimagesize($image);
     if (!$imgData)
     {
+      // Get MIME from php finfo and save to sourceMime property.
+      // 'sourceMime' needs to be set before running getExtract.
+      $this->sourceMime = $this->getMimeType($image);
       $extract = $this->getExtract($image);
       exec($this->magickCommands['identify'].' '.escapeshellarg($image).$extract, $stdout, $retval);
       if ($retval === 1)
@@ -195,7 +198,6 @@ class sfImageMagickAdapter
 
         $this->sourceWidth = $width;
         $this->sourceHeight = $height;
-        $this->sourceMime = $this->getMimeType($image);
       }
     }
     else


### PR DESCRIPTION
This change corrects an issue where the mime class property was not yet
set when getExtract() was called in sfThumbnailPLugin.

The check to determine if the plugin should use pdfinfo to extract pages
and get a page count was made dependent on mime type instead of file
extension in 10675. An issue was uncovered where the mime type was not
yet available when the decision to use pdfinfo needed to be made. This
issue has been corrected by setting mime type earlier in the code.