### PR TITLE
Fix exportCsv referer issue, refs #10174

### DIFF
--- a/apps/qubit/modules/informationobject/actions/exportCsvAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/exportCsvAction.class.php
@@ -71,6 +71,14 @@ class InformationObjectExportCsvAction extends sfAction
       $this->getUser()->setFlash('notice', $message);
     }
 
-    $this->redirect($request->getHttpHeader('referer'));
+    // If referer URL is valid, redirect to it... otherwise, redirect to the information objects browse page)
+    if (filter_var($request->getHttpHeader('referer'), FILTER_VALIDATE_URL) === true)
+    {
+      $this->redirect($request->getHttpHeader('referer'));
+    }
+    else
+    {
+      $this->redirect($this->context->routing->generate(null, array(null, 'module' => 'informationobject', 'action' => 'browse')));
+    }
   }
 }


### PR DESCRIPTION
The exportCsv page (informationobject/exportCsv) was generating a 500 if
visited directly from the browser because it always tries to redirect to
a referer. Fixed by making sure the referer is a valid URL before
redirecting (otherwise redirecting to the information objects browse
page.)