### PR TITLE
Fix DIP upload authentication, refs #11032

### DIFF
--- a/plugins/qtSwordPlugin/lib/qtSwordPluginHttpAuthFilter.class.php
+++ b/plugins/qtSwordPlugin/lib/qtSwordPluginHttpAuthFilter.class.php
@@ -30,20 +30,14 @@ class qtSwordPluginHttpAuthFilter extends sfFilter
         exit;
       }
 
-      $user = QubitUser::checkCredentials($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'], $error);
+      $authenticated = sfContext::getInstance()->user->authenticate($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
 
-      if (null === $user)
+      if (!$authenticated)
       {
         $this->sendHeaders();
 
         return;
       }
-
-      $user = new myUser(new sfEventDispatcher(), new sfNoStorage());
-      $user->authenticate($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
-
-      // We'll need username/email details later
-      sfContext::getInstance()->request->setAttribute('user', $user);
     }
 
     $filterChain->execute();

--- a/plugins/qtSwordPlugin/lib/qtSwordPluginWorker.class.php
+++ b/plugins/qtSwordPlugin/lib/qtSwordPluginWorker.class.php
@@ -26,8 +26,6 @@ class qtSwordPluginWorker extends arBaseJob
 
   public function runJob($package)
   {
-    $this->info('A new job has started to being processed.');
-
     if (isset($package['location']))
     {
       $this->info('A package was deposited by reference.');
@@ -51,8 +49,6 @@ class qtSwordPluginWorker extends arBaseJob
 
     $this->job->setStatusCompleted();
     $this->job->save();
-
-    $this->info('Job finished.');
 
     return true;
   }

--- a/plugins/qtSwordPlugin/modules/qtSwordPlugin/actions/depositAction.class.php
+++ b/plugins/qtSwordPlugin/modules/qtSwordPlugin/actions/depositAction.class.php
@@ -38,7 +38,7 @@ class qtSwordPluginDepositAction extends sfAction
       return $this->generateResponse(400, 'error/ErrorBadRequest', array('summary' => $this->context->i18n->__('Bad request')));
     }
 
-    if (QubitAcl::check(QubitInformationObject::getRoot(), 'create'))
+    if (!QubitAcl::check(QubitInformationObject::getRoot(), 'create'))
     {
       return $this->generateResponse(403, 'error/ErrorBadRequest', array('summary' => $this->context->i18n->__('Forbidden')));
     }
@@ -49,7 +49,7 @@ class qtSwordPluginDepositAction extends sfAction
     }
 
     $this->resource = $this->getRoute()->resource;
-    $this->user = $request->getAttribute('user');
+    $this->user = $this->context->user;
     $this->package = array();
 
     // Package format, check if supported


### PR DESCRIPTION
Properly authenticate in DIP upload requests as the user is needed
in QubitJob to be passed to the worker context. It also fixes a wrong
ACL check and removes some redundant log messages