### PR TITLE
Specify php version in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-fpm-alpine
+FROM php:7.0-fpm-alpine
 
 ARG GIT_BRANCH=stable/2.4.x
 


### PR DESCRIPTION
Thanks for the project!

Currently `php:7-fpm-alpine` seems to install PHP 7.2.
Since mcrypt has been deprecatd in 7.1, `docker-compose up` returns the error below.

> error: /usr/src/php/ext/mcrypt does not exist


https://secure.php.net/manual/en/migration71.deprecated.php