### PR TITLE
Protect user routes, Refs# 11427

### DIFF
--- a/apps/qubit/modules/user/actions/deleteAction.class.php
+++ b/apps/qubit/modules/user/actions/deleteAction.class.php
@@ -25,6 +25,13 @@ class UserDeleteAction extends sfAction
 
     $this->resource = $this->getRoute()->resource;
 
+    if (!isset($this->resource))
+    {
+      $this->forward404();
+    }
+
+    // Check for existing notes since we don't allow user deletion if they've
+    // authored archivist notes in the past.
     if ($this->context->user->user === $this->resource || 0 < count($this->resource->notes))
     {
       QubitAcl::forwardUnauthorized();

--- a/apps/qubit/modules/user/actions/editActorAclAction.class.php
+++ b/apps/qubit/modules/user/actions/editActorAclAction.class.php
@@ -26,10 +26,13 @@ class UserEditActorAclAction extends DefaultEditAction
   {
     $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
 
-    $this->resource = new QubitUser;
     if (isset($this->getRoute()->resource))
     {
       $this->resource = $this->getRoute()->resource;
+    }
+    else
+    {
+      $this->forward404();
     }
 
     // Always include root actor permissions

--- a/apps/qubit/modules/user/actions/editInformationObjectAclAction.class.php
+++ b/apps/qubit/modules/user/actions/editInformationObjectAclAction.class.php
@@ -26,10 +26,13 @@ class UserEditInformationObjectAclAction extends DefaultEditAction
   {
     $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
 
-    $this->resource = new QubitUser;
     if (isset($this->getRoute()->resource))
     {
       $this->resource = $this->getRoute()->resource;
+    }
+    else
+    {
+      $this->forward404();
     }
 
     // Build separate list of permissions by repository and by object

--- a/apps/qubit/modules/user/actions/editRepositoryAclAction.class.php
+++ b/apps/qubit/modules/user/actions/editRepositoryAclAction.class.php
@@ -26,10 +26,13 @@ class UserEditRepositoryAclAction extends DefaultEditAction
   {
     $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
 
-    $this->resource = new QubitUser;
     if (isset($this->getRoute()->resource))
     {
       $this->resource = $this->getRoute()->resource;
+    }
+    else
+    {
+      $this->forward404();
     }
 
     // Always include root repository permissions

--- a/apps/qubit/modules/user/actions/editTermAclAction.class.php
+++ b/apps/qubit/modules/user/actions/editTermAclAction.class.php
@@ -27,10 +27,13 @@ class UserEditTermAclAction extends DefaultEditAction
   {
     $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
 
-    $this->resource = new QubitUser;
     if (isset($this->getRoute()->resource))
     {
       $this->resource = $this->getRoute()->resource;
+    }
+    else
+    {
+      $this->forward404();
     }
 
     $this->permissions = array();

--- a/apps/qubit/modules/user/actions/indexAction.class.php
+++ b/apps/qubit/modules/user/actions/indexAction.class.php
@@ -23,6 +23,11 @@ class UserIndexAction extends sfAction
   {
     $this->resource = $this->getRoute()->resource;
 
+    if (!isset($this->resource))
+    {
+      $this->forward404();
+    }
+
     foreach (array('restApiKey', 'oaiApiKey') as $key)
     {
       // Get API key value, if any

--- a/apps/qubit/modules/user/actions/indexActorAclAction.class.php
+++ b/apps/qubit/modules/user/actions/indexActorAclAction.class.php
@@ -23,6 +23,11 @@ class UserIndexActorAclAction extends sfAction
   {
     $this->resource = $this->getRoute()->resource;
 
+    if (!isset($this->resource))
+    {
+      $this->forward404();
+    }
+
     //except for administrators, only allow users to see their own profile
     if (!$this->context->user->isAdministrator())
     {

--- a/apps/qubit/modules/user/actions/indexInformationObjectAclAction.class.php
+++ b/apps/qubit/modules/user/actions/indexInformationObjectAclAction.class.php
@@ -23,6 +23,11 @@ class UserIndexInformationObjectAclAction extends sfAction
   {
     $this->resource = $this->getRoute()->resource;
 
+    if (!isset($this->resource))
+    {
+      $this->forward404();
+    }
+
     // Except for administrators, only allow users to see their own profile
     if (!$this->context->user->isAdministrator())
     {

--- a/apps/qubit/modules/user/actions/indexRepositoryAclAction.class.php
+++ b/apps/qubit/modules/user/actions/indexRepositoryAclAction.class.php
@@ -23,6 +23,11 @@ class UserIndexRepositoryAclAction extends sfAction
   {
     $this->resource = $this->getRoute()->resource;
 
+    if (!isset($this->resource))
+    {
+      $this->forward404();
+    }
+
     // Except for administrators, only allow users to see their own profile
     if (!$this->context->user->isAdministrator())
     {

--- a/apps/qubit/modules/user/actions/indexTermAclAction.class.php
+++ b/apps/qubit/modules/user/actions/indexTermAclAction.class.php
@@ -23,6 +23,11 @@ class UserIndexTermAclAction extends sfAction
   {
     $this->resource = $this->getRoute()->resource;
 
+    if (!isset($this->resource))
+    {
+      $this->forward404();
+    }
+
     // Except for administrators, only allow users to see their own profile
     if (!$this->context->user->isAdministrator())
     {


### PR DESCRIPTION
These routes were able to be accessed with malformed urls (slug missing
from URL path). Access should only be allowed if the request contains
the user resource:
e.g.
<baseurl>/<userslug>/user or <baseurl>/<userslug>/user/delete