### PR TITLE
Fix edit phys. storage cancel button, refs #10077

### DIFF
--- a/apps/qubit/modules/physicalobject/templates/editSuccess.php
+++ b/apps/qubit/modules/physicalobject/templates/editSuccess.php
@@ -39,8 +39,10 @@
       <ul>
         <?php if (null !== $next = $form->getValue('next')): ?>
           <li><?php echo link_to(__('Cancel'), $next, array('class' => 'c-btn')) ?></li>
-        <?php else: ?>
+        <?php elseif (isset($sf_request->getAttribute('sf_route')->resource)): ?>
           <li><?php echo link_to(__('Cancel'), array($resource, 'module' => 'physicalobject'), array('class' => 'c-btn')) ?></li>
+        <?php else: ?>
+          <li><?php echo link_to(__('Cancel'), array('module' => 'physicalobject', 'action' => 'browse'), array('class' => 'c-btn')) ?></li>
         <?php endif; ?>
         <li><input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Save') ?>"/></li>
       </ul>


### PR DESCRIPTION
Redirect to physical storage browse page when canceling a new creation