### PR TITLE
Arch Descr move and more buttons, Refs# 11410

### DIFF
--- a/apps/qubit/modules/informationobject/templates/_actions.php
+++ b/apps/qubit/modules/informationobject/templates/_actions.php
@@ -14,7 +14,7 @@
         <li><?php echo link_to(__('Duplicate'), array('module' => 'informationobject', 'action' => 'copy', 'source' => $resource->id), array('class' => 'c-btn')) ?></li>
       <?php endif; ?>
 
-      <?php if (QubitAcl::check($resource, 'update')): ?>
+      <?php if (QubitAcl::check($resource, 'update') || (QubitAcl::check($resource, 'translate'))): ?>
 
         <li><?php echo link_to(__('Move'), array($resource, 'module' => 'default', 'action' => 'move'), array('class' => 'c-btn')) ?></li>
 


### PR DESCRIPTION
Move and More buttons were not available to Editor user groups when
culture is not English even when users were in the translate group
with the selected language.

In QubitAclConditionalAssert.class.php there is a conditional check for
'update' - if the IO source culture is not the same as the users current
language, updates are denied. This is the source of this issue and is
by-design for 'update' items.

These buttons should be available to users who are able to translate the
selected language however. I have added an ACL check so that these buttons
can be accessed by users in the 'translate' group with the selected
language.