### PR TITLE
Update async. groups of IOs in ES, refs #11855

### DIFF
--- a/config/gearman.yml
+++ b/config/gearman.yml
@@ -29,3 +29,5 @@ all:
       - arActorXmlExportJob
     repository_csv_export:
       - arRepositoryCsvExportJob
+    update_io_es_documents:
+      - arUpdateEsIoDocumentsJob

--- a/lib/job/arUpdateEsIoDocumentsJob.class.php
+++ b/lib/job/arUpdateEsIoDocumentsJob.class.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Updates information object documents in the Elasticsearch index
+ *
+ * @package    symfony
+ * @subpackage jobs
+ */
+
+class arUpdateEsIoDocumentsJob extends arBaseJob
+{
+  /**
+   * @see arBaseJob::$requiredParameters
+   */
+  protected $extraRequiredParameters = array('ioIds', 'updateIos', 'updateDescendants');
+
+  public function runJob($parameters)
+  {
+    if (empty($parameters['ioIds']) || (!$parameters['updateIos'] && !$parameters['updateDescendants']))
+    {
+      $this->error($this->i18n->__('Called arUpdateEsIoDocumentsJob without specifying what needs to be updated.'));
+
+      return false;
+    }
+
+    if ($parameters['updateIos'] && $parameters['updateDescendants'])
+    {
+      $message = $this->i18n->__('Updating %1 description(s) and their descendants.', array('%1' => count($parameters['ioIds'])));
+    }
+    elseif ($parameters['updateIos'])
+    {
+      $message = $this->i18n->__('Updating %1 description(s).', array('%1' => count($parameters['ioIds'])));
+    }
+    else
+    {
+      $message = $this->i18n->__('Updating descendants of %1 description(s).', array('%1' => count($parameters['ioIds'])));
+    }
+
+    $this->job->addNoteText($message);
+    $this->info($message);
+
+    foreach ($parameters['ioIds'] as $id)
+    {
+      if (null === $object = QubitInformationObject::getById($id))
+      {
+        $this->info($this->i18n->__('Invalid archival description id: %1', array('%1' => $id)));
+
+        continue;
+      }
+
+      $title = $object->getTitle(array('cultureFallback' => true));
+
+      if ($parameters['updateIos'] && $parameters['updateDescendants'])
+      {
+        arElasticSearchInformationObject::update($object, array('updateDescendants' => true));
+        $message = $this->i18n->__('Updating "%1" and descendants.', array('%1' => $title));
+      }
+      elseif ($parameters['updateIos'])
+      {
+        arElasticSearchInformationObject::update($object);
+        $message = $this->i18n->__('Updating "%1".', array('%1' => $title));
+      }
+      else
+      {
+        arElasticSearchInformationObject::updateDescendants($object);
+        $message = $this->i18n->__('Updating descendants of "%1".', array('%1' => $title));
+      }
+
+      $this->info($message);
+    }
+
+    $this->job->setStatusCompleted();
+    $this->job->save();
+
+    return true;
+  }
+}

--- a/lib/model/QubitEvent.php
+++ b/lib/model/QubitEvent.php
@@ -47,14 +47,21 @@ class QubitEvent extends BaseEvent
 
     if ($this->indexOnSave)
     {
+      // Update IO descendants in creation events
+      $options = array();
+      if ($this->typeId == QubitTerm::CREATION_ID)
+      {
+        $options['updateDescendants'] = true;
+      }
+
       if ($this->objectId != $cleanObjectId && null !== QubitObject::getById($cleanObjectId))
       {
-        QubitSearch::getInstance()->update(QubitObject::getById($cleanObjectId));
+        QubitSearch::getInstance()->update(QubitObject::getById($cleanObjectId), $options);
       }
 
       if (isset($this->object))
       {
-        QubitSearch::getInstance()->update($this->object);
+        QubitSearch::getInstance()->update($this->object, $options);
       }
     }
 
@@ -74,7 +81,14 @@ class QubitEvent extends BaseEvent
 
     if (isset($this->object))
     {
-      QubitSearch::getInstance()->update($this->getObject());
+      // Update IO descendants in creation events
+      $options = array();
+      if ($this->typeId == QubitTerm::CREATION_ID)
+      {
+        $options['updateDescendants'] = true;
+      }
+
+      QubitSearch::getInstance()->update($this->getObject(), $options);
     }
   }
 

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -215,7 +215,11 @@ class QubitInformationObject extends BaseInformationObject
     // Save child information objects
     foreach ($this->informationObjectsRelatedByparentId->transient as $item)
     {
-      // TODO Needed if $this is new, should be transparent
+      // TODO Needed if $this is new, should be transparent.
+      // Do not add them to the search index on creation as
+      // they will be added when $this is updated as part of
+      // their descendants in arElasticSearchInformationObject.
+      $item->indexOnSave = false;
       $item->parent = $this;
       $item->save($connection);
     }
@@ -285,7 +289,7 @@ class QubitInformationObject extends BaseInformationObject
 
     if ($this->indexOnSave)
     {
-      QubitSearch::getInstance()->update($this);
+      QubitSearch::getInstance()->update($this, array('updateDescendants' => true));
     }
 
     return $this;
@@ -1425,7 +1429,7 @@ class QubitInformationObject extends BaseInformationObject
     {
       return;
     }
-    
+
     $path = $do->getFullPath();
 
     // If path is external, it's absolute so return it

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPlugin.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPlugin.class.php
@@ -546,7 +546,7 @@ class arElasticSearchPlugin extends QubitSearchEngine
     }
   }
 
-  public function update($object)
+  public function update($object, $options = array())
   {
     if (!$this->enabled)
     {
@@ -560,6 +560,14 @@ class arElasticSearchPlugin extends QubitSearchEngine
 
     $className = 'arElasticSearch'.str_replace('Qubit', '', get_class($object));
 
-    return call_user_func(array($className, 'update'), $object);
+    // Pass options only to information object update
+    if ($object instanceof QubitInformationObject)
+    {
+      call_user_func(array($className, 'update'), $object, $options);
+
+      return;
+    }
+
+    call_user_func(array($className, 'update'), $object);
   }
 }


### PR DESCRIPTION
Creates a job to update information object documents in the Elasticsearch
index. This job is launched in places where multiples IOs may be updated,
like updating the descendants of an IO and the related IOs of terms, actors
and repositories. The new job, called `arUpdateEsIoDocumentsJob` will not
be triggered in CLI tasks or other jobs, where the update will be done sync.

Main changes:
- Creates `arUpdateEsIoDocumentsJob`, capable of updating a group of IOs
  and their descendants, skipping ones or the others if requested.
- Update descendants when a higher level IO changes.
- Update related descriptions when an actor changes, including their
  descendants if the relating event is a creation event.
- Update related descriptions and descendants on repository changes.
- Update related descriptions on term label changes of subjects, places and
  genres.

For now, descendants are being updated entirely, but we should use partial
updates in the future to only update the inherited data.