### PR TITLE
Inst Scoping search text, Refs #10733

### DIFF
--- a/apps/qubit/modules/repository/templates/_holdingsInstitution.php
+++ b/apps/qubit/modules/repository/templates/_holdingsInstitution.php
@@ -25,7 +25,7 @@
       <form class="sidebar-search" action="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse')) ?>">
         <input type="hidden" name="repos" value="<?php echo $resource->id ?>">
         <div class="input-prepend input-append">
-          <input type="text" name="query" placeholder="<?php echo __('Search') ?>">
+          <input type="text" name="query" value="<?php echo $sf_request->query ?>" placeholder="<?php echo __('Search') ?>">
           <button class="btn" type="submit">
             <i class="fa fa-search"></i>
           </button>

--- a/apps/qubit/modules/search/templates/_box.php
+++ b/apps/qubit/modules/search/templates/_box.php
@@ -6,10 +6,10 @@
 
     <input type="hidden" name="topLod" value="0"/>
 
-    <?php if (isset($repository)): ?>
+    <?php if (isset($repository) && !sfConfig::get('app_enable_institutional_scoping')): ?>
       <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php echo $sf_request->query ?>" placeholder="<?php echo __('Search %1%', array('%1%' => render_title($repository))) ?>"/>
     <?php else: ?>
-      <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php echo $sf_request->query ?>" placeholder="<?php echo __('%1%', array('%1%' => sfConfig::get('app_ui_label_globalSearch'))) ?>"/>
+      <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php if (!$sf_user->getAttribute('search-realm') || !sfConfig::get('app_enable_institutional_scoping')) echo $sf_request->query ?>" placeholder="<?php echo __('%1%', array('%1%' => sfConfig::get('app_ui_label_globalSearch'))) ?>"/>
     <?php endif; ?>
 
     <button><span><?php echo __('Search') ?></span></button>


### PR DESCRIPTION
This change controls which search box will contain the searched-for text
after a page refresh when the Institutional Scoping feature is turned on.

- When scoped to an insitution and an institutional search is performed
using the search field in the institutional block, retain the searched-for
text in this search field. Do not display this searched-for text in the
global search box in the header.

- if a institutional search has been performed, and the repo facet is removed
from the results page removing scoping, copy the searched-for text to the
global search box in the header.

- if a user performs a global search using the header search box and on the
results page the institutional facet is ADDED to the results causing the
session to scope to a repository, move the search term from the global
search box in the header to the Institutional Block search field.

Note that this feature only takes effect if Institutional Scoping feature is
ON.