### PR TITLE
Skip objects during XML cache export. refs #11002

### DIFF
--- a/lib/QubitInformationObjectXmlCache.class.php
+++ b/lib/QubitInformationObjectXmlCache.class.php
@@ -81,12 +81,17 @@ class QubitInformationObjectXmlCache
    *
    * @return null
    */
-  public function exportAll()
+  public function exportAll($options = array())
   {
+    $skip = isset($options['skip']) ? $options['skip'] : 0;
+
     // Get not-root and published information objects
     $criteria = new Criteria;
     $criteria->add(QubitInformationObject::ID, QubitInformationObject::ROOT_ID, Criteria::NOT_EQUAL);
     $criteria = QubitAcl::addFilterDraftsCriteria($criteria);
+    $criteria->addAscendingOrderByColumn(QubitInformationObject::ID); // sort so optional skip will be consistent
+    $criteria->setOffset($skip);
+
     $results = QubitInformationObject::get($criteria);
 
     $exporting = 0;

--- a/lib/task/arCacheDescriptionXmlTask.class.php
+++ b/lib/task/arCacheDescriptionXmlTask.class.php
@@ -31,7 +31,9 @@ class arCacheDescriptionXmlTask extends arBaseTask
     $this->addOptions(array(
       new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', 'qubit'),
       new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
-      new sfCommandOption('connection', null, sfCommandOption::PARAMETER_REQUIRED, 'The connection name', 'propel')));
+      new sfCommandOption('connection', null, sfCommandOption::PARAMETER_REQUIRED, 'The connection name', 'propel'),
+      new sfCommandOption('skip', null, sfCommandOption::PARAMETER_OPTIONAL, 'Numble of information objects to skip', 0)
+    ));
 
     $this->namespace = 'cache';
     $this->name = 'xml-representations';
@@ -45,16 +47,16 @@ EOF;
   public function execute($arguments = array(), $options = array())
   {
     parent::execute($arguments, $options);
-    $this->exportAll();
+    $this->exportAll($options);
   }
 
-  private function exportAll()
+  private function exportAll($options)
   {
     $logger = new sfCommandLogger(new sfEventDispatcher);
     $logger->log('Caching XML representations of information objects...');
 
     $cache = new QubitInformationObjectXmlCache(array('logger' => $logger));
-    $cache->exportAll();
+    $cache->exportAll(array('skip' => $options['skip']));
 
     $logger->log('Done.');
   }


### PR DESCRIPTION
Added an option to the cache::xml-representations CLI task to optionally skip
information objects during export. This allows interrupted or aborted exports
to be resumed.