### PR TITLE
Import-bulk output 'error' text, Refs #10729

### DIFF
--- a/lib/task/import/importBulkTask.class.php
+++ b/lib/task/import/importBulkTask.class.php
@@ -146,9 +146,9 @@ EOF;
 
       if ($importer->hasErrors())
       {
-        foreach ($importer->getErrors() as $error)
+        foreach ($importer->getErrors() as $message)
         {
-          $this->log('Error ('. $file .'): '. $error);
+          $this->log('('. $file .'): '. $message);
         }
       }
 


### PR DESCRIPTION
The import:bulk tast output messages were always prefixed with the static
text 'Error'. This text has been removed since this output will contain status
messages as well.