### PR TITLE
Add MARC XML parser and import task

### DIFF
--- a/lib/QubitSaxParser.class.php
+++ b/lib/QubitSaxParser.class.php
@@ -111,15 +111,16 @@ class QubitSaxParser
     $this->storeAncestorIfNesting();
     $this->lastTagStartLevel = $this->level;
 
-    // Store current tag data
-    $this->tag = $tag;
+    // Store current tag data, concatenate namespace
+    // with '_' instead of ':' to allow function calls
+    $this->tag = str_replace(':', '_', $tag);
     unset($this->data);
 
     array_push($this->attrStack, $attr);
 
     // Methods that end with "StartTag" are handlers for specific tags...
     // Call tag handler, if it exists, or generic tag handler
-    $this->callOptionalTagHandlers($tag, 'TagInit', 'startTagHandler');
+    $this->callOptionalTagHandlers($this->tag, 'TagInit', 'startTagHandler');
   }
 
   /**
@@ -238,6 +239,9 @@ class QubitSaxParser
       array_pop($this->ancestors);
     }
     $this->lastTagEndLevel = $this->level;
+
+    // Concatenate namespace with '_' instead of ':' to allow function calls
+    $tag = str_replace(':', '_', $tag);
 
     // Methods that end with "EndTag" are handlers for specific tags...
     // Call tag handler, if it exists, or generic tag handler

--- a/lib/task/import/marc/arMarcXmlParser.class.php
+++ b/lib/task/import/marc/arMarcXmlParser.class.php
@@ -1,0 +1,270 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class arMarcXmlParser extends QubitSaxParser
+{
+  protected $dispatcher;
+  protected $formatter;
+  protected $taxonomy;
+  protected $termCounter;
+  protected $termData;
+  protected $currentTagAttr;
+  protected $currentLabel;
+
+  public function __construct($dispatcher, $formatter, $taxonomy)
+  {
+    parent::__construct();
+
+    $this->dispatcher = $dispatcher;
+    $this->formatter = $formatter;
+    $this->taxonomy = $taxonomy;
+    $this->termCounter = 0;
+  }
+
+  /*
+   * Tags functions
+   */
+
+  protected function marc_collectionTagInit()
+  {
+    $this->log(sprintf('Starting collection import to "%s" taxonomy:', $this->taxonomy));
+  }
+
+  protected function marc_recordTagInit()
+  {
+    // Initiate term data
+    $this->termData = array(
+      'fastIdentifier' => null,
+      'lang' => null,
+      'prefLabel' => '',
+      'altLabels' => array(),
+      'broaderTerms' => array(),
+      'relatedTerms' => array()
+    );
+  }
+
+  protected function marc_datafieldTagInit()
+  {
+    // Get current tag, needed to determine termData
+    // field in the subfield tag function bellow
+    $this->currentTagAttr = $this->attr('tag');
+
+    // Initiate current label, used to determine its
+    // type and value from different subfield elements
+    $this->currentLabel = array(
+      'type' => null,
+      'value' => ''
+    );
+  }
+
+  protected function marc_subfieldTag()
+  {
+    // A tag attribute from the datafield is required
+    if (!isset($this->currentTagAttr))
+    {
+      return;
+    }
+
+    // Data is only needed from the following code attributes
+    $codeAttr = $this->attr('code');
+    if (!isset($codeAttr) || !in_array($codeAttr, array('a', 'b', 'c', 'p', 'x', 'w', 'z', '0')))
+    {
+      return;
+    }
+
+    // Do not import empty subfield elements
+    $data = trim($this->data());
+    if (strlen($data) === 0)
+    {
+      return;
+    }
+
+    // Add data to termData based on the datafield tag attribute
+    switch ($this->currentTagAttr)
+    {
+
+      case '016':
+        // FAST identifier in elements with code="a" attribute
+        if ($codeAttr === 'a' && substr($data, 0, 3) === 'fst')
+        {
+          $this->termData['fastIdentifier'] = ltrim(substr($data, 3), 0);
+        }
+
+        break;
+
+      case '040':
+        // Language in elements with code="b" attribute
+        if ($codeAttr === 'b')
+        {
+          $this->termData['lang'] = $data;
+        }
+
+        break;
+
+      // Labels can be a concatenation of elements,
+      // more info in the processLabel function.
+      // Label types by tag attribute:
+      //   - Preferred label: 150
+      //   - Alternative labels: 410, 430, 450
+      //   - Broader/Related terms labels: 500, 510, 530, 550, 551, 555
+      case '150':
+        $this->processLabel('prefLabel', $data, $codeAttr);
+
+        break;
+
+      case '410':
+      case '430':
+      case '450':
+        $this->processLabel('altLabel', $data, $codeAttr);
+
+        break;
+
+      // Defaults to related term, changes to
+      // broader in processLabel when needed
+      case '500':
+      case '510':
+      case '530':
+      case '550':
+      case '551':
+      case '555':
+        $this->processLabel('relatedTerms', $data, $codeAttr);
+
+        break;
+    }
+  }
+
+  protected function marc_datafieldTag()
+  {
+    // Save current label to term data if needed
+    if (!isset($this->currentLabel['type']) || strlen($this->currentLabel['value']) == 0)
+    {
+      return;
+    }
+
+    if ($this->currentLabel['type'] === 'prefLabel')
+    {
+      $this->termData['prefLabel'] = $this->currentLabel['value'];
+    }
+    else if ($this->currentLabel['type'] === 'altLabel')
+    {
+      $this->termData['altLabels'][] = $this->currentLabel['value'];
+    }
+    else
+    {
+      $term = array(
+        'prefLabel' => $this->currentLabel['value'],
+        'fastIdentifier' => $this->currentLabel['fastIdentifier'] ?
+          $this->currentLabel['fastIdentifier'] :
+          null
+      );
+
+      $this->termData[$this->currentLabel['type']][] = $term;
+    }
+  }
+
+  protected function marc_recordTag()
+  {
+    $this->log('Creating: ' . $this->termData['prefLabel']);
+
+    /*
+    if ($this->termData['prefLabel'] == 'Galleria delle statue (Museo Pio-Clementino, Vatican City)')
+    {
+      $this->log(json_encode($this->termData, JSON_PRETTY_PRINT));
+    }
+
+    $this->term = new QubitTerm();
+    $contHeadIdent = 'http://id.worldcat.org/fast/' . $this->termData['fastIdentifier'];
+    $this->term->save();
+    */
+
+    $this->termCounter++;
+  }
+
+  protected function marc_collectionTag()
+  {
+    $this->log(sprintf('Collection import finished, %d terms have been imported.', $this->termCounter));
+  }
+
+  /*
+   * Helper functions
+   */
+
+  public function log($messages)
+  {
+    if (!is_array($messages))
+    {
+      $messages = array($messages);
+    }
+
+    $this->dispatcher->notify(new sfEvent($this, 'command.log', $messages));
+  }
+
+  protected function processLabel($type, $data, $code)
+  {
+    // Set current label type if it's not already set
+    if (!isset($this->currentLabel['type']))
+    {
+      $this->currentLabel['type'] = $type;
+    }
+
+    // Based on the subfield code attr
+    switch ($code)
+    {
+      // Initiate label value
+      case 'a':
+        $this->currentLabel['value'] = $data;
+
+        break;
+
+      // Concatenate to label value with space
+      case 'b':
+      case 'c':
+      case 'p':
+        $this->currentLabel['value'] .= ' ' . $data;
+
+        break;
+
+      // Concatenate to label value with two hyphens
+      case 'x':
+      case 'z':
+        $this->currentLabel['value'] .= '--' . $data;
+
+        break;
+
+      // Change type to broader instead of related
+      case 'w':
+        if ($data === 'g')
+        {
+          $this->currentLabel['type'] = 'broaderTerms';
+        }
+
+        break;
+
+      // Add FAST identifier to related/broader terms
+      case '0':
+        $pos = strpos($data, 'fst');
+        if ($pos !== false)
+        {
+          $this->currentLabel['fastIdentifier'] = ltrim(substr($data, $pos + 3), '0');
+        }
+
+        break;
+    }
+  }
+}

--- a/lib/task/import/marc/arMarcXmlTermsImportTask.class.php
+++ b/lib/task/import/marc/arMarcXmlTermsImportTask.class.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Parse MARC XML file and create QubitTerms from <marc:record> elements
+ *
+ * @package    symfony
+ * @subpackage task
+ */
+class arMarcXmlTermsImportTask extends arBaseTask
+{
+  /**
+   * @see sfTask
+   */
+  protected function configure()
+  {
+    $this->addArguments(array(
+      new sfCommandArgument('file', sfCommandArgument::REQUIRED, 'The MARC XML input file'),
+      new sfCommandArgument('taxonomy', sfCommandArgument::REQUIRED, 'Taxonomy slug where to import the terms')
+    ));
+
+    $this->addOptions(array(
+      new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
+      new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
+      new sfCommandOption('connection', null, sfCommandOption::PARAMETER_REQUIRED, 'The connection name', 'propel')
+    ));
+
+    $this->namespace = 'import';
+    $this->name = 'marc-xml';
+    $this->briefDescription = 'Import terms from a MARC XML file to a taxonomy';
+
+    $this->detailedDescription = <<<EOF
+Parse a MARC XML file and create QubitTerms from <marc:record> elements, the terms
+will be part of a taxanomy specified by slug.
+EOF;
+  }
+
+  /**
+   * @see sfTask
+   */
+  public function execute($arguments = array(), $options = array())
+  {
+    parent::execute($arguments, $options);
+
+    $databaseManager = new sfDatabaseManager($this->configuration);
+    $conn = $databaseManager->getDatabase('propel')->getConnection();
+
+    $taxonomy = QubitTaxonomy::getBySlug($arguments['taxonomy']);
+
+    if (!isset($taxonomy))
+    {
+      $this->log('Could not find taxonomy with slug: ' . $arguments['taxonomy']);
+
+      return;
+    }
+
+    if (in_array($taxonomy->id, QubitTaxonomy::$lockedTaxonomies))
+    {
+      $this->log(sprintf('Taxonomy "%s" is locked.', $taxonomy));
+
+      return;
+    }
+
+    $parser = new arMarcXmlParser($this->dispatcher, $this->formatter, $taxonomy);
+
+    if (!$parser->parse($arguments['file']))
+    {
+      $errorData = $parser->getErrorData();
+      $this->log($this->context->i18n->__('SAX xml parse error %code% on line %line% in input file: %message%', array('%code%' => $errorData['code'], '%message%' => $errorData['string'], '%line%' => $errorData['line'])));
+    }
+  }
+}


### PR DESCRIPTION
- Add arMarcXmlParser, extending QubitSaxParser. It parses and creates
  terms from a MARC XML file into a determinated taxonomy. Some
  assumptions have been made on how the labels and related/broader
  terms are parsed based on the example XML file used for development.
  This assumptions may not follow completely the MARC21 standart but
  this parser should be a good starting point for future development.

- Add arMarcXmlTermsImportTask, example call:

  `php symfony import:marc-xml /path/to/marc.xml taxonomy-slug`

  It parses the given XML file to the taxonomy (indicated by its
  slug) using the new arMarcXmlParser.

- Small tweak in QubitSaxParser to allow function calls on element tags
  with namespaces, replacing ':' by '_' in the tag names.