### PR TITLE
Remove unneeded Docker volumes, refs #12111

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -9,12 +9,6 @@ volumes:
   percona_data:
     driver: "local"
 
-  atom_uploads:
-    driver: "local"
-
-  atom_downloads:
-    driver: "local"
-
 networks:
 
   net_cache:
@@ -80,8 +74,6 @@ services:
     command: "fpm"
     volumes:
       - "../:/atom/src:rw"
-      - "atom_uploads:/atom/src/uploads:rw"
-      - "atom_downloads:/atom/src/downloads:rw"
     networks:
       - "net_cache"
       - "net_db"
@@ -104,8 +96,6 @@ services:
     command: "worker"
     volumes:
       - "../:/atom/src:rw"
-      - "atom_uploads:/atom/src/uploads:rw"
-      - "atom_downloads:/atom/src/downloads:rw"
     networks:
       - "net_cache"
       - "net_db"
@@ -127,8 +117,6 @@ services:
     volumes:
       - "../:/atom/src:ro"
       - "./etc/nginx/prod.conf:/etc/nginx/nginx.conf:ro"
-      - "atom_uploads:/atom/src/uploads:ro"
-      - "atom_downloads:/atom/src/downloads:ro"
     networks:
       - "net_http"
     depends_on:


### PR DESCRIPTION
The 'atom_uploads' and 'atom_downloads' volumes are placed inside another
volume used to share the entire AtoM directory. This causes data loss when
the container is recreated. The entire AtoM volume is shared by the 'atom',
'nginx' and 'atom_worker' services with the same permissions than this two
volumes, so they are actually not needed.