### PR TITLE
Description updates repository filter, refs #11221

### DIFF
--- a/apps/qubit/modules/informationobject/actions/browseAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/browseAction.class.php
@@ -183,7 +183,7 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
         $criteria->addAscendingOrderByColumn('authorized_form_of_name');
 
         $cache = QubitCache::getInstance();
-        $cacheKey = 'advanced-search:list-of-repositories:'.$this->context->user->getCulture();
+        $cacheKey = 'search:list-of-repositories:'.$this->context->user->getCulture();
         if ($cache->has($cacheKey))
         {
           $choices = $cache->get($cacheKey);

--- a/apps/qubit/modules/search/config/view.yml
+++ b/apps/qubit/modules/search/config/view.yml
@@ -12,3 +12,5 @@ descriptionUpdatesSuccess:
   javascripts:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/tableheader:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/ui/ui.datepicker.js:
+    clipboardToggleAll:
+    descUpdToggleIoOptions:

--- a/apps/qubit/modules/search/templates/_updatesSearch.php
+++ b/apps/qubit/modules/search/templates/_updatesSearch.php
@@ -12,7 +12,7 @@
 
       <div class="criteria">
 
-        <div class="filter-row triple">
+        <div class="filter-row double">
 
           <div class="filter-left">
             <?php echo $form->className
@@ -20,7 +20,7 @@
               ->renderRow() ?>
           </div>
 
-          <div class="filter-center">
+          <div class="filter-right">
             <label class="date-of-label"><?php echo __('Date of') ?></label>
             <div class="date-of">
               <?php foreach ($form->getWidgetSchema()->dateOf->getChoices() as $value => $translatedText): ?>
@@ -32,8 +32,21 @@
             </div>
           </div>
 
-          <div class="filter-right">
-            <label class="publication-status-label"><?php echo __('Publication status (%1% only)', array('%1%' => sfConfig::get('app_ui_label_informationobject'))) ?></label>
+        </div>
+
+        <div class="filter-row double" id="io-options">
+
+          <?php if (sfConfig::get('app_multi_repository')): ?>
+            <div class="filter-left">
+              <?php echo $form->repository
+                ->label(__('Repository'))
+                ->renderRow() ?>
+            </div>
+            <div class="filter-right">
+          <?php else: ?>
+            <div class="filter-left">
+          <?php endif; ?>
+            <label class="publication-status-label"><?php echo __('Publication status') ?></label>
             <div class="publication-status">
               <?php foreach ($form->getWidgetSchema()->publicationStatus->getChoices() as $value => $translatedText): ?>
                 <label>
@@ -43,7 +56,9 @@
               <?php endforeach; ?>
             </div>
           </div>
+
         </div>
+
       </div>
 
       <p><?php echo __('Filter by date range:') ?></p>

--- a/js/descUpdToggleIoOptions.js
+++ b/js/descUpdToggleIoOptions.js
@@ -1,0 +1,48 @@
+(function ($) {
+
+  'use strict';
+
+  // Show/hide information object options in the description
+  // updates filters, depending on the class name selected
+
+  var DescUpdToggleIoOptions = function ()
+    {
+      this.$className = $('select#className');
+      this.$ioOptions = $('#io-options');
+      this.init();
+    };
+
+  DescUpdToggleIoOptions.prototype = {
+
+    constructor: DescUpdToggleIoOptions,
+
+    init: function()
+    {
+      this.$className.on('change', $.proxy(this.onClassNameChange, this));
+      this.onClassNameChange();
+    },
+
+    onClassNameChange: function()
+    {
+      switch (this.$className.val())
+      {
+        case 'QubitInformationObject':
+          this.$ioOptions.show();
+
+          break;
+
+        default:
+          this.$ioOptions.hide();
+
+          break;
+      }
+    }
+
+  };
+
+  $(function ()
+  {
+    new DescUpdToggleIoOptions();
+  });
+
+})(jQuery);

--- a/lib/model/QubitRepository.php
+++ b/lib/model/QubitRepository.php
@@ -117,7 +117,7 @@ class QubitRepository extends BaseRepository
     QubitSearch::getInstance()->update($this);
 
     // Remove adv. search repository options from cache
-    QubitCache::getInstance()->removePattern('advanced-search:list-of-repositories:*');
+    QubitCache::getInstance()->removePattern('search:list-of-repositories:*');
 
     return $this;
   }
@@ -149,7 +149,7 @@ class QubitRepository extends BaseRepository
   public function delete($connection = null)
   {
     // Remove adv. search repository options from cache
-    QubitCache::getInstance()->removePattern('advanced-search:list-of-repositories:*');
+    QubitCache::getInstance()->removePattern('search:list-of-repositories:*');
 
     foreach ($this->informationObjects as $item)
     {


### PR DESCRIPTION
Add a select field with all the repositories to the description updates
page to allow filtering by institution when information object is selected

- Use (and rename) search repositories cache key for the field options
- Add new field in a new row alongside the pub. status field to allow
  showing/hidding both at the same time on type change
- Add clipboardToggleAll.js via view.yml instead of in the action
- Add toggleIoOptions.js in the same way to show/hide information
  object actions based on the type field value