### PR TITLE
Fix granted rights deletion error, refs #11653

### DIFF
--- a/apps/qubit/modules/right/actions/editAction.class.php
+++ b/apps/qubit/modules/right/actions/editAction.class.php
@@ -237,11 +237,23 @@ class RightEditAction extends sfAction
     // to the new/existing rights object
     foreach ($this->form as $field)
     {
-      $this->processField($field);
+      // Delay processing of granted rights so there's not an attempt to save
+      // granted rights that have been deleted
+      if ($field->getName() != 'grantedRights')
+      {
+        $this->processField($field);
+      }
+      else
+      {
+         $grantRightsField = $field;
+      }
     }
 
     // in theory we can save the Right now.
     $this->right->save();
+
+    // Process granted rights
+    $this->processField($grantRightsField);
 
     // if new right, then create QubitRelation
     // to associate it to the resource


### PR DESCRIPTION
Moved logic processing edit/deletion of granted rights, relating to a right,
until after the right is saved so the right doesn't attempt to, when saved,
save related granted rights that were deleted beforehand.