### PR TITLE
i18n extract translatable settings, refs #10469

### DIFF
--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -1037,41 +1037,14 @@ QubitSetting:
     deleteable: 0
     source_culture: en
     value:
-      ca: pdf
-      cy: pdf
-      de: pdf
-      de-CH: pdf
-      el: pdf
       en: pdf
-      es: pdf
-      fr: PDF
-      hu: pdf
-      is: pdf
-      ko: pdf
-      pt: pdf
-      pt-BR: pdf
-      ru: pdf
-      sl: pdf
-      sr: pdf
-      sv: pdf
-      zh: pdf
   Qubit_Settings_findingAidModel:
     name: findingAidModel
     editable: 1
     deleteable: 0
     source_culture: en
     value:
-      de: Inventarübersicht
       en: inventory-summary
-      es: Inventario-Resumen
-      fr: 'inventaire sommaire'
-      hu: készletösszegzés
-      pt: inventário-sumário
-      pt-BR: 'inventário sumário'
-      sl: 'povzeket - seznam'
-      sr: 'Инвентар - извод'
-      sv: 'lager - summering'
-      zh: 详细目录-总结
   Qubit_Settings_publicFindingAid:
     name: publicFindingAid
     editable: 1
@@ -1089,24 +1062,14 @@ QubitSetting:
   Qubit_Settings_digitalObjectDerivativesPdfPageNumber:
     name: digital_object_derivatives_pdf_page_number
     value:
-      de: '1'
       en: 1
-      es: '1'
-      pt: '1'
-      sr: '1'
-      sv: '1'
   Qubit_Settings_treeviewType:
     name: treeview_type
     editable: 1
     deleteable: 0
     source_culture: en
     value:
-      de: Seitenleiste
       en: sidebar
-      es: 'barra lateral'
-      pt: 'barra lateral'
-      sr: 'бочна трака'
-      sv: sidspalt
   Qubit_Settings_stripExtensions:
     name: stripExtensions
     editable: 1

--- a/lib/i18n/QubitI18nConsolidateExtract.class.php
+++ b/lib/i18n/QubitI18nConsolidateExtract.class.php
@@ -234,7 +234,11 @@ class QubitI18nConsolidatedExtract extends sfI18nApplicationExtract
               break;
 
             case 'QubitSetting':
-              $values = $item['value'];
+              if (in_array($item['scope'], QubitSetting::$translatableScopes))
+              {
+                $values = $item['value'];
+              }
+
               break;
           }
 

--- a/lib/model/QubitSetting.php
+++ b/lib/model/QubitSetting.php
@@ -38,7 +38,11 @@ class QubitSetting extends BaseSetting
       'disallow_master'       => 0,
       'disallow_reference'    => 0,
       'disallow_thumb'        => 0
-    );
+    ),
+    // List of scopes with translatable settings,
+    // QubitI18nConsolidatedExtract checks this array to add those
+    // settings value from /data/fixtures/settings.yml to the XLIFF files
+    $translatableScopes = array('ui_label');
 
   public function __toString()
   {


### PR DESCRIPTION
Extract only translatable settings from /data/fixtures/settings.yml
to the XLIFF files.

- Add array of translatable scopes in QubitSetting
- Add scope check in QubitI18nConsolidatedExtract
- Remove unneeded translations in /data/fixtures/settings.yml