### PR TITLE
Fix term-related io results sorting, refs #10958

### DIFF
--- a/apps/qubit/modules/term/actions/indexAction.class.php
+++ b/apps/qubit/modules/term/actions/indexAction.class.php
@@ -275,11 +275,17 @@ EOF;
 
         switch ($request->sort)
         {
-          // I don't think that this is going to scale, but let's leave it for now
+          case 'referenceCode':
+            $this->search->query->setSort(array('referenceCode.untouched' => 'asc'));
+            break;
+
           case 'alphabetic':
             $field = sprintf('i18n.%s.title.untouched', $this->culture);
             $this->search->query->setSort(array($field => 'asc'));
+            break;
 
+          case 'date':
+            $this->search->query->setSort(array('dates.startDate' => 'asc'));
             break;
 
           case 'lastUpdated':

--- a/apps/qubit/modules/term/templates/indexSuccess.php
+++ b/apps/qubit/modules/term/templates/indexSuccess.php
@@ -258,7 +258,7 @@
             'options' => array(
               'lastUpdated' => __('Most recent'),
               'alphabetic'  => __('Alphabetic'),
-              'identifier'  => __('Reference code'),
+              'referenceCode'  => __('Reference code'),
               'date'        => __('Date')))) ?>
         </div>
 


### PR DESCRIPTION
The previous work to sort info objects related to terms by reference code or
date was missing some logic in the controller--this commit adds the proper
logic to do it.