### PR TITLE
Fix IO inherited creators population, refs #11788

### DIFF
--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
@@ -282,7 +282,8 @@ class arElasticSearchInformationObjectPdo
       $sql  = 'SELECT
                   event.actor_id as id';
       $sql .= ' FROM '.QubitEvent::TABLE_NAME.' event';
-      $sql .= ' WHERE event.object_id = ?';
+      $sql .= ' WHERE event.actor_id IS NOT NULL';
+      $sql .= ' AND event.object_id = ?';
       $sql .= ' AND event.type_id = ?';
 
       self::$statements['inheritedCreators'] = self::$conn->prepare($sql);


### PR DESCRIPTION
Query only for events with an `actor_id` as it may be only dates
creation events.