### PR TITLE
Change places/subjects search operator ref #11349

### DIFF
--- a/apps/qubit/modules/taxonomy/actions/indexAction.class.php
+++ b/apps/qubit/modules/taxonomy/actions/indexAction.class.php
@@ -126,7 +126,7 @@ class TaxonomyIndexAction extends sfAction
           $fields = array('i18n.%s.name', 'useFor.i18n.%s.name');
           $boost = array('i18n.%s.name' => 5);
           $queryString->setFields(arElasticSearchPluginUtil::getI18nFieldNames($fields, null, $boost));
-          $queryString->setDefaultOperator('OR');
+          $queryString->setDefaultOperator('AND');
 
           break;
       }


### PR DESCRIPTION
Change the default search operator for subjects and places to AND (previously
was OR). Note, this change will affect all taxonomy searches as well, not
just subjects and places. :)