### PR TITLE
Fix accession counter, refs #11700

### DIFF
--- a/lib/Qubit.class.php
+++ b/lib/Qubit.class.php
@@ -366,4 +366,32 @@ class Qubit
       }
     }
   }
+
+  /**
+   * Generate an identifier using a counter value and a mask
+   *
+   * @param int $counter  current counter value
+   * @param string $mask  mask
+   *
+   * @return string
+   */
+  public static function generateIdentifierFromCounterAndMask($counter, $mask)
+  {
+    return preg_replace_callback('/([#%])([A-z]+)/', function($match) use ($counter)
+    {
+      if ('%' == $match[1])
+      {
+        return strftime('%'. $match[2]);
+      }
+      else if ('#' == $match[1])
+      {
+        if (0 < preg_match('/^i+$/', $match[2], $matches))
+        {
+          return str_pad($counter, strlen($matches[0]), 0, STR_PAD_LEFT);
+        }
+
+        return $match[2];
+      }
+    }, $mask);
+  }
 }

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -3338,22 +3338,6 @@ class QubitInformationObject extends BaseInformationObject
   public static function generateIdentiferFromMask()
   {
     $counter = self::getIdentifierCounter();
-
-    return preg_replace_callback('/([#%])([A-z]+)/', function($match) use ($counter)
-    {
-      if ('%' == $match[1])
-      {
-        return strftime('%'.$match[2]);
-      }
-      else if ('#' == $match[1])
-      {
-        if (0 < preg_match('/^i+$/', $match[2], $matches))
-        {
-          return str_pad($counter->value, strlen($matches[0]), 0, STR_PAD_LEFT);
-        }
-
-        return $match[2];
-      }
-    }, sfConfig::get('app_identifier_mask', ''));
+    return Qubit::generateIdentifierFromCounterAndMask($counter->value, sfConfig::get('app_identifier_mask', ''));
   }
 }

--- a/plugins/qtAccessionPlugin/lib/QubitValidatorAccessionIdentifier.class.php
+++ b/plugins/qtAccessionPlugin/lib/QubitValidatorAccessionIdentifier.class.php
@@ -28,22 +28,26 @@ class QubitValidatorAccessionIdentifier extends sfValidatorBase
 
   protected function doClean($value)
   {
-    // Before allowing use of proposed identifier, we'll check if it has been used
-    $criteria = new Criteria;
-    $criteria->add(QubitAccession::IDENTIFIER, $value);
-
-    // If accession isn't new, make sure no accession other than it is using proposed identifier
-    if (isset($this->getOption('resource')->id))
-    {
-      // If accession isn't new, make sure no accession other than it is using proposed identifier
-      $criteria->add(QubitAccession::ID, $this->getOption('resource')->id, Criteria::NOT_EQUAL);      
-    }
-
-    if (0 == count(QubitAccession::get($criteria)))
+    // Before allowing use of proposed identifier, make sure it's available for use
+    if (self::identifierCanBeUsed($value, $this->getOption('resource')))
     {
       return $value;
     }
 
     throw new sfValidatorError($this, sfContext::getInstance()->i18n->__('This identifer is already in use.'), array('value' => $value));
+  }
+
+  public static function identifierCanBeUsed($identifier, $byResource = null)
+  {
+    $criteria = new Criteria;
+    $criteria->add(QubitAccession::IDENTIFIER, $identifier);
+
+    // If accession isn't new, make sure no accession other than it is using proposed identifier
+    if ($byResource !== null && isset($byResource->id))
+    {
+      $criteria->add(QubitAccession::ID, $byResource->id, Criteria::NOT_EQUAL);
+    }
+
+    return (0 == count(QubitAccession::get($criteria)));
   }
 }

--- a/plugins/qtAccessionPlugin/modules/accession/actions/editAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/editAction.class.php
@@ -189,7 +189,7 @@ class AccessionEditAction extends DefaultEditAction
         if (!isset($this->resource->id) && $accessionMaskEnabled)
         {
           $dt = new DateTime;
-          $this->form->setDefault('identifier', QubitAccession::generateAccessionIdentifier());
+          $this->form->setDefault('identifier', QubitAccession::nextAvailableIdentifier());
         }
 
         $this->form->setValidator('identifier', new QubitValidatorAccessionIdentifier(array('required' => true, 'resource' => $this->resource)));


### PR DESCRIPTION
The accession counter, used to create accession identifiers, wasn't being
incremented.

Fixed this by:
* Changing when accession counter is incremented
* Adding an availability check, to avoid identifiers already in use, when
  determining the next accession identifier to use
* Minor refactor to share mask generation code between accessions and
  information objects