### PR TITLE
Digital object lookup enhancement, refs #12066

### DIFF
--- a/config/schema.yml
+++ b/config/schema.yml
@@ -101,6 +101,8 @@ propel:
     checksum: varchar(255)
     checksum_type: type: varchar(50)
     parent_id: { type: integer, foreignTable: digital_object, foreignReference: id }
+    _indexes:
+      path: [path]
 
   event:
     id: { type: integer, required: true, primaryKey: true, foreignTable: object, foreignReference: id, onDelete: cascade, inheritanceKey: true }
@@ -157,6 +159,7 @@ propel:
     rgt: { type: integer, required: true, nestedSetRightKey: true }
     _indexes:
       lft: [lft]
+      rgt: [rgt]
 
   information_object_i18n:
     title: varchar(1024)

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 160
+    value: 161
   milestone:
     name: milestone
     editable: 0

--- a/data/sql/lib.model.schema.sql
+++ b/data/sql/lib.model.schema.sql
@@ -294,6 +294,7 @@ CREATE TABLE `digital_object`
 	`checksum_type` VARCHAR(50),
 	`parent_id` INTEGER,
 	PRIMARY KEY (`id`),
+	KEY `path`(`path`),
 	CONSTRAINT `digital_object_FK_1`
 		FOREIGN KEY (`id`)
 		REFERENCES `object` (`id`)
@@ -475,6 +476,7 @@ CREATE TABLE `information_object`
 	PRIMARY KEY (`id`),
 	UNIQUE KEY `information_object_U_1` (`oai_local_identifier`),
 	KEY `lft`(`lft`),
+	KEY `rgt`(`rgt`),
 	CONSTRAINT `information_object_FK_1`
 		FOREIGN KEY (`id`)
 		REFERENCES `object` (`id`)

--- a/lib/task/migrate/migrations/arMigration0161.class.php
+++ b/lib/task/migrate/migrations/arMigration0161.class.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add index to the lft column in the information object and term tables
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0161
+{
+  const
+    VERSION = 161, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  /**
+   * Upgrade
+   *
+   * @return bool True if the upgrade succeeded, False otherwise
+   */
+  public function up($configuration)
+  {
+    // Add RGT index to the information object table
+    // if it's not already added
+    $sql = <<<sql
+SHOW INDEX FROM information_object WHERE Column_name = 'rgt';
+sql;
+
+    if (count(QubitPdo::fetchAll($sql)) == 0)
+    {
+      $sql = <<<sql
+CREATE INDEX rgt ON information_object(rgt);
+sql;
+
+      QubitPdo::modify($sql);
+    }
+
+    // Add PATH index to the digital object table
+    // if it's not already added
+    $sql = <<<sql
+SHOW INDEX FROM digital_object WHERE Column_name = 'path';
+sql;
+
+    if (count(QubitPdo::fetchAll($sql)) == 0)
+    {
+      $sql = <<<sql
+CREATE INDEX path ON digital_object (path);
+sql;
+
+      QubitPdo::modify($sql);
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
Adding two new indexes to reduce the number of records scanned.

- New index on column information_object.rgt
Range queries using both LFT and RGT were scanning the whole information
object table to get the RGT value for the comparison.

- New index on column digital_object.path
Queries on digital object path and name were performing whole table
scans. Adding an index on path will narrow the selection to a specific
image and it's derivatives.