### PR TITLE
Remove EAD XML keymap matching, Refs #9992

### DIFF
--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -1075,20 +1075,6 @@ class QubitXmlImport
           $matchResource = QubitInformationObject::getById($matchId);
         }
 
-        // If resource not found, try matching against keymap table.
-        if (!isset($matchResource) && $this->eadUrl)
-        {
-          $criteria = new Criteria;
-          $criteria->add(QubitKeymap::SOURCE_ID, $this->eadUrl);
-          $criteria->add(QubitKeymap::SOURCE_NAME, $this->sourceName);
-          $criteria->add(QubitKeymap::TARGET_NAME, 'information_object');
-
-          if (null !== $keymap = QubitKeymap::getOne($criteria))
-          {
-            $matchResource = QubitInformationObject::getById($keymap->targetId);
-          }
-        }
-
         break;
 
       case 'QubitActor':


### PR DESCRIPTION
The commit removes the XML keymap matching logic. This code did not work as
expected due to issues with uniqueness of the keys used and is currently
causing issues testing --delete-and-replace with --skip-unmatched.