### PR TITLE
Add FW treeview display settings, refs #10909

### DIFF
--- a/apps/qubit/modules/informationobject/actions/fullWidthTreeViewAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/fullWidthTreeViewAction.class.php
@@ -42,16 +42,37 @@ class InformationObjectFullWidthTreeViewAction extends sfAction
       QubitAcl::forwardUnauthorized();
     }
 
+    // Get show identifier setting to prepare the reference code if necessary
+    $this->showIdentifier = sfConfig::get('app_treeview_show_identifier', 'no');
+    $baseReferenceCode = '';
+
     // On first load, retrieve the ancestors of the selected resource, the resource
     // and its children, otherwise get only the resource's children
     if (filter_var($request->getParameter('firstLoad', false), FILTER_VALIDATE_BOOLEAN)
       && null !== $collectionRoot = $this->resource->getCollectionRoot())
     {
-      $data = $this->getNodeOrChildrenNodes($collectionRoot->id);
+      if ($this->showIdentifier === 'referenceCode')
+      {
+        // On first load, get the base reference code from the ORM
+        $baseReferenceCode = $collectionRoot->getInheritedReferenceCode();
+      }
+
+      $data = $this->getNodeOrChildrenNodes($collectionRoot->id, $baseReferenceCode);
     }
     else
     {
-      $data = $this->getNodeOrChildrenNodes($this->resource->id, $children = true);
+      if ($this->showIdentifier === 'referenceCode')
+      {
+        // Try to get the resource's reference code from the request
+        $baseReferenceCode = $request->getParameter('referenceCode');
+        if (empty($baseReferenceCode))
+        {
+          // Or get it from the ORM
+          $baseReferenceCode = $this->resource->getInheritedReferenceCode();
+        }
+      }
+
+      $data = $this->getNodeOrChildrenNodes($this->resource->id, $baseReferenceCode, $children = true);
     }
 
     $this->getResponse()->setContentType('application/json');
@@ -59,9 +80,10 @@ class InformationObjectFullWidthTreeViewAction extends sfAction
     return $this->renderText(json_encode($data));
   }
 
-  protected function getNodeOrChildrenNodes($id, $children = false)
+  protected function getNodeOrChildrenNodes($id, $baseReferenceCode, $children = false)
   {
     $i18n = sfContext::getInstance()->i18n;
+    $culture = $this->getUser()->getCulture();
     $untitled = $i18n->__('Untitled');
 
     // Remove drafts for unauthenticated users
@@ -73,6 +95,7 @@ class InformationObjectFullWidthTreeViewAction extends sfAction
     $sql = "SELECT
       io.id, io.lft, io.rgt,
       io.source_culture,
+      io.identifier,
       current_i18n.title AS current_title,
       IFNULL(source_i18n.title, '<i>$untitled</i>') as text,
       io.parent_id AS parent,
@@ -94,7 +117,7 @@ class InformationObjectFullWidthTreeViewAction extends sfAction
       ORDER BY io.lft;";
 
     $params = array(
-      ':culture' => $this->getUser()->getCulture(),
+      ':culture' => $culture,
       ':pubStatus' => QubitTerm::STATUS_TYPE_PUBLICATION_ID,
       ':id' => $id
     );
@@ -110,10 +133,74 @@ class InformationObjectFullWidthTreeViewAction extends sfAction
         $result['text'] = $result['current_title'];
       }
 
-      $result['a_attr']['title'] = $result['text'];
-      $result['a_attr']['href'] = $this->generateUrl('slug', array('slug' => $result['slug']));
+      // Add identifier based on setting
+      if ($this->showIdentifier === 'identifier' && !empty($result['identifier']))
+      {
+        $result['text'] = "{$result['identifier']} - {$result['text']}";
+      }
 
-      $result['text'] = "<u>{$result['lod']}</u> {$result['text']}";
+      // Add reference code based on setting
+      if ($this->showIdentifier === 'referenceCode' && !empty($baseReferenceCode))
+      {
+        // Add reference code to the result so it can be sent in subsequent requests
+        $result['referenceCode'] = $baseReferenceCode;
+
+        // Append result identifier to the base reference code if we're not loading the collection root
+        if ($result['parent'] != QubitInformationObject::ROOT_ID && !empty($result['identifier']))
+        {
+          $result['referenceCode'] = $result['referenceCode'] . sfConfig::get('app_separator_character', '-') . $result['identifier'];
+        }
+
+        $result['text'] = "{$result['referenceCode']} - {$result['text']}";
+      }
+
+      // Add level of description based on setting
+      if (sfConfig::get('app_treeview_show_level_of_description', 'yes') === 'yes' && strlen($result['lod']) > 0)
+      {
+        $result['text'] = "[{$result['lod']}] {$result['text']}";
+      }
+
+      // Add dates based on setting
+      if (sfConfig::get('app_treeview_show_dates', 'no') === 'yes')
+      {
+        $sql = "SELECT
+          event.start_date, event.end_date,
+          current_i18n.date AS display_date,
+          source_i18n.date AS source_date
+          FROM
+            event
+            LEFT JOIN event_i18n current_i18n ON event.id = current_i18n.id AND current_i18n.culture = :culture
+            LEFT JOIN event_i18n source_i18n ON event.id = source_i18n.id AND source_i18n.culture = event.source_culture
+          WHERE
+            event.object_id = :id;";
+
+        $params = array(
+          ':culture' => $culture,
+          ':id' => $result['id']
+        );
+
+        $events = QubitPdo::fetchAll($sql, $params, array('fetchMode' => PDO::FETCH_ASSOC));
+
+        // As in the search results from ES, get the first event with any date
+        foreach ($events as $event)
+        {
+          if (empty($event['display_date']))
+          {
+            $event['display_date'] = $event['source_date'];
+          }
+
+          if (empty($event['display_date']) && empty($event['start_date']) && empty($event['end_date']))
+          {
+            continue;
+          }
+
+          $date = Qubit::renderDateStartEnd($event['display_date'], $event['start_date'], $event['end_date']);
+          $result['text'] = "{$result['text']} ({$date})";
+
+          break;
+        }
+      }
+
       if ($result['status_id'] == QubitTerm::PUBLICATION_STATUS_DRAFT_ID)
       {
         $result['text'] = "({$result['status']}) {$result['text']}";
@@ -132,6 +219,10 @@ class InformationObjectFullWidthTreeViewAction extends sfAction
         $result['icon'] = 'fa fa-archive';
       }
 
+      // Add node link attributes
+      $result['a_attr']['title'] = $result['text'];
+      $result['a_attr']['href'] = $this->generateUrl('slug', array('slug' => $result['slug']));
+
       // Set children to true for lazy loading or, if we are loading
       // an ancestor of the resource or the resource, load all children
       if ($result['rgt'] - $result['lft'] > 1)
@@ -140,12 +231,18 @@ class InformationObjectFullWidthTreeViewAction extends sfAction
 
         if ($result['lft'] <= $this->resource->lft && $result['rgt'] >= $this->resource->rgt)
         {
-          $result['children'] = $this->getNodeOrChildrenNodes($result['id'], $children = true);
+          $refCode = '';
+          if (!empty($result['referenceCode']))
+          {
+            $refCode = $result['referenceCode'];
+          }
+
+          $result['children'] = $this->getNodeOrChildrenNodes($result['id'], $refCode, $children = true);
         }
       }
 
       // Not used currently
-      $unset = array('lft', 'rgt', 'parent', 'lod', 'status', 'status_id', 'slug', 'source_culture', 'current_title');
+      $unset = array('lft', 'rgt', 'parent', 'lod', 'status', 'status_id', 'slug', 'source_culture', 'current_title', 'identifier');
 
       $data[] = array_diff_key($result, array_flip($unset));
     }

--- a/apps/qubit/modules/settings/actions/globalAction.class.php
+++ b/apps/qubit/modules/settings/actions/globalAction.class.php
@@ -79,8 +79,6 @@ class SettingsGlobalAction extends sfAction
     $accessionCounter = QubitSetting::getByName('accession_counter');
     $separatorCharacter = QubitSetting::getByName('separator_character');
     $inheritCodeInformationObject = QubitSetting::getByName('inherit_code_informationobject');
-    $treeviewType = QubitSetting::getByName('treeview_type');
-    $sortTreeviewInformationObject = QubitSetting::getByName('sort_treeview_informationobject');
     $sortBrowserUser = QubitSetting::getByName('sort_browser_user');
     $sortBrowserAnonymous = QubitSetting::getByName('sort_browser_anonymous');
     $defaultRepositoryView = QubitSetting::getByName('default_repository_browse_view');
@@ -109,8 +107,6 @@ class SettingsGlobalAction extends sfAction
       'accession_counter' => (isset($accessionCounter)) ? intval($accessionCounter->getValue(array('sourceCulture'=>true))) : 1,
       'separator_character' => (isset($separatorCharacter)) ? $separatorCharacter->getValue(array('sourceCulture'=>true)) : null,
       'inherit_code_informationobject' => (isset($inheritCodeInformationObject)) ? intval($inheritCodeInformationObject->getValue(array('sourceCulture'=>true))) : 1,
-      'treeview_type' => (isset($treeviewType)) ? $treeviewType->getValue(array('sourceCulture'=>true)) : 'sidebar',
-      'sort_treeview_informationobject' => (isset($sortTreeviewInformationObject)) ? $sortTreeviewInformationObject->getValue(array('sourceCulture'=>true)) : 0,
       'sort_browser_user' => (isset($sortBrowserUser)) ? $sortBrowserUser->getValue(array('sourceCulture'=>true)) : 0,
       'sort_browser_anonymous' => (isset($sortBrowserAnonymous)) ? $sortBrowserAnonymous->getValue(array('sourceCulture'=>true)) : 0,
       'default_repository_browse_view' => (isset($defaultRepositoryView)) ? $defaultRepositoryView->getValue(array('sourceCulture' => true)) : 'card',
@@ -234,26 +230,6 @@ class SettingsGlobalAction extends sfAction
 
        // Force sourceCulture update to prevent discrepency in settings between cultures
       $setting->setValue($inheritCodeInformationObjectValue, array('sourceCulture'=>true));
-      $setting->save();
-    }
-
-    // Treeview type
-    if (null !== $treeviewType = $thisForm->getValue('treeview_type'))
-    {
-      $setting = QubitSetting::getByName('treeview_type');
-
-       // Force sourceCulture update to prevent discrepency in settings between cultures
-      $setting->setValue($treeviewType, array('sourceCulture'=>true));
-      $setting->save();
-    }
-
-    // Sort Treeview (Information Object)
-    if (null !== $sortTreeviewInformationObjectValue = $thisForm->getValue('sort_treeview_informationobject'))
-    {
-      $setting = QubitSetting::getByName('sort_treeview_informationobject');
-
-       // Force sourceCulture update to prevent discrepency in settings between cultures
-      $setting->setValue($sortTreeviewInformationObjectValue, array('sourceCulture'=>true));
       $setting->save();
     }
 

--- a/apps/qubit/modules/settings/actions/menuComponent.class.php
+++ b/apps/qubit/modules/settings/actions/menuComponent.class.php
@@ -75,6 +75,10 @@ class SettingsMenuComponent extends sfComponent
       array(
         'label' => $i18n->__('DIP upload'),
         'action' => 'dipUpload'
+      ),
+      array(
+        'label' => $i18n->__('Treeview'),
+        'action' => 'treeview'
       )
     );
 

--- a/apps/qubit/modules/settings/actions/treeviewAction.class.php
+++ b/apps/qubit/modules/settings/actions/treeviewAction.class.php
@@ -1,0 +1,174 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class SettingsTreeviewAction extends DefaultEditAction
+{
+  // Arrays not allowed in class constants
+  public static
+    $NAMES = array(
+      'type',
+      'ioSort',
+      'showIdentifier',
+      'showLevelOfDescription',
+      'showDates');
+
+  protected function earlyExecute()
+  {
+    $this->i18n = sfContext::getInstance()->i18n;
+  }
+
+  protected function addField($name)
+  {
+    switch ($name)
+    {
+      case 'type':
+        $this->typeSetting = QubitSetting::getByName('treeview_type');
+        $default = 'sidebar';
+        $options = array(
+          'sidebar' => $this->i18n->__('Sidebar'),
+          'fullWidth' => $this->i18n->__('Full width'));
+
+        $this->addSettingRadioButtonsField($this->typeSetting, $name, $default, $options);
+
+        break;
+
+      case 'ioSort':
+        $this->ioSortSetting = QubitSetting::getByName('sort_treeview_informationobject');
+        $default = 'none';
+        $options = array(
+          'none' => $this->i18n->__('Manual'),
+          'title' => $this->i18n->__('Title'),
+          'identifierTitle' => $this->i18n->__('Identifier - Title'));
+
+        $this->addSettingRadioButtonsField($this->ioSortSetting, $name, $default, $options);
+
+        break;
+
+      case 'showIdentifier':
+        $this->showIdentifierSetting = QubitSetting::getByName('treeview_show_identifier');
+        $default = 'no';
+        $options = array(
+          'no' => $this->i18n->__('No'),
+          'identifier' => $this->i18n->__('Identifier'),
+          'referenceCode' => $this->i18n->__('Inherit reference code'));
+
+        $this->addSettingRadioButtonsField($this->showIdentifierSetting, $name, $default, $options);
+
+        break;
+
+      case 'showLevelOfDescription':
+        $this->showLevelOfDescriptionSetting = QubitSetting::getByName('treeview_show_level_of_description');
+        $default = 'yes';
+        $options = array(
+          'no' => $this->i18n->__('No'),
+          'yes' => $this->i18n->__('Yes'));
+
+        $this->addSettingRadioButtonsField($this->showLevelOfDescriptionSetting, $name, $default, $options);
+
+        break;
+
+      case 'showDates':
+        $this->showDatesSetting = QubitSetting::getByName('treeview_show_dates');
+        $default = 'no';
+        $options = array(
+          'no' => $this->i18n->__('No'),
+          'yes' => $this->i18n->__('Yes'));
+
+        $this->addSettingRadioButtonsField($this->showDatesSetting, $name, $default, $options);
+
+        break;
+    }
+  }
+
+  private function addSettingRadioButtonsField($setting, $fieldName, $default, $options)
+  {
+    if (isset($setting))
+    {
+      $default = $setting->getValue(array('sourceCulture' => true));
+    }
+
+    $this->form->setDefault($fieldName, $default);
+    $this->form->setValidator($fieldName, new sfValidatorString(array('required' => false)));
+    $this->form->setWidget($fieldName, new sfWidgetFormSelectRadio(array('choices' => $options), array('class' => 'radio')));
+  }
+
+
+  protected function processField($field)
+  {
+    switch ($field->getName())
+    {
+      case 'type':
+        $this->createOrUpdateSetting($this->typeSetting, 'treeview_type', $field->getValue());
+
+        break;
+
+      case 'ioSort':
+        $this->createOrUpdateSetting($this->ioSortSetting, 'sort_treeview_informationobject', $field->getValue());
+
+        break;
+
+      case 'showIdentifier':
+        $this->createOrUpdateSetting($this->showIdentifierSetting, 'treeview_show_identifier', $field->getValue());
+
+        break;
+
+      case 'showLevelOfDescription':
+        $this->createOrUpdateSetting($this->showLevelOfDescriptionSetting, 'treeview_show_level_of_description', $field->getValue());
+
+        break;
+
+      case 'showDates':
+        $this->createOrUpdateSetting($this->showDatesSetting, 'treeview_show_dates', $field->getValue());
+
+        break;
+    }
+  }
+
+  private function createOrUpdateSetting($setting, $name, $value)
+  {
+    if (!isset($setting))
+    {
+      $setting = new QubitSetting;
+      $setting->name = $name;
+      $setting->sourceCulture = 'en';
+    }
+
+    $setting->setValue($value, array('culture' => 'en'));
+    $setting->save();
+  }
+
+  public function execute($request)
+  {
+    parent::execute($request);
+
+    if ($request->isMethod('post'))
+    {
+      $this->form->bind($request->getPostParameters());
+
+      if ($this->form->isValid())
+      {
+        $this->processForm();
+
+        QubitCache::getInstance()->removePattern('settings:i18n:*');
+
+        $this->redirect(array('module' => 'settings', 'action' => 'treeview'));
+      }
+    }
+  }
+}

--- a/apps/qubit/modules/settings/config/view.yml
+++ b/apps/qubit/modules/settings/config/view.yml
@@ -5,3 +5,6 @@ all:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/form:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/tableheader:
 
+treeviewSuccess:
+  javascripts:
+    description:

--- a/apps/qubit/modules/settings/templates/treeviewSuccess.php
+++ b/apps/qubit/modules/settings/templates/treeviewSuccess.php
@@ -1,0 +1,80 @@
+<?php decorate_with('layout_2col.php') ?>
+
+<?php slot('sidebar') ?>
+
+  <?php echo get_component('settings', 'menu') ?>
+
+<?php end_slot() ?>
+
+<?php slot('title') ?>
+
+  <h1><?php echo __('Treeview settings') ?></h1>
+
+<?php end_slot() ?>
+
+<?php slot('content') ?>
+
+  <?php echo $form->renderFormTag(url_for(array('module' => 'settings', 'action' => 'treeview'))) ?>
+
+    <div id="content">
+
+      <fieldset class="collapsible">
+
+        <legend><?php echo __('General') ?></legend>
+
+        <?php echo $form->type
+          ->label(__('Type'))
+          ->renderRow() ?>
+
+      </fieldset>
+
+      <fieldset class="collapsible">
+
+        <legend><?php echo __('Sidebar') ?></legend>
+
+        <?php echo $form->ioSort
+          ->label(__('Sort (information object)'))
+          ->help(__('Determines whether to sort siblings in the information object treeview control and, if so, what sort criteria to use'))
+          ->renderRow() ?>
+
+      </fieldset>
+
+      <fieldset class="collapsible">
+
+        <legend><?php echo __('Full width') ?></legend>
+
+        <div class="row">
+
+          <div class="span3">
+            <?php echo $form->showIdentifier
+              ->label(__('Show identifier'))
+              ->renderRow() ?>
+          </div>
+
+          <div class="span3">
+            <?php echo $form->showLevelOfDescription
+              ->label(__('Show level of description'))
+              ->renderRow() ?>
+          </div>
+
+          <div class="span2">
+            <?php echo $form->showDates
+              ->label(__('Show dates'))
+              ->renderRow() ?>
+          </div>
+
+        </div>
+
+      </fieldset>
+
+    </div>
+
+    <section class="actions">
+      <ul>
+        <li><input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Save') ?>"/></li>
+      </ul>
+    </section>
+
+  </form>
+
+<?php end_slot() ?>

--- a/js/fullWidthTreeView.js
+++ b/js/fullWidthTreeView.js
@@ -54,7 +54,7 @@
           'data': function (node) {
             return node.id === '#' ?
               {'firstLoad': true} :
-              {'firstLoad': false};
+              {'firstLoad': false, 'referenceCode': node.original.referenceCode};
           }
         }
       }

--- a/lib/form/SettingsGlobalForm.class.php
+++ b/lib/form/SettingsGlobalForm.class.php
@@ -48,8 +48,6 @@ class SettingsGlobalForm extends sfForm
       'accession_counter' => new sfWidgetFormInput,
       'separator_character' => new sfWidgetFormInput(array(), array('maxlength' => 1)),
       'inherit_code_informationobject' => new sfWidgetFormSelectRadio(array('choices' => array(1 => 'yes', 0 => 'no')), array('class' => 'radio')),
-      'treeview_type' => new sfWidgetFormSelectRadio(array('choices' => array('sidebar' => $this->i18n->__('Sidebar'), 'fullWidth' => $this->i18n->__('Full width'))), array('class' => 'radio')),
-      'sort_treeview_informationobject' => new sfWidgetFormSelectRadio(array('choices' => array('none' => 'manual', 'title' => 'title', 'identifierTitle' => 'identifier - title')), array('class' => 'radio')),
       'sort_browser_user' => new sfWidgetFormSelectRadio(array('choices' => array('alphabetic' => 'alphabetic', 'lastUpdated' => 'last updated', 'identifier' => 'identifier', 'referenceCode' => $this->i18n->__('reference code'))), array('class' => 'radio')),
       'sort_browser_anonymous' => new sfWidgetFormSelectRadio(array('choices' => array('alphabetic' => 'alphabetic', 'lastUpdated' => 'last updated', 'identifier' => 'identifier', 'referenceCode' => $this->i18n->__('reference code'))), array('class' => 'radio')),
       'default_repository_browse_view' => new sfWidgetFormSelectRadio(array('choices' => array('card' => $this->i18n->__('card'), 'table' => $this->i18n->__('table'))), array('class' => 'radio')),
@@ -80,8 +78,6 @@ class SettingsGlobalForm extends sfForm
       'accession_counter' => $this->i18n->__('Accession counter'),
       'separator_character' => $this->i18n->__('Reference code separator'),
       'inherit_code_informationobject' => $this->i18n->__('Inherit reference code (information object)'),
-      'treeview_type' => $this->i18n->__('Treeview type'),
-      'sort_treeview_informationobject' => $this->i18n->__('Sort treeview (information object)'),
       'sort_browser_user' => $this->i18n->__('Sort browser (users)'),
       'sort_browser_anonymous' => $this->i18n->__('Sort browser (anonymous)'),
       'default_repository_browse_view' => $this->i18n->__('Default repository browse view'),
@@ -115,7 +111,6 @@ class SettingsGlobalForm extends sfForm
       'default_archival_description_browse_view' => $this->i18n->__('Set the default view template when browsing archival descriptions'),
       'separator_character' => $this->i18n->__('The character separating hierarchical elements in a reference code'),
       'inherit_code_informationobject' => $this->i18n->__('When set to &quot;yes&quot;, the reference code string will be built using the information object identifier plus the identifiers of all its ancestors'),
-      'sort_treeview_informationobject' => $this->i18n->__('Determines whether to sort siblings in the information object treeview control and, if so, what sort criteria to use'),
       'multi_repository' => $this->i18n->__('When set to &quot;no&quot;, the repository name is excluded from certain displays because it will be too repetitive'),
       'enable_institutional_scoping' => $this->i18n->__('Applies to multi-repository sites only. When set to &quot;yes&quot;, additional search and browse options will be available at the repository level'),
       'repository_quota' => $this->i18n->__('Default %1% upload limit for a new %2%.  A value of &quot;0&quot; (zero) disables file upload.  A value of &quot;-1&quot; allows unlimited uploads', array('%1%' => strtolower(sfConfig::get('app_ui_label_digitalobject')), '%2%' => strtolower(sfConfig::get('app_ui_label_repository')))),
@@ -161,8 +156,6 @@ class SettingsGlobalForm extends sfForm
     $this->validatorSchema['separator_character'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['accession_counter'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['inherit_code_informationobject'] = new sfValidatorInteger(array('required' => false));
-    $this->validatorSchema['treeview_type'] = new sfValidatorString(array('required' => false));
-    $this->validatorSchema['sort_treeview_informationobject'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['sort_browser_user'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['sort_browser_anonymous'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['multi_repository'] = new sfValidatorInteger(array('required' => false));


### PR DESCRIPTION
Add new settings to choose what is displayed in the full width treeview nodes,
available options are: identifier/referenceCode/none, LoD yes/no, dates yes/no.

All treeview settings have been relocated to a new setting page.

Redmine: https://projects.artefactual.com/issues/10909