### PR TITLE
Hide physical locations for --public ref #8993

### DIFF
--- a/lib/task/export/csvExportInformationObjectsTask.class.php
+++ b/lib/task/export/csvExportInformationObjectsTask.class.php
@@ -75,6 +75,8 @@ class csvExportInformationObjectsTask extends exportBulkBaseTask
       $options['rows-per-file']
     );
 
+    $writer->setOptions($options);
+
     foreach ($rows as $row)
     {
       $sf_context->getUser()->setCulture($row['culture']);


### PR DESCRIPTION
Hide physical location data from resulting csv in csv:export while using the
--public option and setting physical locations to not visible in the visible
elements module.