### PR TITLE
Fix name access point lists #11828

### DIFF
--- a/apps/qubit/modules/informationobject/templates/_nameAccessPoints.php
+++ b/apps/qubit/modules/informationobject/templates/_nameAccessPoints.php
@@ -10,13 +10,16 @@
 
   <div>
     <ul>
-      <?php $actorsShown = array(); ?>
-      <?php foreach ($resource->getActorEvents() as $item): ?>
-        <?php if (isset($item->actor) && !isset($actorsShown[$item->actor->id])): ?>
-          <li><?php echo link_to(render_title($item->actor), array($item->actor)) ?> <span class="note2">(<?php echo $item->type->getRole() ?>)</span></li>
-          <?php $actorsShown[$item->actor->id] = true; ?>
-        <?php endif; ?>
-      <?php endforeach; ?>
+      <?php if (isset($sidebar)): ?>
+        <?php $actorsShown = array(); ?>
+        <?php foreach ($resource->getActorEvents() as $item): ?>
+          <?php if (isset($item->actor) && !isset($actorsShown[$item->actor->id])): ?>
+            <li><?php echo link_to(render_title($item->actor), array($item->actor)) ?> <span class="note2">(<?php echo $item->type->getRole() ?>)</span></li>
+            <?php $actorsShown[$item->actor->id] = true; ?>
+          <?php endif; ?>
+        <?php endforeach; ?>
+      <?php endif; ?>
+
       <?php foreach ($resource->relationsRelatedBysubjectId as $item): ?>
         <?php if (isset($item->type) && QubitTerm::NAME_ACCESS_POINT_ID == $item->type->id): ?>
           <li><?php echo link_to(render_title($item->object), array($item->object, 'module' => 'actor')) ?><span class="note2"> <?php if (!isset($mods)): ?>(<?php echo __('Subject') ?>)<?php endif; ?></span></li>

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
@@ -559,12 +559,6 @@ class arElasticSearchInformationObjectPdo
       $names[$item->id] = $item;
     }
 
-    // Get actors linked via the "event" table (e.g. creators)
-    foreach ($this->getActors() as $item)
-    {
-      $names[$item->id] = $item;
-    }
-
     return $names;
   }
 


### PR DESCRIPTION
Previously, non-subject authority records were being added to the name access
point lists of archival descriptions. This was by design, however we have
decided to change this so only authority records that are actually subjects of
the archival description appear under the name access points. This PR also
removes the duplicate link between creators (or other roles) and the
"Subject of" lists when viewing an authority record page.