### PR TITLE
Institutional Scoping migration conf, Refs #10733

### DIFF
--- a/apps/qubit/modules/actor/actions/browseAction.class.php
+++ b/apps/qubit/modules/actor/actions/browseAction.class.php
@@ -81,6 +81,19 @@ class ActorBrowseAction extends DefaultBrowseAction
   {
     parent::execute($request);
 
+    if (isset($request->repos) && ctype_digit($request->repos))
+    {
+      $this->repos = QubitRepository::getById($request->repos);
+
+      // Add repo to the user session as realm
+      $this->context->user->setAttribute('search-realm', $request->repos);
+    }
+    elseif (sfConfig::get('app_enable_institutional_scoping'))
+    {
+      // Remove search realm
+      $this->context->user->removeAttribute('search-realm');
+    }
+
     if (1 === preg_match('/^[\s\t\r\n]*$/', $request->subquery))
     {
       $this->search->queryBool->addMust(new \Elastica\Query\MatchAll());

--- a/apps/qubit/modules/actor/actions/browseAction.class.php
+++ b/apps/qubit/modules/actor/actions/browseAction.class.php
@@ -88,7 +88,7 @@ class ActorBrowseAction extends DefaultBrowseAction
       // Add repo to the user session as realm
       $this->context->user->setAttribute('search-realm', $request->repos);
     }
-    elseif (sfConfig::get('app_enable_institutional_scoping'))
+    else if (sfConfig::get('app_enable_institutional_scoping'))
     {
       // Remove search realm
       $this->context->user->removeAttribute('search-realm');

--- a/apps/qubit/modules/informationobject/actions/browseAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/browseAction.class.php
@@ -339,7 +339,7 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
       // Add repo to the user session as realm
       $this->context->user->setAttribute('search-realm', $request->repos);
     }
-    elseif (sfConfig::get('app_enable_institutional_scoping') &&
+    else if (sfConfig::get('app_enable_institutional_scoping') &&
       !(isset($request->collection) && ctype_digit($request->collection)))
     {
       // Remove realm

--- a/apps/qubit/modules/informationobject/actions/browseAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/browseAction.class.php
@@ -339,6 +339,12 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
       // Add repo to the user session as realm
       $this->context->user->setAttribute('search-realm', $request->repos);
     }
+    elseif (sfConfig::get('app_enable_institutional_scoping') &&
+      !(isset($request->collection) && ctype_digit($request->collection)))
+    {
+      // Remove realm
+      $this->context->user->removeAttribute('search-realm');
+    }
 
     if (isset($request->creators) && ctype_digit($request->creators))
     {

--- a/apps/qubit/modules/informationobject/actions/stylesheetComponent.class.php
+++ b/apps/qubit/modules/informationobject/actions/stylesheetComponent.class.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class InformationObjectStylesheetComponent extends sfComponent
+{
+  public function execute($request)
+  {
+    if (sfConfig::get('app_enable_institutional_scoping') && sfContext::getInstance()->user->hasAttribute('search-realm'))
+    {
+      $repository = QubitRepository::getById(sfContext::getInstance()->user->getAttribute('search-realm'));
+    }
+    else
+    {
+      return sfView::NONE;
+    }
+
+    if (null === $repository || null === $repository->backgroundColor)
+    {
+      return sfView::NONE;
+    }
+
+    // Get value
+    $this->backgroundColor = $repository->backgroundColor->__toString();
+
+    if (0 == strlen($this->backgroundColor))
+    {
+      return sfView::NONE;
+    }
+  }
+}

--- a/apps/qubit/modules/informationobject/config/view.yml
+++ b/apps/qubit/modules/informationobject/config/view.yml
@@ -80,3 +80,8 @@ uploadFindingAidSuccess:
     /vendor/yui/connection/connection-min:
     /vendor/yui/container/container-min:
     repositoryHoldings:
+
+all:
+  components:
+    css:
+      [informationobject, stylesheet]

--- a/apps/qubit/modules/informationobject/templates/_actionIcons.php
+++ b/apps/qubit/modules/informationobject/templates/_actionIcons.php
@@ -26,12 +26,22 @@
     <?php endif; ?>
 
     <li>
-      <a href="<?php echo url_for(array(
-        'module' => 'informationobject',
-        'action' => 'browse',
-        'collection' => $resource->getCollectionRoot()->id,
-        'topLod' => false)) ?>">
-        <i class="fa fa-list"></i>
+      <?php if (isset($resource) && sfConfig::get('app_enable_institutional_scoping') && $sf_user->hasAttribute('search-realm') ): ?>
+        <a href="<?php echo url_for(array(
+          'module' => 'informationobject',
+          'action' => 'browse',
+          'collection' => $resource->getCollectionRoot()->id,
+          'repos' => $sf_user->getAttribute('search-realm'),
+          'topLod' => false)) ?>">
+      <?php else: ?>
+        <a href="<?php echo url_for(array(
+          'module' => 'informationobject',
+          'action' => 'browse',
+          'collection' => $resource->getCollectionRoot()->id,
+          'topLod' => false)) ?>">
+      <?php endif; ?>
+
+        <i class="icon-list"></i>
         <?php echo __('Browse as list') ?>
       </a>
     </li>

--- a/apps/qubit/modules/informationobject/templates/_contextMenu.php
+++ b/apps/qubit/modules/informationobject/templates/_contextMenu.php
@@ -1,9 +1,9 @@
-<?php echo get_component('repository', 'logo') ?>
+<?php if ($sf_user->getAttribute('search-realm') && sfConfig::get('app_enable_institutional_scoping')): ?>
+  <?php include_component('repository', 'holdingsInstitution', array('resource' => QubitRepository::getById($sf_user->getAttribute('search-realm')))) ?>
+<?php else: ?>
+  <?php echo get_component('repository', 'logo') ?>
+<?php endif; ?>
 
 <?php echo get_component('informationobject', 'treeView') ?>
 
 <?php echo get_component('menu', 'staticPagesMenu') ?>
-
-<?php // echo get_component('informationobject', 'creator', array('resource' => $resource)) ?>
-
-<?php // echo get_component('digitalobject', 'imageflow', array('resource' => $resource)) ?>

--- a/apps/qubit/modules/informationobject/templates/_stylesheet.php
+++ b/apps/qubit/modules/informationobject/templates/_stylesheet.php
@@ -1,0 +1,6 @@
+<style type="text/css">
+  html, body {
+    background-image: none !important;
+    background-color: <?php echo $backgroundColor ?> !important;
+  }
+</style>

--- a/apps/qubit/modules/informationobject/templates/browseSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/browseSuccess.php
@@ -43,6 +43,10 @@
 
       <div class="content">
 
+        <?php if ($sf_user->getAttribute('search-realm') && sfConfig::get('app_enable_institutional_scoping')): ?>
+          <?php include_component('repository', 'holdingsInstitution', array('resource' => QubitRepository::getById($sf_user->getAttribute('search-realm')))) ?>
+        <?php endif; ?>
+
         <h2><?php echo sfConfig::get('app_ui_label_facetstitle') ?></h2>
 
         <?php echo get_partial('search/facetLanguage', array(

--- a/apps/qubit/modules/menu/actions/browseMenuInstitutionComponent.class.php
+++ b/apps/qubit/modules/menu/actions/browseMenuInstitutionComponent.class.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Build browse menu as simple xhtml lists, relying on css styling to
+ * format the display of the menus.
+ *
+ * @package    AccesstoMemory
+ * @subpackage menu
+ */
+class MenuBrowseMenuInstitutionComponent extends sfComponent
+{
+  public function execute($request)
+  {
+    // Get menu objects
+    $this->browseMenuInstitution = QubitMenu::getByName('browseInstitution');
+
+    if (!$this->browseMenuInstitution instanceof QubitMenu)
+    {
+      return sfView::NONE;
+    }
+  }
+}

--- a/apps/qubit/modules/menu/templates/_browseMenuInstitution.php
+++ b/apps/qubit/modules/menu/templates/_browseMenuInstitution.php
@@ -1,0 +1,26 @@
+<nav>
+  <div id="browse-menu">
+
+    <button class="top-item top-dropdown" data-toggle="dropdown" data-target="#" aria-expanded="false"><?php echo $browseMenuInstitution->getLabel(array('cultureFallback' => true)) ?></button>
+
+    <div class="top-dropdown-container top-dropdown-container-right">
+
+      <div class="top-dropdown-arrow">
+        <div class="arrow"></div>
+      </div>
+
+      <div class="top-dropdown-header">
+        <h2><?php echo $browseMenuInstitution->getLabel(array('cultureFallback' => true)) ?></h2>
+      </div>
+
+      <div class="top-dropdown-body">
+        <ul>
+          <?php echo QubitMenu::displayHierarchyAsList($browseMenuInstitution, 0) ?>
+        </ul>
+      </div>
+
+      <div class="top-dropdown-bottom"></div>
+
+    </div>
+  </div>
+</nav>

--- a/apps/qubit/modules/physicalobject/actions/browseAction.class.php
+++ b/apps/qubit/modules/physicalobject/actions/browseAction.class.php
@@ -31,6 +31,12 @@ class PhysicalObjectBrowseAction extends sfAction
       $request->limit = sfConfig::get('app_hits_per_page');
     }
 
+    if (sfConfig::get('app_enable_institutional_scoping'))
+    {
+      //remove search-realm
+      $this->context->user->removeAttribute('search-realm');
+    }
+
     $criteria = new Criteria;
 
     // Do source culture fallback

--- a/apps/qubit/modules/repository/actions/browseAction.class.php
+++ b/apps/qubit/modules/repository/actions/browseAction.class.php
@@ -94,6 +94,22 @@ class RepositoryBrowseAction extends DefaultBrowseAction
     $this->tableView = 'table';
     $allowedViews = array($this->cardView, $this->tableView);
 
+    if (sfConfig::get('app_enable_institutional_scoping'))
+    {
+      if (isset($request->repos) && ctype_digit($request->repos) && null !== $this->repos = QubitRepository::getById($request->repos))
+      {
+        $this->search->queryBool->addMust(new \Elastica\Query\Term(array('repository.id' => $request->repos)));
+
+        // Store realm in user session
+        $this->context->user->setAttribute('search-realm', $request->repos);
+      }
+      else
+      {
+        // Remove search-realm
+        $this->context->user->removeAttribute('search-realm');
+      }
+    }
+
     if (1 === preg_match('/^[\s\t\r\n]*$/', $request->subquery))
     {
       $this->search->queryBool->addMust(new \Elastica\Query\MatchAll());

--- a/apps/qubit/modules/repository/actions/holdingsInstitutionComponent.class.php
+++ b/apps/qubit/modules/repository/actions/holdingsInstitutionComponent.class.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class RepositoryHoldingsInstitutionComponent extends sfComponent
+{
+  public function execute($request)
+  {
+    $page = 1;
+    $limit = sfConfig::get('app_hits_per_page', 10);
+    $resultSet = RepositoryHoldingsAction::getHoldings($this->resource->id, $page, $limit);
+
+    $this->pager = new QubitSearchPager($resultSet);
+    $this->pager->setPage($page);
+    $this->pager->setMaxPerPage($limit);
+    $this->pager->init();
+  }
+}

--- a/apps/qubit/modules/repository/templates/_contextMenu.php
+++ b/apps/qubit/modules/repository/templates/_contextMenu.php
@@ -1,9 +1,17 @@
-<?php echo get_component('repository', 'logo') ?>
+<?php if (isset($resource) && ($resource->getRawValue() instanceof QubitRepository) && sfConfig::get('app_enable_institutional_scoping')): ?>
+  <?php include_component('repository', 'holdingsInstitution', array('resource' => $resource)) ?>
 
-<?php if ($resource->getRawValue() instanceof QubitRepository): ?>
   <?php if (QubitAcl::check($resource, 'update')): ?>
     <?php include_component('repository', 'uploadLimit', array('resource' => $resource)) ?>
   <?php endif; ?>
+<?php else: ?>
+  <?php echo get_component('repository', 'logo') ?>
 
-  <?php include_component('repository', 'holdings', array('resource' => $resource)) ?>
+  <?php if ($resource->getRawValue() instanceof QubitRepository): ?>
+    <?php if (QubitAcl::check($resource, 'update')): ?>
+      <?php include_component('repository', 'uploadLimit', array('resource' => $resource)) ?>
+    <?php endif; ?>
+
+    <?php include_component('repository', 'holdings', array('resource' => $resource)) ?>
+  <?php endif; ?>
 <?php endif; ?>

--- a/apps/qubit/modules/repository/templates/_holdingsInstitution.php
+++ b/apps/qubit/modules/repository/templates/_holdingsInstitution.php
@@ -1,0 +1,39 @@
+<section id="repo-holdings" class="list-menu"
+  data-total-pages="<?php echo $pager->getLastPage() ?>"
+  data-url="<?php echo url_for(array('module' => 'repository', 'action' => 'holdingsInstitution', 'id' => $resource->id)) ?>">
+
+  <div class="panel panel-gray">
+    <div class="panel-body">
+
+      <?php use_helper('Text') ?>
+
+      <div class="repository-logo<?php echo $resource->existsLogo() ? '' : ' repository-logo-text' ?>">
+        <a href="<?php echo url_for(array($resource, 'module' => 'repository')) ?>">
+          <?php if ($resource->existsLogo()): ?>
+            <?php echo image_tag($resource->getLogoPath(), array('alt' => __('Go to %1%', array('%1%' => esc_entities(render_title(truncate_text($resource), 100)))))) ?>
+          <?php else: ?>
+            <h2><?php echo render_title($resource) ?></h2>
+          <?php endif; ?>
+        </a>
+      </div>
+
+      <h3>
+        <?php echo sfConfig::get('app_ui_label_institutionSearchHoldings') ?>
+        <?php echo image_tag('loading.small.gif', array('class' => 'hidden', 'id' => 'spinner', 'alt' => __('Loading ...'))) ?>
+      </h3>
+
+      <form class="sidebar-search" action="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse')) ?>">
+        <input type="hidden" name="repos" value="<?php echo $resource->id ?>">
+        <div class="input-prepend input-append">
+          <input type="text" name="query" placeholder="<?php echo __('Search') ?>">
+          <button class="btn" type="submit">
+            <i class="fa fa-search"></i>
+          </button>
+        </div>
+      </form>
+
+      <?php echo get_component('menu', 'browseMenuInstitution', array('sf_cache_key' => $sf_user->getCulture().$sf_user->getUserID())) ?>
+
+    </div>
+  </div>
+</section>

--- a/apps/qubit/modules/search/actions/autocompleteAction.class.php
+++ b/apps/qubit/modules/search/actions/autocompleteAction.class.php
@@ -102,7 +102,7 @@ class SearchAutocompleteAction extends sfAction
         // Store realm in user session
         $this->context->user->setAttribute('search-realm', $request->repos);
       }
-      elseif (sfConfig::get('app_enable_institutional_scoping'))
+      else if (sfConfig::get('app_enable_institutional_scoping'))
       {
         // Remove search-realm
         $this->context->user->removeAttribute('search-realm');

--- a/apps/qubit/modules/search/actions/autocompleteAction.class.php
+++ b/apps/qubit/modules/search/actions/autocompleteAction.class.php
@@ -102,6 +102,11 @@ class SearchAutocompleteAction extends sfAction
         // Store realm in user session
         $this->context->user->setAttribute('search-realm', $request->repos);
       }
+      elseif (sfConfig::get('app_enable_institutional_scoping'))
+      {
+        // Remove search-realm
+        $this->context->user->removeAttribute('search-realm');
+      }
 
       $query->setQuery($queryBool);
       $search->setQuery($query);

--- a/apps/qubit/modules/search/actions/boxComponent.class.php
+++ b/apps/qubit/modules/search/actions/boxComponent.class.php
@@ -21,6 +21,14 @@ class SearchBoxComponent extends sfComponent
 {
   public function execute($request)
   {
+    // if the institutional scoping setting is on, search is always global.
+    if (sfConfig::get('app_enable_institutional_scoping'))
+    {
+      $this->repository = NULL;
+      $this->altRepository = NULL;
+      return;
+    }
+
     // Check if the user is browsing a repo
     $route = $request->getAttribute('sf_route');
     if (isset($route->resource))

--- a/apps/qubit/modules/search/actions/boxComponent.class.php
+++ b/apps/qubit/modules/search/actions/boxComponent.class.php
@@ -24,8 +24,8 @@ class SearchBoxComponent extends sfComponent
     // if the institutional scoping setting is on, search is always global.
     if (sfConfig::get('app_enable_institutional_scoping'))
     {
-      $this->repository = NULL;
-      $this->altRepository = NULL;
+      $this->repository = null;
+      $this->altRepository = null;
       return;
     }
 

--- a/apps/qubit/modules/search/actions/indexAction.class.php
+++ b/apps/qubit/modules/search/actions/indexAction.class.php
@@ -86,7 +86,15 @@ class SearchIndexAction extends DefaultBrowseAction
       $response['results'][] = $result;
     }
 
-    $url = url_for(array('module' => 'informationobject', 'action' => 'browse', 'collection' =>  $request->collection, 'query' => $request->query, 'topLod' => '0'));
+    if (sfConfig::get('app_enable_institutional_scoping') && $this->context->user->hasAttribute('search-realm'))
+    {
+      $url = url_for(array('module' => 'informationobject', 'action' => 'browse', 'collection' =>  $request->collection, 'repos' => $this->context->user->getAttribute('search-realm'), 'query' => $request->query, 'topLod' => '0'));
+    }
+    else
+    {
+      $url = url_for(array('module' => 'informationobject', 'action' => 'browse', 'collection' =>  $request->collection, 'query' => $request->query, 'topLod' => '0'));
+    }
+
     $link = $this->context->i18n->__('Browse all descriptions');
     $response['more'] = <<<EOF
 <div class="more">

--- a/apps/qubit/modules/search/templates/_box.php
+++ b/apps/qubit/modules/search/templates/_box.php
@@ -9,7 +9,7 @@
     <?php if (isset($repository)): ?>
       <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php echo $sf_request->query ?>" placeholder="<?php echo __('Search %1%', array('%1%' => render_title($repository))) ?>"/>
     <?php else: ?>
-      <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php echo $sf_request->query ?>" placeholder="<?php echo __('Search') ?>"/>
+      <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php echo $sf_request->query ?>" placeholder="<?php echo __('%1%', array('%1%' => sfConfig::get('app_ui_label_globalSearch'))) ?>"/>
     <?php endif; ?>
 
     <button><span><?php echo __('Search') ?></span></button>

--- a/apps/qubit/modules/settings/actions/globalAction.class.php
+++ b/apps/qubit/modules/settings/actions/globalAction.class.php
@@ -95,6 +95,7 @@ class SettingsGlobalAction extends sfAction
     $googleMapsApiKey = QubitSetting::getByName('google_maps_api_key');
     $slugTypeInformationObject = QubitSetting::getByName('slug_basis_informationobject');
     $generateReportsAsPubUser = QubitSetting::getByName('generate_reports_as_pub_user');
+    $enableInstitutionalScoping = QubitSetting::getByName('enable_institutional_scoping');
 
     // Set defaults for global form
     $this->globalForm->setDefaults(array(
@@ -123,6 +124,7 @@ class SettingsGlobalAction extends sfAction
       'sword_deposit_dir' => (isset($swordDepositDir)) ? $swordDepositDir->getValue(array('sourceCulture'=>true)) : null,
       'google_maps_api_key' => (isset($googleMapsApiKey)) ? $googleMapsApiKey->getValue(array('sourceCulture'=>true)) : null,
       'generate_reports_as_pub_user' => (isset($generateReportsAsPubUser)) ? $generateReportsAsPubUser->getValue(array('sourceCulture'=>true)) : 1,
+      'enable_institutional_scoping' => (isset($enableInstitutionalScoping)) ? intval($enableInstitutionalScoping->getValue(array('sourceCulture'=>true))) : 0,
     ));
   }
 
@@ -402,6 +404,16 @@ class SettingsGlobalAction extends sfAction
     // Force sourceCulture update to prevent discrepency in settings between cultures
     $setting->setValue($googleMapsApiKey, array('sourceCulture' => true));
     $setting->save();
+
+    // Enable Institutional Scoping
+    if (null !== $enableInstitutionalScoping = $thisForm->getValue('enable_institutional_scoping'))
+    {
+      $setting = QubitSetting::getByName('enable_institutional_scoping');
+
+      // Force sourceCulture update to prevent discrepency in settings between cultures
+      $setting->setValue($enableInstitutionalScoping, array('sourceCulture' => true));
+      $setting->save();
+    }
 
     return $this;
   }

--- a/apps/qubit/modules/staticpage/actions/indexAction.class.php
+++ b/apps/qubit/modules/staticpage/actions/indexAction.class.php
@@ -31,6 +31,12 @@ class StaticPageIndexAction extends sfAction
     $this->response->setTitle("$title - {$this->response->getTitle()}");
 
     $this->content = $this->getPurifiedStaticPageContent();
+
+    if (sfConfig::get('app_enable_institutional_scoping') && $this->resource->slug == 'home')
+    {
+      // Remove the search-realm attribute
+      $this->context->user->removeAttribute('search-realm');
+    }
   }
 
   protected function getPurifiedStaticPageContent()

--- a/apps/qubit/modules/taxonomy/actions/browseAction.class.php
+++ b/apps/qubit/modules/taxonomy/actions/browseAction.class.php
@@ -26,6 +26,12 @@ class TaxonomyBrowseAction extends sfAction
       $request->limit = sfConfig::get('app_hits_per_page');
     }
 
+    if (sfConfig::get('app_enable_institutional_scoping'))
+    {
+      // Remove search-realm
+      $this->context->user->removeAttribute('search-realm');
+    }
+
     // HACK Use id deliberately, vs. slug, because "Subjects" and "Places"
     // menus still use id
     $this->resource = QubitTaxonomy::getById($request->id);

--- a/apps/qubit/modules/taxonomy/actions/indexAction.class.php
+++ b/apps/qubit/modules/taxonomy/actions/indexAction.class.php
@@ -21,6 +21,12 @@ class TaxonomyIndexAction extends sfAction
 {
   public function execute($request)
   {
+    if (sfConfig::get('app_enable_institutional_scoping'))
+    {
+      // Remove search-realm
+      $this->context->user->removeAttribute('search-realm');
+    }
+
     // HACK Use id deliberately, vs. slug, because "Subjects" and "Places"
     // menus still use id
     if (isset($request->id))

--- a/apps/qubit/modules/term/actions/indexAction.class.php
+++ b/apps/qubit/modules/term/actions/indexAction.class.php
@@ -98,6 +98,12 @@ class TermIndexAction extends DefaultBrowseAction
       $this->forward404();
     }
 
+    if (sfConfig::get('app_enable_institutional_scoping'))
+    {
+      // Remove search-realm
+      $this->context->user->removeAttribute('search-realm');
+    }
+
     if (isset($request->languages))
     {
       $this->culture = $request->languages;

--- a/data/fixtures/menus.yml
+++ b/data/fixtures/menus.yml
@@ -119,6 +119,13 @@ QubitMenu:
       vi: 'Quản lý'
       zh: 管理
     path: accession/browse
+  QubitMenu_browseinstitution:
+    id: 11
+    parent_id: QubitMenu_root
+    source_culture: en
+    name: browseInstitution
+    label:
+      en: Browse our collection
   QubitMenu_mainmenu_manage_accessions:
     parent_id: QubitMenu_mainmenu_manage
     source_culture: en
@@ -1806,3 +1813,35 @@ QubitMenu:
       pt: 'Ir para a área de transferência'
       sr: 'Иди у међумеморију (clipboard)'
     path: user/clipboard
+  QubitMenu_browseinstitution_informationobjects:
+    parent_id: QubitMenu_browseinstitution
+    source_culture: en
+    name: browseInformationObjectsInstitution
+    label:
+      ca: 'Descripcions arxivístiques'
+      ca@valencia: 'Descripcions arxivístiques'
+      cs: 'Archivní popisy'
+      cy: 'Disgrifiadau archifol'
+      de: 'Archivische Beschreibungen'
+      de-CH: 'Archivische Beschreibungen'
+      el: 'Αρχειακές περιγραφές'
+      en: 'Archival descriptions'
+      es: 'Descripción archivística'
+      eu: 'Artxibo deskribapenak'
+      fr: 'Descriptions archivistiques'
+      gl: 'Descrición arquivística'
+      hu: 'Levéltári leírások'
+      is: 'Lýsandi samantektir'
+      it: 'Descrizioni archivistiche'
+      ko: '기록물 기술'
+      nl: 'archivistische beschrijving'
+      pt: 'Descrições arquivísticas'
+      pt-BR: 'Descrições arquivísticas'
+      pt_BR: 'Descrições arquivísticas'
+      ru: 'Архивные описания'
+      sl: 'arhivski opisi'
+      sr: 'Архивски описи'
+      sv: Arkivbeskrivningar
+      vi: 'Mô tả lưu trữ'
+      zh: 文献著录
+    path: informationobject/browse?repos=%currentRealm%

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -663,6 +663,22 @@ QubitSetting:
       sr: Жанр
       sv: Genre
       zh: 体裁
+  QubitSetting_globalSearch:
+    name: globalSearch
+    scope: ui_label
+    editable: 1
+    deleteable: 0
+    source_culture: en
+    value:
+      en: Search
+  QubitSetting_institutionSearchHoldings:
+    name: institutionSearchHoldings
+    scope: ui_label
+    editable: 1
+    deleteable: 0
+    source_culture: en
+    value:
+      en: Search our collection
   QubitSetting_26:
     name: en
     scope: i18n_languages
@@ -779,6 +795,9 @@ QubitSetting:
   QubitSetting_swordDepositDir:
     name: sword_deposit_dir
     value: /tmp
+  QubitSetting_enableInstitutionalScoping:
+    name: enable_institutional_scoping
+    value: 0
   QubitSetting_requireSslAdmin:
     name: require_ssl_admin
     value: 0

--- a/lib/form/SettingsGlobalForm.class.php
+++ b/lib/form/SettingsGlobalForm.class.php
@@ -55,6 +55,7 @@ class SettingsGlobalForm extends sfForm
       'default_repository_browse_view' => new sfWidgetFormSelectRadio(array('choices' => array('card' => $this->i18n->__('card'), 'table' => $this->i18n->__('table'))), array('class' => 'radio')),
       'default_archival_description_browse_view' => new sfWidgetFormSelectRadio(array('choices' => array('card' => $this->i18n->__('card'), 'table' => $this->i18n->__('table'))), array('class' => 'radio')),
       'multi_repository' => new sfWidgetFormSelectRadio(array('choices' => array(1 => 'yes', 0 => 'no')), array('class' => 'radio')),
+      'enable_institutional_scoping' => new sfWidgetFormSelectRadio(array('choices'=>array(1=>'yes', 0=>'no')), array('class'=>'radio')),
       'repository_quota' => new sfWidgetFormInput,
       'upload_quota' => new arWidgetFormUploadQuota,
       'explode_multipage_files' => new sfWidgetFormSelectRadio(array('choices' => array(1 => 'yes', 0 => 'no')), array('class' => 'radio')),
@@ -85,6 +86,7 @@ class SettingsGlobalForm extends sfForm
       'default_repository_browse_view' => $this->i18n->__('Default repository browse view'),
       'default_archival_description_browse_view' => $this->i18n->__('Default archival description browse view'),
       'multi_repository' => $this->i18n->__('Multiple repositories'),
+      'enable_institutional_scoping' => $this->i18n->__('Enable institutional scoping'),
       'repository_quota' => $this->i18n->__('Default %1% upload limit (GB)', array('%1%' => strtolower(sfConfig::get('app_ui_label_repository')))),
       'upload_quota' => $this->i18n->__('Total space available for uploads'),
       'explode_multipage_files' => $this->i18n->__('Upload multi-page files as multiple descriptions'),
@@ -113,6 +115,7 @@ class SettingsGlobalForm extends sfForm
       'inherit_code_informationobject' => $this->i18n->__('When set to &quot;yes&quot;, the reference code string will be built using the information object identifier plus the identifiers of all its ancestors'),
       'sort_treeview_informationobject' => $this->i18n->__('Determines whether to sort siblings in the information object treeview control and, if so, what sort criteria to use'),
       'multi_repository' => $this->i18n->__('When set to &quot;no&quot;, the repository name is excluded from certain displays because it will be too repetitive'),
+      'enable_institutional_scoping' => $this->i18n->__('Applies to multi-repository sites only. When set to &quot;yes&quot;, additional search and browse options will be available at the repository level'),
       'repository_quota' => $this->i18n->__('Default %1% upload limit for a new %2%.  A value of &quot;0&quot; (zero) disables file upload.  A value of &quot;-1&quot; allows unlimited uploads', array('%1%' => strtolower(sfConfig::get('app_ui_label_digitalobject')), '%2%' => strtolower(sfConfig::get('app_ui_label_repository')))),
       'defaultPubStatus' => $this->i18n->__('Default publication status for newly created or imported %1%', array('%1%' => sfConfig::get('app_ui_label_informationobject'))),
       'slug_basis_informationobject' => $this->i18n->__('Choose whether permalinks for descriptions are generated from reference code or title'),
@@ -161,6 +164,7 @@ class SettingsGlobalForm extends sfForm
     $this->validatorSchema['sort_browser_user'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['sort_browser_anonymous'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['multi_repository'] = new sfValidatorInteger(array('required' => false));
+    $this->validatorSchema['enable_institutional_scoping'] = new sfValidatorInteger(array('required' => false));
     $this->validatorSchema['default_repository_browse_view'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['default_archival_description_browse_view'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['slug_basis_informationobject'] = $this->getSlugBasisInformationObjectValidator();

--- a/lib/model/QubitMenu.php
+++ b/lib/model/QubitMenu.php
@@ -52,7 +52,15 @@ class QubitMenu extends BaseMenu
     $aliases = array(
       '%profile%' => sfContext::getInstance()->routing->generate(null, array('module' => 'user', 'slug' => sfContext::getInstance()->user->getUserSlug())),
       '%currentId%' => sfContext::getInstance()->request->id,
-      '%currentSlug%' => @sfContext::getInstance()->request->getAttribute('sf_route')->resource->slug
+      '%currentSlug%' => @sfContext::getInstance()->request->getAttribute('sf_route')->resource->slug,
+
+      // 'currentRealm' is used by menu items on the Institutional Block as part of the enable_institutional_scoping feature.
+      // Try using search-realm if available, else try resource->id from sf_route, else try repos param on request.
+      '%currentRealm%' => (@sfContext::getInstance()->user->getAttribute('search-realm')
+        ? @sfContext::getInstance()->user->getAttribute('search-realm')
+        : (@sfContext::getInstance()->request->getAttribute('sf_route')->resource->id
+          ? @sfContext::getInstance()->request->getAttribute('sf_route')->resource->id
+          : @sfContext::getInstance()->request->getParameter('repos')) )
     );
 
     $path = parent::offsetGet('path', $options);

--- a/lib/model/QubitMenu.php
+++ b/lib/model/QubitMenu.php
@@ -49,18 +49,34 @@ class QubitMenu extends BaseMenu
    */
   public function getPath($options = array())
   {
+    // 'currentRealm' is used by menu items on the Institutional Block as part of the
+    // enable_institutional_scoping feature. Try using search-realm if available, else
+    // try resource->id from sf_route, else try repos param on request.
+    if (null !== sfContext::getInstance()->user->getAttribute('search-realm'))
+    {
+      $currentRealm = sfContext::getInstance()->user->getAttribute('search-realm');
+    }
+    else if (isset(sfContext::getInstance()->request->getAttribute('sf_route')->resource->id))
+    {
+      $currentRealm = sfContext::getInstance()->request->getAttribute('sf_route')->resource->id;
+    }
+    else if (null !== sfContext::getInstance()->request->getParameter('repos'))
+    {
+      $currentRealm = sfContext::getInstance()->request->getParameter('repos');
+    }
+    else
+    {
+      $currentRealm = null;
+    }
+
+    $currentSlug = isset(sfContext::getInstance()->request->getAttribute('sf_route')->resource->slug) ?
+      sfContext::getInstance()->request->getAttribute('sf_route')->resource->slug : null;
+
     $aliases = array(
       '%profile%' => sfContext::getInstance()->routing->generate(null, array('module' => 'user', 'slug' => sfContext::getInstance()->user->getUserSlug())),
       '%currentId%' => sfContext::getInstance()->request->id,
-      '%currentSlug%' => @sfContext::getInstance()->request->getAttribute('sf_route')->resource->slug,
-
-      // 'currentRealm' is used by menu items on the Institutional Block as part of the enable_institutional_scoping feature.
-      // Try using search-realm if available, else try resource->id from sf_route, else try repos param on request.
-      '%currentRealm%' => (@sfContext::getInstance()->user->getAttribute('search-realm')
-        ? @sfContext::getInstance()->user->getAttribute('search-realm')
-        : (@sfContext::getInstance()->request->getAttribute('sf_route')->resource->id
-          ? @sfContext::getInstance()->request->getAttribute('sf_route')->resource->id
-          : @sfContext::getInstance()->request->getParameter('repos')) )
+      '%currentSlug%' => $currentSlug,
+      '%currentRealm%' => $currentRealm
     );
 
     $path = parent::offsetGet('path', $options);

--- a/lib/myUser.class.php
+++ b/lib/myUser.class.php
@@ -103,6 +103,11 @@ class myUser extends sfBasicSecurityUser implements Zend_Acl_Role_Interface
     $this->getAttributeHolder()->remove('nav_context_module');
   }
 
+  public function removeAttribute($attribute)
+  {
+    $this->getAttributeHolder()->remove($attribute);
+  }
+
   public function getUserID()
   {
     return $this->getAttribute('user_id');

--- a/lib/task/migrate/migrations/arMigration0149.class.php
+++ b/lib/task/migrate/migrations/arMigration0149.class.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add new setting for enabling institutional scoping.
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0149
+{
+  const
+    VERSION = 149, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  /**
+   * Upgrade
+   *
+   * @return bool True if the upgrade succeeded, False otherwise
+   */
+  public function up($configuration)
+  {
+    if (null === QubitSetting::getByName('enable_institutional_scoping'))
+    {
+      $setting = new QubitSetting;
+      $setting->name = 'enable_institutional_scoping';
+      $setting->value = 0;
+      $setting->editable = 1;
+      $setting->culture = 'en';
+      $setting->save();
+    }
+
+    if (null === QubitSetting::getByName('globalSearch'))
+    {
+      $setting = new QubitSetting;
+      $setting->name  = 'globalSearch';
+      $setting->scope = 'ui_label';
+      $setting->editable = 1;
+      $setting->deleteable = 0;
+      $setting->source_culture = 'en';
+      $setting->setValue('Search', array('culture' => 'en'));
+      $setting->save();
+    }
+
+    if (null === QubitSetting::getByName('institutionSearchHoldings'))
+    {
+      $setting = new QubitSetting;
+      $setting->name  = 'institutionSearchHoldings';
+      $setting->scope = 'ui_label';
+      $setting->editable = 1;
+      $setting->deleteable = 0;
+      $setting->source_culture = 'en';
+      $setting->setValue('Search our collection', array('culture' => 'en'));
+      $setting->save();
+    }
+
+    if (null === QubitMenu::getByName('browseInstitution'))
+    {
+      $browseInstMenu = new QubitMenu;
+      $browseInstMenu->parentId = QubitMenu::ROOT_ID;
+      $browseInstMenu->name = 'browseInstitution';
+      $browseInstMenu->label = 'Browse our collection';
+      $browseInstMenu->culture = 'en';
+      $browseInstMenu->save();
+
+      if (null === QubitMenu::getByName('browseInformationObjectsInstitution'))
+      {
+        $menu = new QubitMenu;
+        $menu->parentId = $browseInstMenu->id;
+        $menu->name = 'browseInformationObjectsInstitution';
+        $menu->path = 'informationobject/browse?repos=%currentRealm%';
+        $menu->sourceCulture = 'en';
+        $menu->label = 'Archival descriptions';
+        $menu->save();
+      }
+    }
+
+    return true;
+  }
+}

--- a/plugins/arDacsPlugin/modules/arDacsPlugin/config/view.yml
+++ b/plugins/arDacsPlugin/modules/arDacsPlugin/config/view.yml
@@ -31,4 +31,4 @@ indexSuccess:
 all:
   components:
     css:
-      [repository, stylesheet]
+      [sfIsadPlugin, stylesheet]

--- a/plugins/arDominionPlugin/css/less/header.less
+++ b/plugins/arDominionPlugin/css/less/header.less
@@ -190,6 +190,19 @@ nav > div {
   }
 }
 
+// Institutional block dropdown menu css.
+// Institutional block present when 'Enable institutional scoping' is on.
+#repo-holdings #browse-menu {
+  float: none;
+  width: 100%;
+  > button {
+    width: 100%;
+    float: none;
+    .border-radius(4px);
+    background-color: lighten(@grayDark, 5%);
+  }
+}
+
 #user-menu {
   > button {
     margin-left: 12px;

--- a/plugins/arDominionPlugin/css/less/panels.less
+++ b/plugins/arDominionPlugin/css/less/panels.less
@@ -5,9 +5,16 @@
 .panel {
   padding: 15px;
   margin-bottom: 20px;
-  background-color: @white;
   border: 1px solid #dddddd;
   border-radius: 4px;
   -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+}
+
+.panel-default {
+  background-color: @white;
+}
+
+.panel-gray {
+  background-color: @grayLighter;
 }

--- a/plugins/sfDcPlugin/modules/sfDcPlugin/config/view.yml
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/config/view.yml
@@ -30,4 +30,4 @@ indexSuccess:
 all:
   components:
     css:
-      [repository, stylesheet]
+      [sfIsadPlugin, stylesheet]

--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/actions/indexAction.class.php
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/actions/indexAction.class.php
@@ -31,6 +31,12 @@ class sfIsaarPluginIndexAction extends ActorIndexAction
   {
     parent::execute($request);
 
+    if (sfConfig::get('app_enable_institutional_scoping'))
+    {
+      // remove search-realm
+      $this->context->user->removeAttribute('search-realm');
+    }
+
     $this->isaar = new sfIsaarPlugin($this->resource);
 
     if (1 > strlen($title = $this->resource->__toString()))

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/actions/stylesheetComponent.class.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/actions/stylesheetComponent.class.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class sfIsadPluginStylesheetComponent extends sfComponent
+{
+  public function execute($request)
+  {
+    // If institutional scoping is on, repo comes from the search-realm
+    if (sfConfig::get('app_enable_institutional_scoping') && sfContext::getInstance()->user->hasAttribute('search-realm') )
+    {
+      $repository = QubitRepository::getById(sfContext::getInstance()->user->getAttribute('search-realm'));
+    }
+    // If the feature is off, fall back to the repository component rules.
+    else if (!sfConfig::get('app_enable_institutional_scoping'))
+    {
+      if (!isset($request->getAttribute('sf_route')->resource))
+      {
+        return sfView::NONE;
+      }
+
+      $resource = $request->getAttribute('sf_route')->resource;
+
+      switch (true)
+      {
+        case $resource instanceof QubitInformationObject:
+          $repository = $resource->getRepository(array('inherit' => true));
+
+          break;
+
+        case $resource instanceof QubitRepository:
+          $repository = $resource;
+
+          break;
+
+        default:
+          return sfView::NONE;
+      }
+    }
+    else
+    {
+      return sfView::NONE;
+    }
+
+    if (null === $repository || null === $repository->backgroundColor)
+    {
+      return sfView::NONE;
+    }
+
+    // Get value
+    $this->backgroundColor = $repository->backgroundColor->__toString();
+
+    if (0 == strlen($this->backgroundColor))
+    {
+      return sfView::NONE;
+    }
+  }
+}

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/config/view.yml
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/config/view.yml
@@ -36,4 +36,4 @@ indexSuccess:
 all:
   components:
     css:
-      [repository, stylesheet]
+      [sfIsadPlugin, stylesheet]

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/_stylesheet.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/_stylesheet.php
@@ -1,0 +1,6 @@
+<style type="text/css">
+  html, body {
+    background-image: none !important;
+    background-color: <?php echo $backgroundColor ?> !important;
+  }
+</style>

--- a/plugins/sfModsPlugin/modules/sfModsPlugin/config/view.yml
+++ b/plugins/sfModsPlugin/modules/sfModsPlugin/config/view.yml
@@ -30,4 +30,4 @@ indexSuccess:
 all:
   components:
     css:
-      [repository, stylesheet]
+      [sfIsadPlugin, stylesheet]

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/config/view.yml
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/config/view.yml
@@ -32,4 +32,4 @@ indexSuccess:
 all:
   components:
     css:
-      [repository, stylesheet]
+      [sfIsadPlugin, stylesheet]


### PR DESCRIPTION
Institutional Scoping enhancement for AtoM. When activated, the feature
will allow users to be scoped to a specific repository such that browsing
and searching will restict a user to a specific repository. Repository
theming will apply to pages when scoped to give the user visual cues
indicating they are browsing with a repository. A new search block will
be present on the left hand side from which browse and search will be done.

This is the first of several commits to pull this into 2.4.x

This commit includes:
- migration 149 to set up new settings and menu items
- settings and menu item config in menus.yml and settings.yml
- Global Settings page change to add new option to "Enable insitutional
scoping"