### PR TITLE
Term delete skip nested set option, refs #10962

### DIFF
--- a/lib/model/QubitTerm.php
+++ b/lib/model/QubitTerm.php
@@ -303,6 +303,7 @@ class QubitTerm extends BaseTerm
     {
       foreach ($children as $child)
       {
+        $child->disableNestedSetUpdating = $this->disableNestedSetUpdating;
         $child->delete($connection);
       }
     }
@@ -336,7 +337,24 @@ class QubitTerm extends BaseTerm
 
     QubitSearch::getInstance()->delete($this);
 
-    parent::delete($connection);
+    // Replicate parent class delete functionality, skipping nested set updating
+    if ($this->disableNestedSetUpdating === true)
+    {
+      if ($this->deleted)
+      {
+        throw new PropelException('This object has already been deleted.');
+      }
+
+      $this->clear();
+
+      // Call grandparent's delete method
+      $reflectionMethod = new ReflectionMethod(get_parent_class(get_parent_class($this)), 'delete');
+      $reflectionMethod->invoke($this);
+    }
+    else
+    {
+      parent::delete($connection);
+    }
   }
 
   public function getRole()


### PR DESCRIPTION
Added the ability to, when programatically deleting a term node, set the
disableNestedSetUpdating to true so the nested set isn't updated during
the delete. This allows much faster batch deletion of terms and the nested
set can be updated manually afterwards.