### PR TITLE
Fix PHP 7 issue with build SQL task, refs #11639

### DIFF
--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/phing/AbstractPropelDataModelTask.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/phing/AbstractPropelDataModelTask.php
@@ -438,8 +438,10 @@ abstract class AbstractPropelDataModelTask extends Task {
 						$this->includeExternalSchemas($dom, $srcDir);
 						// normalize the document using normalizer stylesheet
 
+                                                $doc = new DOMDocument();
+                                                $doc->load($this->xslFile->getAbsolutePath());
 						$xsl = new XsltProcessor();
-						$xsl->importStyleSheet(DomDocument::load($this->xslFile->getAbsolutePath()));
+                                                $xsl->importStyleSheet($doc);
 						$transformed = $xsl->transformToDoc($dom);
 						$newXmlFilename = substr($xmlFile->getName(), 0, strrpos($xmlFile->getName(), '.')) . '-transformed.xml';
 


### PR DESCRIPTION
The propel:build-sql task was generating an error in PHP 7 due to the
DOMDocument's load method being called statically (although it's supposed
to work in PHP 7). Removed static call.