### PR TITLE
Dev/issue 11534 csv export job

### DIFF
--- a/lib/job/arInformationObjectXmlExportJob.class.php
+++ b/lib/job/arInformationObjectXmlExportJob.class.php
@@ -41,7 +41,7 @@ class arInformationObjectXmlExportJob extends arBaseJob
     $this->params['format'] = 'ead';
 
     // Create query increasing limit from default
-    $this->search = new arElasticSearchPluginQuery(1000000000);
+    $this->search = new arElasticSearchPluginQuery(arElasticSearchPluginUtil::SCROLL_SIZE);
 
     if ($this->params['params']['fromClipboard'])
     {
@@ -101,11 +101,12 @@ class arInformationObjectXmlExportJob extends arBaseJob
 
     exportBulkBaseTask::includeXmlExportClassesAndHelpers();
 
-    $resultSet = QubitSearch::getInstance()->index->getType('QubitInformationObject')->search($this->search->getQuery(false, false));
+    $search = QubitSearch::getInstance()->index->getType('QubitInformationObject')->createSearch($this->search->getQuery(false, false));
 
-    foreach ($resultSet as $hit)
+    // Scroll through results then iterate through resulting IDs
+    foreach (arElasticSearchPluginUtil::getScrolledSearchResultIdentifiers($search) as $id)
     {
-      $resource = QubitInformationObject::getById($hit->getId());
+      $resource = QubitInformationObject::getById($id);
 
       // If ElasticSearch document is stale (corresponding MySQL data deleted), ignore
       if ($resource !== null)

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
@@ -25,6 +25,11 @@
  */
 class arElasticSearchPluginUtil
 {
+  /**
+   * Scroll per-page limit to use for bulk queries
+   */
+  const SCROLL_SIZE = 1000;
+
   public static function convertDate($date)
   {
     if (is_null($date))
@@ -687,5 +692,36 @@ class arElasticSearchPluginUtil
     }
 
     return $term;
+  }
+
+  /**
+   * Scroll through search, returning hit IDs as an array
+   *
+   * Scrolled queries are a way to return search result sets larger than the limit
+   * index.max_result_window sets. Scrolled results, however, by default expire
+   * fairly quickly to free Elasticsearch resources. Returning these results as an
+   * array allows the results to be processed even after the scroll result expires.
+   *
+   * @param \Elastica\Search $search Search to cache
+   *
+   * @return array Array of IDs
+   */
+  public static function getScrolledSearchResultIdentifiers($search)
+  {
+    $hitIds = array();
+
+    // Create scroll of search
+    $scroll = new \Elastica\Scroll($search);
+
+    // Scroll and add hit IDs to array
+    foreach ($scroll as $resultSet)
+    {
+      foreach ($resultSet as $hit)
+      {
+       array_push($hitIds, $hit->getId()); 
+      }
+    }
+
+    return $hitIds;
   }
 }


### PR DESCRIPTION
* Use scroll API for export jobs

Fixes issue with export jobs where large result sets can't be retrieved from Elasticsearch without pagination.