### PR TITLE
Fix job statuses taxonomy and terms, refs #9970

### DIFF
--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 152
+    value: 153
   milestone:
     name: milestone
     editable: 0

--- a/data/fixtures/taxonomyTerms.yml
+++ b/data/fixtures/taxonomyTerms.yml
@@ -10108,18 +10108,21 @@ QubitTerm:
       es: 'Nota de créditos'
   QubtTerm_job_status_in_progress:
     taxonomy_id: QubitTaxonomy_job_status
+    parent_id: QubitTerm_110
     id: 183
     source_culture: en
     name:
       en: 'In progress'
   QubtTerm_job_status_in_completed:
     taxonomy_id: QubitTaxonomy_job_status
+    parent_id: QubitTerm_110
     id: 184
     source_culture: en
     name:
       en: 'Completed'
   QubtTerm_job_status_error:
     taxonomy_id: QubitTaxonomy_job_status
+    parent_id: QubitTerm_110
     id: 185
     source_culture: en
     name:

--- a/lib/model/QubitTaxonomy.php
+++ b/lib/model/QubitTaxonomy.php
@@ -82,7 +82,9 @@ class QubitTaxonomy extends BaseTaxonomy
     RIGHTS_STATUTES_ID = 75,
 
     // Genre taxonomy
-    GENRE_ID = 78;
+    GENRE_ID = 78,
+
+    JOB_STATUS_ID = 79;
 
   public static
     $lockedTaxonomies = array(
@@ -97,7 +99,8 @@ class QubitTaxonomy extends BaseTaxonomy
       self::STATUS_TYPE_ID,
       self::PUBLICATION_STATUS_ID,
       self::ACTOR_NAME_TYPE_ID,
-      self::INFORMATION_OBJECT_TEMPLATE_ID);
+      self::INFORMATION_OBJECT_TEMPLATE_ID,
+      self::JOB_STATUS_ID);
 
   public function __toString()
   {

--- a/lib/model/QubitTerm.php
+++ b/lib/model/QubitTerm.php
@@ -233,7 +233,10 @@ class QubitTerm extends BaseTerm
       QubitTerm::TEXT_ID,
       QubitTerm::THUMBNAIL_ID,
       QubitTerm::TITLE_NOTE_ID,
-      QubitTerm::VIDEO_ID));
+      QubitTerm::VIDEO_ID,
+      QubitTerm::JOB_STATUS_IN_PROGRESS_ID,
+      QubitTerm::JOB_STATUS_COMPLETED_ID,
+      QubitTerm::JOB_STATUS_ERROR_ID));
   }
 
   public function __toString()

--- a/lib/task/migrate/migrations/arMigration0153.class.php
+++ b/lib/task/migrate/migrations/arMigration0153.class.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add taxonomy and terms for job statuses
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0153
+{
+  const
+    VERSION = 153, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  public function up($configuration)
+  {
+    QubitMigrate::bumpTaxonomy(QubitTaxonomy::JOB_STATUS_ID, $configuration);
+    $taxonomy = new QubitTaxonomy;
+    $taxonomy->id = QubitTaxonomy::JOB_STATUS_ID;
+    $taxonomy->parentId = QubitTaxonomy::ROOT_ID;
+    $taxonomy->sourceCulture = 'en';
+    $taxonomy->setName('Job status', array('culture' => 'en'));
+    $taxonomy->save();
+
+    $terms = array(
+      QubitTerm::JOB_STATUS_IN_PROGRESS_ID => 'In progress',
+      QubitTerm::JOB_STATUS_COMPLETED_ID => 'Completed',
+      QubitTerm::JOB_STATUS_ERROR_ID => 'Error'
+    );
+
+    foreach ($terms as $id => $name)
+    {
+      QubitMigrate::bumpTerm($id, $configuration);
+      $term = new QubitTerm;
+      $term->id = $id;
+      $term->parentId = QubitTerm::ROOT_ID;
+      $term->taxonomyId = QubitTaxonomy::JOB_STATUS_ID;
+      $term->sourceCulture = 'en';
+      $term->setName($name, array('culture' => 'en'));
+      $term->save();
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
- Add missing terms parent in fixtures
- Add migration for terms and taxonomy creation
- Add missing taxonomy id constant
- Protect taxonomy and terms