### PR TITLE
Deletion nested set update disabling, refs #10962

### DIFF
--- a/lib/model/QubitActor.php
+++ b/lib/model/QubitActor.php
@@ -25,6 +25,8 @@
  */
 class QubitActor extends BaseActor
 {
+  public $disableNestedSetUpdating = false;
+
   const
     ROOT_ID = 3;
 

--- a/lib/model/QubitMenu.php
+++ b/lib/model/QubitMenu.php
@@ -19,6 +19,8 @@
 
 class QubitMenu extends BaseMenu
 {
+  public $disableNestedSetUpdating = false;
+
   const
 
     // Root menu

--- a/lib/model/QubitPhysicalObject.php
+++ b/lib/model/QubitPhysicalObject.php
@@ -19,6 +19,8 @@
 
 class QubitPhysicalObject extends BasePhysicalObject
 {
+  public $disableNestedSetUpdating = false;
+
   /**
    * Call this function when casting object instance as type string
    *

--- a/lib/model/QubitTaxonomy.php
+++ b/lib/model/QubitTaxonomy.php
@@ -19,6 +19,8 @@
 
 class QubitTaxonomy extends BaseTaxonomy
 {
+  public $disableNestedSetUpdating = false;
+
   const
     ROOT_ID = 30,
     DESCRIPTION_DETAIL_LEVEL_ID = 31,

--- a/lib/model/om/BaseActor.php
+++ b/lib/model/om/BaseActor.php
@@ -475,7 +475,10 @@ abstract class BaseActor extends QubitObject implements ArrayAccess
     }
 
     $this->clear();
-    $this->deleteFromNestedSet($connection);
+    if (!property_exists($this, 'disableNestedSetUpdating') || $this->disableNestedSetUpdating !== true)
+    {
+      $this->deleteFromNestedSet($connection);
+    }
 
     parent::delete($connection);
 

--- a/lib/model/om/BaseInformationObject.php
+++ b/lib/model/om/BaseInformationObject.php
@@ -461,7 +461,10 @@ abstract class BaseInformationObject extends QubitObject implements ArrayAccess
     }
 
     $this->clear();
-    $this->deleteFromNestedSet($connection);
+    if (!property_exists($this, 'disableNestedSetUpdating') || $this->disableNestedSetUpdating !== true)
+    {
+      $this->deleteFromNestedSet($connection);
+    }
 
     parent::delete($connection);
 

--- a/lib/model/om/BaseMenu.php
+++ b/lib/model/om/BaseMenu.php
@@ -721,7 +721,10 @@ abstract class BaseMenu implements ArrayAccess
     }
 
     $this->clear();
-    $this->deleteFromNestedSet($connection);
+    if (!property_exists($this, 'disableNestedSetUpdating') || $this->disableNestedSetUpdating !== true)
+    {
+      $this->deleteFromNestedSet($connection);
+    }
 
     $criteria = new Criteria;
     $criteria->add(QubitMenu::ID, $this->id);

--- a/lib/model/om/BasePhysicalObject.php
+++ b/lib/model/om/BasePhysicalObject.php
@@ -399,7 +399,10 @@ abstract class BasePhysicalObject extends QubitObject implements ArrayAccess
     }
 
     $this->clear();
-    $this->deleteFromNestedSet($connection);
+    if (!property_exists($this, 'disableNestedSetUpdating') || $this->disableNestedSetUpdating !== true)
+    {
+      $this->deleteFromNestedSet($connection);
+    }
 
     parent::delete($connection);
 

--- a/lib/model/om/BaseTaxonomy.php
+++ b/lib/model/om/BaseTaxonomy.php
@@ -421,7 +421,10 @@ abstract class BaseTaxonomy extends QubitObject implements ArrayAccess
     }
 
     $this->clear();
-    $this->deleteFromNestedSet($connection);
+    if (!property_exists($this, 'disableNestedSetUpdating') || $this->disableNestedSetUpdating !== true)
+    {
+      $this->deleteFromNestedSet($connection);
+    }
 
     parent::delete($connection);
 

--- a/lib/model/om/BaseTerm.php
+++ b/lib/model/om/BaseTerm.php
@@ -1149,7 +1149,10 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
     }
 
     $this->clear();
-    $this->deleteFromNestedSet($connection);
+    if (!property_exists($this, 'disableNestedSetUpdating') || $this->disableNestedSetUpdating !== true)
+    {
+      $this->deleteFromNestedSet($connection);
+    }
 
     parent::delete($connection);
 

--- a/lib/propel/builder/QubitObjectBuilder.php
+++ b/lib/propel/builder/QubitObjectBuilder.php
@@ -1698,7 +1698,10 @@ script;
       $script .= <<<script
 
     \$this->clear();
-    \$this->deleteFromNestedSet(\$connection);
+    if (!property_exists(\$this, 'disableNestedSetUpdating') || \$this->disableNestedSetUpdating !== true)
+    {
+      \$this->deleteFromNestedSet(\$connection);
+    }
 
 script;
     }

--- a/plugins/qbAclPlugin/lib/model/om/BaseAclGroup.php
+++ b/plugins/qbAclPlugin/lib/model/om/BaseAclGroup.php
@@ -761,7 +761,10 @@ abstract class BaseAclGroup implements ArrayAccess
     }
 
     $this->clear();
-    $this->deleteFromNestedSet($connection);
+    if (!property_exists($this, 'disableNestedSetUpdating') || $this->disableNestedSetUpdating !== true)
+    {
+      $this->deleteFromNestedSet($connection);
+    }
 
     $criteria = new Criteria;
     $criteria->add(QubitAclGroup::ID, $this->id);


### PR DESCRIPTION
Added the ability to, when programatically deleting a term node, set the disableNestedSetUpdating to true so the nested set isn't updated during the delete. This allows much faster batch deletion of terms and the nested set can be updated manually afterwards.

Implemented by modifying the QubitObjectBuilder class to generate model code that suppports this and updated existng model code.