### PR TITLE
Improve sorting options to term page, refs #10958

### DIFF
--- a/apps/qubit/modules/term/templates/indexSuccess.php
+++ b/apps/qubit/modules/term/templates/indexSuccess.php
@@ -254,11 +254,12 @@
           <?php endif; ?>
 
         <div id="sort-header">
-          <?php echo get_partial('default/sortPicker',
-            array(
-              'options' => array(
-                'lastUpdated' => __('Most recent'),
-                'alphabetic' => __('Alphabetic')))) ?>
+          <?php echo get_partial('default/sortPicker', array(
+            'options' => array(
+              'lastUpdated' => __('Most recent'),
+              'alphabetic'  => __('Alphabetic'),
+              'identifier'  => __('Reference code'),
+              'date'        => __('Date')))) ?>
         </div>
 
     </section>


### PR DESCRIPTION
Added sort by date and reference code when on a term page that has linked
archival description results.