### PR TITLE
Fix thumbnailPath in ES, refs #10758

### DIFF
--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
@@ -1132,15 +1132,7 @@ class arElasticSearchInformationObjectPdo
       $serialized['digitalObject']['mediaTypeId'] = $this->media_type_id;
       $serialized['digitalObject']['usageId'] = $this->usage_id;
       $serialized['digitalObject']['filename'] = $this->filename;
-
-      if (QubitTerm::EXTERNAL_URI_ID == $this->usage_id)
-      {
-        $serialized['digitalObject']['thumbnailPath'] = $this->path;
-      }
-      else
-      {
-        $serialized['digitalObject']['thumbnailPath'] = $this->getThumbnailPath();
-      }
+      $serialized['digitalObject']['thumbnailPath'] = $this->getThumbnailPath();
 
       $serialized['hasDigitalObject'] = true;
     }


### PR DESCRIPTION
The getFullPath method from QubitDigitalObject takes care of
the differences between external and internal resources