### PR TITLE
EAD import emph tag to Parsedown, refs# 12032

### DIFF
--- a/apps/qubit/modules/object/config/import/ead.yml
+++ b/apps/qubit/modules/object/config/import/ead.yml
@@ -45,10 +45,13 @@ information_object:
       Parameters: ["array('typeId' => QubitTerm::STATUS_TYPE_PUBLICATION_ID, 'statusId' => sfConfig::get('app_defaultPubStatus', QubitTerm::PUBLICATION_STATUS_DRAFT_ID))"]
 
     # each of the following XPath expressions are relative to the current matched node:
-
     title:
       XPath: "did/unittitle[not(@type)]"
       Method:  setTitle
+      Filters:
+        -
+          emph:
+            QubitMarkdown: eadTagToMarkdown
 
     level:
       XPath:  "@level"
@@ -113,6 +116,10 @@ information_object:
     edition:
       XPath:   "did/unittitle[not(@type)]/edition"
       Method:  setEdition
+      Filters:
+        -
+          emph:
+            QubitMarkdown: eadTagToMarkdown
 
     edition_statement_of_responsibility:
       XPath:   "did/unittitle[@type='statRep']/edition"
@@ -338,6 +345,10 @@ information_object:
       XPath:  "(note | descgrp/note | did/note[not(@type='sourcesDescription')])"
       Method: importEadNote
       Parameters: ["$options = array('note' => $nodeValue, 'noteTypeId' => QubitTerm::GENERAL_NOTE_ID)"]
+      Filters:
+        -
+          emph:
+            QubitMarkdown: eadTagToMarkdown
 
     sources:
       XPath:  "did/note[@type='sourcesDescription']"
@@ -347,6 +358,10 @@ information_object:
       XPath:  "(bioghist | descgrp/bioghist)"
       Method: importBioghistEadData
       Parameters: ["$domNode2", "$key"]
+      Filters:
+        -
+          emph:
+            QubitMarkdown: eadTagToMarkdown
 
     # this will overwrite any values entered for <abstract>
     scopeandcontent:
@@ -439,6 +454,10 @@ information_object:
       XPath:  "../eadheader/filedesc/titlestmt/author[@encodinganalog='creator']"
       Method: importEadNote
       Parameters: ["$options = array('note' => $nodeValue, 'noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID)"]
+      Filters:
+        -
+          emph:
+            QubitMarkdown: eadTagToMarkdown
 
     revision_history:
       XPath:  "(processinfo/date | processinfo/p/date | descgrp/processinfo/date | descgrp/processinfo/p/date | ../eadheader/filedesc/publicationstmt/date)"

--- a/lib/QubitMarkdown.class.php
+++ b/lib/QubitMarkdown.class.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Import an XML document into Qubit.
+ *
+ * @package    AccesstoMemory
+ * @subpackage library
+ * @author     Steve Breker <sbreker@artefactual.com>
+ */
+class QubitMarkdown
+{
+  protected static
+    $markdownMap = array(
+      'bolditalic' => '___',
+      'italic' => '_',
+      'bold' => '__',
+    );
+
+  /**
+   * Convert an EAD markup tag to it's corresponding markdown symbols.
+   *
+   * @return ead string with markdown replacement
+   */
+  public static function eadTagToMarkdown($eadTag, $node)
+  {
+    switch ($eadTag)
+    {
+      // EAD tags that we want to convert to markdown.
+      case 'emph':
+        // Set default to italic when no render attribute is present.
+        $markdownSymbol = (!empty($node->getAttribute('render')))
+          ? QubitMarkdown::$markdownMap[$node->getAttribute('render')]
+          : QubitMarkdown::$markdownMap['italic'];
+        return $markdownSymbol . $node->nodeValue . $markdownSymbol;
+    }
+  }
+}


### PR DESCRIPTION
Convert <emph> tags to Parsedown on import. Ignore all other EAD
markdown on import.

- Modified QubitXmlImport to take a new 'Filter' param defined in the
object schema files.
- Added a new QubitMarkdown.class.php to contain markdown specific
functionality.