### PR TITLE
OAI resumption token issue fix, refs #11042

### DIFF
--- a/plugins/arOaiPlugin/lib/arOaiPluginComponent.class.php
+++ b/plugins/arOaiPlugin/lib/arOaiPluginComponent.class.php
@@ -111,7 +111,7 @@ abstract class arOaiPluginComponent extends sfComponent
     $extraOptions = array(
       'from'   => $this->from,
       'until'  => $this->until,
-      'cursor' => $this->cursor,
+      'offset' => $this->cursor,
       'limit' => QubitSetting::getByName('resumption_token_limit')->__toString(),
       'set' => $oaiSet);
 


### PR DESCRIPTION
Fixed issue with an incorrectly named parameter causing OAI resumption tokens not to work.