### PR TITLE
Improve description autocomplete fields #9255

### DIFF
--- a/apps/qubit/modules/informationobject/actions/autocompleteAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/autocompleteAction.class.php
@@ -51,7 +51,8 @@ class InformationObjectAutocompleteAction extends sfAction
     }
     else
     {
-      $queryString = new \Elastica\Query\QueryString('*'.arElasticSearchPluginUtil::escapeTerm($request->query).'*');
+      $queryString = new \Elastica\Query\QueryString(arElasticSearchPluginUtil::escapeTerm($request->query));
+      $queryString->setDefaultOperator('AND');
 
       // Search for referenceCode or identifier, and title
       if (1 == sfConfig::get('app_inherit_code_informationobject', 1))


### PR DESCRIPTION
Change autocomplete ES search query when editing archival descriptions to use 
AND operator for terms instead of a wildcard query.