### PR TITLE
Inst Scoping ensure 2 col layout, Refs# 10733

### DIFF
--- a/apps/qubit/modules/informationobject/templates/browseSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/browseSuccess.php
@@ -1,4 +1,4 @@
-<?php if (isset($pager) && $pager->hasResults()): ?>
+<?php if (isset($pager) && $pager->hasResults() || sfConfig::get('app_enable_institutional_scoping')): ?>
   <?php decorate_with('layout_2col') ?>
 <?php else: ?>
   <?php decorate_with('layout_1col') ?>
@@ -28,7 +28,7 @@
   </div>
 <?php endif; ?>
 
-<?php if (isset($pager) && $pager->hasResults()): ?>
+<?php if (isset($pager) && $pager->hasResults() || sfConfig::get('app_enable_institutional_scoping')): ?>
 
   <?php slot('sidebar') ?>
 


### PR DESCRIPTION
This change creates an exception in the information object browse template
to ensure that the 2 column layout is kept when the Institutional Scoping
feature is turned ON.

When Insitutional Scoping is OFF and a user performs a search that returns
zero results, the information object browse template changes to a 1 col
layout removing the sidebar. The change creates an exception for that rule
so that when Institutional Scoping is ON, the 2 column layout will be used
and the sidebar including the Institutional Block will be displayed, which
will provide context to the user and allow the user to perform another
scoped search.