### PR TITLE
Fix realm in search box links, refs #10295

### DIFF
--- a/js/dominion.js
+++ b/js/dominion.js
@@ -352,7 +352,7 @@
         this.$element.addClass('loading');
 
         var radio = this.$form.find('[type=radio]:checked');
-        var realm = radio.length ? radio.get(0).value : 'all';
+        var realm = radio.length ? radio.get(0).value : '';
 
         $.ajax(this.source,
           {


### PR DESCRIPTION
When the multi-repository setting is set to 'no', no realm check-boxes are
added to the search-box drop-down, adding the 'repos=all' parameter to
the 'all matching ...' links, which leads to a page without results

Redmine: https://projects.artefactual.com/issues/10295#note-9