### PR TITLE
sf_culture validation issue, Refs #10673

### DIFF
--- a/vendor/symfony/lib/user/sfUser.class.php
+++ b/vendor/symfony/lib/user/sfUser.class.php
@@ -100,7 +100,7 @@ class sfUser implements ArrayAccess
     //  - use the culture defined in the user session
     //  - use the default culture set in settings.yml
     $currentCulture = $storage->read(self::CULTURE_NAMESPACE);
-    $this->setCulture(null !== $this->options['culture'] ? $this->options['culture'] : (null !== $currentCulture ? $currentCulture : $this->options['default_culture']));
+    $this->setCulture(sfCultureInfo::validCulture($this->options['culture']) ? $this->options['culture'] : (null !== $currentCulture ? $currentCulture : $this->options['default_culture']));
 
     // flag current flash to be removed at shutdown
     if ($this->options['use_flash'] && $names = $this->attributeHolder->getNames('symfony/user/sfUser/flash'))


### PR DESCRIPTION
I have added code to filter bad sf_culture values. I have changed the
check in sfUser.class.php to instead verify that it is a valid
sf_culture, and if not, fall back to:

- use the culture defined in the user session
- use the default culture set in settings.yml

This prevents 500 errors and prevents the ability to inject paths and
files into the cache directory.