### PR TITLE
Inst Scoping repo holdings list, Refs #10733

### DIFF
--- a/apps/qubit/modules/repository/actions/holdingsListComponent.class.php
+++ b/apps/qubit/modules/repository/actions/holdingsListComponent.class.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class RepositoryHoldingsListComponent extends sfComponent
+{
+  public function execute($request)
+  {
+    $page = 1;
+    $limit = sfConfig::get('app_hits_per_page', 10);
+    $resultSet = RepositoryHoldingsAction::getHoldings($this->resource->id, $page, $limit);
+
+    $this->pager = new QubitSearchPager($resultSet);
+    $this->pager->setPage($page);
+    $this->pager->setMaxPerPage($limit);
+    $this->pager->init();
+  }
+}

--- a/apps/qubit/modules/repository/templates/_contextMenu.php
+++ b/apps/qubit/modules/repository/templates/_contextMenu.php
@@ -1,6 +1,6 @@
 <?php if (isset($resource) && ($resource->getRawValue() instanceof QubitRepository) && sfConfig::get('app_enable_institutional_scoping')): ?>
   <?php include_component('repository', 'holdingsInstitution', array('resource' => $resource)) ?>
-
+  <?php include_component('repository', 'holdingsList', array('resource' => $resource)) ?>
   <?php if (QubitAcl::check($resource, 'update')): ?>
     <?php include_component('repository', 'uploadLimit', array('resource' => $resource)) ?>
   <?php endif; ?>
@@ -13,5 +13,6 @@
     <?php endif; ?>
 
     <?php include_component('repository', 'holdings', array('resource' => $resource)) ?>
+    <?php include_component('repository', 'holdingsList', array('resource' => $resource)) ?>
   <?php endif; ?>
 <?php endif; ?>

--- a/apps/qubit/modules/repository/templates/_holdings.php
+++ b/apps/qubit/modules/repository/templates/_holdings.php
@@ -1,32 +1,13 @@
-<section class="sidebar-paginated-list list-menu"
-  data-total-pages="<?php echo $pager->getLastPage() ?>"
-  data-url="<?php echo url_for(array('module' => 'repository', 'action' => 'holdings', 'id' => $resource->id)) ?>">
-
-  <h3>
-    <?php echo sfConfig::get('app_ui_label_holdings') ?>
-    <?php echo image_tag('loading.small.gif', array('class' => 'hidden', 'id' => 'spinner', 'alt' => __('Loading ...'))) ?>
-  </h3>
-  <form class="sidebar-search" action="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse')) ?>">
-    <input type="hidden" name="repos" value="<?php echo $resource->id ?>">
-    <div class="input-prepend input-append">
-      <input type="text" name="query" placeholder="<?php echo __('Search holdings') ?>">
-      <button class="btn" type="submit">
-        <i class="fa fa-search"></i>
-      </button>
-    </div>
-  </form>
-  <div class="more">
-    <a href="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse', 'repos' => $resource->id)) ?>">
+<h3>
+  <?php echo sfConfig::get('app_ui_label_holdings') ?>
+  <?php echo image_tag('loading.small.gif', array('class' => 'hidden', 'id' => 'spinner', 'alt' => __('Loading ...'))) ?>
+</h3>
+<form class="sidebar-search" action="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse')) ?>">
+  <input type="hidden" name="repos" value="<?php echo $resource->id ?>">
+  <div class="input-prepend input-append">
+    <input type="text" name="query" placeholder="<?php echo __('Search holdings') ?>">
+    <button class="btn" type="submit">
       <i class="fa fa-search"></i>
-      <?php echo __('Browse %1% holdings', array('%1%' => $pager->getNbResults())) ?>
-    </a>
+    </button>
   </div>
-  <ul>
-    <?php foreach ($pager->getResults() as $hit): ?>
-      <?php $doc = $hit->getData() ?>
-      <li><?php echo link_to(get_search_i18n($doc, 'title', array('allowEmpty' => false)), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?></li>
-    <?php endforeach; ?>
-  </ul>
-
-  <?php echo get_partial('default/sidebarPager', array('pager' => $pager)) ?>
-</section>
+</form>

--- a/apps/qubit/modules/repository/templates/_holdingsList.php
+++ b/apps/qubit/modules/repository/templates/_holdingsList.php
@@ -1,0 +1,20 @@
+<section class="sidebar-paginated-list list-menu"
+  data-total-pages="<?php echo $pager->getLastPage() ?>"
+  data-url="<?php echo url_for(array('module' => 'repository', 'action' => 'holdings', 'id' => $resource->id)) ?>">
+
+  <div class="more">
+    <a href="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse', 'repos' => $resource->id)) ?>">
+      <i class="fa fa-search"></i>
+      <?php echo __('Browse %1% holdings', array('%1%' => $pager->getNbResults())) ?>
+    </a>
+  </div>
+  <ul>
+    <?php foreach ($pager->getResults() as $hit): ?>
+      <?php $doc = $hit->getData() ?>
+      <li><?php echo link_to(get_search_i18n($doc, 'title', array('allowEmpty' => false)), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?></li>
+    <?php endforeach; ?>
+  </ul>
+
+  <?php echo get_partial('default/sidebarPager', array('pager' => $pager)) ?>
+</section>
+


### PR DESCRIPTION
The change breaks the repository holdings component list and pager out into
it's own component so that it can be re-used in the holdingsInstitution
component.

Altered the _contextMenu template so the new list component is included with
the call to the original holdings component, and with the holdingsInstitution
component which is activated when Institutional Scoping feature is turned ON.