### PR TITLE
Remove orphaned tag in header HTML, refs #10711

### DIFF
--- a/apps/qubit/templates/_header.php
+++ b/apps/qubit/templates/_header.php
@@ -42,8 +42,6 @@
 
   </div>
 
-  </section>
-
   <?php echo get_component_slot('header') ?>
 
 </header>


### PR DESCRIPTION
Redmine: https://projects.artefactual.com/issues/10711

Removed an orphaned `</section>` tag in the header template.