### PR TITLE
Slug generation culture fix, Refs# 11554

### DIFF
--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -3200,14 +3200,8 @@ class QubitInformationObject extends BaseInformationObject
    */
   private function generateSlug()
   {
-    if (null === $slugBasis = QubitSetting::getByName('slug_basis_informationobject'))
-    {
-      $slugBasis = QubitSlug::SLUG_BASIS_TITLE; // Fall back to title as slug basis
-    }
-    else
-    {
-      $slugBasis = $slugBasis->getValue();
-    }
+    // Fall back to title as slug basis
+    $slugBasis = sfConfig::get('app_slug_basis_informationobject', QubitSlug::SLUG_BASIS_TITLE);
 
     $stringToSlugify = null;
 

--- a/lib/task/propel/propelGenerateSlugsTask.class.php
+++ b/lib/task/propel/propelGenerateSlugsTask.class.php
@@ -258,14 +258,10 @@ EOF;
    */
   private function getInformationObjectStringToSlugify($row)
   {
-    if (null === $basis = QubitSetting::getByName('slug_basis_informationobject'))
-    {
-      return $row[1]; // Fall back to title as the slug basis if no setting present
-    }
-
     // Note: pull reference codes from ES, as hydrating an ORM object and building the inherited
     // reference code on-the-fly is not performant.
-    switch ($basis->getValue())
+    // Fall back to title as the slug basis if no setting present
+    switch (sfConfig::get('app_slug_basis_informationobject', QubitSlug::SLUG_BASIS_TITLE))
     {
       case QubitSlug::SLUG_BASIS_REFERENCE_CODE:
         return $this->getSlugStringFromES($row[0], 'referenceCode');


### PR DESCRIPTION
Change logic that retrieves the slug generation setting to use
sfConfig::get() instead of QubitSetting::getByName(). This setting is not
translatable and sfConfig must be used to ensure the 'en' setting value
is retrieved.

Using getByName() led to two issues:

1) When default language was 'en' and the user interface culture is set
to another language (e.g. 'es'), getByName() returns null, and the default
slug generation setting is used: generate from title. Actual setting
value is ignored (e.g. set to reference code).

2) When the default install language was set to 'es' and the CLI task
'generate-slugs' is run, getByName() returns null and the slug generation
setting is ignored. Default value of 'title' is used.