### PR TITLE
Fix event deletion, refs #10278

### DIFF
--- a/apps/qubit/modules/event/actions/editComponent.class.php
+++ b/apps/qubit/modules/event/actions/editComponent.class.php
@@ -147,14 +147,9 @@ class EventEditComponent extends sfComponent
         {
           $params = $this->context->routing->parse(Qubit::pathInfo($item['id']));
 
-          if ($this->resource instanceof QubitActor)
-          {
-            $this->resource->events[] = $this->event = $params['_sf_route']->resource;
-          }
-          else
-          {
-            $this->resource->eventsRelatedByobjectId[] = $this->event = $params['_sf_route']->resource;
-          }
+          // Do not add exiting events to the eventsRelatedByobjectId or events
+          // array, as they could be deleted before saving the resource
+          $this->event = $params['_sf_route']->resource;
         }
         elseif ($this->resource instanceof QubitActor)
         {
@@ -171,6 +166,13 @@ class EventEditComponent extends sfComponent
           {
             $this->processField($field);
           }
+        }
+
+        // Save existing events as they are not attached
+        // to the eventsRelatedByobjectId or events array
+        if (isset($this->event->id))
+        {
+          $this->event->save();
         }
       }
     }

--- a/plugins/sfDcPlugin/modules/sfDcPlugin/actions/dcDatesComponent.class.php
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/actions/dcDatesComponent.class.php
@@ -50,7 +50,9 @@ class sfDcPluginDcDatesComponent extends InformationObjectEventComponent
         $this->event = null;
         if (isset($item['id']))
         {
-          $this->resource->eventsRelatedByobjectId[] = $this->event = QubitEvent::getById($item['id']);
+          // Do not add exiting events to the eventsRelatedByobjectId
+          // array, as they could be deleted before saving the resource
+          $this->event = QubitEvent::getById($item['id']);
         }
         if (is_null($this->event))
         {
@@ -67,6 +69,13 @@ class sfDcPluginDcDatesComponent extends InformationObjectEventComponent
           {
             $this->processField($field);
           }
+        }
+
+        // Save existing events as they are not attached
+        // to the eventsRelatedByobjectId array
+        if (isset($this->event->id))
+        {
+          $this->event->save();
         }
       }
     }

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/actions/eventComponent.class.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/actions/eventComponent.class.php
@@ -92,7 +92,10 @@ class sfIsadPluginEventComponent extends InformationObjectEventComponent
         if (!isset($this->request->sourceId) && isset($item['id']))
         {
           $params = $this->context->routing->parse(Qubit::pathInfo($item['id']));
-          $this->resource->eventsRelatedByobjectId[] = $this->event = $params['_sf_route']->resource;
+
+          // Do not add exiting events to the eventsRelatedByobjectId
+          // array, as they could be deleted before saving the resource
+          $this->event = $params['_sf_route']->resource;
           array_push($finalEventIds, $this->event->id);
         }
         else
@@ -106,6 +109,13 @@ class sfIsadPluginEventComponent extends InformationObjectEventComponent
           {
             $this->processField($field);
           }
+        }
+
+        // Save existing events as they are not attached
+        // to the eventsRelatedByobjectId array
+        if (isset($this->event->id))
+        {
+          $this->event->save();
         }
       }
     }


### PR DESCRIPTION
Existing events can be deleted after the form fields are processed, so we
don't want them in the related events array of the current resource where,
when the resource is saved, they are tried to be saved causing an error.
They need to be saved independently after the fields are processed.