### PR TITLE
Avoid multi-update of IOs in ES, refs #11855

### DIFF
--- a/apps/qubit/modules/event/actions/editComponent.class.php
+++ b/apps/qubit/modules/event/actions/editComponent.class.php
@@ -172,6 +172,7 @@ class EventEditComponent extends sfComponent
         // to the eventsRelatedByobjectId or events array
         if (isset($this->event->id))
         {
+          $this->event->indexOnSave = false;
           $this->event->save();
         }
       }
@@ -188,7 +189,9 @@ class EventEditComponent extends sfComponent
       foreach ($this->request->deleteEvents as $item)
       {
         $params = $this->context->routing->parse(Qubit::pathInfo($item));
-        $params['_sf_route']->resource->delete();
+        $event = $params['_sf_route']->resource;
+        $event->indexOnSave = false;
+        $event->delete();
       }
     }
   }

--- a/lib/model/QubitEvent.php
+++ b/lib/model/QubitEvent.php
@@ -77,9 +77,14 @@ class QubitEvent extends BaseEvent
 
   public function delete($connection = null)
   {
+    // Get related object
+    $object = $this->getObject();
+
+    // Delete event
     parent::delete($connection);
 
-    if (isset($this->object))
+    // Update object
+    if (isset($object) && $this->indexOnSave)
     {
       // Update IO descendants in creation events
       $options = array();
@@ -88,7 +93,7 @@ class QubitEvent extends BaseEvent
         $options['updateDescendants'] = true;
       }
 
-      QubitSearch::getInstance()->update($this->getObject(), $options);
+      QubitSearch::getInstance()->update($object, $options);
     }
   }
 

--- a/plugins/sfDcPlugin/modules/sfDcPlugin/actions/dcDatesComponent.class.php
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/actions/dcDatesComponent.class.php
@@ -75,6 +75,7 @@ class sfDcPluginDcDatesComponent extends InformationObjectEventComponent
         // to the eventsRelatedByobjectId array
         if (isset($this->event->id))
         {
+          $this->event->indexOnSave = false;
           $this->event->save();
         }
       }
@@ -84,6 +85,7 @@ class sfDcPluginDcDatesComponent extends InformationObjectEventComponent
     {
       if (false === array_search($item->id, $dontDeleteIds))
       {
+        $item->indexOnSave = false;
         $item->delete();
       }
     }

--- a/plugins/sfDcPlugin/modules/sfDcPlugin/actions/dcNamesComponent.class.php
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/actions/dcNamesComponent.class.php
@@ -67,6 +67,14 @@ class sfDcPluginDcNamesComponent extends InformationObjectEventComponent
             $this->processField($field);
           }
         }
+
+        // Save existing events as they are not attached
+        // to the eventsRelatedByobjectId array
+        if (isset($this->event->id))
+        {
+          $this->event->indexOnSave = false;
+          $this->event->save();
+        }
       }
     }
 
@@ -74,6 +82,7 @@ class sfDcPluginDcNamesComponent extends InformationObjectEventComponent
     {
       if (isset($item->actor) && false === array_search($item->id, $dontDeleteIds))
       {
+        $item->indexOnSave = false;
         $item->delete();
       }
     }

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/actions/eventComponent.class.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/actions/eventComponent.class.php
@@ -115,6 +115,7 @@ class sfIsadPluginEventComponent extends InformationObjectEventComponent
         // to the eventsRelatedByobjectId array
         if (isset($this->event->id))
         {
+          $this->event->indexOnSave = false;
           $this->event->save();
         }
       }
@@ -126,6 +127,7 @@ class sfIsadPluginEventComponent extends InformationObjectEventComponent
     {
       if (isset($item->id) && false === array_search($item->id, $finalEventIds))
       {
+        $item->indexOnSave = false;
         $item->delete();
       }
     }


### PR DESCRIPTION
Do not update the related IO in ES when events are saved or deleted
from and IO edit page as it will be updated by itself.