### PR TITLE
Add identifier mask for descriptions, refs #11162

### DIFF
--- a/apps/qubit/modules/informationobject/actions/editAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/editAction.class.php
@@ -600,6 +600,7 @@ class InformationObjectEditAction extends DefaultEditAction
     $this->deleteNotes();
     $this->updateChildLevels();
     $this->removeDuplicateRepositoryAssociations();
+    $this->incrementMaskCounter();
   }
 
   public function execute($request)
@@ -789,7 +790,7 @@ class InformationObjectEditAction extends DefaultEditAction
 
   /**
    * If identifier mask is enabled, set our new info obj to an identifier generated
-   * from the mask. Also increment the mask counter.
+   * from the mask.
    */
   private function handleIdentifierFromMask()
   {
@@ -801,9 +802,23 @@ class InformationObjectEditAction extends DefaultEditAction
     if ($maskEnabled->value)
     {
       $this->resource->identifier = QubitInformationObject::generateIdentiferFromMask();
-      $counter = QubitInformationObject::getIdentifierCounter();
-      $counter->value++;
-      $counter->save();
     }
+
+    $this->mask = $maskEnabled->value; // Pass if we're using an identifier generated from mask to template
+  }
+
+  /**
+   * If the user is using an identifier generated from the mask, increment the mask counter.
+   */
+  private function incrementMaskCounter()
+  {
+    if (!filter_var($this->request->getPostParameter('usingMask'), FILTER_VALIDATE_BOOLEAN))
+    {
+      return;
+    }
+
+    $counter = QubitInformationObject::getIdentifierCounter();
+    $counter->value++;
+    $counter->save();
   }
 }

--- a/apps/qubit/modules/informationobject/actions/editAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/editAction.class.php
@@ -794,17 +794,12 @@ class InformationObjectEditAction extends DefaultEditAction
    */
   private function handleIdentifierFromMask()
   {
-    if (null === $maskEnabled = QubitSetting::getByName('identifier_mask_enabled'))
-    {
-      throw new sfException('identifier_mask_enabled setting not found--is your database upgraded?');
-    }
-
-    if ($maskEnabled->value)
+    // Pass if we're using mask or not to template, fill in identifier with generated
+    // identifier if so.
+    if ($this->mask = sfConfig::get('app_identifier_mask_enabled', 0))
     {
       $this->resource->identifier = QubitInformationObject::generateIdentiferFromMask();
     }
-
-    $this->mask = $maskEnabled->value; // Pass if we're using an identifier generated from mask to template
   }
 
   /**

--- a/apps/qubit/modules/informationobject/actions/generateIdentifierAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/generateIdentifierAction.class.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class InformationObjectGenerateIdentifierAction extends sfAction
+{
+  public function execute($request)
+  {
+    $identifier = QubitInformationObject::generateIdentiferFromMask();
+    $this->response->setHttpHeader('Content-Type', 'application/json; charset=utf-8');
+
+    return $this->renderText(json_encode(array('identifier' => $identifier)));
+  }
+}

--- a/apps/qubit/modules/informationobject/templates/_alternativeIdentifiers.php
+++ b/apps/qubit/modules/informationobject/templates/_alternativeIdentifiers.php
@@ -1,8 +1,3 @@
-<div class="section">
-  <a href="#" id="alternative-identifiers"><?php echo __('Add alternative identifier(s)') ?></a>
-  <a data-endpoint-url="<?php echo url_for(array('module' => 'informationobject', 'action' => 'generateIdentifier')) ?>" id="generate-identifier"><?php echo __('Generate identifier') ?></a>
-</div>
-
 <div class="section" id="alternative-identifiers-table"<?php echo 0 < count($alternativeIdentifiers) ? '' : 'style="display:none"' ?>>
 
   <h3><?php echo __('Alternative identifier(s)') ?></h3>

--- a/apps/qubit/modules/informationobject/templates/_alternativeIdentifiers.php
+++ b/apps/qubit/modules/informationobject/templates/_alternativeIdentifiers.php
@@ -1,5 +1,6 @@
 <div class="section">
-  <a href="#" id="alternative-identifiers">Add alternative identifier(s)</a>
+  <a href="#" id="alternative-identifiers"><?php echo __('Add alternative identifier(s)') ?></a>
+  <a data-endpoint-url="<?php echo url_for(array('module' => 'informationobject', 'action' => 'generateIdentifier')) ?>" id="generate-identifier"><?php echo __('Generate identifier') ?></a>
 </div>
 
 <div class="section" id="alternative-identifiers-table"<?php echo 0 < count($alternativeIdentifiers) ? '' : 'style="display:none"' ?>>

--- a/apps/qubit/modules/informationobject/templates/_identifierOptions.php
+++ b/apps/qubit/modules/informationobject/templates/_identifierOptions.php
@@ -1,0 +1,11 @@
+<div class="section">
+  <a href="#" class="identifier-action" id="alternative-identifiers">
+    <?php echo __('Add alternative identifier(s)') ?>
+  </a>
+  <a href="#" class="identifier-action" id="generate-identifier"
+    data-generate-identifier-url="<?php echo url_for(array('module' => 'informationobject', 'action' => 'generateIdentifier')) ?>">
+    <?php echo __('Generate identifier') ?>
+  </a>
+</div>
+
+<input name="usingMask" id="using-identifier-mask" type="hidden" value="<?php echo $mask ?>"/>

--- a/apps/qubit/modules/informationobject/templates/_identifierOptions.php
+++ b/apps/qubit/modules/informationobject/templates/_identifierOptions.php
@@ -1,7 +1,10 @@
 <div class="section">
-  <a href="#" class="identifier-action" id="alternative-identifiers">
-    <?php echo __('Add alternative identifier(s)') ?>
-  </a>
+  <?php if (!isset($hideAltIdButton)): // Some templates don't have alt id support yet ?>
+    <a href="#" class="identifier-action" id="alternative-identifiers">
+      <?php echo __('Add alternative identifier(s)') ?>
+    </a>
+  <?php endif; ?>
+
   <a href="#" class="identifier-action" id="generate-identifier"
     data-generate-identifier-url="<?php echo url_for(array('module' => 'informationobject', 'action' => 'generateIdentifier')) ?>">
     <?php echo __('Generate identifier') ?>

--- a/apps/qubit/modules/settings/actions/globalAction.class.php
+++ b/apps/qubit/modules/settings/actions/globalAction.class.php
@@ -77,6 +77,9 @@ class SettingsGlobalAction extends sfAction
     $accessionMaskEnabled = QubitSetting::getByName('accession_mask_enabled');
     $accessionMask = QubitSetting::getByName('accession_mask');
     $accessionCounter = QubitSetting::getByName('accession_counter');
+    $identifierMaskEnabled = QubitSetting::getByName('identifier_mask_enabled');
+    $identifierMask = QubitSetting::getByName('identifier_mask');
+    $identifierCounter = QubitSetting::getByName('identifier_counter');
     $separatorCharacter = QubitSetting::getByName('separator_character');
     $inheritCodeInformationObject = QubitSetting::getByName('inherit_code_informationobject');
     $sortBrowserUser = QubitSetting::getByName('sort_browser_user');
@@ -105,6 +108,9 @@ class SettingsGlobalAction extends sfAction
       'accession_mask_enabled' => (isset($accessionMaskEnabled)) ? intval($accessionMaskEnabled->getValue(array('sourceCulture'=>true))) : 1,
       'accession_mask' => (isset($accessionMask)) ? $accessionMask->getValue(array('sourceCulture'=>true)) : null,
       'accession_counter' => (isset($accessionCounter)) ? intval($accessionCounter->getValue(array('sourceCulture'=>true))) : 1,
+      'identifier_mask_enabled' => (isset($identifierMaskEnabled)) ? intval($identifierMaskEnabled->getValue(array('sourceCulture'=>true))) : 1,
+      'identifier_mask' => (isset($identifierMask)) ? $identifierMask->getValue(array('sourceCulture'=>true)) : null,
+      'identifier_counter' => (isset($identifierCounter)) ? intval($identifierCounter->getValue(array('sourceCulture'=>true))) : 1,
       'separator_character' => (isset($separatorCharacter)) ? $separatorCharacter->getValue(array('sourceCulture'=>true)) : null,
       'inherit_code_informationobject' => (isset($inheritCodeInformationObject)) ? intval($inheritCodeInformationObject->getValue(array('sourceCulture'=>true))) : 1,
       'sort_browser_user' => (isset($sortBrowserUser)) ? $sortBrowserUser->getValue(array('sourceCulture'=>true)) : 0,
@@ -209,6 +215,43 @@ class SettingsGlobalAction extends sfAction
 
         // Force sourceCulture update to prevent discrepency in settings between cultures
         $setting->setValue($accessionCounter, array('sourceCulture' => true));
+        $setting->save();
+      }
+    }
+
+    // Identifier mask enabled
+    if (null !== $identifierMaskEnabled = $thisForm->getValue('identifier_mask_enabled'))
+    {
+      if (null === $setting = QubitSetting::getByName('identifier_mask_enabled'))
+      {
+        $setting = new QubitSetting;
+        $setting->name = 'identifier_mask_enabled';
+      }
+
+      // Force sourceCulture update to prevent discrepency in settings between cultures
+      $setting->setValue($identifierMaskEnabled, array('sourceCulture' => true));
+      $setting->save();
+    }
+
+    // Identifier mask
+    if (null !== $identifierMask = $thisForm->getValue('identifier_mask'))
+    {
+      $setting = QubitSetting::getByName('identifier_mask');
+
+      // Force sourceCulture update to prevent discrepency in settings between cultures
+      $setting->setValue($identifierMask, array('sourceCulture' => true));
+      $setting->save();
+    }
+
+    // Identifier counter
+    if (null !== $identifierCounter = $thisForm->getValue('identifier_counter'))
+    {
+      if (ctype_digit($identifierCounter) && $identifierCounter > -1)
+      {
+        $setting = QubitSetting::getByName('identifier_counter');
+
+        // Force sourceCulture update to prevent discrepency in settings between cultures
+        $setting->setValue($identifierCounter, array('sourceCulture' => true));
         $setting->save();
       }
     }

--- a/apps/qubit/modules/settings/actions/globalAction.class.php
+++ b/apps/qubit/modules/settings/actions/globalAction.class.php
@@ -209,7 +209,7 @@ class SettingsGlobalAction extends sfAction
     // Accession counter
     if (null !== $accessionCounter = $thisForm->getValue('accession_counter'))
     {
-      if (ctype_digit($accessionCounter) && $accessionCounter > -1)
+      if (ctype_digit($accessionCounter))
       {
         $setting = QubitSetting::getByName('accession_counter');
 
@@ -222,15 +222,12 @@ class SettingsGlobalAction extends sfAction
     // Identifier mask enabled
     if (null !== $identifierMaskEnabled = $thisForm->getValue('identifier_mask_enabled'))
     {
-      if (null === $setting = QubitSetting::getByName('identifier_mask_enabled'))
+      if (null !== $setting = QubitSetting::getByName('identifier_mask_enabled'))
       {
-        $setting = new QubitSetting;
-        $setting->name = 'identifier_mask_enabled';
+        // Force sourceCulture update to prevent discrepency in settings between cultures
+        $setting->setValue($identifierMaskEnabled, array('sourceCulture' => true));
+        $setting->save();
       }
-
-      // Force sourceCulture update to prevent discrepency in settings between cultures
-      $setting->setValue($identifierMaskEnabled, array('sourceCulture' => true));
-      $setting->save();
     }
 
     // Identifier mask
@@ -246,7 +243,7 @@ class SettingsGlobalAction extends sfAction
     // Identifier counter
     if (null !== $identifierCounter = $thisForm->getValue('identifier_counter'))
     {
-      if (ctype_digit($identifierCounter) && $identifierCounter > -1)
+      if (ctype_digit($identifierCounter))
       {
         $setting = QubitSetting::getByName('identifier_counter');
 

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 152
+    value: 153
   milestone:
     name: milestone
     editable: 0

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 153
+    value: 154
   milestone:
     name: milestone
     editable: 0

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -1089,3 +1089,24 @@ QubitSetting:
     source_culture: en
     value:
       en: 0
+  Qubit_Settings_identifierMask:
+    name: identifier_mask
+    editable: 1
+    deleteable: 0
+    source_culture: en
+    value:
+      en: %Y-%m-%d/#i
+  Qubit_Settings_identifierCounter:
+    name: identifier_counter
+    editable: 1
+    deleteable: 0
+    source_culture: en
+    value:
+      en: 0
+  Qubit_Settings_identifierMaskEnabled:
+    name: identifier_mask_enabled
+    editable: 1
+    deleteable: 0
+    source_culture: en
+    value:
+      en: 0

--- a/js/generateIdentifier.js
+++ b/js/generateIdentifier.js
@@ -6,6 +6,7 @@
     {
       this.$generateIdentifierBtn = $('#generate-identifier');
       this.$identifier = $('#identifier');
+      this.$maskEnabled = $('#using-identifier-mask');
       this.init();
     };
 
@@ -16,21 +17,34 @@
     init: function()
     {
       this.$generateIdentifierBtn.on('click', $.proxy(this.genIdentifier, this));
+      this.$identifier.on('input', $.proxy(this.identifierChanged, this));
     },
 
-    genIdentifier: function (event)
+    genIdentifier: function(event)
     {
       var identifier = this.$identifier;
+      var maskEnabled = this.$maskEnabled;
+      event.preventDefault(); // Prevent page from jumping to top when clicking href="#"
 
       // Return deferred object
       return $.ajax({
-        url: this.$generateIdentifierBtn.data('endpoint-url'),
+        url: this.$generateIdentifierBtn.data('generate-identifier-url'),
         type: 'GET',
         success: function (data)
           {
             identifier.val(data['identifier']);
+            // Freshly generated identifier, using mask!
+            maskEnabled.attr('value', '1');
           }
       });
+    },
+
+    // If user changes identifier manually, we're no longer using an auto-generated
+    // identifier from the mask, so do not increment counter. Using-mask will signal
+    // to the action whether or not to increment the counter.
+    identifierChanged: function(event)
+    {
+      this.$maskEnabled.attr('value', '0');
     }
   };
 

--- a/js/generateIdentifier.js
+++ b/js/generateIdentifier.js
@@ -1,0 +1,41 @@
+(function ($) {
+
+  'use strict';
+
+  var GenerateIdentifier = function ()
+    {
+      this.$generateIdentifierBtn = $('#generate-identifier');
+      this.$identifier = $('#identifier');
+      this.init();
+    };
+
+  GenerateIdentifier.prototype = {
+
+    constructor: GenerateIdentifier,
+
+    init: function()
+    {
+      this.$generateIdentifierBtn.on('click', $.proxy(this.genIdentifier, this));
+    },
+
+    genIdentifier: function (event)
+    {
+      var identifier = this.$identifier;
+
+      // Return deferred object
+      return $.ajax({
+        url: this.$generateIdentifierBtn.data('endpoint-url'),
+        type: 'GET',
+        success: function (data)
+          {
+            identifier.val(data['identifier']);
+          }
+      });
+    }
+  };
+
+  $(function ()
+  {
+    new GenerateIdentifier();
+  });
+})(jQuery);

--- a/lib/form/SettingsGlobalForm.class.php
+++ b/lib/form/SettingsGlobalForm.class.php
@@ -46,6 +46,9 @@ class SettingsGlobalForm extends sfForm
       'accession_mask_enabled' => new sfWidgetFormSelectRadio(array('choices' => array(1 => 'yes', 0 => 'no')), array('class' => 'radio')),
       'accession_mask' => new sfWidgetFormInput,
       'accession_counter' => new sfWidgetFormInput,
+      'identifier_mask_enabled' => new sfWidgetFormSelectRadio(array('choices' => array(1 => 'yes', 0 => 'no')), array('class' => 'radio')),
+      'identifier_mask' => new sfWidgetFormInput,
+      'identifier_counter' => new sfWidgetFormInput,
       'separator_character' => new sfWidgetFormInput(array(), array('maxlength' => 1)),
       'inherit_code_informationobject' => new sfWidgetFormSelectRadio(array('choices' => array(1 => 'yes', 0 => 'no')), array('class' => 'radio')),
       'sort_browser_user' => new sfWidgetFormSelectRadio(array('choices' => array('alphabetic' => 'alphabetic', 'lastUpdated' => 'last updated', 'identifier' => 'identifier', 'referenceCode' => $this->i18n->__('reference code'))), array('class' => 'radio')),
@@ -76,6 +79,9 @@ class SettingsGlobalForm extends sfForm
       'accession_mask_enabled' => $this->i18n->__('Accession mask enabled'),
       'accession_mask' => $this->i18n->__('Accession mask'),
       'accession_counter' => $this->i18n->__('Accession counter'),
+      'identifier_mask_enabled' => $this->i18n->__('Identifier mask enabled'),
+      'identifier_mask' => $this->i18n->__('Identifier mask'),
+      'identifier_counter' => $this->i18n->__('Identifier counter'),
       'separator_character' => $this->i18n->__('Reference code separator'),
       'inherit_code_informationobject' => $this->i18n->__('Inherit reference code (information object)'),
       'sort_browser_user' => $this->i18n->__('Sort browser (users)'),
@@ -163,6 +169,9 @@ class SettingsGlobalForm extends sfForm
     $this->validatorSchema['default_repository_browse_view'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['default_archival_description_browse_view'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['slug_basis_informationobject'] = $this->getSlugBasisInformationObjectValidator();
+    $this->validatorSchema['identifier_mask_enabled'] = new sfValidatorInteger(array('required' => false));
+    $this->validatorSchema['identifier_mask'] = new sfValidatorString(array('required' => false));
+    $this->validatorSchema['identifier_counter'] = new sfValidatorString(array('required' => false));
 
     $this->validatorSchema['repository_quota'] = new sfValidatorNumber(
       array('required' => true, 'min' => -1),

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -3347,7 +3347,7 @@ class QubitInformationObject extends BaseInformationObject
       throw new sfException('identifier_mask setting not found--is your database upgraded?');
     }
 
-    return preg_replace_callback('/([#%])([A-z]+)/', function($match)
+    return preg_replace_callback('/([#%])([A-z]+)/', function($match) use ($counter)
     {
       if ('%' == $match[1])
       {

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -3317,4 +3317,51 @@ class QubitInformationObject extends BaseInformationObject
       $item->delete();
     }
   }
+
+  /**
+   * Get current identifier counter for identifier mask from database.
+   *
+   * @return QubitSetting  The identifier counter setting (use ->value to get value).
+   */
+  public static function getIdentifierCounter()
+  {
+    if (null === $counter = QubitSetting::getByName('identifier_counter'))
+    {
+      throw new sfException('identifier_counter setting not found--is your database upgraded?');
+    }
+
+    return $counter;
+  }
+
+  /**
+   * Generate identifier based on identifier mask and current counter.
+   *
+   * @return string  The generated identifier.
+   */
+  public static function generateIdentiferFromMask()
+  {
+    $counter = self::getIdentifierCounter();
+
+    if (null === $mask = QubitSetting::getByName('identifier_mask'))
+    {
+      throw new sfException('identifier_mask setting not found--is your database upgraded?');
+    }
+
+    return preg_replace_callback('/([#%])([A-z]+)/', function($match)
+    {
+      if ('%' == $match[1])
+      {
+        return strftime('%'.$match[2]);
+      }
+      else if ('#' == $match[1])
+      {
+        if (0 < preg_match('/^i+$/', $match[2], $matches))
+        {
+          return str_pad($counter->value, strlen($matches[0]), 0, STR_PAD_LEFT);
+        }
+
+        return $match[2];
+      }
+    }, $mask->value);
+  }
 }

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -3342,11 +3342,6 @@ class QubitInformationObject extends BaseInformationObject
   {
     $counter = self::getIdentifierCounter();
 
-    if (null === $mask = QubitSetting::getByName('identifier_mask'))
-    {
-      throw new sfException('identifier_mask setting not found--is your database upgraded?');
-    }
-
     return preg_replace_callback('/([#%])([A-z]+)/', function($match) use ($counter)
     {
       if ('%' == $match[1])
@@ -3362,6 +3357,6 @@ class QubitInformationObject extends BaseInformationObject
 
         return $match[2];
       }
-    }, $mask->value);
+    }, sfConfig::get('app_identifier_mask', ''));
   }
 }

--- a/lib/task/migrate/migrations/arMigration0153.class.php
+++ b/lib/task/migrate/migrations/arMigration0153.class.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add new settings for identifier mask.
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0153
+{
+  const
+    VERSION = 153, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  /**
+   * Upgrade
+   *
+   * @return bool True if the upgrade succeeded, False otherwise
+   */
+  public function up($configuration)
+  {
+    $identifierSettings = array(
+      array('identifier_mask', '%Y-%m-%d/#i'),
+      array('identifier_mask_enabled', 0),
+      array('identifier_counter', 0)
+    );
+
+    foreach ($identifierSettings as $setting)
+    {
+      list($name, $val) = $setting;
+
+      if (null === QubitSetting::getByName($name))
+      {
+        $setting = new QubitSetting;
+        $setting->name = $name;
+        $setting->value = $val;
+        $setting->editable = 1;
+        $setting->culture = 'en';
+        $setting->save();
+      }
+    }
+
+    return true;
+  }
+}

--- a/lib/task/migrate/migrations/arMigration0154.class.php
+++ b/lib/task/migrate/migrations/arMigration0154.class.php
@@ -23,10 +23,10 @@
  * @package    AccesstoMemory
  * @subpackage migration
  */
-class arMigration0153
+class arMigration0154
 {
   const
-    VERSION = 153, // The new database version
+    VERSION = 154, // The new database version
     MIN_MILESTONE = 2; // The minimum milestone required
 
   /**

--- a/plugins/arDacsPlugin/modules/arDacsPlugin/config/view.yml
+++ b/plugins/arDacsPlugin/modules/arDacsPlugin/config/view.yml
@@ -11,6 +11,7 @@ editSuccess:
     /vendor/yui/container/container-min:
     /vendor/yui/autocomplete/autocomplete-min:
     /vendor/imageflow/imageflow.packed.js:
+    /js/generateIdentifier.js:
     autocomplete:
     blank:
     imageflow:

--- a/plugins/arDacsPlugin/modules/arDacsPlugin/templates/editSuccess.php
+++ b/plugins/arDacsPlugin/modules/arDacsPlugin/templates/editSuccess.php
@@ -42,6 +42,7 @@
           ->label(__('Identifier').' <span class="form-required" title="'.__('This is a mandatory element.').'">*</span>')
           ->renderRow() ?>
 
+        <?php echo get_partial('informationobject/identifierOptions', array('mask' => $mask)) ?>
         <?php echo get_partial('informationobject/alternativeIdentifiers', $sf_data->getRaw('alternativeIdentifiersComponent')->getVarHolder()->getAll()) ?>
 
         <div class="form-item">

--- a/plugins/arDominionPlugin/css/less/forms.less
+++ b/plugins/arDominionPlugin/css/less/forms.less
@@ -366,10 +366,11 @@ button.delete-small {
   margin-bottom: 10px;
 }
 
-#alternative-identifiers {
+.identifier-action {
   float: right;
   font-size: 11px;
   margin-top: -10px;
+  margin-left: 10px;
 }
 
 // Tabbable area

--- a/plugins/sfDcPlugin/modules/sfDcPlugin/config/view.yml
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/config/view.yml
@@ -11,6 +11,7 @@ editSuccess:
     /vendor/yui/container/container-min:
     /vendor/yui/autocomplete/autocomplete-min:
     /vendor/imageflow/imageflow.packed.js:
+    /js/generateIdentifier.js:
     autocomplete:
     blank:
     imageflow:

--- a/plugins/sfDcPlugin/modules/sfDcPlugin/templates/editSuccess.php
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/templates/editSuccess.php
@@ -42,6 +42,8 @@
           ->label(__('Identifier').' <span class="form-required" title="'.__('This is a mandatory element.').'">*</span>')
           ->renderRow() ?>
 
+        <?php echo get_partial('informationobject/identifierOptions', array('mask' => $mask)) ?>
+
         <?php echo render_field($form->title
           ->help(__('The name given to this resource.'))
           ->label(__('Title').' <span class="form-required" title="'.__('This is a mandatory element.').'">*</span>'), $resource) ?>

--- a/plugins/sfDcPlugin/modules/sfDcPlugin/templates/editSuccess.php
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/templates/editSuccess.php
@@ -42,7 +42,7 @@
           ->label(__('Identifier').' <span class="form-required" title="'.__('This is a mandatory element.').'">*</span>')
           ->renderRow() ?>
 
-        <?php echo get_partial('informationobject/identifierOptions', array('mask' => $mask)) ?>
+        <?php echo get_partial('informationobject/identifierOptions', array('mask' => $mask, 'hideAltIdButton' => true)) ?>
 
         <?php echo render_field($form->title
           ->help(__('The name given to this resource.'))

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/config/view.yml
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/config/view.yml
@@ -11,6 +11,7 @@ editSuccess:
     /vendor/yui/container/container-min:
     /vendor/yui/autocomplete/autocomplete-min:
     /vendor/imageflow/imageflow.packed.js:
+    /js/generateIdentifier.js:
     autocomplete:
     blank:
     imageflow:

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/editSuccess.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/editSuccess.php
@@ -8,7 +8,6 @@
 <?php end_slot() ?>
 
 <?php slot('title') ?>
-
   <h1><?php echo render_title($isad) ?></h1>
 
   <?php if (isset($sf_request->source)): ?>
@@ -44,6 +43,7 @@
           ->label(__('Identifier').' <span class="form-required" title="'.__('This is a mandatory element.').'">*</span>')
           ->renderRow() ?>
 
+        <?php echo get_partial('informationobject/identifierOptions', array('mask' => $mask)) ?>
         <?php echo get_partial('informationobject/alternativeIdentifiers', $sf_data->getRaw('alternativeIdentifiersComponent')->getVarHolder()->getAll()) ?>
 
         <?php echo render_field($form->title

--- a/plugins/sfModsPlugin/modules/sfModsPlugin/config/view.yml
+++ b/plugins/sfModsPlugin/modules/sfModsPlugin/config/view.yml
@@ -11,6 +11,7 @@ editSuccess:
     /vendor/yui/container/container-min:
     /vendor/yui/autocomplete/autocomplete-min:
     /vendor/imageflow/imageflow.packed.js:
+    /js/generateIdentifier.js:
     autocomplete:
     blank:
     imageflow:

--- a/plugins/sfModsPlugin/modules/sfModsPlugin/templates/editSuccess.php
+++ b/plugins/sfModsPlugin/modules/sfModsPlugin/templates/editSuccess.php
@@ -41,7 +41,7 @@
           ->help(__('Contains a unique standard number or code that distinctively identifies a resource.'))
           ->renderRow() ?>
 
-        <?php echo get_partial('informationobject/identifierOptions', array('mask' => $mask)) ?>
+        <?php echo get_partial('informationobject/identifierOptions', array('mask' => $mask, 'hideAltIdButton' => true)) ?>
 
         <?php echo render_field($form->title
           ->help(__('A word, phrase, character, or group of characters, normally appearing in a resource, that names it or the work contained in it. Choice and format of titles should be governed by a content standard such as the Anglo-American Cataloging Rules, 2nd edition (AACR2), Cataloguing Cultural Objects (CCO), or Describing Archives: A Content Standard (DACS). Details such as capitalization, choosing among the forms of titles presented on an item, and use of abbreviations should be determined based on the rules in a content standard. One standard should be chosen and used consistently for all records in a set.')), $resource) ?>

--- a/plugins/sfModsPlugin/modules/sfModsPlugin/templates/editSuccess.php
+++ b/plugins/sfModsPlugin/modules/sfModsPlugin/templates/editSuccess.php
@@ -41,6 +41,8 @@
           ->help(__('Contains a unique standard number or code that distinctively identifies a resource.'))
           ->renderRow() ?>
 
+        <?php echo get_partial('informationobject/identifierOptions', array('mask' => $mask)) ?>
+
         <?php echo render_field($form->title
           ->help(__('A word, phrase, character, or group of characters, normally appearing in a resource, that names it or the work contained in it. Choice and format of titles should be governed by a content standard such as the Anglo-American Cataloging Rules, 2nd edition (AACR2), Cataloguing Cultural Objects (CCO), or Describing Archives: A Content Standard (DACS). Details such as capitalization, choosing among the forms of titles presented on an item, and use of abbreviations should be determined based on the rules in a content standard. One standard should be chosen and used consistently for all records in a set.')), $resource) ?>
 

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/config/view.yml
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/config/view.yml
@@ -11,6 +11,7 @@ editSuccess:
     /vendor/yui/container/container-min:
     /vendor/yui/autocomplete/autocomplete-min:
     /vendor/imageflow/imageflow.packed.js:
+    /js/generateIdentifier.js:
     autocomplete:
     blank:
     imageflow:

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/templates/editSuccess.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/templates/editSuccess.php
@@ -81,6 +81,7 @@
           ->help(__('Enter an unambiguous code used to uniquely identify the description.'))
           ->renderRow() ?>
 
+        <?php echo get_partial('informationobject/identifierOptions', array('mask' => $mask)) ?>
         <?php echo get_partial('informationobject/alternativeIdentifiers', $sf_data->getRaw('alternativeIdentifiersComponent')->getVarHolder()->getAll()) ?>
 
         <?php echo render_show(__('Reference code'), $rad->referenceCode) ?>


### PR DESCRIPTION
This PR implements a similar feature to our existing accession mask settings,
except for archival descriptions' identifiers instead.

Feature details:

- New admin->settings fields for identifier mask, identifier counter, and
  identifier mask enable / disable.

- If identifier mask is enabled, when creating new descriptions the identifier
  will automatically fill in an auto-generated identifier in the form for the
  user, based on the mask & counter.

- There will be a button underneath the identifier text box when editing that
  will use an XHR to manually generate an identifier from an end point and fill
  the box in.

- In the identifier mask (like accession mask), %<letter> indicates the
  identifier generation should interpret this with strftime. #i should be
  interpreted as the place to insert the current counter value.

- If the user edits the identifier either during the creation process if
  identifier mask is enabled, or after the user clicks generate identifier
  manually, the counter will not be incremented.