### PR TITLE
Fix show all link in DO imageflow, refs #11669

### DIFF
--- a/apps/qubit/modules/digitalobject/templates/_imageflow.php
+++ b/apps/qubit/modules/digitalobject/templates/_imageflow.php
@@ -14,7 +14,7 @@
       <a href="<?php echo url_for(array(
         'module' => 'informationobject',
         'action' => 'browse',
-        'collection' => $resource->getCollectionRoot()->id,
+        'ancestor' => $resource->id,
         'topLod' => false,
         'view' => 'card',
         'onlyMedia' => true)) ?>"><?php echo __('Show all') ?></a>

--- a/apps/qubit/modules/informationobject/actions/browseAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/browseAction.class.php
@@ -333,10 +333,12 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
       $this->repos = QubitRepository::getById($request->repos);
 
       // Add repo to the user session as realm
-      $this->context->user->setAttribute('search-realm', $request->repos);
+      if (sfConfig::get('app_enable_institutional_scoping'))
+      {
+        $this->context->user->setAttribute('search-realm', $request->repos);
+      }
     }
-    else if (sfConfig::get('app_enable_institutional_scoping') &&
-      !(isset($request->collection) && ctype_digit($request->collection)))
+    else if (sfConfig::get('app_enable_institutional_scoping'))
     {
       // Remove realm
       $this->context->user->removeAttribute('search-realm');
@@ -418,6 +420,11 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
 
           break;
       }
+    }
+
+    if (isset($request->ancestor) && ctype_digit($request->ancestor))
+    {
+      $this->ancestor = QubitInformationObject::getById($request->ancestor);
     }
   }
 

--- a/apps/qubit/modules/informationobject/templates/browseSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/browseSuccess.php
@@ -269,10 +269,18 @@
         <?php echo $findingAidStatusTag ?>
         <?php $params = $sf_data->getRaw('sf_request')->getGetParameters() ?>
         <?php unset($params['findingAidStatus']) ?>
-        <a href="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse') + $params) ?>" class="remove-filter"><i class="icon-remove"></i></a>
+        <a href="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse') + $params) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
       </span>
     <?php endif; ?>
 
+    <?php if (isset($ancestor)): ?>
+      <span class="search-filter">
+        <?php echo $ancestor->__toString() ?>
+        <?php $params = $sf_data->getRaw('sf_request')->getGetParameters() ?>
+        <?php unset($params['ancestor']) ?>
+        <a href="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse') + $params) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
+      </span>
+    <?php endif; ?>
   </section>
 
 <?php end_slot() ?>

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginQuery.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginQuery.class.php
@@ -188,6 +188,12 @@ class arElasticSearchPluginQuery
 
       $this->queryBool->addMust($queryNested);
     }
+
+    // Show descendants from resource
+    if (isset($params['ancestor']) && ctype_digit($params['ancestor']))
+    {
+      $this->queryBool->addMust(new \Elastica\Query\Term(array('ancestors' => $params['ancestor'])));
+    }
   }
 
   /**


### PR DESCRIPTION
Show only the DOs from the descendants of the current resource instead
of all the DOs in the collection:

- Send ancestor id instead of collection id from show all link.
- Allow filtering by ancestor in arElasticSearchPluginQuery.
- Add ancestor filter tag.

We could have used the collection parameter and change the related facet
to use the ancestors field, but the collection filter shows all descendants
and itself and in this case we only want the descendants.

Minor related changes:

- Fix add/remove realm in institutional scoping enabled instances.
- Fix Finding Aids search filter tag icon.