### PR TITLE
Add setting to escape string queries, refs #11299

### DIFF
--- a/apps/qubit/modules/actor/actions/browseAction.class.php
+++ b/apps/qubit/modules/actor/actions/browseAction.class.php
@@ -105,7 +105,7 @@ class ActorBrowseAction extends DefaultBrowseAction
     }
     else
     {
-      $queryText = new \Elastica\Query\QueryString($request->subquery);
+      $queryText = new \Elastica\Query\QueryString(arElasticSearchPluginUtil::escapeTerm($request->subquery));
       $queryText->setDefaultOperator('OR');
       arElasticSearchPluginUtil::setFields($queryText, 'actor');
 

--- a/apps/qubit/modules/default/actions/moveAction.class.php
+++ b/apps/qubit/modules/default/actions/moveAction.class.php
@@ -103,7 +103,7 @@ class DefaultMoveAction extends sfAction
 
     if (isset($request->query))
     {
-      $query = new \Elastica\Query\QueryString($request->query);
+      $query = new \Elastica\Query\QueryString(arElasticSearchPluginUtil::escapeTerm($request->query));
       $query->setDefaultOperator('AND');
       $query->setFields(array(
         'identifier',

--- a/apps/qubit/modules/informationobject/actions/autocompleteAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/autocompleteAction.class.php
@@ -49,7 +49,7 @@ class InformationObjectAutocompleteAction extends sfAction
     }
     else
     {
-      $queryString = new \Elastica\Query\QueryString('*'.$request->query.'*');
+      $queryString = new \Elastica\Query\QueryString('*'.arElasticSearchPluginUtil::escapeTerm($request->query).'*');
 
       // Search for referenceCode or identifier, and title
       if (1 == sfConfig::get('app_inherit_code_informationobject', 1))

--- a/apps/qubit/modules/repository/actions/browseAction.class.php
+++ b/apps/qubit/modules/repository/actions/browseAction.class.php
@@ -116,7 +116,7 @@ class RepositoryBrowseAction extends DefaultBrowseAction
     }
     else
     {
-      $queryText = new \Elastica\Query\QueryString($request->subquery);
+      $queryText = new \Elastica\Query\QueryString(arElasticSearchPluginUtil::escapeTerm($request->subquery));
       $queryText->setDefaultOperator('OR');
       arElasticSearchPluginUtil::setFields($queryText, 'repository');
 

--- a/apps/qubit/modules/search/actions/indexAction.class.php
+++ b/apps/qubit/modules/search/actions/indexAction.class.php
@@ -28,7 +28,7 @@ class SearchIndexAction extends DefaultBrowseAction
   {
     parent::execute($request);
 
-    $queryText = new \Elastica\Query\QueryString($request->query);
+    $queryText = new \Elastica\Query\QueryString(arElasticSearchPluginUtil::escapeTerm($request->query));
     $queryText->setDefaultOperator('AND');
     arElasticSearchPluginUtil::setFields($queryText, 'informationObject');
 

--- a/apps/qubit/modules/settings/actions/globalAction.class.php
+++ b/apps/qubit/modules/settings/actions/globalAction.class.php
@@ -114,7 +114,7 @@ class SettingsGlobalAction extends sfAction
       'identifier_counter' => (isset($identifierCounter)) ? intval($identifierCounter->getValue(array('sourceCulture'=>true))) : 1,
       'separator_character' => (isset($separatorCharacter)) ? $separatorCharacter->getValue(array('sourceCulture'=>true)) : null,
       'inherit_code_informationobject' => (isset($inheritCodeInformationObject)) ? intval($inheritCodeInformationObject->getValue(array('sourceCulture'=>true))) : 1,
-      'escape_queries' => (isset($escapeQueries)) ? $escapeQueries->getValue(array('sourceCulture'=>true)) : '/',
+      'escape_queries' => (isset($escapeQueries)) ? $escapeQueries->getValue(array('sourceCulture'=>true)) : null,
       'sort_browser_user' => (isset($sortBrowserUser)) ? $sortBrowserUser->getValue(array('sourceCulture'=>true)) : 0,
       'sort_browser_anonymous' => (isset($sortBrowserAnonymous)) ? $sortBrowserAnonymous->getValue(array('sourceCulture'=>true)) : 0,
       'default_repository_browse_view' => (isset($defaultRepositoryView)) ? $defaultRepositoryView->getValue(array('sourceCulture' => true)) : 'card',

--- a/apps/qubit/modules/settings/actions/globalAction.class.php
+++ b/apps/qubit/modules/settings/actions/globalAction.class.php
@@ -82,6 +82,7 @@ class SettingsGlobalAction extends sfAction
     $identifierCounter = QubitSetting::getByName('identifier_counter');
     $separatorCharacter = QubitSetting::getByName('separator_character');
     $inheritCodeInformationObject = QubitSetting::getByName('inherit_code_informationobject');
+    $escapeQueries = QubitSetting::getByName('escape_queries');
     $sortBrowserUser = QubitSetting::getByName('sort_browser_user');
     $sortBrowserAnonymous = QubitSetting::getByName('sort_browser_anonymous');
     $defaultRepositoryView = QubitSetting::getByName('default_repository_browse_view');
@@ -113,6 +114,7 @@ class SettingsGlobalAction extends sfAction
       'identifier_counter' => (isset($identifierCounter)) ? intval($identifierCounter->getValue(array('sourceCulture'=>true))) : 1,
       'separator_character' => (isset($separatorCharacter)) ? $separatorCharacter->getValue(array('sourceCulture'=>true)) : null,
       'inherit_code_informationobject' => (isset($inheritCodeInformationObject)) ? intval($inheritCodeInformationObject->getValue(array('sourceCulture'=>true))) : 1,
+      'escape_queries' => (isset($escapeQueries)) ? $escapeQueries->getValue(array('sourceCulture'=>true)) : '/',
       'sort_browser_user' => (isset($sortBrowserUser)) ? $sortBrowserUser->getValue(array('sourceCulture'=>true)) : 0,
       'sort_browser_anonymous' => (isset($sortBrowserAnonymous)) ? $sortBrowserAnonymous->getValue(array('sourceCulture'=>true)) : 0,
       'default_repository_browse_view' => (isset($defaultRepositoryView)) ? $defaultRepositoryView->getValue(array('sourceCulture' => true)) : 'card',
@@ -272,6 +274,16 @@ class SettingsGlobalAction extends sfAction
       $setting->setValue($inheritCodeInformationObjectValue, array('sourceCulture'=>true));
       $setting->save();
     }
+
+    // Escape queries, add setting if it's not already created (to avoid adding it in a migration)
+    if (null === $setting = QubitSetting::getByName('escape_queries'))
+    {
+      $setting = QubitSetting::createNewSetting('escape_queries', null);
+    }
+
+    // Force sourceCulture update to prevent discrepency in settings between cultures
+    $setting->setValue($thisForm->getValue('escape_queries'), array('sourceCulture' => true));
+    $setting->save();
 
     // Sort Browser (for users)
     if (null !== $sortBrowserUser = $thisForm->getValue('sort_browser_user'))

--- a/apps/qubit/modules/taxonomy/actions/indexAction.class.php
+++ b/apps/qubit/modules/taxonomy/actions/indexAction.class.php
@@ -106,7 +106,7 @@ class TaxonomyIndexAction extends sfAction
 
     if (1 !== preg_match('/^[\s\t\r\n]*$/', $request->subquery))
     {
-      $queryString = new \Elastica\Query\QueryString($request->subquery);
+      $queryString = new \Elastica\Query\QueryString(arElasticSearchPluginUtil::escapeTerm($request->subquery));
 
       switch ($request->subqueryField)
       {

--- a/lib/form/SettingsGlobalForm.class.php
+++ b/lib/form/SettingsGlobalForm.class.php
@@ -51,6 +51,7 @@ class SettingsGlobalForm extends sfForm
       'identifier_counter' => new sfWidgetFormInput,
       'separator_character' => new sfWidgetFormInput(array(), array('maxlength' => 1)),
       'inherit_code_informationobject' => new sfWidgetFormSelectRadio(array('choices' => array(1 => 'yes', 0 => 'no')), array('class' => 'radio')),
+      'escape_queries' => new sfWidgetFormInput,
       'sort_browser_user' => new sfWidgetFormSelectRadio(array('choices' => array('alphabetic' => 'alphabetic', 'lastUpdated' => 'last updated', 'identifier' => 'identifier', 'referenceCode' => $this->i18n->__('reference code'))), array('class' => 'radio')),
       'sort_browser_anonymous' => new sfWidgetFormSelectRadio(array('choices' => array('alphabetic' => 'alphabetic', 'lastUpdated' => 'last updated', 'identifier' => 'identifier', 'referenceCode' => $this->i18n->__('reference code'))), array('class' => 'radio')),
       'default_repository_browse_view' => new sfWidgetFormSelectRadio(array('choices' => array('card' => $this->i18n->__('card'), 'table' => $this->i18n->__('table'))), array('class' => 'radio')),
@@ -84,6 +85,7 @@ class SettingsGlobalForm extends sfForm
       'identifier_counter' => $this->i18n->__('Identifier counter'),
       'separator_character' => $this->i18n->__('Reference code separator'),
       'inherit_code_informationobject' => $this->i18n->__('Inherit reference code (information object)'),
+      'escape_queries' => $this->i18n->__('Escape special chars from searches'),
       'sort_browser_user' => $this->i18n->__('Sort browser (users)'),
       'sort_browser_anonymous' => $this->i18n->__('Sort browser (anonymous)'),
       'default_repository_browse_view' => $this->i18n->__('Default repository browse view'),
@@ -117,6 +119,7 @@ class SettingsGlobalForm extends sfForm
       'default_archival_description_browse_view' => $this->i18n->__('Set the default view template when browsing archival descriptions'),
       'separator_character' => $this->i18n->__('The character separating hierarchical elements in a reference code'),
       'inherit_code_informationobject' => $this->i18n->__('When set to &quot;yes&quot;, the reference code string will be built using the information object identifier plus the identifiers of all its ancestors'),
+      'escape_queries' => $this->i18n->__('A list of special chars, separated by coma, to be escaped in string queries'),
       'multi_repository' => $this->i18n->__('When set to &quot;no&quot;, the repository name is excluded from certain displays because it will be too repetitive'),
       'enable_institutional_scoping' => $this->i18n->__('Applies to multi-repository sites only. When set to &quot;yes&quot;, additional search and browse options will be available at the repository level'),
       'repository_quota' => $this->i18n->__('Default %1% upload limit for a new %2%.  A value of &quot;0&quot; (zero) disables file upload.  A value of &quot;-1&quot; allows unlimited uploads', array('%1%' => strtolower(sfConfig::get('app_ui_label_digitalobject')), '%2%' => strtolower(sfConfig::get('app_ui_label_repository')))),
@@ -162,6 +165,7 @@ class SettingsGlobalForm extends sfForm
     $this->validatorSchema['separator_character'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['accession_counter'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['inherit_code_informationobject'] = new sfValidatorInteger(array('required' => false));
+    $this->validatorSchema['escape_queries'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['sort_browser_user'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['sort_browser_anonymous'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['multi_repository'] = new sfValidatorInteger(array('required' => false));

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPlugin.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPlugin.class.php
@@ -495,7 +495,7 @@ class arElasticSearchPlugin extends QubitSearchEngine
       throw new Exception('No search terms specified.');
     }
 
-    $query = new \Elastica\Query\QueryString($query);
+    $query = new \Elastica\Query\QueryString(arElasticSearchPluginUtil::escapeTerm($query));
     $query->setDefaultOperator('AND');
 
     return $query;

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginQuery.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginQuery.class.php
@@ -302,6 +302,8 @@ class arElasticSearchPluginQuery
 
   protected function queryField($field, $query, $archivalStandard)
   {
+    $query = arElasticSearchPluginUtil::escapeTerm($query);
+
     switch ($field)
     {
       case 'identifier':

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
@@ -658,7 +658,7 @@ class arElasticSearchPluginUtil
    */
   public static function escapeTerm($term)
   {
-    $specialChars = trim(sfConfig::get('app_escape_queries', '/'));
+    $specialChars = trim(sfConfig::get('app_escape_queries', ''));
 
     // Return term directly if the setting is empty
     if (empty($specialChars))

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
@@ -648,4 +648,44 @@ class arElasticSearchPluginUtil
       return $premisData;
     }
   }
+
+  /**
+   * Escapes the special chars specified in the "escape_queries" setting
+   *
+   * @param string $term Query term to escape
+   *
+   * @return string Escaped query term
+   */
+  public static function escapeTerm($term)
+  {
+    $specialChars = trim(sfConfig::get('app_escape_queries', '/'));
+
+    // Return term directly if the setting is empty
+    if (empty($specialChars))
+    {
+      return $term;
+    }
+
+    // Split into array removing whitespaces
+    $specialChars = preg_split('/\s*,\s*/', $specialChars);
+
+    // Escaping \ has to be first
+    if (in_array('\\', $specialChars))
+    {
+      $term = str_replace('\\', '\\\\', $term);
+    }
+
+    foreach ($specialChars as $char)
+    {
+      // Ignore empty chars and \
+      if (empty($char) || $char == '\\')
+      {
+        continue;
+      }
+
+      $term = str_replace($char, '\\' . $char, $term);
+    }
+
+    return $term;
+  }
 }

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
@@ -136,8 +136,13 @@ class arElasticSearchPluginUtil
   {
     // Create array with relations (hidden field => ES mapping field) for the actual template and cultures
     $relations = array();
+    $cultures = array();
+    foreach (QubitSetting::getByScope('i18n_languages') as $setting)
+    {
+      $cultures[] = $setting->getValue(array('sourceCulture' => true));
+    }
 
-    if (null !== $template = self::getTemplate())
+    if (null !== $template = self::getTemplate('informationObject'))
     {
       switch ($template)
       {

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchModelBase.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchModelBase.class.php
@@ -149,7 +149,7 @@ abstract class arElasticSearchModelBase
     // Expand all the i18n fields into their various cultures, add boost values
     $i18nBoostFields = arElasticSearchPluginUtil::getI18nFieldNames(
       array_keys($i18nFields),
-      $cultures,
+      null,
       $i18nFields
     );
 

--- a/plugins/qtAccessionPlugin/modules/accession/actions/browseAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/browseAction.class.php
@@ -71,7 +71,7 @@ class AccessionBrowseAction extends sfAction
     }
     else
     {
-      $queryString = new \Elastica\Query\QueryString($request->subquery);
+      $queryString = new \Elastica\Query\QueryString(arElasticSearchPluginUtil::escapeTerm($request->subquery));
 
       $boost = array(
         'donors.i18n.%s.authorizedFormOfName' => 10,

--- a/test/unit/escapeTermTest.php
+++ b/test/unit/escapeTermTest.php
@@ -25,12 +25,12 @@ $configuration = ProjectConfiguration::getApplicationConfiguration('qubit', 'tes
 sfContext::createInstance($configuration);
 
 // Default setting
-sfConfig::set('app_escape_queries', '/');
-$t->is(arElasticSearchPluginUtil::escapeTerm('FO1/23-BAR\\456'), 'FO1\\/23-BAR\\456', 'Default setting, escapes only /');
-
-// Empty setting
 sfConfig::set('app_escape_queries', '');
-$t->is(arElasticSearchPluginUtil::escapeTerm('FO1/23-BAR\\456'), 'FO1/23-BAR\\456', 'Empty setting, doesn\'t escape');
+$t->is(arElasticSearchPluginUtil::escapeTerm('FO1/23-BAR\\456'), 'FO1/23-BAR\\456', 'Default setting, doesn\'t escape');
+
+// Setting with value
+sfConfig::set('app_escape_queries', '\\,/');
+$t->is(arElasticSearchPluginUtil::escapeTerm('FO1/23-BAR\\456'), 'FO1\\/23-BAR\\\\456', 'Setting with value, escapes the term');
 
 // Un-ordered setting
 sfConfig::set('app_escape_queries', '/,\\');

--- a/test/unit/escapeTermTest.php
+++ b/test/unit/escapeTermTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once dirname(__FILE__).'/../bootstrap/unit.php';
+
+$t = new lime_test(5, new lime_output_color);
+
+$configuration = ProjectConfiguration::getApplicationConfiguration('qubit', 'test', true);
+sfContext::createInstance($configuration);
+
+// Default setting
+sfConfig::set('app_escape_queries', '/');
+$t->is(arElasticSearchPluginUtil::escapeTerm('FO1/23-BAR\\456'), 'FO1\\/23-BAR\\456', 'Default setting, escapes only /');
+
+// Empty setting
+sfConfig::set('app_escape_queries', '');
+$t->is(arElasticSearchPluginUtil::escapeTerm('FO1/23-BAR\\456'), 'FO1/23-BAR\\456', 'Empty setting, doesn\'t escape');
+
+// Un-ordered setting
+sfConfig::set('app_escape_queries', '/,\\');
+$t->is(arElasticSearchPluginUtil::escapeTerm('FO1/23-BAR\\456'), 'FO1\\/23-BAR\\\\456', 'Un-ordered setting, escapes \\ first');
+
+// Malformed setting
+sfConfig::set('app_escape_queries', '/, ,[,]');
+$t->is(arElasticSearchPluginUtil::escapeTerm('FO1/23-BAR[456]'), 'FO1\\/23-BAR\\[456\\]', 'Malformed setting, ignores empty chars');
+sfConfig::set('app_escape_queries', ' / , [ , ] ');
+$t->is(arElasticSearchPluginUtil::escapeTerm('FO1/23-BAR[456]'), 'FO1\\/23-BAR\\[456\\]', 'Malformed setting, ignores white spaces');


### PR DESCRIPTION
To avoid Elasticsearch errors while searching using usual special chars,
like '/' in an instance where that's the reference code separator, a new
setting has been added to determine which chars should be escaped
before performing the string query.

- Add escape_queries setting
- Add escapeTerm function to arElasticSearchPluginUtil
- Use new escapeTerm function in ES string queries
- Add unit test