### PR TITLE
Accession counter incrementing fix, refs #11700

### DIFF
--- a/plugins/qtAccessionPlugin/modules/accession/actions/editAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/editAction.class.php
@@ -183,10 +183,7 @@ class AccessionEditAction extends DefaultEditAction
         $this->form->setDefault('identifier', $this->resource['identifier']);
 
         // If accession mask enable setting isn't set or is set to on, then populate default with mask value
-        $accessionMaskEnabledSetting = QubitSetting::getByName('accession_mask_enabled');
-        $accessionMaskEnabled = (null === $accessionMaskEnabledSetting || boolval($accessionMaskEnabledSetting->getValue(array('sourceCulture'=>true))));
-
-        if (!isset($this->resource->id) && $accessionMaskEnabled)
+        if (!isset($this->resource->id) && QubitAccession::maskEnabled())
         {
           $dt = new DateTime;
           $this->form->setDefault('identifier', QubitAccession::nextAvailableIdentifier());


### PR DESCRIPTION
Added helper function to check whether mask's enabled and fixed inconsistent
accession counter incrementing.

Changes to logic relating to accession identifiers during database insert:
* Removed automatic population of identifier, via the mask, if no accession
  identifier is specified
* Added logic to, if an identifier is specified and mask is enabled, increment
  the accession counter