### PR TITLE
Arch Descr move and more buttons, Refs# 11410

### DIFF
--- a/apps/qubit/modules/informationobject/templates/_actions.php
+++ b/apps/qubit/modules/informationobject/templates/_actions.php
@@ -14,7 +14,7 @@
         <li><?php echo link_to(__('Duplicate'), array('module' => 'informationobject', 'action' => 'copy', 'source' => $resource->id), array('class' => 'c-btn')) ?></li>
       <?php endif; ?>
 
-      <?php if (QubitAcl::check($resource, 'update') || (QubitAcl::check($resource, 'translate'))): ?>
+      <?php if (QubitAcl::check($resource, 'update')): ?>
 
         <li><?php echo link_to(__('Move'), array($resource, 'module' => 'default', 'action' => 'move'), array('class' => 'c-btn')) ?></li>
 


### PR DESCRIPTION
Removing change to add an ACL check so that 'move' & 'more' buttons
could be accessed by users in the 'translate' group. This did not
achieve the desired behaviour.