### PR TITLE
Accession Import col fix, refs #11993

### DIFF
--- a/lib/task/import/csvAccessionImportTask.class.php
+++ b/lib/task/import/csvAccessionImportTask.class.php
@@ -303,7 +303,7 @@ EOF;
       }
     ));
 
-    $import->addColumnHandler('acquisitionDate', function(&$self, $data)
+    $import->addColumnHandler('acquisitionDate', function($self, $data)
     {
       if ($data)
       {
@@ -318,7 +318,7 @@ EOF;
       }
     });
 
-    $import->addColumnHandler('resourceType', function(&$self, $data)
+    $import->addColumnHandler('resourceType', function($self, $data)
     {
       setObjectPropertyToTermIdLookedUpFromTermNameArray(
         $self,
@@ -329,7 +329,7 @@ EOF;
       );
     });
 
-    $import->addColumnHandler('acquisitionType', function(&$self, $data)
+    $import->addColumnHandler('acquisitionType', function($self, $data)
     {
       setObjectPropertyToTermIdLookedUpFromTermNameArray(
         $self,
@@ -340,7 +340,7 @@ EOF;
       );
     });
 
-    $import->addColumnHandler('processingStatus', function(&$self, $data)
+    $import->addColumnHandler('processingStatus', function($self, $data)
     {
       setObjectPropertyToTermIdLookedUpFromTermNameArray(
         $self,
@@ -351,7 +351,7 @@ EOF;
       );
     });
 
-    $import->addColumnHandler('processingPriority', function(&$self, $data)
+    $import->addColumnHandler('processingPriority', function($self, $data)
     {
       setObjectPropertyToTermIdLookedUpFromTermNameArray(
         $self,


### PR DESCRIPTION
Remove reference (&) from $self param to addColumnHandler. Passing $self
as a reference was preventing the column handler functions from running.

This change will allow the correct import of the accession columns:
- acquisitionDate
- resourceType
- acquisitionType
- processingStatus
- processingPriority