### PR TITLE
Prevent article removal slugs, Refs #11260

### DIFF
--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -3230,7 +3230,7 @@ class QubitInformationObject extends BaseInformationObject
 
     // If we still have a blank or null value here, QubitObject will eventually create a random
     // slug for us. See QubitObject::insertSlug().
-    return QubitSlug::slugify($stringToSlugify, false);
+    return QubitSlug::slugify($stringToSlugify);
   }
 
   /**

--- a/lib/model/QubitSlug.php
+++ b/lib/model/QubitSlug.php
@@ -61,7 +61,7 @@ class QubitSlug extends BaseSlug
    * @param bool $dropArticles  Whether or not to drop English articles from the slug.
    *                            We can disable this when we generate slugs by identifier.
    */
-  public static function slugify($slug, $dropArticles = true)
+  public static function slugify($slug)
   {
     // Handle exotic characters gracefully.
     // TRANSLIT doesn't work in musl's iconv, see #9855.
@@ -80,14 +80,6 @@ class QubitSlug extends BaseSlug
     $slug = preg_replace('/[^0-9a-z]+/', '-', $slug);
 
     $slug = "-$slug-";
-
-    // Drop (English) articles
-    if ($dropArticles)
-    {
-      $slug = str_replace('-a-', '-', $slug);
-      $slug = str_replace('-an-', '-', $slug);
-      $slug = str_replace('-the-', '-', $slug);
-    }
 
     $slug = trim($slug, '-');
 


### PR DESCRIPTION
English articles "a," "an," and the "the" will no longer be stripped
from slugs.

Post deployment be sure to run CLI tasks:
- php symfony propel:generate-slugs --delete
- php symfony search:populate