### PR TITLE
Fix description deletion approach, refs #11404

### DIFF
--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -3295,13 +3295,19 @@ class QubitInformationObject extends BaseInformationObject
 
   /**
    * Delete this information object as well as all children information objects.
+   *
+   * @return int  Number of QubitInformationObjects deleted.
    */
   public function deleteFullHierarchy()
   {
+    $n = 0;
     foreach ($this->descendants->andSelf()->orderBy('rgt') as $item)
     {
       $item->delete();
+      $n++;
     }
+
+    return $n;
   }
 
   /**


### PR DESCRIPTION
There was a bug related to the lft/rgt values not staying up to date during a
single ORM query while we're deleting things and the nested set is updating,
which sometimes resulted in unrelated records being accessed in the loop.

Splitting up the ORM queries on a per-top-leve-description basis with getById
rectifies this.