### PR TITLE
Fix Descr Update repository display, Refs# 10730

### DIFF
--- a/apps/qubit/modules/search/templates/descriptionUpdatesSuccess.php
+++ b/apps/qubit/modules/search/templates/descriptionUpdatesSuccess.php
@@ -91,7 +91,7 @@
 
             <?php if ('QubitInformationObject' == $className && 0 < sfConfig::get('app_multi_repository')): ?>
               <td>
-                <?php if (null !== $repository = (isset($doc['repository'])) ? truncate_text(get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false)), 100) : null): ?>
+                <?php if (null !== $repository = (isset($doc['repository'])) ? truncate_text(get_search_i18n($doc['repository'], 'authorizedFormOfName', array('allowEmpty' => false)), 100) : null): ?>
                   <?php echo $repository ?>
                 <?php endif; ?>
               </td>


### PR DESCRIPTION
The 'Repository' column on the Description Updates page was always displaying
'Untitled'. This change corrects this and the repository will now display for
each record.