### PR TITLE
Fix "Use For" label for browsing terms ref #10949

### DIFF
--- a/apps/qubit/modules/taxonomy/templates/indexSuccess.php
+++ b/apps/qubit/modules/taxonomy/templates/indexSuccess.php
@@ -75,7 +75,16 @@
             <?php endif; ?>
 
             <?php if (isset($doc['useFor']) && count($doc['useFor']) > 0): ?>
-              <p><?php echo 'Use for: '.get_search_i18n(array_pop($doc['useFor']), 'name', array('allowEmpty' => false)) ?><?php foreach ($doc['useFor'] as $label): ?><?php echo ', '.get_search_i18n($label, 'name', true, false) ?><?php endforeach; ?></p>
+              <p>
+                <?php $labels = array() ?>
+                <?php echo __('Use for: ') ?>
+
+                <?php foreach ($doc['useFor'] as $label): ?>
+                  <?php $labels[] = get_search_i18n($label, 'name', array('allowEmpty' => false)) ?>
+                <?php endforeach; ?>
+
+                <?php echo implode(', ', $labels) ?>
+              </p>
             <?php endif; ?>
 
           </td><td>


### PR DESCRIPTION
The code was incorrect when rendering the "Use For" alternative labels when
browsing terms. It'd always show "Untitled" before if you ever displayed a
term's Use For label(s).