### PR TITLE
Remove APCu back. compatibility dep, refs #11387

### DIFF
--- a/config/ProjectConfiguration.class.php
+++ b/config/ProjectConfiguration.class.php
@@ -21,10 +21,9 @@ require_once dirname(__FILE__).'/../vendor/symfony/lib/autoload/sfCoreAutoload.c
 sfCoreAutoload::register();
 
 require_once __DIR__.'/../vendor/symfony2/src/Symfony/Component/ClassLoader/UniversalClassLoader.php';
-require_once __DIR__.'/../vendor/symfony2/src/Symfony/Component/ClassLoader/ApcUniversalClassLoader.php';
+require_once __DIR__.'/../lib/QubitApcUniversalClassLoader.php';
 
 use Symfony\Component\ClassLoader\UniversalClassLoader;
-use Symfony\Component\ClassLoader\ApcUniversalClassLoader;
 
 class ProjectConfiguration extends sfProjectConfiguration
 {
@@ -60,11 +59,11 @@ class ProjectConfiguration extends sfProjectConfiguration
     $rootDir = sfConfig::get('sf_root_dir');
 
     // Use APC when available to cache the location of namespaced classes
-    if (extension_loaded('apc'))
+    if (extension_loaded('apcu')|| extension_loaded('apc'))
     {
       // Use unique prefix to avoid cache clashing
       $prefix = sprintf('atom:%s:', md5($rootDir));
-      $loader = new ApcUniversalClassLoader($prefix);
+      $loader = new QubitApcUniversalClassLoader($prefix);
     }
     else
     {

--- a/lib/QubitApcUniversalClassLoader.php
+++ b/lib/QubitApcUniversalClassLoader.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use Symfony\Component\ClassLoader\UniversalClassLoader;
+
+/**
+ * QubicApcUniversalClassLoader implements a "universal" autoloader cached in APCu/APC.
+ *
+ * Based on ApcUniversalClassLoader.
+ *
+ * @author Mike Cantelon <mike@artefactual.com>
+ *
+ */
+class QubitApcUniversalClassLoader extends UniversalClassLoader
+{
+    private $prefix;
+
+    /**
+     * Constructor.
+     *
+     * @param string $prefix A prefix to create a namespace in APCu/APC
+     *
+     * @throws \RuntimeException
+     */
+    public function __construct($prefix)
+    {
+        if (!extension_loaded('apcu') && !extension_loaded('apc')) {
+            throw new \RuntimeException('Unable to use QubitApcUniversalClassLoader as neither APCu or APC are enabled.');
+        }
+
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * Finds a file by class name while caching lookups to APCu/APC.
+     *
+     * @param string $class A class name to resolve to file
+     *
+     * @return string|null The path, if found
+     */
+    public function findFile($class)
+    {
+        $functionPrefix = (extension_loaded('apc')) ? 'apcu' : 'apc';
+        $fetchFunction = $functionPrefix .'_fetch';
+        $storeFunction = $functionPrefix .'_store';
+
+        if (false === $file = $fetchFunction($this->prefix.$class)) {
+            $storeFunction($this->prefix.$class, $file = parent::findFile($class));
+        }
+
+        return $file;
+    }
+}

--- a/plugins/sfInstallPlugin/lib/sfInstall.class.php
+++ b/plugins/sfInstallPlugin/lib/sfInstall.class.php
@@ -244,9 +244,9 @@ class sfInstall
     {
       opcache_reset();
     }
-    if (function_exists('apc_clear_cache'))
+    if (function_exists('apcu_clear_cache'))
     {
-      apc_clear_cache();
+      apcu_clear_cache();
     }
 
     return $settingsYml;
@@ -306,10 +306,6 @@ class sfInstall
     if (function_exists('opcache_invalidate'))
     {
       $e = opcache_invalidate($configFile, true);
-    }
-    if (function_exists('apc_delete_file'))
-    {
-      $e = apc_delete_file($configFile);
     }
 
     $databaseManager = sfContext::getInstance()->databaseManager;


### PR DESCRIPTION
Remove reliance on APCu's API backwards compatibility to eliminate need to install APCu-bc. Fixed issue with creation time and modification time not working with older versions of APCu.