### PR TITLE
Fix duplication issues for alternative identifiers and notes, refs #8400

### DIFF
--- a/apps/qubit/modules/informationobject/actions/alternativeIdentifiersComponent.class.php
+++ b/apps/qubit/modules/informationobject/actions/alternativeIdentifiersComponent.class.php
@@ -70,7 +70,11 @@ class InformationObjectAlternativeIdentifiersComponent extends sfComponent
 
         // Save the old properties, because adding a new property with "$this->resource->properties[] ="
         // overrides the unsaved changes
-        if (isset($item['id']))
+        //
+        // We also do an additional check against resource id and property objectId; if they do
+        // not match, we're in duplicate record mode and want to avoid modifying the original
+        // record's alternative identifiers.
+        if (isset($item['id']) && $property->objectId == $this->resource->id)
         {
           $property->save();
         }

--- a/apps/qubit/modules/informationobject/actions/editAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/editAction.class.php
@@ -516,19 +516,8 @@ class InformationObjectEditAction extends DefaultEditAction
         $this->resource->addPhysicalObject($physicalObject);
       }
 
-      // Duplicate notes
-      foreach ($sourceInformationObject->notes as $sourceNote)
-      {
-        if (!isset($this->request->delete_notes[$sourceNote->id]))
-        {
-          $note = new QubitNote;
-          $note->content = $sourceNote->content;
-          $note->typeId = $sourceNote->type->id;
-          $note->userId = $this->context->user->getAttribute('user_id');
-
-          $this->resource->notes[] = $note;
-        }
-      }
+      $this->duplicateNotes($sourceInformationObject);
+      $this->duplicateAlternativeIdentifiers($sourceInformationObject);
 
       foreach (QubitRelation::getRelationsBySubjectId($sourceInformationObject->id, array('typeId' => QubitTerm::RIGHT_ID)) as $item)
       {
@@ -634,6 +623,47 @@ class InformationObjectEditAction extends DefaultEditAction
     }
 
     QubitDescription::addAssets($this->response);
+  }
+
+  /**
+   * Copy over a source information object's alternative identifiers when duplicating.
+   *
+   * @param QubitInformationObject $sourceIo  The source information object we're duplicating from.
+   */
+  private function duplicateAlternativeIdentifiers($sourceIo)
+  {
+    foreach ($sourceIo->getProperties(null, 'alternativeIdentifiers') as $sourceAltId)
+    {
+      $altId = new QubitProperty;
+      $altId->scope = 'alternativeIdentifiers';
+      $altId->name = $sourceAltId->name;
+      $altId->sourceCulture = $sourceAltId->sourceCulture;
+      $altId->value = $sourceAltId->value;
+
+      $this->resource->propertys[] = $altId;
+    }
+  }
+
+  /**
+   * Copy over a source information object's notes when duplicating.
+   *
+   * @param QubitInformationObject $sourceIo  The source information object we're duplicating from.
+   */
+  private function duplicateNotes($sourceIo)
+  {
+    // Duplicate notes
+    foreach ($sourceIo->notes as $sourceNote)
+    {
+      if (!isset($this->request->delete_notes[$sourceNote->id]))
+      {
+        $note = new QubitNote;
+        $note->content = $sourceNote->content;
+        $note->typeId = $sourceNote->type->id;
+        $note->userId = $this->context->user->getAttribute('user_id');
+
+        $this->resource->notes[] = $note;
+      }
+    }
   }
 
   /**

--- a/apps/qubit/modules/informationobject/actions/notesComponent.class.php
+++ b/apps/qubit/modules/informationobject/actions/notesComponent.class.php
@@ -223,8 +223,12 @@ class InformationObjectNotesComponent extends sfComponent
         }
 
         // Save the old notes, because adding a new note with "$this->resource->notes[] ="
-        // overrides the unsaved changes
-        if (isset($item['id']))
+        // overrides the unsaved changes.
+        //
+        // We also do an additional check against resource id and note objectId; if they do
+        // not match, we're in duplicate record mode and want to avoid modifying the original
+        // record's notes.
+        if (isset($item['id']) && $this->note->objectId == $this->resource->id)
         {
           $this->note->save();
         }


### PR DESCRIPTION
This ticket is actually 3 separate but related bugs. This PR fixes all 3 (each with their own commit). The bugs were:

- When duplicating an archival description, if the user modifies an existing _note_ that was copied from the source archival description before hitting save, the change to the note also changes in the source archival description.

- When duplicating an archival description, if the user modifies an existing _alternative identifier_ that was copied from the source archival description before hitting save, the change to the alt identifier also changes in the source archival description.

- When duplicating an archival description, any alternative identifiers from the source archival description don't actually get copied to the new duplicate record (despite showing in the edit screen). So that means when the user hits save, said alternative identifier won't be saved to the new record. If the user modified that alt identifier in the edit page, it'll be modified in the source record (2nd bug in this list).

I feel like these 3 commits should just be merged as is without squashing, since they're 3 different, self-contained fixes. What do you guys think?