### PR TITLE
ES 5.x: fix fields included in all, refs #10847

### DIFF
--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
@@ -458,8 +458,11 @@ class arElasticSearchPluginUtil
           $fields = array_merge($fields, $foreignObjectFields);
         }
         // Get string fields included in _all
-        else if ((!isset($propertyProperties['include_in_all']) || $propertyProperties['include_in_all'])
-          && (isset($propertyProperties['type']) && $propertyProperties['type'] == 'string'))
+        else if ((!isset($propertyProperties['include_in_all'])
+          || $propertyProperties['include_in_all'])
+          && (isset($propertyProperties['type'])
+          && ($propertyProperties['type'] == 'text'
+          || $propertyProperties['type'] == 'keyword')))
         {
           self::handleNonI18nStringFields($rootIndexType, $fields, $prefix, $propertyName, $foreignType);
         }


### PR DESCRIPTION
String fields are now two different types in the ES mapping: 'keyword'
and 'text'. We now need to check those types instead of 'string' to
determine if a field should be included in the 'all' query.