### PR TITLE
Warning translation and CSS fixes, refs #10473

### DIFF
--- a/apps/qubit/templates/_header.php
+++ b/apps/qubit/templates/_header.php
@@ -1,8 +1,8 @@
 <?php echo get_component('default', 'updateCheck') ?>
 
 <?php if ($sf_user->isAdministrator() && (string)QubitSetting::getByName('siteBaseUrl') === ''): ?>
-  <div id="update-check">
-    <?php echo link_to('Please configure your site base URL', 'settings/siteInformation', array('rel' => 'home', 'title' => __('Home'))) ?>
+  <div class="site-warning">
+    <?php echo link_to(__('Please configure your site base URL'), 'settings/siteInformation', array('rel' => 'home', 'title' => __('Home'))) ?>
   </div>
 <?php endif; ?>
 

--- a/plugins/arDominionPlugin/css/less/scaffolding.less
+++ b/plugins/arDominionPlugin/css/less/scaffolding.less
@@ -1507,7 +1507,7 @@ body.login #content {
 
 // Update check
 
-#update-check {
+#update-check, .site-warning {
   background-color: #ff8800;
   color: @black;
   border-bottom: 1px solid @gray;


### PR DESCRIPTION
* Wrapped warning, when base URL not set, with translation helper
* Changed CSS specifier used for warning to a class instead of an ID