### PR TITLE
Improve DO representations, refs #11904

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/showDownloadComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/showDownloadComponent.class.php
@@ -59,6 +59,7 @@ class DigitalObjectShowDownloadComponent extends sfComponent
 
     // Build a fully qualified URL to this digital object asset
     if ((QubitTerm::IMAGE_ID != $this->resource->mediaTypeId || QubitTerm::REFERENCE_ID == $this->usageType)
+        && $this->resource->usageId != QubitTerm::OFFLINE_ID
         && QubitAcl::check($this->resource->informationObject, 'readMaster'))
     {
       $this->link = $this->resource->getPublicPath();

--- a/apps/qubit/modules/digitalobject/templates/_showAudio.php
+++ b/apps/qubit/modules/digitalobject/templates/_showAudio.php
@@ -14,7 +14,7 @@
     <?php echo link_to(__('Download audio'), $link, array('class' => 'download')) ?>
   <?php endif; ?>
 
-<?php elseif (QubitTerm::THUMBNAIL_ID == $usageType): ?>
+<?php elseif (QubitTerm::THUMBNAIL_ID == $usageType && isset($link)): ?>
 
   <?php if ($iconOnly): ?>
 
@@ -35,5 +35,13 @@
     </div>
 
   <?php endif; ?>
+
+<?php else: ?>
+
+  <div class="resource">
+
+    <?php echo image_tag('play', array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
+
+  </div>
 
 <?php endif; ?>

--- a/apps/qubit/modules/digitalobject/templates/_showDownload.php
+++ b/apps/qubit/modules/digitalobject/templates/_showDownload.php
@@ -5,12 +5,12 @@
   <?php if (isset($link)): ?>
     <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
   <?php else: ?>
-    <?php echo image_tag($representation->getFullPath(), array('alt' => '')) ?>
+    <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
   <?php endif; ?>
 
 <?php else: ?>
 
-  <?php if ($iconOnly): ?>
+  <?php if ($iconOnly && isset($link)): ?>
 
     <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
 
@@ -21,7 +21,7 @@
       <?php if (isset($link)): ?>
         <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
       <?php else: ?>
-        <?php echo image_tag($representation->getFullPath(), array('alt' => '')) ?>
+        <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% is not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
       <?php endif; ?>
 
       <?php echo wrap_text($digitalObject->name, 15) ?>

--- a/apps/qubit/modules/digitalobject/templates/_showGenericIcon.php
+++ b/apps/qubit/modules/digitalobject/templates/_showGenericIcon.php
@@ -6,7 +6,7 @@
     <?php if (isset($link) && $canReadMaster): ?>
       <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link, array('target' => '_blank')) ?>
     <?php else: ?>
-      <?php echo image_tag($representation->getFullPath(), array('alt' => '')) ?>
+      <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
     <?php endif; ?>
   </div>
 

--- a/apps/qubit/modules/digitalobject/templates/_showImage.php
+++ b/apps/qubit/modules/digitalobject/templates/_showImage.php
@@ -5,7 +5,7 @@
   <?php if (isset($link)): ?>
     <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link, array('target' => '_blank')) ?>
   <?php else: ?>
-    <?php echo image_tag($representation->getFullPath(), array('alt' => '')) ?>
+    <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
   <?php endif; ?>
 
 <?php elseif (QubitTerm::THUMBNAIL_ID == $usageType): ?>
@@ -15,7 +15,7 @@
     <?php if (isset($link)): ?>
       <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
     <?php else: ?>
-      <?php echo image_tag($representation->getFullPath(), array('alt' => '')) ?>
+      <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
     <?php endif; ?>
 
   <?php else: ?>
@@ -26,7 +26,7 @@
         <?php if (isset($link)): ?>
           <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
         <?php else: ?>
-          <?php echo image_tag($representation->getFullPath(), array('alt' => '')) ?>
+          <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
         <?php endif; ?>
       </div>
 

--- a/apps/qubit/modules/digitalobject/templates/_showText.php
+++ b/apps/qubit/modules/digitalobject/templates/_showText.php
@@ -1,5 +1,5 @@
 <?php if (isset($link)): ?>
   <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link, array('target' => '_blank')) ?>
 <?php else: ?>
-  <?php echo image_tag($representation->getFullPath(), array('alt' => '')) ?>
+  <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
 <?php endif; ?>

--- a/apps/qubit/modules/digitalobject/templates/_showVideo.php
+++ b/apps/qubit/modules/digitalobject/templates/_showVideo.php
@@ -2,8 +2,8 @@
 
 <?php if ($usageType == QubitTerm::MASTER_ID): ?>
 
-  <?php if ($link == null): ?>
-    <?php echo image_tag($representation->getFullPath(), array('alt' => '')) ?>
+  <?php if (isset($link)): ?>
+    <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
   <?php else: ?>
     <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
   <?php endif; ?>
@@ -14,12 +14,12 @@
     <a class="flowplayer" href="<?php echo public_path($representation->getFullPath()) ?>"></a>
   <?php else: ?>
     <div style="text-align: center">
-      <?php echo image_tag($representation->getFullPath(), array('style' => 'border: #999 1px solid', 'alt' => '')) ?>
+      <?php echo image_tag($representation->getFullPath(), array('style' => 'border: #999 1px solid', 'alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
     </div>
   <?php endif;?>
 
   <!-- link to download master -->
-  <?php if ($link != null): ?>
+  <?php if (isset($link)): ?>
     <?php echo link_to(__('Download movie'), $link, array('class' => 'download')) ?>
   <?php endif; ?>
 
@@ -30,7 +30,7 @@
     <?php if (isset($link)): ?>
       <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
     <?php else: ?>
-      <?php echo image_tag($representation->getFullPath(), array('alt' => '')) ?>
+      <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
     <?php endif; ?>
 
   <?php else: ?>
@@ -40,7 +40,7 @@
         <?php if (isset($link)): ?>
           <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
         <?php else: ?>
-          <?php echo image_tag($representation->getFullPath(), array('alt' => '')) ?>
+          <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
         <?php endif; ?>
       </div>
       <div class="digitalObjectDesc">

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -1416,31 +1416,31 @@ class QubitInformationObject extends BaseInformationObject
   {
     // Set digital object URL
     $do = $this->digitalObjects[0];
-
-    if (isset($do))
+    if (!isset($do))
     {
-      $path = $do->getFullPath();
-
-      // if path is external, it's absolute so return it
-      if (QubitTerm::EXTERNAL_URI_ID == $do->usageId)
-      {
-        return $path;
-      }
-      else if (QubitTerm::OFFLINE_ID === $do->usageId)
-      {
-        throw new sfException('getDigitalObjectPublicUrl() is not available for offline digital objects');
-      }
-      else
-      {
-        if (!QubitAcl::check($this, 'readMaster') && null !== $do->reference &&
-            QubitAcl::check($this, 'readReference'))
-        {
-          $path = $do->reference->getFullPath();
-        }
-
-        return rtrim(QubitSetting::getByName('siteBaseUrl'), '/').'/'.ltrim($path, '/');
-      }
+      return;
     }
+
+    if (QubitTerm::OFFLINE_ID == $do->usageId)
+    {
+      return;
+    }
+    
+    $path = $do->getFullPath();
+
+    // If path is external, it's absolute so return it
+    if (QubitTerm::EXTERNAL_URI_ID == $do->usageId)
+    {
+      return $path;
+    }
+
+    if (!QubitAcl::check($this, 'readMaster') && null !== $do->reference &&
+        QubitAcl::check($this, 'readReference'))
+    {
+      $path = $do->reference->getFullPath();
+    }
+
+    return rtrim(QubitSetting::getByName('siteBaseUrl'), '/').'/'.ltrim($path, '/');
   }
 
   /****************
@@ -3169,9 +3169,9 @@ class QubitInformationObject extends BaseInformationObject
     }
 
     $digitalObject = $this->digitalObjects[0];
-    if (QubitTerm::OFFLINE_ID === $digitalObject->usageId)
+    if (QubitTerm::OFFLINE_ID == $digitalObject->usageId)
     {
-      throw new sfException('getDigitalObjectLink() is not available for offline digital objects');
+      return;
     }
 
     $isText = in_array($digitalObject->mediaTypeId, array(QubitTerm::TEXT_ID));


### PR DESCRIPTION
- Fix IO getDigitalObjectLink and getDigitalObjectPublicUrl:
  - Soften comparision of DO usage id.
  - Avoid exceptions in offline DO.
  - Cosmetic changes.
- Don't get link for offline DOs in DO download component.
- Fix non existing link checks in DO components.
- Improve accessibility of representations without link by adding
  alternate text to the images.