### PR TITLE
Make cached EAD XML exclude drafts, refs #11197

### DIFF
--- a/lib/QubitInformationObjectXmlCacheResource.class.php
+++ b/lib/QubitInformationObjectXmlCacheResource.class.php
@@ -43,7 +43,8 @@ class QubitInformationObjectXmlCacheResource
   public function generateXmlRepresentation($format)
   {
     exportBulkBaseTask::includeXmlExportClassesAndHelpers();
-    $rawXml = exportBulkBaseTask::captureResourceExportTemplateOutput($this->resource, $format);
+    $options = ($format == 'ead') ? array('public' => true) : array();
+    $rawXml = exportBulkBaseTask::captureResourceExportTemplateOutput($this->resource, $format, $options);
     return Qubit::tidyXml($rawXml);
   }
 


### PR DESCRIPTION
Prevent drafts from inclusion in cached XML representations.