### PR TITLE
Sidebar treeview quick search fixes, refs #10173

### DIFF
--- a/apps/qubit/modules/informationobject/templates/_treeView.php
+++ b/apps/qubit/modules/informationobject/templates/_treeView.php
@@ -13,7 +13,7 @@
   </li>
 </ul>
 
-<div id="treeview" data-current-id="<?php echo $resource->id ?>" data-sortable="<?php echo $sortable ? 'true' : 'false' ?>">
+<div id="treeview" data-current-id="<?php echo $resource->id ?>" data-sortable="<?php echo empty($sortable) ? 'false' : 'true' ?>">
 
   <?php if ($treeviewType == 'sidebar'): ?>
 

--- a/apps/qubit/modules/search/actions/indexAction.class.php
+++ b/apps/qubit/modules/search/actions/indexAction.class.php
@@ -69,7 +69,7 @@ class SearchIndexAction extends DefaultBrowseAction
       return;
     }
 
-    sfContext::getInstance()->getConfiguration()->loadHelpers(array('Url', 'Escaping'));
+    sfContext::getInstance()->getConfiguration()->loadHelpers(array('Url', 'Escaping', 'Qubit'));
 
     $response = array('results' => array());
     foreach ($resultSet->getResults() as $item)
@@ -79,7 +79,7 @@ class SearchIndexAction extends DefaultBrowseAction
 
       $result = array(
         'url' => url_for(array('module' => 'informationobject', 'slug' => $data['slug'])),
-        'title' => esc_specialchars($data['i18n'][$this->context->user->getCulture()]['title']),
+        'title' => esc_specialchars(get_search_i18n($data, 'title', array('allowEmpty' => false))),
         'identifier' => isset($data['identifier']) && !empty($data['identifier']) ? esc_specialchars($data['identifier']).' - ' : '',
         'level' => null !== $levelOfDescription ? esc_specialchars($levelOfDescription->getName()) : '');
 

--- a/plugins/arDominionPlugin/css/less/treeview.less
+++ b/plugins/arDominionPlugin/css/less/treeview.less
@@ -24,7 +24,6 @@
 
 #treeview {
   max-height: 480px;
-  margin-bottom: 10px;
   overflow: auto;
   overflow-x: hidden;
   background-color: #eee;


### PR DESCRIPTION
- Add culture fallback in results title
- Avoid warning when treeview is set to full-width mode
- Remove treeview margin