### PR TITLE
Active Directory Login Integration

### DIFF
--- a/apps/qubit/modules/settings/actions/adAction.class.php
+++ b/apps/qubit/modules/settings/actions/adAction.class.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class SettingsadAction extends DefaultEditAction
+{
+  // Arrays not allowed in class constants
+  public static
+    $NAMES = array(
+      'ldapHost',
+      'ldapBaseDn',
+      'ldapBindAttribute');
+
+  protected function earlyExecute()
+  {
+
+  }
+
+  protected function addField($name)
+  {
+    switch ($name)
+    {
+
+      case 'ldapHost':
+      case 'ldapBaseDn':
+        // Determine and set field default value
+        if (null !== $this->{$name} = QubitSetting::getByName($name))
+        {
+          $default = $this->{$name}->getValue(array('sourceCulture' => true));
+        }
+        else
+        {
+
+          $default = (isset($defaults[$name])) ? $defaults[$name] : '';
+        }
+
+        $this->form->setDefault($name, $default);
+
+        // Set validator and widget
+        //$validator = ($name == 'ldapPort') ? new sfValidatorInteger(array('min' => 1, 'max' => 65535)) : new sfValidatorPass;
+        //$this->form->setValidator($name, $validator);
+        $this->form->setWidget($name, new sfWidgetFormInput);
+
+        break;
+    }
+  }
+
+  protected function processField($field)
+  {
+    switch ($name = $field->getName())
+    {
+		case 'ldapHost':
+      case 'ldapBaseDn':
+        if (null === $this->{$name})
+        {
+          $this->{$name} = new QubitSetting;
+          $this->{$name}->name = $name;
+          $this->{$name}->scope = 'ad';
+        }
+        $this->{$name}->setValue($field->getValue(), array('sourceCulture' => true));
+        $this->{$name}->save();
+
+        break;
+    }
+  }
+
+  public function execute($request)
+  {
+    parent::execute($request);
+
+    if ($request->isMethod('post'))
+    {
+      $this->form->bind($request->getPostParameters());
+
+      if ($this->form->isValid())
+      {
+        $this->processForm();
+
+        QubitCache::getInstance()->removePattern('settings:i18n:*');
+
+        $this->redirect(array('module' => 'settings', 'action' => 'ad'));
+      }
+    }
+  }
+}

--- a/apps/qubit/modules/settings/actions/adAction.class.php
+++ b/apps/qubit/modules/settings/actions/adAction.class.php
@@ -34,28 +34,21 @@ class SettingsadAction extends DefaultEditAction
   {
     switch ($name)
     {
-
       case 'ldapHost':
       case 'ldapBaseDn':
-        // Determine and set field default value
-        if (null !== $this->{$name} = QubitSetting::getByName($name))
-        {
-          $default = $this->{$name}->getValue(array('sourceCulture' => true));
-        }
-        else
-        {
-
-          $default = (isset($defaults[$name])) ? $defaults[$name] : '';
-        }
-
-        $this->form->setDefault($name, $default);
-
-        // Set validator and widget
-        //$validator = ($name == 'ldapPort') ? new sfValidatorInteger(array('min' => 1, 'max' => 65535)) : new sfValidatorPass;
-        //$this->form->setValidator($name, $validator);
-        $this->form->setWidget($name, new sfWidgetFormInput);
-
-        break;
+      // Determine and set field default value
+      if (null !== $this->{$name} = QubitSetting::getByName($name))
+      {
+        $default = $this->{$name}->getValue(array('sourceCulture' => true));
+      }
+      else
+      {
+        $default = (isset($defaults[$name])) ? $defaults[$name] : '';
+      }
+      $this->form->setDefault($name, $default);
+      // Set validator and widget
+      $this->form->setWidget($name, new sfWidgetFormInput);
+      break;
     }
   }
 
@@ -63,18 +56,17 @@ class SettingsadAction extends DefaultEditAction
   {
     switch ($name = $field->getName())
     {
-		case 'ldapHost':
+      case 'ldapHost':
       case 'ldapBaseDn':
-        if (null === $this->{$name})
-        {
-          $this->{$name} = new QubitSetting;
-          $this->{$name}->name = $name;
-          $this->{$name}->scope = 'ad';
-        }
-        $this->{$name}->setValue($field->getValue(), array('sourceCulture' => true));
-        $this->{$name}->save();
-
-        break;
+      if (null === $this->{$name})
+      {
+        $this->{$name} = new QubitSetting;
+        $this->{$name}->name = $name;
+        $this->{$name}->scope = 'ad';
+      }
+      $this->{$name}->setValue($field->getValue(), array('sourceCulture' => true));
+      $this->{$name}->save();
+      break;
     }
   }
 
@@ -85,13 +77,10 @@ class SettingsadAction extends DefaultEditAction
     if ($request->isMethod('post'))
     {
       $this->form->bind($request->getPostParameters());
-
       if ($this->form->isValid())
       {
         $this->processForm();
-
         QubitCache::getInstance()->removePattern('settings:i18n:*');
-
         $this->redirect(array('module' => 'settings', 'action' => 'ad'));
       }
     }

--- a/apps/qubit/modules/settings/actions/adAction.class.php
+++ b/apps/qubit/modules/settings/actions/adAction.class.php
@@ -17,7 +17,7 @@
  * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
  */
 
-class SettingsadAction extends DefaultEditAction
+class SettingsADAction extends DefaultEditAction
 {
   // Arrays not allowed in class constants
   public static

--- a/apps/qubit/modules/settings/actions/adAction.class.php
+++ b/apps/qubit/modules/settings/actions/adAction.class.php
@@ -23,8 +23,7 @@ class SettingsadAction extends DefaultEditAction
   public static
     $NAMES = array(
       'ldapHost',
-      'ldapBaseDn',
-      'ldapBindAttribute');
+      'ldapBaseDn');
 
   protected function earlyExecute()
   {

--- a/apps/qubit/modules/settings/actions/menuComponent.class.php
+++ b/apps/qubit/modules/settings/actions/menuComponent.class.php
@@ -99,7 +99,6 @@ class SettingsMenuComponent extends sfComponent
         'action' => 'ad'
       ));
     }
-
     
     foreach ($this->nodes as $i => &$node)
     {

--- a/apps/qubit/modules/settings/actions/menuComponent.class.php
+++ b/apps/qubit/modules/settings/actions/menuComponent.class.php
@@ -92,7 +92,7 @@ class SettingsMenuComponent extends sfComponent
     }
 
     // Only show Active Directory authentication settings if Active Directory authentication's used
-    if ($this->context->user instanceof adUser)
+    if ($this->context->user instanceof ADUser)
     {
       array_push($this->nodes, array(
         'label' => $i18n->__('Active Directory Authentication'),

--- a/apps/qubit/modules/settings/actions/menuComponent.class.php
+++ b/apps/qubit/modules/settings/actions/menuComponent.class.php
@@ -91,6 +91,16 @@ class SettingsMenuComponent extends sfComponent
       ));
     }
 
+    // Only show Active Directory authentication settings if Active Directory authentication's used
+    if ($this->context->user instanceof adUser)
+    {
+      array_push($this->nodes, array(
+        'label' => $i18n->__('Active Directory Authentication'),
+        'action' => 'ad'
+      ));
+    }
+
+    
     foreach ($this->nodes as $i => &$node)
     {
       // Remove hidden nodes

--- a/apps/qubit/modules/settings/templates/adSuccess.php
+++ b/apps/qubit/modules/settings/templates/adSuccess.php
@@ -29,7 +29,6 @@
         <?php echo $form->ldapBaseDn
           ->label(__('Base DN'))
           ->renderRow() ?>
-
 		  
       </fieldset>
 

--- a/apps/qubit/modules/settings/templates/adSuccess.php
+++ b/apps/qubit/modules/settings/templates/adSuccess.php
@@ -1,0 +1,46 @@
+<?php decorate_with('layout_2col.php') ?>
+
+<?php slot('sidebar') ?>
+
+  <?php echo get_component('settings', 'menu') ?>
+
+<?php end_slot() ?>
+
+<?php slot('title') ?>
+
+  <h1><?php echo __('Active Directory authentication') ?></h1>
+
+<?php end_slot() ?>
+
+<?php slot('content') ?>
+
+  <?php echo $form->renderFormTag(url_for(array('module' => 'settings', 'action' => 'ad'))) ?>
+
+    <div id="content">
+
+      <fieldset class="collapsible">
+
+        <legend><?php echo __('Active Directory authentication settings') ?></legend>
+
+        <?php echo $form->ldapHost
+          ->label(__('DC or GC URI'))
+          ->renderRow() ?>
+
+        <?php echo $form->ldapBaseDn
+          ->label(__('Base DN'))
+          ->renderRow() ?>
+
+		  
+      </fieldset>
+
+    </div>
+
+    <section class="actions">
+      <ul>
+        <li><input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Save') ?>"/></li>
+      </ul>
+    </section>
+
+  </form>
+
+<?php end_slot() ?>

--- a/lib/adUser.class.php
+++ b/lib/adUser.class.php
@@ -1,0 +1,192 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+include sfConfig::get('sf_root_dir') .'/vendor/password_compat/password.php';
+
+class adUser extends myUser implements Zend_Acl_Role_Interface
+{
+  protected $ldapConnection;
+  protected $ldapBound;
+
+  public function initialize(sfEventDispatcher $dispatcher, sfStorage $storage, $options = array())
+  {
+    // initialize parent
+    parent::initialize($dispatcher, $storage, $options);
+
+    if (!extension_loaded('ldap'))
+    {
+      throw new sfConfigurationException('ldapUser class needs the "ldap" extension to be loaded.');
+    }
+  }
+
+  public function authenticate($username, $password)
+  {
+    // Allow LDAP authentication to be overridden during development
+    $configuration = sfContext::getInstance()->getConfiguration();
+    if ($configuration->isDebug() || 'dev' == $configuration->getEnvironment())
+    {
+      return parent::authenticate($username, $password);
+    }
+
+    // Anonymous is not a real user
+    if ($username == 'anonymous')
+    {
+      return false;
+    }
+
+    $authenticated = $this->ldapAuthenticate($username, $password);
+
+    // Fallback to non-LDAP authentication if need be and load/create user data
+    if (!$authenticated)
+    {
+      $authenticated = parent::authenticate($username, $password);
+
+      // Load user
+      $criteria = new Criteria;
+      $criteria->add(QubitUser::EMAIL, $username);
+      $user = QubitUser::getOne($criteria);
+    }
+    else
+    {
+      // Load user using username or, if one doesn't exist, create it
+      $criteria = new Criteria;
+      //$criteria->add(QubitUser::USERNAME, $username);
+      //Use the AD Username or else you will get the UPN as username.
+      $criteria->add(QubitUser::EMAIL, $username);
+      if (null === $user = QubitUser::getOne($criteria))
+      {
+        $user = $this->createUserFromLdapInfo($username);
+      }
+    }
+
+    // Unbind if necessary to be easy on the LDAP server
+    if ($this->ldapBound)
+    {
+      ldap_unbind($this->ldapConnection);
+    }
+
+    // Sign in user if authentication was successful
+    if ($authenticated)
+    {
+      $this->signIn($user);
+    }
+
+    return $authenticated;
+  }
+
+  protected function createUserFromLdapInfo($username)
+  {
+    $user = new QubitUser();
+    //$user->username = $username;
+
+    $conn = $this->getLdapConnection();
+    
+    // Do AD search for user's email address
+    $base_dn = (string)QubitSetting::getByName('ldapBaseDn');
+    $filter='(&(objectCategory=person)(objectClass=user)(userPrincipalName='. $username .'))';
+	  
+    $result = ldap_search($conn, $base_dn, $filter);
+    $entries = ldap_get_entries($conn, $result);
+    $noentries = ldap_count_entries($conn, $result);
+    
+    // If user is found and email exists, store it
+    if ($noentries > 0)
+    {
+      //In order to relocate the user when logging in again, the email must match the UPN
+      //which in some organisations will match the email address in any case.
+      //if (!empty($entries[0]['mail'])) $user->email = $entries[0]['mail'][0];
+      $user->email = $username;
+      $user->username = $entries[0]['name'][0];
+    } else { $user->username = $username; }
+
+    $user->save();
+
+
+    return $user;
+  }
+
+  protected function getLdapConnection()
+  {
+    if (isset($this->ldapConnection))
+    {
+      return $this->ldapConnection;
+    }
+
+    $host = QubitSetting::getByName('ldapHost');
+    //$port = QubitSetting::getByName('ldapPort');
+
+    if (null !== $host)
+    {
+		
+			// If using an URI you only need to send the host URI, so the $port will be null
+			$connection = ldap_connect($host->getValue(array('sourceCulture' => true)));
+      		ldap_set_option($connection, LDAP_OPT_PROTOCOL_VERSION, 3);
+          
+      		$this->ldapConnection = $connection;
+      		return $connection;
+		//}
+    }
+  }
+
+  protected function ldapBind($username, $password)
+  {
+    if ($conn = $this->getLdapConnection())
+    {
+      $this->ldapBound = ldap_bind($conn, $username, $password);
+      return $this->ldapBound;
+    }
+  }
+
+  /**
+   * ldapAuthenticate caches the result of ldapBind with a short TTL
+   * to avoid hitting the directory.
+   */
+  private function ldapAuthenticate($username, $password)
+  {
+    try
+    {
+      // Try to load a cache engine
+      $cache = QubitCache::getInstance();
+    }
+    catch (Exception $e)
+    {
+      return $this->ldapBind($username, $password);
+    }
+
+    $cacheKey = 'ldap-hash:'.$username;
+
+    // Look up cache entry and verify hash if exists
+    if ($cache->has($cacheKey) && (null !== $hash = $cache->get($cacheKey)))
+    {
+      return password_verify($password, $hash);
+    }
+
+    // Authenticate against LDAP
+    if (!$this->ldapBind($username, $password))
+    {
+      return false;
+    }
+
+    // Cache entry
+    $hash = password_hash($password, PASSWORD_BCRYPT, array('cost' => 10));
+    $cache->set($cacheKey, $hash, 120);
+
+    return true;
+  }
+}

--- a/lib/adUser.class.php
+++ b/lib/adUser.class.php
@@ -19,7 +19,7 @@
 
 include sfConfig::get('sf_root_dir') .'/vendor/password_compat/password.php';
 
-class adUser extends myUser implements Zend_Acl_Role_Interface
+class ADUser extends myUser implements Zend_Acl_Role_Interface
 {
   protected $ldapConnection;
   protected $ldapBound;
@@ -31,7 +31,7 @@ class adUser extends myUser implements Zend_Acl_Role_Interface
 
     if (!extension_loaded('ldap'))
     {
-      throw new sfConfigurationException('ldapUser class needs the "ldap" extension to be loaded.');
+      throw new sfConfigurationException('ADUser class needs the "ldap" extension to be loaded.');
     }
   }
 


### PR DESCRIPTION
This addition based on the LDAP module adds basic Active Directory login integration support for logging in to AtoM.

Our Archivist wants users to use their existing credentials and auto-creation of accounts in AtoM for our ~740 pupils and ~300 staff. Importing is not possible as AD stores credentials in a non-reversible format as per policy. Only a handful of staff will be given additional permissions.

The Active Directory module differs from the LDAP module in only a handful of ways:

Allows for LDAPS using a URI (e.g. LDAPS://[:]) rather than a host and port. For this to work the CA Certificate of the issuing authority that issues the LDAP server's certificate must be entered in to the file specified in /etc/ldap/ldap.conf (or equivalent.)

Uses the UserPrincipalName (UPN) to identify the user to the AD server. This is the Windows 2003+ user login of @ that replaced the <username> a long time ago. This allows for identification of users throughout the directory, not just on a specified Organisational Unit within the directory.

Reduces the number of settings to 2 - the URI and the Search Base - which should be the root of the directory.

Uses the email address to store the UPN and identify the returning user. It pulls the name attribute from the directory to store as the user name. The additional benefit of this is that a user that is already created in AtoM will not have the account overridden or re-created (should the email address match the UPN.)

I created a separate class so that the LDAP module can continue to be developed and this class will not interfere with that Module.