### PR TITLE
Avoid job temp folder collision, refs #11882

### DIFF
--- a/lib/job/arActorCsvExportJob.class.php
+++ b/lib/job/arActorCsvExportJob.class.php
@@ -41,9 +41,7 @@ class arActorCsvExportJob extends arBaseJob
     $this->search = new arElasticSearchPluginQuery(arElasticSearchPluginUtil::SCROLL_SIZE);
     $this->search->queryBool->addMust(new \Elastica\Query\Terms('slug', $this->params['params']['slugs']));
 
-    // Create temp directory in which CSV export files will be written
-    $tempPath = sys_get_temp_dir(). '/actor_clipboard_export_'.$this->job->id;
-    mkdir($tempPath);
+    $tempPath = $this->createJobTempDir();
 
     // Export CSV to temp directory
     $this->info($this->i18n->__('Starting export to %1', array('%1' => $tempPath)));

--- a/lib/job/arActorXmlExportJob.class.php
+++ b/lib/job/arActorXmlExportJob.class.php
@@ -41,9 +41,7 @@ class arActorXmlExportJob extends arBaseJob
 
     $this->search->queryBool->addMust(new \Elastica\Query\Terms('slug', $this->params['params']['slugs']));
 
-    // Create temp directory in which CSV export files will be written
-    $tempPath = sys_get_temp_dir().'/actor_clipboard_export_'.$this->job->id;
-    mkdir($tempPath);
+    $tempPath = $this->createJobTempDir();
 
     // Export CSV to temp directory
     $this->info($this->i18n->__('Starting export to %1.', array('%1' => $tempPath)));

--- a/lib/job/arBaseJob.class.php
+++ b/lib/job/arBaseJob.class.php
@@ -241,6 +241,32 @@ class arBaseJob extends Net_Gearman_Job_Common
   }
 
   /**
+   * Create job temporary directory where the files will be added before
+   * they are compressed and added to the downloads folder. Use a MD5 hash
+   * created from instance info, job id and the current Epoch time to avoid
+   * collisions when multiple AtoM instances are available on the same machine
+   * and in instances where the database is regenerated from another dump (like
+   * it's done in sites with public and private instances), where the job id
+   * could be repeated, adding the export results to an existing export folder.
+   *
+   * @return string  Temporary directory path
+   */
+  protected function createJobTempDir()
+  {
+    $name = md5(
+      sfConfig::get('app_siteTitle') .
+      sfConfig::get('app_siteBaseUrl') .
+      sfConfig::get('sf_root_dir') .
+      $this->job->id .
+      date_timestamp_get()
+    );
+    $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $name;
+    mkdir($path);
+
+    return $path;
+  }
+
+  /**
    * Create jobs download directory, a subdirectory of main AtoM downloads
    * directory, if it doesn't already exist.
    *

--- a/lib/job/arInformationObjectCsvExportJob.class.php
+++ b/lib/job/arInformationObjectCsvExportJob.class.php
@@ -62,9 +62,7 @@ class arInformationObjectCsvExportJob extends arBaseJob
 
     $this->search->query->setSort(array('lft' => 'asc'));
 
-    // Create temp directory in which CSV export files will be written
-    $tempPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'search_export_'. $this->job->id;
-    mkdir($tempPath);
+    $tempPath = $this->createJobTempDir();
 
     // Export CSV to temp directory
     $this->info($this->i18n->__('Starting export to %1.', array('%1' => $tempPath)));

--- a/lib/job/arInformationObjectXmlExportJob.class.php
+++ b/lib/job/arInformationObjectXmlExportJob.class.php
@@ -55,9 +55,7 @@ class arInformationObjectXmlExportJob extends arBaseJob
 
     $this->search->query->setSort(array('lft' => 'asc'));
 
-    // Create temp directory in which CSV export files will be written
-    $tempPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'search_export_'. $this->job->id;
-    mkdir($tempPath);
+    $tempPath = $this->createJobTempDir();
 
     // Export CSV to temp directory
     $this->info($this->i18n->__('Starting export to %1.', array('%1' => $tempPath)));

--- a/lib/job/arRepositoryCsvExportJob.class.php
+++ b/lib/job/arRepositoryCsvExportJob.class.php
@@ -41,9 +41,7 @@ class arRepositoryCsvExportJob extends arBaseJob
     $this->search = new arElasticSearchPluginQuery(arElasticSearchPluginUtil::SCROLL_SIZE);
     $this->search->queryBool->addMust(new \Elastica\Query\Terms('slug', $this->params['params']['slugs']));
 
-    // Create temp directory in which CSV export files will be written
-    $tempPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'repository_export_'. $this->job->id;
-    mkdir($tempPath);
+    $tempPath = $this->createJobTempDir();
 
     // Export CSV to temp directory
     $this->info($this->i18n->__('Starting export to %1', array('%1' => $tempPath)));


### PR DESCRIPTION
To create the export job temporary directory where the files will be added
before they are compressed and added to the downloads folder, use a MD5
hash created from instance info, job id and the current Epoch time to avoid
collisions when multiple AtoM instances are available on the same machine
and in instances where the database is regenerated from another dump (like
it's done in sites with public and private instances), where the job id
could be repeated, adding the export results to an existing export folder.