### PR TITLE
CSV import issue qubitParentSlug, Refs# 11409

### DIFF
--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -2236,7 +2236,7 @@ class QubitFlatfileImport
     }
   }
 
-  public function getIdCorrespondingToSlug($slug)
+  public static function getIdCorrespondingToSlug($slug)
   {
     $query = "SELECT object_id FROM slug WHERE slug=?";
 

--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -194,7 +194,7 @@ EOF;
     // Allow default parent ID to be overridden by CLI options
     if ($options['default-parent-slug'])
     {
-      $defaultParentId = getIdCorrespondingToSlug($options['default-parent-slug']);
+      $defaultParentId = QubitFlatfileImport::getIdCorrespondingToSlug($options['default-parent-slug']);
 
       if (!$options['quiet'])
       {
@@ -640,7 +640,7 @@ EOF;
 
         if (isset($self->rowStatusVars['qubitParentSlug']) && $self->rowStatusVars['qubitParentSlug'])
         {
-          $parentId = getIdCorrespondingToSlug($self->rowStatusVars['qubitParentSlug']);
+          $parentId = $self->getIdCorrespondingToSlug($self->rowStatusVars['qubitParentSlug']);
         }
         else
         {


### PR DESCRIPTION
This commit fixes an issue where CSVs with the qubitParentSlug column
populated would not import without errors.

Root cause of this issue was that the QubitFlatfileImport method
getIdCorrespondingToSlug() was not being referenced correctly from
functions in csvImportTask.class.php.