### PR TITLE
Permissive slug generation, refs #11761

### DIFF
--- a/lib/job/arFindingAidJob.class.php
+++ b/lib/job/arFindingAidJob.class.php
@@ -107,7 +107,7 @@ class arFindingAidJob extends arBaseJob
     // Call generate EAD task
     $slug = $this->resource->slug;
     $output = array();
-    exec("php $appRoot/symfony export:bulk --single-slug=$slug $public $eadFilePath 2>&1", $output, $exitCode);
+    exec("php $appRoot/symfony export:bulk --single-slug=\"$slug\" $public $eadFilePath 2>&1", $output, $exitCode);
 
     if ($exitCode > 0)
     {

--- a/lib/routing/QubitRoute.class.php
+++ b/lib/routing/QubitRoute.class.php
@@ -52,6 +52,25 @@ class QubitRoute extends sfRoute
   }
 
   /**
+  * Used to correctly represent the characters * ; : @ = , in the slug part
+  * of a URI - this is the path segment.
+  *  - these chars are allowed in slugs when 'permissive slugs' setting is on.
+  *  - if 'permissive slugs' is OFF, use urlencode as normal.
+  *  - this should ONLY affect the slug portion of an AtoM URI
+  */
+  public static function urlencode3986($string)
+  {
+    if (QubitSlug::SLUG_PERMISSIVE == sfConfig::get('app_permissive_slug_creation', QubitSlug::SLUG_RESTRICTIVE))
+    {
+      $entities = array('%2A', '%3A', '%40', '%3D', '%2C');
+      $replacements = array('*', ':', '@', '=', ',');
+      return str_replace($entities, $replacements, urlencode($string));
+    }
+
+    return urlencode($string);
+  }
+
+  /**
    * @see sfRoute
    */
   public function matchesParameters($params, $context = array())

--- a/vendor/symfony/lib/routing/sfRoute.class.php
+++ b/vendor/symfony/lib/routing/sfRoute.class.php
@@ -283,7 +283,7 @@ class sfRoute implements Serializable
         case 'variable':
           if (!$optional || !isset($this->defaults[$token[3]]) || $parameters[$token[3]] != $this->defaults[$token[3]])
           {
-            $url[] = QubitRoute::urlencode3986($parameters[$token[3]]);
+            $url[] = urlencode($parameters[$token[3]]);
             $optional = false;
           }
           break;

--- a/vendor/symfony/lib/routing/sfRoute.class.php
+++ b/vendor/symfony/lib/routing/sfRoute.class.php
@@ -283,7 +283,7 @@ class sfRoute implements Serializable
         case 'variable':
           if (!$optional || !isset($this->defaults[$token[3]]) || $parameters[$token[3]] != $this->defaults[$token[3]])
           {
-            $url[] = urlencode($parameters[$token[3]]);
+            $url[] = QubitRoute::urlencode3986($parameters[$token[3]]);
             $optional = false;
           }
           break;
@@ -577,7 +577,7 @@ class sfRoute implements Serializable
         throw new InvalidArgumentException(sprintf('Unable to parse "%s" route near "%s".', $this->pattern, $buffer));
       }
     }
-    
+
     // check for suffix
     if ($this->suffix)
     {


### PR DESCRIPTION
Ensure the characters * : @ = , are represented as literals in the
browser address bar when the 'Permissive Slugs' setting is activated.

- this will prevent these chars from being percent-encoded when
  'permissive slugs' setting is turned on in AtoM
- these chars are allowed in slugs when 'permissive slugs' setting is on.
- if 'permissive slugs' is OFF, use PHP's urlencode as normal.
- this should only affect the PATH segment of an AtoM URI.
- this will affect URI construction for page links and address bar.