### PR TITLE
Correct event date behaviour on save, Refs #10278

### DIFF
--- a/apps/qubit/modules/event/actions/editComponent.class.php
+++ b/apps/qubit/modules/event/actions/editComponent.class.php
@@ -146,7 +146,15 @@ class EventEditComponent extends sfComponent
         if (isset($item['id']))
         {
           $params = $this->context->routing->parse(Qubit::pathInfo($item['id']));
-          $this->event = $params['_sf_route']->resource;
+
+          if ($this->resource instanceof QubitActor)
+          {
+            $this->resource->events[] = $this->event = $params['_sf_route']->resource;
+          }
+          else
+          {
+            $this->resource->eventsRelatedByobjectId[] = $this->event = $params['_sf_route']->resource;
+          }
         }
         elseif ($this->resource instanceof QubitActor)
         {

--- a/plugins/sfDcPlugin/modules/sfDcPlugin/actions/dcDatesComponent.class.php
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/actions/dcDatesComponent.class.php
@@ -50,7 +50,7 @@ class sfDcPluginDcDatesComponent extends InformationObjectEventComponent
         $this->event = null;
         if (isset($item['id']))
         {
-          $this->event = QubitEvent::getById($item['id']);
+          $this->resource->eventsRelatedByobjectId[] = $this->event = QubitEvent::getById($item['id']);
         }
         if (is_null($this->event))
         {

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/actions/eventComponent.class.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/actions/eventComponent.class.php
@@ -92,7 +92,7 @@ class sfIsadPluginEventComponent extends InformationObjectEventComponent
         if (!isset($this->request->sourceId) && isset($item['id']))
         {
           $params = $this->context->routing->parse(Qubit::pathInfo($item['id']));
-          $this->event = $params['_sf_route']->resource;
+          $this->resource->eventsRelatedByobjectId[] = $this->event = $params['_sf_route']->resource;
           array_push($finalEventIds, $this->event->id);
         }
         else


### PR DESCRIPTION
An issue was reported where if modifications to existing dates were made,
and a new date was added, and then the description was saved that the new
date would be saved but the modified dates would not. This issue affects
all description templates.

On informationObject save, without any modifications to the dates,
eventsRelatedByobjectId[] would contain all events. In addition, with
modifications to one of many dates, eventsRelatedByobjectId[] would contain
all events associated with the informationObject. When there was a combination
of new records and updated ones, only the new records were contained in
eventsRelatedByobjectId[], causing only those updates to be saved.

Ensuring that eventsRelatedByobjectId[] was always populated with the date
events corrects this issue.

When using the MODS and RAD templates where an actor is also saved on the
same dialog, the same issue was occurring when there was a combination of
new actors/dates and updated actors or dates. This has also been addressed
in this fix.