### PR TITLE
ES5 XML import query error, Refs# 11527

### DIFF
--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -1106,7 +1106,8 @@ class QubitXmlImport
         $matchId = QubitInformationObject::getByTitleIdentifierAndRepo(
           $resource->identifier,
           $resource->title,
-          $resource->repository->authorizedFormOfName
+          // EAD XML does not include repo in child recs - Use parent's repo.
+          ($this->rootObject !== $resource) ? $this->rootObject->repository->authorizedFormOfName : $resource->repository->authorizedFormOfName
         );
 
         if ($matchId)


### PR DESCRIPTION
Change ES query in getByTitleIdentifierAndRepo() to use a match query
instead of term query. Match query should be used for exact match as it
compares to exact strings instead of analyzed text.

Prevent null values from getting passed in to query. Querying on null
values triggers errors under ES5.

Fix issue in QubitXmlImport where repository name was not being passed
in to getByTitleIdentifierAndRepo() for EAD XML child records.