### PR TITLE
Inst Scoping descr list realm fix, refs #10733

### DIFF
--- a/apps/qubit/modules/function/actions/browseAction.class.php
+++ b/apps/qubit/modules/function/actions/browseAction.class.php
@@ -32,6 +32,12 @@ class FunctionBrowseAction extends sfAction
       $request->limit = sfConfig::get('app_hits_per_page');
     }
 
+    if (sfConfig::get('app_enable_institutional_scoping'))
+    {
+      // remove search-realm
+      $this->context->user->removeAttribute('search-realm');
+    }
+
     if (!isset($request->sort))
     {
       if ($this->getUser()->isAuthenticated())

--- a/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/actions/indexAction.class.php
+++ b/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/actions/indexAction.class.php
@@ -33,6 +33,13 @@ class sfIsdiahPluginIndexAction extends RepositoryIndexAction
 
     $this->isdiah = new sfIsdiahPlugin($this->resource);
 
+    if (null !== $this->resource->id &&
+      sfConfig::get('app_enable_institutional_scoping'))
+    {
+      // Add repo to the user session as realm
+      $this->context->user->setAttribute('search-realm', $this->resource->id);
+    }
+
     if (1 > strlen($title = $this->resource->__toString()))
     {
       $title = $this->context->i18n->__('Untitled');


### PR DESCRIPTION
Redmine: https://projects.artefactual.com/issues/10733

This commit corrects an issue found when testing the new Institutional
Scoping feature's Archival Description List in the sidebar. The
search-realm was not set when accessing the archival descriptions directly
from the list. This has been resolved by assigning the search-realm earlier
inside the sfIsiahPlugin.

Also added one additional change where the search-realm needed to be cleared
in the functions browse controller.