### PR TITLE
Update descendant inherited fields refs #11855

### DIFF
--- a/apps/qubit/modules/informationobject/actions/editAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/editAction.class.php
@@ -597,6 +597,8 @@ class InformationObjectEditAction extends DefaultEditAction
       $this->getUser()->setFlash('notice', $message);
     }
 
+    QubitJob::runJob('arUpdateDescendantsJob', array('tldId' => $this->resource->id));
+
     $this->deleteNotes();
     $this->updateChildLevels();
     $this->removeDuplicateRepositoryAssociations();

--- a/apps/qubit/modules/informationobject/actions/editAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/editAction.class.php
@@ -597,10 +597,9 @@ class InformationObjectEditAction extends DefaultEditAction
       $this->getUser()->setFlash('notice', $message);
     }
 
-    QubitJob::runJob('arUpdateDescendantsJob', array('tldId' => $this->resource->id));
-
     $this->deleteNotes();
     $this->updateChildLevels();
+    $this->updateDescendantInheritedFields();
     $this->removeDuplicateRepositoryAssociations();
     $this->incrementMaskCounter();
   }
@@ -817,5 +816,22 @@ class InformationObjectEditAction extends DefaultEditAction
     $counter = QubitInformationObject::getIdentifierCounter();
     $counter->value++;
     $counter->save();
+  }
+
+  /**
+   * Trigger a job to update inherited fields in descendant records. Flash job started message to user.
+   */
+  private function updateDescendantInheritedFields()
+  {
+    $job = QubitJob::runJob('arUpdateDescendantsJob', array('tldId' => $this->resource->id));
+
+    $params = array(
+      '%1%' => sprintf('<a href="%s">', $this->context->routing->generate(null, array('module' => 'jobs', 'action' => 'report', 'id' => $job->id))),
+      '%2%' => $job->id,
+      '%3%' => '</a>'
+    );
+
+    $message = $this->context->i18n->__('Updating inherited fields for descendants. Check %1%job %2%%3% to view the status of the job.', $params);
+    $this->getUser()->setFlash('notice', $message);
   }
 }

--- a/apps/qubit/modules/informationobject/actions/editAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/editAction.class.php
@@ -823,6 +823,11 @@ class InformationObjectEditAction extends DefaultEditAction
    */
   private function updateDescendantInheritedFields()
   {
+    if ($this->resource->rgt - $this->resource->lft <= 1)
+    {
+      return;
+    }
+
     $job = QubitJob::runJob('arUpdateDescendantsJob', array('tldId' => $this->resource->id));
 
     $params = array(

--- a/config/gearman.yml
+++ b/config/gearman.yml
@@ -29,3 +29,5 @@ all:
       - arActorXmlExportJob
     repository_csv_export:
       - arRepositoryCsvExportJob
+    update_descendants:
+      - arUpdateDescendantsJob

--- a/lib/job/arUpdateDescendantsJob.class.php
+++ b/lib/job/arUpdateDescendantsJob.class.php
@@ -19,7 +19,6 @@
 
 /**
  *
- *
  * @package    symfony
  * @subpackage jobs
  */
@@ -43,8 +42,6 @@ class arUpdateDescendantsJob extends arBaseJob
     $searchIo = new arElasticSearchInformationObject;
     $searchIo->recursivelyUpdateInformationObjects($parameters['tldId'], count($this->topLevelDesc->descendants),
       'updateInheritedFields');
-
-
     $this->info($this->i18n->__('Update(s) completed.'));
     $this->job->setStatusCompleted();
     $this->job->save();

--- a/lib/job/arUpdateDescendantsJob.class.php
+++ b/lib/job/arUpdateDescendantsJob.class.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ *
+ *
+ * @package    symfony
+ * @subpackage jobs
+ */
+
+class arUpdateDescendantsJob extends arBaseJob
+{
+  /**
+   * @see arBaseJob::$requiredParameters
+   */
+  protected $extraRequiredParameters = array('tldId');
+
+  public function runJob($parameters)
+  {
+    if (null === $this->topLevelDesc = QubitInformationObject::getById($parameters['tldId']))
+    {
+      $this->error($this->i18n->__('Invalid description id: %1', array('%1' => $parameters['tldId'])));
+      return false;
+    }
+
+    $this->info($this->i18n->__("Updating child descriptions' inherited fields from ancestors (id: %1)", array('%1' => $this->topLevelDesc->id)));
+    $searchIo = new arElasticSearchInformationObject;
+    $searchIo->recursivelyUpdateInformationObjects($parameters['tldId'], count($this->topLevelDesc->descendants),
+      'updateInheritedFields');
+
+
+    $this->info($this->i18n->__('Update(s) completed.'));
+    $this->job->setStatusCompleted();
+    $this->job->save();
+
+    return true;
+  }
+}

--- a/lib/job/arUpdateDescendantsJob.class.php
+++ b/lib/job/arUpdateDescendantsJob.class.php
@@ -41,7 +41,9 @@ class arUpdateDescendantsJob extends arBaseJob
     $this->info($this->i18n->__("Updating child descriptions' inherited fields from ancestors (id: %1)", array('%1' => $this->topLevelDesc->id)));
     $searchIo = new arElasticSearchInformationObject;
     $searchIo->recursivelyUpdateInformationObjects($parameters['tldId'], count($this->topLevelDesc->descendants),
-      'updateInheritedFields');
+      'updateInheritedFields', array('repository' => $this->topLevelDesc->getRepository(),
+      'inheritedCreators' => $this->topLevelDesc->getCreators()));
+
     $this->info($this->i18n->__('Update(s) completed.'));
     $this->job->setStatusCompleted();
     $this->job->save();

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
@@ -721,7 +721,7 @@ class arElasticSearchPluginUtil
     {
       foreach ($resultSet as $hit)
       {
-       array_push($hitIds, $hit->getId()); 
+       array_push($hitIds, $hit->getId());
       }
     }
 

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
@@ -28,11 +28,6 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
 
   public function populate()
   {
-    if (!isset(self::$conn))
-    {
-      self::$conn = Propel::getConnection();
-    }
-
     // Get count of all information objects
     $sql  = 'SELECT COUNT(*)';
     $sql .= ' FROM '.QubitInformationObject::TABLE_NAME;
@@ -44,6 +39,21 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
     $this->recursivelyUpdateInformationObjects(QubitInformationObject::ROOT_ID, $this->count, 'updateAllFields');
 
     return $this->errors;
+  }
+
+  /**
+   * Return a sql connection singleton.
+   *
+   * @return A Propel sql connection.
+   */
+  private static function getSqlConnection()
+  {
+    if (!isset(self::$conn))
+    {
+      self::$conn = Propel::getConnection();
+    }
+
+    return self::$conn;
   }
 
   /**
@@ -61,11 +71,6 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
    */
   public function recursivelyUpdateInformationObjects($parentId, $totalRows, $updateFunc, $options = array())
   {
-    if (!isset(self::$conn))
-    {
-      self::$conn = Propel::getConnection();
-    }
-
     // Get information objects
     if (!isset(self::$statements['getChildren']))
     {
@@ -77,7 +82,7 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
       $sql .= ' WHERE io.parent_id = ?';
       $sql .= ' ORDER BY io.lft';
 
-      self::$statements['getChildren'] = self::$conn->prepare($sql);
+      self::$statements['getChildren'] = self::getSqlConnection()->prepare($sql);
     }
 
     self::$statements['getChildren']->execute(array($parentId));

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
@@ -125,7 +125,7 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
   }
 
   /**
-   * Update ES fields descendants inherit from their ancestors.
+   * Update ES fields descendants inherit from their ancestors. This assumes QubitInformationObject atm.
    */
   private function updateInheritedFields($item, $options = array())
   {
@@ -139,10 +139,13 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
 
     if (isset($options['inheritedCreators']))
     {
-      $data['inheritedCreators'] = array();
-
       foreach ($options['inheritedCreators'] as $creator)
       {
+        if (!isset($data['inheritedCreators']))
+        {
+          $data['inheritedCreators'] = array();
+        }
+
         $creatorNode = new arElasticSearchActorPdo($creator->id);
         $data['inheritedCreators'][] = $creatorNode->serialize();
       }
@@ -154,10 +157,10 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
       $data['partOf'] = $partOf;
     }
 
-    if ($data)
+    // If any of the inherited fields have been set to other than null, do partial update
+    if (array_filter($data))
     {
-      $data['_id'] = $item->id;
-      QubitSearch::getInstance()->addDocument($data, 'QubitInformationObject');
+      QubitSearch::getInstance()->partialUpdate(QubitInformationObject::getById($item->id), $data);
     }
   }
 

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
@@ -1066,11 +1066,10 @@ class arElasticSearchInformationObjectPdo
   /**
    * Get an array outlining which top level description the current description is part of.
    *
-   * @param int $collectionRootId  The id for the top level description in this hierarchy.
    * @return array  An array containing the id and various i18n titles of the top level description.
    *                If this description is already a TLD or another issue occurs, return null.
    */
-  public function getPartOf($collectionRootId)
+  public function getPartOf()
   {
     $collectionRootId = $this->getCollectionRootId();
 
@@ -1377,7 +1376,7 @@ class arElasticSearchInformationObjectPdo
         array('fields' => array('title'))
       );
 
-      if (null !== $partOf = $this->getPartOf($collectionRootId))
+      if (null !== $partOf = $this->getPartOf())
       {
         $serialized['partOf'] = $partOf;
       }

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
@@ -1082,11 +1082,7 @@ class arElasticSearchInformationObjectPdo
       }
 
       $rootSourceCulture = QubitPdo::fetchColumn('SELECT source_culture FROM information_object WHERE id=?',
-                                                array($collectionRootId));
-      if (!$rootSourceCulture)
-      {
-        throw new sfException("No source culture found for information object $collectionRootId");
-      }
+                                                 array($collectionRootId));
 
       $i18nFields = arElasticSearchModelBase::serializeI18ns(
         $collectionRootId,
@@ -1094,12 +1090,18 @@ class arElasticSearchInformationObjectPdo
         array('fields' => array('title'))
       );
 
-      return array(
+      $result = array(
         'id' => $collectionRootId,
-        'sourceCulture' => $rootSourceCulture,
         'slug' => $rootSlug,
         'i18n' => $i18nFields,
       );
+
+      if ($rootSourceCulture)
+      {
+        $result['sourceCulture'] = $rootSourceCulture;
+      }
+
+      return $result;
     }
 
     return null;


### PR DESCRIPTION
For fields such as creator, repository and 'part of', descendant records were
not being updated on-the-fly to reflect said inherited fields from their parent
records when they were updated. This fix adds an async job to update descendant
records when the parent changes the mentioned fields.