### PR TITLE
Avoid pagination over 10K records, refs #11999

### DIFF
--- a/apps/qubit/modules/actor/actions/relatedInformationObjectsAction.class.php
+++ b/apps/qubit/modules/actor/actions/relatedInformationObjectsAction.class.php
@@ -33,6 +33,13 @@ class ActorRelatedInformationObjectsAction extends sfAction
     $limit = sfConfig::get('app_hits_per_page', 10);
     $culture = $this->context->user->getCulture();
 
+    // Avoid pagination over 10000 records
+    if ((int)$limit * (int)$request->page > 1000)
+    {
+      // Return nothing to not break the list
+      return;
+    }
+
     $resultSet = self::getRelatedInformationObjects($request->actorId, $request->page, $limit, $request->eventTypeId);
 
     $pager = new QubitSearchPager($resultSet);
@@ -81,7 +88,7 @@ class ActorRelatedInformationObjectsAction extends sfAction
     }
     else
     {
-      // Get related by event IOs 
+      // Get related by event IOs
       $queryBoolDates = new \Elastica\Query\BoolQuery;
       $queryBoolDates->addMust(new \Elastica\Query\Term(array('dates.actorId' => $actorId)));
       $queryBoolDates->addMust(new \Elastica\Query\Term(array('dates.typeId' => $eventTypeId)));

--- a/apps/qubit/modules/default/actions/browseAction.class.php
+++ b/apps/qubit/modules/default/actions/browseAction.class.php
@@ -152,6 +152,19 @@ class DefaultBrowseAction extends sfAction
       $skip = ($request->page - 1) * $this->limit;
     }
 
+    // Avoid pagination over 10000 records
+    if ((int)$this->limit + (int)$skip > 10000)
+    {
+      // Show alert
+      $message = $this->context->i18n->__("We've redirected you to the first page of results. To avoid using vast amounts of memory, AtoM limits pagination to 10,000 records. To view the last records in the current result set, try changing the sort direction.");
+      $this->getUser()->setFlash('notice', $message);
+
+      // Redirect to fist page
+      $params = $request->getParameterHolder()->getAll();
+      unset($params['page']);
+      $this->redirect($params);
+    }
+
     $this->search = new arElasticSearchPluginQuery($this->limit, $skip);
 
     if (property_exists($this, 'AGGS'))

--- a/apps/qubit/modules/repository/actions/holdingsAction.class.php
+++ b/apps/qubit/modules/repository/actions/holdingsAction.class.php
@@ -32,6 +32,13 @@ class RepositoryHoldingsAction extends sfAction
     $limit = sfConfig::get('app_hits_per_page', 10);
     $culture = $this->context->user->getCulture();
 
+    // Avoid pagination over 10000 records
+    if ((int)$limit * (int)$request->page > 10000)
+    {
+      // Return nothing to not break the list
+      return;
+    }
+    
     $resultSet = self::getHoldings($request->id, $request->page, $limit);
 
     $pager = new QubitSearchPager($resultSet);

--- a/apps/qubit/modules/repository/actions/maintainedActorsAction.class.php
+++ b/apps/qubit/modules/repository/actions/maintainedActorsAction.class.php
@@ -32,6 +32,13 @@ class RepositoryMaintainedActorsAction extends sfAction
     $limit = sfConfig::get('app_hits_per_page', 10);
     $culture = $this->context->user->getCulture();
 
+    // Avoid pagination over 10000 records
+    if ((int)$limit * (int)$request->page > 10000)
+    {
+      // Return nothing to not break the list
+      return;
+    }
+
     $resultSet = self::getActors($request->repositoryId, $request->page, $limit);
 
     $pager = new QubitSearchPager($resultSet);

--- a/apps/qubit/modules/taxonomy/actions/indexAction.class.php
+++ b/apps/qubit/modules/taxonomy/actions/indexAction.class.php
@@ -54,6 +54,34 @@ class TaxonomyIndexAction extends sfAction
       $request->limit = sfConfig::get('app_hits_per_page');
     }
 
+    if (!isset($request->page))
+    {
+      $request->page = 1;
+    }
+
+    // Avoid pagination over 10000 records
+    if ((int)$request->limit * (int)$request->page > 10000)
+    {
+      // Don't show alert or redirect in XHR requests made
+      // from the list tab in the terms index page. It requires
+      // to go one by one to the page over 10,000 records.
+      // Returning nothing doesn't break the list but it doesn't
+      // show any notice.
+      if ($request->isXmlHttpRequest())
+      {
+        return;
+      }
+
+      // Show alert
+      $message = $this->context->i18n->__("We've redirected you to the first page of results. To avoid using vast amounts of memory, AtoM limits pagination to 10,000 records. To view the last records in the current result set, try changing the sort direction.");
+      $this->getUser()->setFlash('notice', $message);
+
+      // Redirect to fist page
+      $params = $request->getParameterHolder()->getAll();
+      unset($params['page']);
+      $this->redirect($params);
+    }
+
     if ($this->getUser()->isAuthenticated())
     {
       $this->sortSetting = sfConfig::get('app_sort_browser_user');
@@ -91,11 +119,7 @@ class TaxonomyIndexAction extends sfAction
 
     $this->query = new \Elastica\Query();
     $this->query->setSize($request->limit);
-
-    if (!empty($request->page))
-    {
-      $this->query->setFrom(($request->page - 1) * $request->limit);
-    }
+    $this->query->setFrom(($request->page - 1) * $request->limit);
 
     $this->queryBool = new \Elastica\Query\BoolQuery;
 

--- a/apps/qubit/modules/user/actions/clipboardAction.class.php
+++ b/apps/qubit/modules/user/actions/clipboardAction.class.php
@@ -52,8 +52,6 @@ class UserClipboardAction extends DefaultBrowseAction
     }
     else
     {
-      parent::execute($request);
-
       $slugs = $allSlugs[$this->entityType];
       $this->search->queryBool->addMust(new \Elastica\Query\Terms('slug', $slugs));
       $this->setSortOptions();

--- a/lib/job/arInformationObjectCsvExportJob.class.php
+++ b/lib/job/arInformationObjectCsvExportJob.class.php
@@ -38,30 +38,6 @@ class arInformationObjectCsvExportJob extends arBaseJob
 
   public function runJob($parameters)
   {
-    $this->params = $parameters;
-
-    // If not using RAD, default to ISAD CSV export format
-    $this->archivalStandard = 'isad';
-    if (QubitSetting::getByNameAndScope('informationobject', 'default_template') == 'rad')
-    {
-      $this->archivalStandard = 'rad';
-    }
-
-    // Create query increasing limit from default
-    $this->search = new arElasticSearchPluginQuery(arElasticSearchPluginUtil::SCROLL_SIZE);
-
-    if ($this->params['params']['fromClipboard'])
-    {
-      $this->search->queryBool->addMust(new \Elastica\Query\Terms('slug', $this->params['params']['slugs']));
-    }
-    else
-    {
-      $this->search->addAggFilters(InformationObjectBrowseAction::$AGGS, $this->params['params']);
-      $this->search->addAdvancedSearchFilters(InformationObjectBrowseAction::$NAMES, $this->params['params'], $this->archivalStandard);
-    }
-
-    $this->search->query->setSort(array('lft' => 'asc'));
-
     $tempPath = $this->createJobTempDir();
 
     // Export CSV to temp directory
@@ -122,8 +98,8 @@ class arInformationObjectCsvExportJob extends arBaseJob
    */
   static public function searchFromParameters($parameters)
   {
-    // Create query increasing limit from default
-    $search = new arElasticSearchPluginQuery(10000);
+    // Create query
+    $search = new arElasticSearchPluginQuery(arElasticSearchPluginUtil::SCROLL_SIZE);
 
     if ($parameters['params']['fromClipboard'])
     {
@@ -131,7 +107,7 @@ class arInformationObjectCsvExportJob extends arBaseJob
     }
     else
     {
-      $search->addAggFilters(InformationObjectBrowseAction::$AGGS, $this->params['params']);
+      $search->addAggFilters(InformationObjectBrowseAction::$AGGS, $parameters['params']);
       $search->addAdvancedSearchFilters(
         InformationObjectBrowseAction::$NAMES,
         $parameters['params'],

--- a/plugins/arRestApiPlugin/modules/api/actions/informationobjectsBrowseAction.class.php
+++ b/plugins/arRestApiPlugin/modules/api/actions/informationobjectsBrowseAction.class.php
@@ -43,6 +43,14 @@ class ApiInformationObjectsBrowseAction extends QubitApiAction
       $skip = $request->skip;
     }
 
+    // Avoid pagination over 10000 records
+    if ((int)$limit + (int)$skip > 10000)
+    {
+      // Return 400 response with error message
+      $message = $this->context->i18n->__("Pagination limit reached. To avoid using vast amounts of memory, AtoM limits pagination to 10,000 records. Please, narrow down your results.");
+      throw new QubitApiBadRequestException($message);
+    }
+
     // Default to show all level descriptions
     if (!isset($request->topLod) || !filter_var($request->topLod, FILTER_VALIDATE_BOOLEAN))
     {


### PR DESCRIPTION
In Elasticsearch versions after 1.x they introduced a new setting to avoid
memory issues in deep pagination, which limits pagination by default to
10,000 records. This value could be increased but the requirements will
be too high in instances with a really high amount of records.

Other solutions, like the 'Search after' and 'Scroll' APIs added to ES doesn't
suit our needs in most of the cases. Therefore, this commit avoids pagination
over 10,000 records when hitting the ES index.

The following pages will redirect the user to the first page with an alert when
they go over 10,000 records:

- IO browse
- Actor browse
- Repository browse
- Accessions browse
- Clipboard
- Move action
- Description updates
- IO inventory report
- Taxonomy index page
- Term index page (IO results)

The following sidebar lists will stop paginating after 10,000 records. They
won't show any warning and will allow paginating back but not after:

- Actor index page (related descriptions lists)
- Repository index page (holdings list)
- Repository index page (maintained actors list)
- Term index page (taxonomy terms list)

The following API endpoint will return an error message about the issue
when paginating over 10,000 records:

- IO browse endpoint

This lists and the API endpoint are good candidates to implement the 'Search
after' API in the future.

The pager template has not been modified, so it will still show the pages over
10,000 records, this is also something that could be improved later.

This commit also fixes a regression in arInformationObjectCsvExportJob.