### PR TITLE
Fix i18n repository region filter, refs #11121

### DIFF
--- a/apps/qubit/modules/repository/actions/browseAction.class.php
+++ b/apps/qubit/modules/repository/actions/browseAction.class.php
@@ -40,7 +40,7 @@ class RepositoryBrowseAction extends DefaultBrowseAction
               'size' => 10),
       'regions' =>
         array('type' => 'term',
-              'field' => 'contactInformations.i18n.en.region.untouched',
+              'field' => 'contactInformations.i18n.%s.region.untouched',
               'size' => 10),
       'geographicSubregions' =>
         array('type' => 'term',
@@ -48,7 +48,7 @@ class RepositoryBrowseAction extends DefaultBrowseAction
               'size' => 10),
       'locality' =>
         array('type' => 'term',
-              'field' => 'contactInformations.i18n.en.city.untouched',
+              'field' => 'contactInformations.i18n.%s.city.untouched',
               'size' => 10),
       'thematicAreas' =>
         array('type' => 'term',
@@ -88,6 +88,9 @@ class RepositoryBrowseAction extends DefaultBrowseAction
 
   public function execute($request)
   {
+    // Must call this first as parent::execute() calls addFacets().
+    $this->setI18nFieldCultures();
+
     parent::execute($request);
 
     $this->cardView = 'card';
@@ -209,5 +212,20 @@ class RepositoryBrowseAction extends DefaultBrowseAction
     $query->setLimit($limit);
 
     $this->repositories = QubitSearch::getInstance()->index->getType('QubitRepository')->search($query);
+  }
+
+  /**
+   * Set FACET i18n fields to the current culture. In the future, we'll want to implement culture fallback
+   * for these fields as well (see #11121).
+   */
+  private function setI18nFieldCultures()
+  {
+    foreach (self::$FACETS as $key => &$value)
+    {
+      if (false !== array_search('i18n.%s', $value['field']))
+      {
+        $value['field'] = sprintf($value['field'], $this->context->user->getCulture());
+      }
+    }
   }
 }

--- a/apps/qubit/modules/repository/templates/_advancedFilters.php
+++ b/apps/qubit/modules/repository/templates/_advancedFilters.php
@@ -48,7 +48,8 @@
           <option selected="selected"></option>
           <?php $regions = array() ?>
           <?php foreach ($repositories as $r): ?>
-            <?php $region = get_search_i18n($r->getData(), 'region', array('allowEmpty' => false, 'culture' => $this->selectedCulture, 'cultureFallback' => true)) ?>
+            <?php $region = get_search_i18n($r->getData(), 'region', array('allowEmpty' => true, 'culture' => $sf_user->getCulture(), 'cultureFallback' => false)) ?>
+
             <?php if ($region && !in_array($region, $regions)): ?>
               <?php $regions[] = $region ?>
               <option value="<?php echo $region ?>"><?php echo $region ?></option>


### PR DESCRIPTION
This fix will make it so when browsing repositories and setting the region
filter, only show regions in the dropdown for the current culture. This also
fixes repo browse so the region filter works for non-English cultures.

NOTE: This filter does not support culture fallback! You can only set the
region filter on terms for the current culture.