### PR TITLE
Fix slug increment issue, refs #11728

### DIFF
--- a/lib/model/QubitObject.php
+++ b/lib/model/QubitObject.php
@@ -190,6 +190,8 @@ class QubitObject extends BaseObject implements Zend_Acl_Resource_Interface
       // Compute unique slug adding contiguous numeric suffix
       $suffix = 2;
       $triedQuery = false;
+      $stem = $this->slug;
+
       do
       {
         try
@@ -200,8 +202,6 @@ class QubitObject extends BaseObject implements Zend_Acl_Resource_Interface
         // Collision? Try next suffix
         catch (PDOException $e)
         {
-          $stem = preg_replace('/-\d+$/', '', $this->slug, 1);
-
           if (!$triedQuery)
           {
             $triedQuery = true;


### PR DESCRIPTION
The existing logic would, when a slug was created for a resource with a title
ending in a number and the slug already existed, interpret the number as
existing to differentiate the slug from a previous resource and would end up
incrementing it in the slug.

For example, if an information object with the title "Rick 1900" already
exists, with the slug "rick-1900", then the next information object created
with the title "Rick 1900" would end up having the slug "rick-1901" instead of
"rick-1900-2".

Fixed this issue by removing logic that set the slug base, upon which numbers
may be added to differentiate it from existing slugs, to the starting slug with
any number found removed from the end of it. Changed it, instead, so that the
slug base is simply the starting slug.