### PR TITLE
Deaccessions CLI import enhancement, Refs #12020

### DIFF
--- a/lib/task/import/csvDeaccessionImportTask.class.php
+++ b/lib/task/import/csvDeaccessionImportTask.class.php
@@ -97,7 +97,7 @@ EOF;
       ),
 
       'columnMap' => array(
-        'accessionNumber' => 'identifier',
+        'deaccessionNumber' => 'identifier',
       ),
 
       // These values get stored to the rowStatusVars array
@@ -150,7 +150,7 @@ EOF;
             " AND deaccession_i18n.description=?" .
             " AND deaccession_i18n.extent=?" .
             " AND deaccession_i18n.reason=?" .
-            " and deaccession.source_culture=?",
+            " AND deaccession.source_culture=?",
             $params = array($self->object->identifier,
               $self->object->date,
               $self->object->scopeId,
@@ -170,7 +170,7 @@ EOF;
         if (!$createDeaccession)
         {
           $self->object = null;
-          $error = "Skipping duplicate deaccession: ". $accessionIdentifier;
+          $error = "Skipping duplicate deaccession: ". $self->rowStatusVars['accessionNumber'];
           print $self->logError($error);
         }
       },

--- a/lib/task/import/example/example_deaccessions.csv
+++ b/lib/task/import/example/example_deaccessions.csv
@@ -1,3 +1,3 @@
-accessionNumber,date,scope,description,extent,reason,culture
-Example Accession Number,2012-02-15,Part,Example Deaccession Description,Example Extent,Example Reason,en
-Example Accession Number,2015-11-06,Whole,Example Deaccession Description,Example Extent,Example Reason,en
+accessionNumber,deaccessionNumber,date,scope,description,extent,reason,culture
+Example Accession Number,Example Deaccession Number,2012-02-15,Part,Example Deaccession Description,Example Extent,Example Reason,en
+Example Accession Number,Example Deaccession Number,2015-11-06,Whole,Example Deaccession Description,Example Extent,Example Reason,en


### PR DESCRIPTION
This commit modified the deaccession import CLI task to separate out
the identifier field. In the import CSV, there are now two columns:
- accessionNumber: used to match to accession
- deaccessionNumber: used to populate the identifier field in the DB.
  Shows up in the "Deaccession Number" field in the WebUI.