### PR TITLE
Add default for QubitPdo::modify params, #10971

### DIFF
--- a/lib/QubitPdo.class.php
+++ b/lib/QubitPdo.class.php
@@ -72,7 +72,7 @@ class QubitPdo
     return $fetchedColumn;
   }
 
-  public static function modify($query, $parameters)
+  public static function modify($query, $parameters = array())
   {
     $modifyStmt = self::prepareAndExecute($query, $parameters);
 


### PR DESCRIPTION
We were calling QubitPdo::modify with only one parameter throughout the
application. This fixes the issue by making the second parameter optional
(now defaults to empty array).