### PR TITLE
Fix CSV updating of script/language, refs #11990

### DIFF
--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -1222,13 +1222,13 @@ class QubitFlatfileImport
       // Add language properties
       if (isset($self->languageMap) && isset($self->languageMap[$columnName]) && $value)
       {
-        $self->createLanguageSerializedProperty($self->languageMap[$columnName], explode('|', $value));
+        $self->storeLanguageSerializedProperty($self->languageMap[$columnName], explode('|', $value));
       }
 
       // Add script properties
       if (isset($self->scriptMap) && isset($self->scriptMap[$columnName]) && $value)
       {
-        $self->createScriptSerializedProperty($self->scriptMap[$columnName], explode('|', $value));
+        $self->storeScriptSerializedProperty($self->scriptMap[$columnName], explode('|', $value));
       }
     });
   }
@@ -2154,7 +2154,7 @@ class QubitFlatfileImport
   }
 
   /**
-   * Add a property to the imported object containing a serialized array of
+   * Store a property of the imported object containing a serialized array of
    * language values
    *
    * @param string $propertyName  Name of QubitProperty to create
@@ -2162,14 +2162,14 @@ class QubitFlatfileImport
    *
    * @return void
    */
-  public function createLanguageSerializedProperty($propertyName, $values)
+  public function storeLanguageSerializedProperty($propertyName, $values)
   {
     $languages = array_keys(sfCultureInfo::getInstance()->getLanguages());
-    $this->createSerializedPropertyFromControlledVocabulary($propertyName, $values, $languages);
+    $this->storeSerializedPropertyUsingControlledVocabulary($propertyName, $values, $languages);
   }
 
   /**
-   * Add a property to the imported object containing a serialized array of
+   * Store a property of the imported object containing a serialized array of
    * script values
    *
    * @param string $propertyName  Name of QubitProperty to create
@@ -2177,14 +2177,14 @@ class QubitFlatfileImport
    *
    * @return void
    */
-  public function createScriptSerializedProperty($propertyName, $values)
+  public function storeScriptSerializedProperty($propertyName, $values)
   {
     $scripts = array_keys(sfCultureInfo::getInstance()->getScripts());
-    $this->createSerializedPropertyFromControlledVocabulary($propertyName, $values, $scripts);
+    $this->storeSerializedPropertyUsingControlledVocabulary($propertyName, $values, $scripts);
   }
 
   /**
-   * Add a property to the imported object containing a serialized array of
+   * Store a property of the imported object containing a serialized array of
    * values from a controlled vocabulary
    *
    * @param string $propertyName  Name of QubitProperty to create
@@ -2193,7 +2193,7 @@ class QubitFlatfileImport
    *
    * @return void
    */
-  private function createSerializedPropertyFromControlledVocabulary($propertyName, $values, $vocabulary)
+  private function storeSerializedPropertyUsingControlledVocabulary($propertyName, $values, $vocabulary)
   {
     // Validate and normalize values
     foreach ($values as $valueIndex => $value)
@@ -2208,12 +2208,21 @@ class QubitFlatfileImport
       $values[$valueIndex] = $vocabulary[$vocabularyIndex];
     }
 
-    // Creation property manually rather than using addProperty model methods
-    // as they are implemented inconsistently
-    $property = new QubitProperty;
-    $property->objectId = $this->object->id;
-    $property->name = $propertyName;
-    $property->setValue(serialize($values), array('sourceCulture' => true));
+    $criteria = new Criteria;
+    $criteria->add(QubitProperty::OBJECT_ID, $this->object->id);
+    $criteria->add(QubitProperty::NAME, $propertyName);
+
+    // Get property if it exists
+    if (null === $property = QubitProperty::getOne($criteria))
+    {
+      // Create property manually rather than using addProperty model methods
+      // as they are implemented inconsistently
+      $property = new QubitProperty;
+      $property->objectId = $this->object->id;
+      $property->name = $propertyName;
+    }
+
+    $property->setValue(serialize(array_unique($values)), array('sourceCulture' => true));
     $property->indexOnSave = !$this->searchIndexingDisabled;
     $property->save();
   }


### PR DESCRIPTION
Changed import logic so script and language properties, in which values are
stored in properties as serialized data, can be updated as well as created
anew if they don't exist. Without this fix, the properties were being
duplicated during CSV updating which caused issues (after CSV update no values
would show at all).

Also tweaked logic to remove any duplicates from values.