### PR TITLE
Dev/issue 9970 job schema fix

### DIFF
--- a/config/schema.yml
+++ b/config/schema.yml
@@ -48,10 +48,10 @@ propel:
     id: { type: integer, required: true, primaryKey: true, foreignTable: object, foreignReference: id, onDelete: cascade, inheritanceKey: true }
     name: varchar(255)
     download_path: longvarchar
-    status_id: { type: integer, required: true }
     completed_at: timestamp
     user_id: { type: integer, required: false, foreignTable: user, foreignReference: id, onDelete: setnull  }
     object_id: { type: integer, require: false, foreignTable: object, foreignReference: id, onDelete: setnull }
+    status_id: { type: integer, required: false, foreignTable: term, foreignReference: id, onDelete: setnull }
     output: longvarchar
 
   contact_information:

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 149
+    value: 152
   milestone:
     name: milestone
     editable: 0

--- a/data/fixtures/taxonomyTerms.yml
+++ b/data/fixtures/taxonomyTerms.yml
@@ -1325,6 +1325,12 @@ QubitTaxonomy:
       sv: PREMIS-rättigheter
     note:
       en: 'Used to store Statute values when defining PREMIS rights statements with a statute Basis.'
+  QubitTaxonomy_job_status:
+    source_culture: en
+    id: 79
+    parent_id: QubitTaxonomy_root
+    name:
+      en: 'Job status'
 QubitTerm:
   QubitTerm_110:
     taxonomy_id: 30
@@ -10100,6 +10106,24 @@ QubitTerm:
     name:
       en: 'Credits note'
       es: 'Nota de créditos'
+  QubtTerm_job_status_in_progress:
+    taxonomy_id: QubitTaxonomy_job_status
+    id: 183
+    source_culture: en
+    name:
+      en: 'In progress'
+  QubtTerm_job_status_in_completed:
+    taxonomy_id: QubitTaxonomy_job_status
+    id: 184
+    source_culture: en
+    name:
+      en: 'Completed'
+  QubtTerm_job_status_error:
+    taxonomy_id: QubitTaxonomy_job_status
+    id: 185
+    source_culture: en
+    name:
+      en: 'Error'
 QubitNote:
   QubitNote_1:
     object_id: QubitTerm_111

--- a/data/sql/lib.model.schema.sql
+++ b/data/sql/lib.model.schema.sql
@@ -147,10 +147,10 @@ CREATE TABLE `job`
 	`id` INTEGER  NOT NULL,
 	`name` VARCHAR(255),
 	`download_path` TEXT,
-	`status_id` INTEGER  NOT NULL,
 	`completed_at` DATETIME,
 	`user_id` INTEGER,
 	`object_id` INTEGER,
+	`status_id` INTEGER,
 	`output` TEXT,
 	PRIMARY KEY (`id`),
 	CONSTRAINT `job_FK_1`
@@ -166,6 +166,11 @@ CREATE TABLE `job`
 	CONSTRAINT `job_FK_3`
 		FOREIGN KEY (`object_id`)
 		REFERENCES `object` (`id`)
+		ON DELETE SET NULL,
+	INDEX `job_FI_4` (`status_id`),
+	CONSTRAINT `job_FK_4`
+		FOREIGN KEY (`status_id`)
+		REFERENCES `term` (`id`)
 		ON DELETE SET NULL
 )Engine=InnoDB;
 

--- a/lib/model/map/JobTableMap.php
+++ b/lib/model/map/JobTableMap.php
@@ -39,10 +39,10 @@ class JobTableMap extends TableMap {
 		$this->addForeignPrimaryKey('ID', 'id', 'INTEGER' , 'object', 'ID', true, null, null);
 		$this->addColumn('NAME', 'name', 'VARCHAR', false, 255, null);
 		$this->addColumn('DOWNLOAD_PATH', 'downloadPath', 'LONGVARCHAR', false, null, null);
-		$this->addColumn('STATUS_ID', 'statusId', 'INTEGER', true, null, null);
 		$this->addColumn('COMPLETED_AT', 'completedAt', 'TIMESTAMP', false, null, null);
 		$this->addForeignKey('USER_ID', 'userId', 'INTEGER', 'user', 'ID', false, null, null);
 		$this->addForeignKey('OBJECT_ID', 'objectId', 'INTEGER', 'object', 'ID', false, null, null);
+		$this->addForeignKey('STATUS_ID', 'statusId', 'INTEGER', 'term', 'ID', false, null, null);
 		$this->addColumn('OUTPUT', 'output', 'LONGVARCHAR', false, null, null);
 		// validators
 	} // initialize()
@@ -55,6 +55,7 @@ class JobTableMap extends TableMap {
     $this->addRelation('objectRelatedByid', 'object', RelationMap::MANY_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('user', 'user', RelationMap::MANY_TO_ONE, array('user_id' => 'id', ), 'SET NULL', null);
     $this->addRelation('objectRelatedByobjectId', 'object', RelationMap::MANY_TO_ONE, array('object_id' => 'id', ), 'SET NULL', null);
+    $this->addRelation('term', 'term', RelationMap::MANY_TO_ONE, array('status_id' => 'id', ), 'SET NULL', null);
 	} // buildRelations()
 
 } // JobTableMap

--- a/lib/model/map/TermTableMap.php
+++ b/lib/model/map/TermTableMap.php
@@ -63,6 +63,7 @@ class TermTableMap extends TableMap {
     $this->addRelation('actorRelatedBydescriptionStatusId', 'actor', RelationMap::ONE_TO_MANY, array('id' => 'description_status_id', ), 'SET NULL', null);
     $this->addRelation('actorRelatedBydescriptionDetailId', 'actor', RelationMap::ONE_TO_MANY, array('id' => 'description_detail_id', ), 'SET NULL', null);
     $this->addRelation('aip', 'aip', RelationMap::ONE_TO_MANY, array('id' => 'type_id', ), 'SET NULL', null);
+    $this->addRelation('job', 'job', RelationMap::ONE_TO_MANY, array('id' => 'status_id', ), 'SET NULL', null);
     $this->addRelation('digitalObjectRelatedByusageId', 'digitalObject', RelationMap::ONE_TO_MANY, array('id' => 'usage_id', ), 'SET NULL', null);
     $this->addRelation('digitalObjectRelatedBymediaTypeId', 'digitalObject', RelationMap::ONE_TO_MANY, array('id' => 'media_type_id', ), 'SET NULL', null);
     $this->addRelation('event', 'event', RelationMap::ONE_TO_MANY, array('id' => 'type_id', ), 'CASCADE', null);

--- a/lib/model/om/BaseJob.php
+++ b/lib/model/om/BaseJob.php
@@ -10,10 +10,10 @@ abstract class BaseJob extends QubitObject implements ArrayAccess
     ID = 'job.ID',
     NAME = 'job.NAME',
     DOWNLOAD_PATH = 'job.DOWNLOAD_PATH',
-    STATUS_ID = 'job.STATUS_ID',
     COMPLETED_AT = 'job.COMPLETED_AT',
     USER_ID = 'job.USER_ID',
     OBJECT_ID = 'job.OBJECT_ID',
+    STATUS_ID = 'job.STATUS_ID',
     OUTPUT = 'job.OUTPUT';
 
   public static function addSelectColumns(Criteria $criteria)
@@ -25,10 +25,10 @@ abstract class BaseJob extends QubitObject implements ArrayAccess
     $criteria->addSelectColumn(QubitJob::ID);
     $criteria->addSelectColumn(QubitJob::NAME);
     $criteria->addSelectColumn(QubitJob::DOWNLOAD_PATH);
-    $criteria->addSelectColumn(QubitJob::STATUS_ID);
     $criteria->addSelectColumn(QubitJob::COMPLETED_AT);
     $criteria->addSelectColumn(QubitJob::USER_ID);
     $criteria->addSelectColumn(QubitJob::OBJECT_ID);
+    $criteria->addSelectColumn(QubitJob::STATUS_ID);
     $criteria->addSelectColumn(QubitJob::OUTPUT);
 
     return $criteria;
@@ -86,6 +86,13 @@ abstract class BaseJob extends QubitObject implements ArrayAccess
   public static function addJoinobjectCriteria(Criteria $criteria)
   {
     $criteria->addJoin(QubitJob::OBJECT_ID, QubitObject::ID);
+
+    return $criteria;
+  }
+
+  public static function addJoinstatusCriteria(Criteria $criteria)
+  {
+    $criteria->addJoin(QubitJob::STATUS_ID, QubitTerm::ID);
 
     return $criteria;
   }

--- a/lib/model/om/BaseTerm.php
+++ b/lib/model/om/BaseTerm.php
@@ -154,6 +154,11 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
       return true;
     }
 
+    if ('jobs' == $name)
+    {
+      return true;
+    }
+
     if ('digitalObjectsRelatedByusageId' == $name)
     {
       return true;
@@ -479,6 +484,23 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
       }
 
       return $this->refFkValues['aips'];
+    }
+
+    if ('jobs' == $name)
+    {
+      if (!isset($this->refFkValues['jobs']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['jobs'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['jobs'] = self::getjobsById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['jobs'];
     }
 
     if ('digitalObjectsRelatedByusageId' == $name)
@@ -1326,6 +1348,26 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
   public function addaipsCriteria(Criteria $criteria)
   {
     return self::addaipsCriteriaById($criteria, $this->id);
+  }
+
+  public static function addjobsCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitJob::STATUS_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getjobsById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addjobsCriteriaById($criteria, $id);
+
+    return QubitJob::get($criteria, $options);
+  }
+
+  public function addjobsCriteria(Criteria $criteria)
+  {
+    return self::addjobsCriteriaById($criteria, $this->id);
   }
 
   public static function adddigitalObjectsRelatedByusageIdCriteriaById(Criteria $criteria, $id)

--- a/lib/task/migrate/migrations/arMigration0152.class.php
+++ b/lib/task/migrate/migrations/arMigration0152.class.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add relation between job status IDs and terms.
+*
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0152
+{
+  const
+    VERSION = 152, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  /**
+   * Upgrade
+   *
+   * @return bool True if the upgrade succeeded, False otherwise
+   */
+  public function up($configuration)
+  {
+    // Change job column so NULL is allowed
+    $sql = "ALTER TABLE `job` MODIFY `status_id` INT(11)";
+    QubitPdo::modify($sql);
+
+    // Add constraint so status_id must be associated with a term ID
+    $sql = "ALTER TABLE `job` ADD CONSTRAINT `job_FK_4` FOREIGN KEY (`status_id`) REFERENCES `term` (`id`) ON DELETE SET NULL;";
+    QubitPdo::modify($sql);
+
+    // Add index to status_id
+    $sql = "CREATE INDEX `job_FI_4` ON `job` (`status_id`)";
+    QubitPdo::modify($sql);
+
+    return true;
+  }
+}


### PR DESCRIPTION
Added a new taxonomy, and corresponding terms, for the three job statuses (completed, in progress, and halted due to an error). Make the statusId property of the QubitJob model a foreign key to QubitTerm. Added migration to make these changes on old versions of the database.