### PR TITLE
Correct parameters to logSection, Refs# 11542

### DIFF
--- a/lib/task/digitalobject/digitalObjectDeleteTask.class.php
+++ b/lib/task/digitalobject/digitalObjectDeleteTask.class.php
@@ -70,7 +70,7 @@ EOF;
 
     foreach ($ios as $io)
     {
-      $this->logSection(sprintf('(%d of %d) deleting digital object for: %s',
+      $this->logSection('digital-object', sprintf('(%d of %d) deleting digital object for: %s',
                         ++$nDeleted, count($ios), $io->getTitle(array('cultureFallback' => true))));
 
       // Remove appropriate digital object files, empty directories left behind, and db entries
@@ -82,7 +82,7 @@ EOF;
       }
     }
 
-    $this->logSection(sprintf('%d digital objects deleted successfully (%.2fs elapsed)', $nDeleted, $t->elapsed()));
+    $this->logSection('digital-object', sprintf('%d digital objects deleted successfully (%.2fs elapsed)', $nDeleted, $t->elapsed()));
   }
 
   private function deleteDigitalObjectFiles($digitalObject)

--- a/lib/task/digitalobject/digitalObjectLoadTask.class.php
+++ b/lib/task/digitalobject/digitalObjectLoadTask.class.php
@@ -90,7 +90,7 @@ EOF;
       QubitSearch::disable();
     }
 
-    $this->logSection("Load digital objects from {$arguments['filename']}...");
+    $this->logSection('digital-object', "Load digital objects from {$arguments['filename']}...");
 
     // Get header (first) row
     $header = fgetcsv($fh, 1000);
@@ -223,12 +223,12 @@ EOF;
       $importedCount++;
     }
 
-    $this->logSection('Successfully Loaded '.self::$count.' digital objects.');
+    $this->logSection('digital-object', 'Successfully Loaded '.self::$count.' digital objects.');
 
     // Warn user to manually update search index
     if (!$options['index'])
     {
-      $this->logSection('Please update the search index manually to reflect any changes');
+      $this->logSection('digital-object', 'Please update the search index manually to reflect any changes');
     }
   }
 

--- a/lib/task/import/csvRepositoryImportTask.class.php
+++ b/lib/task/import/csvRepositoryImportTask.class.php
@@ -91,7 +91,7 @@ EOF;
 
     $this->validateOptions($options);
 
-    $this->logSection("Importing repository objects from CSV to AtoM");
+    $this->logSection('repository-import', 'Importing repository objects from CSV to AtoM');
 
     $skipRows = ($options['skip-rows']) ? $options['skip-rows'] : 0;
 
@@ -318,6 +318,6 @@ EOF;
     $import->setUpdateOptions($options);
 
     $import->csv($fh, $skipRows);
-    $this->logSection("Imported repositories successfully!");
+    $this->logSection('repository-import', 'Imported repositories successfully!');
   }
 }

--- a/lib/task/import/importDipObjectsTask.class.php
+++ b/lib/task/import/importDipObjectsTask.class.php
@@ -117,14 +117,14 @@ EOF;
 
     // Set path to DIP objects
     $objectsPath = rtrim($this->dipDir, '/') .'/objects';
-    $this->logSection(sprintf("Looking for objects in: %s", $this->dipDir));
+    $this->logSection('dip-import', sprintf('Looking for objects in: %s', $this->dipDir));
 
     // Parse CSV file and import/audit objects
     $digitalObjects = $this->parseCsvData($this->openFirstCsvFile($objectsPath), $objectsPath);
     $count = $this->importDigitalObjects($digitalObjects, $options['audit'], $undoLog);
 
     $verb = ($options['audit']) ? 'audited' : 'processed';
-    $this->logSection(sprintf('Successfully %s %d digital objects.', $verb, $count));
+    $this->logSection('dip-import', sprintf('Successfully %s %d digital objects.', $verb, $count));
   }
 
   /**
@@ -320,7 +320,7 @@ EOF;
     foreach ($digitalObjects as $key => $item)
     {
       $opDescription = ($auditMode) ? 'Auditing' : 'Importing to';
-      $this->logSection(sprintf("%s '$key'...", $opDescription));
+      $this->logSection('dip-import', sprintf("%s '$key'...", $opDescription));
 
       if ($auditMode)
       {
@@ -560,7 +560,7 @@ EOF;
     }
 
     // If UUIDs found, inform user and return first UUID found
-    $this->logSection("UUID found: ". $matches[0][0] ." in ". $subject);
+    $this->logSection('dip-import', 'UUID found: '. $matches[0][0] ." in ". $subject);
 
     return $matches[0][0];
   }

--- a/lib/task/tools/deleteDescriptionTask.class.php
+++ b/lib/task/tools/deleteDescriptionTask.class.php
@@ -60,7 +60,7 @@ EOF;
 
     if (!$this->confirmDeletion($options['no-confirmation']))
     {
-      $this->logSection(sprintf('[%s] Task aborted.', strftime('%r')));
+      $this->logSection('delete-description', sprintf('[%s] Task aborted.', strftime('%r')));
       return;
     }
 
@@ -75,7 +75,7 @@ EOF;
         break;
     }
 
-    $this->logSection(sprintf('[%s] Finished: %d descriptions deleted.', strftime('%r'), $this->nDeleted));
+    $this->logSection('delete-description', sprintf('[%s] Finished: %d descriptions deleted.', strftime('%r'), $this->nDeleted));
   }
 
   /**
@@ -138,9 +138,9 @@ EOF;
    */
   private function deleteDescriptions($root)
   {
-    $this->logSection(sprintf('[%s] Deleting description "%s" (slug: %s, +%d descendants)', strftime('%r'),
-                              $root->getTitle(array('cultureFallback' => true)),
-                              $root->slug, count($root->descendants)));
+    $this->logSection('delete-description', sprintf('[%s] Deleting description "%s" (slug: %s, +%d descendants)', strftime('%r'),
+      $root->getTitle(array('cultureFallback' => true)),
+      $root->slug, count($root->descendants)));
 
     $this->nDeleted += $root->deleteFullHierarchy();
   }
@@ -151,9 +151,9 @@ EOF;
    */
   private function deleteDescriptionsFromRepository()
   {
-    $this->logSection(sprintf('[%s] Removing descriptions from repository "%s" (slug: %s)...', strftime('%r'),
-                      $this->resource->getAuthorizedFormOfName(array('cultureFallback' => true)),
-                      $this->resource->slug));
+    $this->logSection('delete-description', sprintf('[%s] Removing descriptions from repository "%s" (slug: %s)...', strftime('%r'),
+      $this->resource->getAuthorizedFormOfName(array('cultureFallback' => true)),
+      $this->resource->slug));
 
     $rows = QubitPdo::fetchAll('SELECT id FROM information_object WHERE parent_id = ? AND repository_id = ?',
                                array(QubitInformationObject::ROOT_ID, $this->resource->id));


### PR DESCRIPTION
Under PHP 7.1, ArgumentCountError as now being elevated to an error
instead of a warning. This commit corrects the number of parameters being
passed to logSection() in the following CLI tasks:

- lib/task/digitalobject/digitalObjectDeleteTask.class.php
- lib/task/digitalobject/digitalObjectLoadTask.class.php
- lib/task/import/csvRepositoryImportTask.class.php
- lib/task/import/importDipObjectsTask.class.php
- lib/task/tools/deleteDescriptionTask.class.php

These jobs were failing to run under PHP 7.1 giving the error:

"PHP Fatal error: Uncaught ArgumentCountError: Too few arguments to
function sfCommandApplicationTask::logSection()"