### PR TITLE
Add Markdown support, refs #12148

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -218,3 +218,15 @@ elasticsearch-php
 Url: https://github.com/elastic/elasticsearch-php
 Copyright: 2013-2016 Elasticsearch
 License: Apache 2.0 and LGPL v2.1
+
+Parsedown
+---------
+Url: https://github.com/erusev/parsedown
+Copyright: Emanuil Rusev, erusev.com
+License: MIT
+
+Parsedown Extra
+---------------
+Url: https://github.com/erusev/parsedown-extra
+Copyright: Emanuil Rusev, erusev.com
+License: MIT

--- a/apps/qubit/config/autoload.yml
+++ b/apps/qubit/config/autoload.yml
@@ -16,3 +16,6 @@ autoload:
   EasyRdf:
     path: %SF_ROOT_DIR%/vendor/easyrdf/EasyRdf
     recursive: on
+
+  ParseDown:
+    path: %SF_ROOT_DIR%/vendor/parsedown

--- a/apps/qubit/modules/actor/actions/autocompleteAction.class.php
+++ b/apps/qubit/modules/actor/actions/autocompleteAction.class.php
@@ -45,7 +45,14 @@ class ActorAutocompleteAction extends sfAction
 
     if (isset($request->query))
     {
-      $criteria->add(QubitActorI18n::AUTHORIZED_FORM_OF_NAME, "$request->query%", Criteria::LIKE);
+      if (sfConfig::get('app_markdown_enabled', true))
+      {
+        $criteria->add(QubitActorI18n::AUTHORIZED_FORM_OF_NAME, "%$request->query%", Criteria::LIKE);
+      }
+      else
+      {
+        $criteria->add(QubitActorI18n::AUTHORIZED_FORM_OF_NAME, "$request->query%", Criteria::LIKE);
+      }
     }
 
     // Exclude the calling actor from the list

--- a/apps/qubit/modules/actor/actions/relatedInformationObjectsAction.class.php
+++ b/apps/qubit/modules/actor/actions/relatedInformationObjectsAction.class.php
@@ -55,7 +55,7 @@ class ActorRelatedInformationObjectsAction extends sfAction
       $doc = $item->getData();
       $results[] = array(
         'url' => url_for(array('module' => 'informationobject', 'slug' => $doc['slug'])),
-        'title' => get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture, 'cultureFallback' => true))
+        'title' => render_value_inline(get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture, 'cultureFallback' => true)))
       );
     }
 

--- a/apps/qubit/modules/actor/templates/_contextMenu.php
+++ b/apps/qubit/modules/actor/templates/_contextMenu.php
@@ -21,7 +21,7 @@
       <ul>
         <?php foreach ($list['pager']->getResults() as $hit): ?>
           <?php $doc = $hit->getData() ?>
-          <li><?php echo link_to(get_search_i18n($doc, 'title', array('allowEmpty' => false)), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?></li>
+          <li><?php echo link_to(render_value_inline(get_search_i18n($doc, 'title', array('allowEmpty' => false))), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?></li>
         <?php endforeach; ?>
       </ul>
 

--- a/apps/qubit/modules/actor/templates/_searchResult.php
+++ b/apps/qubit/modules/actor/templates/_searchResult.php
@@ -4,21 +4,23 @@
 
   <div class="search-result-description">
 
-    <p class="title"><?php echo link_to(get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false, 'culture' => $culture)), array('module' => 'actor', 'slug' => $doc['slug'])) ?></p>
+    <p class="title"><?php echo link_to(render_value_inline(get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false, 'culture' => $culture))), array('module' => 'actor', 'slug' => $doc['slug'])) ?></p>
 
     <?php echo get_component('object', 'clipboardButton', array('slug' => $doc['slug'], 'wide' => false)) ?>
 
     <ul class="result-details">
 
       <?php if (!empty($doc['descriptionIdentifier'])): ?>
-        <li class="reference-code"><?php echo $doc['descriptionIdentifier'] ?></li>
+        <li class="reference-code"><?php echo render_value_inline($doc['descriptionIdentifier']) ?></li>
       <?php endif; ?>
 
-      <?php if (!empty($types[$doc['entityTypeId']])): ?>
-        <li><?php echo $types[$doc['entityTypeId']] ?></li>
+      <?php if (!empty($doc['entityTypeId']) && null !== $term = QubitTerm::getById($doc['entityTypeId'])): ?>
+        <li><?php echo render_value_inline($term) ?></li>
       <?php endif; ?>
 
-      <li><?php echo get_search_i18n($doc, 'datesOfExistence', array('culture' => $culture)) ?></li>
+      <?php if (strlen($dates = get_search_i18n($doc, 'datesOfExistence', array('culture' => $culture))) > 0): ?>
+        <li><?php echo render_value_inline($dates) ?></li>
+      <?php endif; ?>
 
     </ul>
 

--- a/apps/qubit/modules/actor/templates/autocompleteSuccess.php
+++ b/apps/qubit/modules/actor/templates/autocompleteSuccess.php
@@ -25,7 +25,7 @@
           <td>
             <?php echo link_to(render_title($item), array($item, 'module' => 'actor')) ?>
           </td><td>
-            <?php echo $item->entityType ?>
+            <?php echo render_value_inline($item->entityType) ?>
           </td>
         </tr>
       <?php endforeach; ?>

--- a/apps/qubit/modules/contactinformation/templates/_contactInformation.php
+++ b/apps/qubit/modules/contactinformation/templates/_contactInformation.php
@@ -4,7 +4,7 @@
     <div class="field">
       <h3>&nbsp;</h3>
       <div class="agent">
-        <?php echo render_value($contactInformation->contactPerson) ?>
+        <?php echo render_value_inline($contactInformation->contactPerson) ?>
         <?php if ($contactInformation->primaryContact): ?>
           <span class="primary-contact">
             <?php echo __('Primary contact') ?>
@@ -17,7 +17,7 @@
   <div class="field">
     <h3><?php echo __('Type') ?></h3>
     <div class="type">
-      <?php echo render_value($contactInformation->getContactType(array('cultureFallback' => true))) ?>
+      <?php echo render_value_inline($contactInformation->getContactType(array('cultureFallback' => true))) ?>
     </div>
   </div>
 
@@ -30,21 +30,21 @@
       <div class="field">
         <h3><?php echo __('Street address') ?></h3>
         <div class="street-address">
-          <?php echo render_value($contactInformation->streetAddress) ?>
+          <?php echo render_value_inline($contactInformation->streetAddress) ?>
         </div>
       </div>
 
       <div class="field">
         <h3><?php echo __('Locality') ?></h3>
         <div class="locality">
-          <?php echo render_value($contactInformation->getCity(array('cultureFallback' => true))) ?>
+          <?php echo render_value_inline($contactInformation->getCity(array('cultureFallback' => true))) ?>
         </div>
       </div>
 
       <div class="field">
         <h3><?php echo __('Region') ?></h3>
         <div class="region">
-          <?php echo render_value($contactInformation->getRegion(array('cultureFallback' => true))) ?>
+          <?php echo render_value_inline($contactInformation->getRegion(array('cultureFallback' => true))) ?>
         </div>
       </div>
 
@@ -58,7 +58,7 @@
       <div class="field">
         <h3><?php echo __('Postal code') ?></h3>
         <div class="postal-code">
-          <?php echo render_value($contactInformation->postalCode) ?>
+          <?php echo render_value_inline($contactInformation->postalCode) ?>
         </div>
       </div>
 
@@ -69,35 +69,35 @@
   <div class="field">
     <h3><?php echo __('Telephone') ?></h3>
     <div class="tel">
-      <?php echo render_value($contactInformation->telephone) ?>
+      <?php echo render_value_inline($contactInformation->telephone) ?>
     </div>
   </div>
 
   <div class="field">
     <h3 class="type"><?php echo __('Fax') ?></h3>
     <div class="fax">
-      <?php echo render_value($contactInformation->fax) ?>
+      <?php echo render_value_inline($contactInformation->fax) ?>
     </div>
   </div>
 
   <div class="field">
     <h3><?php echo __('Email') ?></h3>
     <div class="email">
-      <?php echo render_value($contactInformation->email) ?>
+      <?php echo render_value_inline($contactInformation->email) ?>
     </div>
   </div>
 
   <div class="field">
     <h3><?php echo __('URL') ?></h3>
     <div class="url">
-      <?php echo render_value($contactInformation->website) ?>
+      <?php echo render_value_inline($contactInformation->website) ?>
     </div>
   </div>
 
   <div class="field">
     <h3><?php echo __('Note') ?></h3>
     <div class="note">
-      <?php echo render_value($contactInformation->getNote(array('cultureFallback' => true))) ?>
+      <?php echo render_value_inline($contactInformation->getNote(array('cultureFallback' => true))) ?>
     </div>
   </div>
 

--- a/apps/qubit/modules/contactinformation/templates/_edit.php
+++ b/apps/qubit/modules/contactinformation/templates/_edit.php
@@ -25,7 +25,7 @@
       <?php foreach ($resource->contactInformations as $item): ?>
         <tr class="<?php echo 0 == @++$row % 2 ? 'even' : 'odd' ?> related_obj_<?php echo $item->id ?>" id="<?php echo url_for(array($item, 'module' => 'contactinformation')) ?>">
           <td>
-            <?php echo $item->contactPerson ?>
+            <?php echo render_title($item->contactPerson) ?>
           </td><td>
             <input type="checkbox"<?php echo $item->primaryContact ? " checked=\"checked\"" : "" ?> disabled="disabled" />
           </td><td style="text-align: center">

--- a/apps/qubit/modules/default/actions/fullTreeViewAction.class.php
+++ b/apps/qubit/modules/default/actions/fullTreeViewAction.class.php
@@ -28,6 +28,8 @@ class DefaultFullTreeViewAction extends sfAction
 {
   public function execute($request)
   {
+    ProjectConfiguration::getActive()->loadHelpers('Qubit');
+
     // Get show identifier setting to prepare the reference code if necessary
     $this->showIdentifier = sfConfig::get('app_treeview_show_identifier', 'no');
 
@@ -39,7 +41,15 @@ class DefaultFullTreeViewAction extends sfAction
   {
     $i18n = sfContext::getInstance()->i18n;
     $culture = $this->getUser()->getCulture();
-    $untitled = $i18n->__('Untitled');
+
+    if (sfConfig::get('app_markdown_enabled', true))
+    {
+      $untitled = '_'.$i18n->__('Untitled').'_';
+    }
+    else
+    {
+      $untitled = '<em>'.$i18n->__('Untitled').'</em>';
+    }
 
     // Remove drafts for unauthenticated users
     $draftsSql = !$this->getUser()->user ? 'AND status.status_id <> ' . QubitTerm::PUBLICATION_STATUS_DRAFT_ID : '' ;
@@ -66,7 +76,7 @@ class DefaultFullTreeViewAction extends sfAction
       io.source_culture,
       io.identifier,
       current_i18n.title AS current_title,
-      IFNULL(source_i18n.title, '<i>$untitled</i>') as text,
+      IFNULL(source_i18n.title, '$untitled') as text,
       io.parent_id AS parent,
       slug.slug,
       IFNULL(lod.name, '') AS lod,
@@ -101,16 +111,18 @@ class DefaultFullTreeViewAction extends sfAction
 
     foreach ($results as $result)
     {
+      $result['text'] = render_value_inline($result['text']);
+
       // Overwrite source culture title if the current culture title is populated
       if ($this->getUser()->getCulture() != $result['source_culture'] && !empty($result['current_title']))
       {
-        $result['text'] = $result['current_title'];
+        $result['text'] = render_value_inline($result['current_title']);
       }
 
       // Add identifier based on setting
       if ($this->showIdentifier === 'identifier' && !empty($result['identifier']))
       {
-        $result['text'] = "{$result['identifier']} - {$result['text']}";
+        $result['text'] = render_value_inline($result['identifier']).' - '.render_value_inline($result['text']);
       }
 
       // Add reference code based on setting
@@ -120,7 +132,7 @@ class DefaultFullTreeViewAction extends sfAction
         {
           // If this is a top-level node, the passed reference will be "true" so
           // replace it with the description identifier
-          $result['referenceCode'] = $result['identifier'];
+          $result['referenceCode'] = render_value_inline($result['identifier']);
         }
         else
         {
@@ -133,7 +145,7 @@ class DefaultFullTreeViewAction extends sfAction
           // Append result identifier, if it exists, to the reference passed to the function
           if (!empty($result['identifier']))
           {
-            $result['referenceCode'] = $result['referenceCode'] . sfConfig::get('app_separator_character', '-') . $result['identifier'];
+            $result['referenceCode'] = $result['referenceCode'] . sfConfig::get('app_separator_character', '-') . render_value_inline($result['identifier']);
           }
         }
 
@@ -144,7 +156,8 @@ class DefaultFullTreeViewAction extends sfAction
       // Add level of description based on setting
       if (sfConfig::get('app_treeview_show_level_of_description', 'yes') === 'yes' && strlen($result['lod']) > 0)
       {
-        $result['text'] = "[{$result['lod']}] {$result['text']}";
+        $lod = render_value_inline($result['lod']);
+        $result['text'] = "[{$lod}] {$result['text']}";
       }
 
       // Add dates based on setting
@@ -181,7 +194,7 @@ class DefaultFullTreeViewAction extends sfAction
             continue;
           }
 
-          $date = Qubit::renderDateStartEnd($event['display_date'], $event['start_date'], $event['end_date']);
+          $date = render_value_inline(Qubit::renderDateStartEnd($event['display_date'], $event['start_date'], $event['end_date']));
           $result['text'] = "{$result['text']}, {$date}";
 
           break;
@@ -190,7 +203,8 @@ class DefaultFullTreeViewAction extends sfAction
 
       if ($result['status_id'] == QubitTerm::PUBLICATION_STATUS_DRAFT_ID)
       {
-        $result['text'] = "({$result['status']}) {$result['text']}";
+        $status = render_value_inline($result['status']);
+        $result['text'] = "({$status}) {$result['text']}";
       }
 
       // Some special flags on our current selected item
@@ -207,7 +221,7 @@ class DefaultFullTreeViewAction extends sfAction
       }
 
       // Add node link attributes
-      $result['a_attr']['title'] = $result['text'];
+      $result['a_attr']['title'] = strip_tags($result['text']);
       $result['a_attr']['href'] = $this->generateUrl('slug', array('slug' => $result['slug']));
 
       // Set children to true for lazy loading or, if we are loading

--- a/apps/qubit/modules/default/templates/_popular.php
+++ b/apps/qubit/modules/default/templates/_popular.php
@@ -4,7 +4,7 @@
   <ul>
     <?php foreach ($popularThisWeek as $item): ?>
       <?php $object = QubitObject::getById($item[0]); ?>
-      <li><a href="<?php echo url_for(array($object)) ?>"><?php echo render_title(esc_entities($object->__toString())) ?><strong>&nbsp;&nbsp;<?php echo __('%1% visits', array('%1%' => $item[1])) ?></strong></a></li>
+      <li><a href="<?php echo url_for(array($object)) ?>"><?php echo render_title($object) ?><strong>&nbsp;&nbsp;<?php echo __('%1% visits', array('%1%' => $item[1])) ?></strong></a></li>
     <?php endforeach; ?>
   </ul>
 

--- a/apps/qubit/modules/default/templates/moveSuccess.php
+++ b/apps/qubit/modules/default/templates/moveSuccess.php
@@ -57,7 +57,7 @@
         <?php foreach ($results as $item): ?>
           <tr>
             <td width="15%">
-              <?php echo $item->identifier ?>
+              <?php echo render_value_inline($item->identifier) ?>
             </td>
             <td width="85%">
               <?php echo link_to_if($resource->lft > $item->lft || $resource->rgt < $item->rgt, render_title($item), array($resource, 'module' => 'default', 'action' => 'move', 'parent' => $item->slug)) ?>

--- a/apps/qubit/modules/digitalobject/templates/_editRepresentation.php
+++ b/apps/qubit/modules/digitalobject/templates/_editRepresentation.php
@@ -12,7 +12,7 @@
 
   <div>
 
-    <?php echo render_show(__('Filename'), $representation->name) ?>
+    <?php echo render_show(__('Filename'), render_value($representation->name)) ?>
 
     <?php echo render_show(__('Filesize'), hr_filesize($representation->byteSize)) ?>
 

--- a/apps/qubit/modules/digitalobject/templates/_imageflow.php
+++ b/apps/qubit/modules/digitalobject/templates/_imageflow.php
@@ -4,7 +4,7 @@
 
   <div class="imageflow clearfix" id="imageflow">
     <?php foreach ($thumbnails as $item): ?>
-      <?php echo image_tag($item->getFullPath(), array('longdesc' => url_for(array($item->parent->informationObject, 'module' => 'informationobject')), 'alt' => esc_entities(render_title(truncate_text($item->parent->informationObject, 100))))) ?>
+      <?php echo image_tag($item->getFullPath(), array('longdesc' => url_for(array($item->parent->informationObject, 'module' => 'informationobject')), 'alt' => truncate_text(strip_markdown($item->parent->informationObject), 100))) ?>
     <?php endforeach; ?>
   </div>
 

--- a/apps/qubit/modules/digitalobject/templates/_metadata.php
+++ b/apps/qubit/modules/digitalobject/templates/_metadata.php
@@ -18,21 +18,21 @@
     <?php endif; ?>
   <?php else: ?>
     <?php if (check_field_visibility('app_element_visibility_digital_object_file_name') && !$denyFileNameByPremis): ?>
-      <?php echo render_show(__('Filename'), $resource->name, array('fieldLabel' => 'filename')) ?>
+      <?php echo render_show(__('Filename'), render_value($resource->name), array('fieldLabel' => 'filename')) ?>
     <?php endif; ?>
   <?php endif; ?>
 
   <?php if (check_field_visibility('app_element_visibility_digital_object_geolocation')): ?>
-    <?php echo render_show(__('Latitude'), $latitude, array('fieldLabel' => 'latitude')) ?>
-    <?php echo render_show(__('Longitude'), $longitude, array('fieldLabel' => 'longitude')) ?>
+    <?php echo render_show(__('Latitude'), render_value($latitude), array('fieldLabel' => 'latitude')) ?>
+    <?php echo render_show(__('Longitude'), render_value($longitude), array('fieldLabel' => 'longitude')) ?>
   <?php endif; ?>
 
   <?php if (check_field_visibility('app_element_visibility_digital_object_media_type')): ?>
-    <?php echo render_show(__('Media type'), $resource->mediaType, array('fieldLabel' => 'mediaType')) ?>
+    <?php echo render_show(__('Media type'), render_value($resource->mediaType), array('fieldLabel' => 'mediaType')) ?>
   <?php endif; ?>
 
   <?php if (check_field_visibility('app_element_visibility_digital_object_mime_type')): ?>
-    <?php echo render_show(__('Mime-type'), $resource->mimeType, array('fieldLabel' => 'mimeType')) ?>
+    <?php echo render_show(__('Mime-type'), render_value($resource->mimeType), array('fieldLabel' => 'mimeType')) ?>
   <?php endif; ?>
 
   <?php if (check_field_visibility('app_element_visibility_digital_object_file_size')): ?>
@@ -44,12 +44,12 @@
   <?php endif; ?>
 
   <?php if ($sf_user->isAuthenticated()): ?>
-    <?php echo render_show(__('Object UUID'), $resource->informationObject->objectUUID, array('fieldLabel' => 'objectUUID')) ?>
-    <?php echo render_show(__('AIP UUID'), $resource->informationObject->aipUUID, array('fieldLabel' => 'aipUUID')) ?>
-    <?php echo render_show(__('Format name'), $resource->informationObject->formatName, array('fieldLabel' => 'formatName')) ?>
-    <?php echo render_show(__('Format version'), $resource->informationObject->formatVersion, array('fieldLabel' => 'formatVersion')) ?>
-    <?php echo render_show(__('Format registry key'), $resource->informationObject->formatRegistryKey, array('fieldLabel' => 'formatRegistryKey')) ?>
-    <?php echo render_show(__('Format registry name'), $resource->informationObject->formatRegistryName, array('fieldLabel' => 'formatRegistryName')) ?>
+    <?php echo render_show(__('Object UUID'), render_value($resource->informationObject->objectUUID), array('fieldLabel' => 'objectUUID')) ?>
+    <?php echo render_show(__('AIP UUID'), render_value($resource->informationObject->aipUUID), array('fieldLabel' => 'aipUUID')) ?>
+    <?php echo render_show(__('Format name'), render_value($resource->informationObject->formatName), array('fieldLabel' => 'formatName')) ?>
+    <?php echo render_show(__('Format version'), render_value($resource->informationObject->formatVersion), array('fieldLabel' => 'formatVersion')) ?>
+    <?php echo render_show(__('Format registry key'), render_value($resource->informationObject->formatRegistryKey), array('fieldLabel' => 'formatRegistryKey')) ?>
+    <?php echo render_show(__('Format registry name'), render_value($resource->informationObject->formatRegistryName), array('fieldLabel' => 'formatRegistryName')) ?>
   <?php endif; ?>
 
 </section>

--- a/apps/qubit/modules/digitalobject/templates/editSuccess.php
+++ b/apps/qubit/modules/digitalobject/templates/editSuccess.php
@@ -27,7 +27,7 @@
 
         <legend><?php echo __('Master') ?></legend>
 
-        <?php echo render_show(__('Filename'), $resource->name) ?>
+        <?php echo render_show(__('Filename'), render_value($resource->name)) ?>
 
         <?php echo render_show(__('Filesize'), hr_filesize($resource->byteSize)) ?>
 

--- a/apps/qubit/modules/digitalobject/templates/viewCopyrightStatementSuccess.php
+++ b/apps/qubit/modules/digitalobject/templates/viewCopyrightStatementSuccess.php
@@ -8,7 +8,7 @@
     </div>
   <?php endif; ?>
 
-  <h1><?php echo render_title($resource->getTitle(array('cultureFallback' => true))) ?></h1>
+  <h1><?php echo render_title($resource) ?></h1>
 
 <?php end_slot() ?>
 

--- a/apps/qubit/modules/function/actions/autocompleteAction.class.php
+++ b/apps/qubit/modules/function/actions/autocompleteAction.class.php
@@ -39,7 +39,14 @@ class FunctionAutocompleteAction extends sfAction
 
     if (isset($request->query))
     {
-      $criteria->add(QubitFunctionI18n::AUTHORIZED_FORM_OF_NAME, "$request->query%", Criteria::LIKE);
+      if (sfConfig::get('app_markdown_enabled', true))
+      {
+        $criteria->add(QubitFunctionI18n::AUTHORIZED_FORM_OF_NAME, "%$request->query%", Criteria::LIKE);
+      }
+      else
+      {
+        $criteria->add(QubitFunctionI18n::AUTHORIZED_FORM_OF_NAME, "$request->query%", Criteria::LIKE);
+      }
     }
 
     // Exclude the calling function from the list

--- a/apps/qubit/modules/function/templates/listSuccess.php
+++ b/apps/qubit/modules/function/templates/listSuccess.php
@@ -33,7 +33,7 @@
       <?php foreach ($pager->getResults() as $item): ?>
         <tr>
           <td>
-            <?php echo link_to(render_title($item->getAuthorizedFormOfName(array('cultureFallback' => true))), $item) ?>
+            <?php echo link_to(render_title($item), $item) ?>
           </td><td>
             <?php echo format_date($item->updatedAt, 'f') ?>
           </td>

--- a/apps/qubit/modules/informationobject/actions/fullWidthTreeViewAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/fullWidthTreeViewAction.class.php
@@ -54,7 +54,7 @@ class InformationObjectFullWidthTreeViewAction extends DefaultFullTreeViewAction
       if ($this->showIdentifier === 'referenceCode')
       {
         // On first load, get the base reference code from the ORM
-        $baseReferenceCode = $collectionRoot->getInheritedReferenceCode();
+        $baseReferenceCode = render_value_inline($collectionRoot->getInheritedReferenceCode());
       }
 
       $data = $this->getNodeOrChildrenNodes($collectionRoot->id, $baseReferenceCode);
@@ -68,7 +68,7 @@ class InformationObjectFullWidthTreeViewAction extends DefaultFullTreeViewAction
         if (empty($baseReferenceCode))
         {
           // Or get it from the ORM
-          $baseReferenceCode = $this->resource->getInheritedReferenceCode();
+          $baseReferenceCode = render_value_inline($this->resource->getInheritedReferenceCode());
         }
       }
 

--- a/apps/qubit/modules/informationobject/actions/indexAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/indexAction.class.php
@@ -126,8 +126,8 @@ class InformationObjectIndexAction extends sfAction
     $scopeAndContent = $this->resource->getScopeAndContent(array('cultureFallback' => true));
     if (!empty($scopeAndContent))
     {
-      $this->getContext()->getConfiguration()->loadHelpers(array('Text'));
-      $this->response->addMeta('description', truncate_text($scopeAndContent, 150));
+      $this->getContext()->getConfiguration()->loadHelpers(array('Text', 'Qubit'));
+      $this->response->addMeta('description', truncate_text(strip_markdown($scopeAndContent), 150));
     }
 
     $this->digitalObjectLink = $this->resource->getDigitalObjectLink();

--- a/apps/qubit/modules/informationobject/actions/inventoryAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/inventoryAction.class.php
@@ -33,7 +33,7 @@ class InformationObjectInventoryAction extends DefaultBrowseAction
 
     // Set title header
     sfContext::getInstance()->getConfiguration()->loadHelpers(array('Qubit'));
-    $title = render_title($this->resource, false);
+    $title = strip_markdown($this->resource);
     $this->response->setTitle("$title - Inventory list - {$this->response->getTitle()}");
 
     $limit = sfConfig::get('app_hits_per_page');

--- a/apps/qubit/modules/informationobject/templates/_alternativeIdentifiersIndex.php
+++ b/apps/qubit/modules/informationobject/templates/_alternativeIdentifiersIndex.php
@@ -4,7 +4,7 @@
 
   <div>
     <?php foreach ($resource->getProperties(null, 'alternativeIdentifiers') as $item): ?>
-      <?php echo render_show(render_value($item->name), render_value($item->getValue(array('cultureFallback' => true)))) ?>
+      <?php echo render_show(render_value_inline($item->name), render_value_inline($item->getValue(array('cultureFallback' => true)))) ?>
     <?php endforeach; ?>
   </div>
 

--- a/apps/qubit/modules/informationobject/templates/_cardViewResults.php
+++ b/apps/qubit/modules/informationobject/templates/_cardViewResults.php
@@ -1,8 +1,10 @@
+<?php use_helper('Text') ?>
+
 <section class="masonry browse-masonry">
 
   <?php foreach ($pager->getResults() as $hit): ?>
     <?php $doc = $hit->getData() ?>
-    <?php $title = render_title(get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $selectedCulture))) ?>
+    <?php $title = get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $selectedCulture)) ?>
 
     <?php if (!empty($doc['hasDigitalObject'])): ?>
       <div class="brick">
@@ -16,24 +18,24 @@
           && QubitGrantedRight::checkPremis($hit->getId(), 'readThumb')): ?>
 
           <?php echo link_to(image_tag($doc['digitalObject']['thumbnailPath'],
-            array('alt' => esc_entities($title, 100))),
+            array('alt' => truncate_text(strip_markdown($title), 100))),
             array('module' => 'informationobject', 'slug' => $doc['slug'])) ?>
 
         <?php elseif (isset($doc['digitalObject']) && !empty($doc['digitalObject']['mediaTypeId'])): // Show generic icon since no thumbnail present ?>
 
           <?php echo link_to(image_tag(QubitDigitalObject::getGenericIconPathByMediaTypeId($doc['digitalObject']['mediaTypeId']),
-            array('alt' => esc_entities($title, 100))),
+            array('alt' => truncate_text(strip_markdown($title), 100))),
             array('module' => 'informationobject', 'slug' => $doc['slug'])) ?>
 
         <?php else: // No digital object, just display description title ?>
 
-          <h4><?php echo mb_strimwidth($title, 0, 80, '...') ?></h4>
+          <h5><?php echo render_title($title) ?></h5>
 
         <?php endif; ?>
       </a>
 
       <div class="bottom">
-        <?php echo get_component('object', 'clipboardButton', array('slug' => $doc['slug'], 'wide' => false, 'repositoryOrDigitalObjBrowse' => true)) ?><?php echo $title ?>
+        <?php echo get_component('object', 'clipboardButton', array('slug' => $doc['slug'], 'wide' => false, 'repositoryOrDigitalObjBrowse' => true)) ?><?php echo render_title($title) ?>
       </div>
     </div>
   <?php endforeach; ?>

--- a/apps/qubit/modules/informationobject/templates/_creatorDetail.php
+++ b/apps/qubit/modules/informationobject/templates/_creatorDetail.php
@@ -15,7 +15,7 @@
 
         <?php if (isset($item->datesOfExistence)): ?>
           <div class="datesOfExistence">
-            (<?php echo $item->getDatesOfExistence(array('cultureFallback' => true)) ?>)
+            (<?php echo render_value_inline($item->getDatesOfExistence(array('cultureFallback' => true))) ?>)
           </div>
         <?php endif; ?>
 

--- a/apps/qubit/modules/informationobject/templates/_dates.php
+++ b/apps/qubit/modules/informationobject/templates/_dates.php
@@ -7,22 +7,22 @@
       <?php foreach ($resource->getDates() as $item): ?>
         <li>
           <div class="date">
-            <span property="dc:date" start="<?php echo $item->startDate ?>" end="<?php echo $item->endDate ?>"><?php echo Qubit::renderDateStartEnd($item->getDate(array('cultureFallback' => true)), $item->startDate, $item->endDate) ?></span>
+            <span property="dc:date" start="<?php echo $item->startDate ?>" end="<?php echo $item->endDate ?>"><?php echo render_value_inline(Qubit::renderDateStartEnd($item->getDate(array('cultureFallback' => true)), $item->startDate, $item->endDate)) ?></span>
             <?php if (sfConfig::get('app_default_template_informationobject') !== 'dc'): ?>
-              <span class="date-type">(<?php echo $item->type->__toString() ?>)</span>
+              <span class="date-type">(<?php echo render_value_inline($item->type->__toString()) ?>)</span>
             <?php endif; ?>
             <dl>
               <?php if (isset($item->actor) && null !== $item->type->getRole()): ?>
-                <dt><?php echo $item->type->getRole() ?></dt>
+                <dt><?php echo render_value_inline($item->type->getRole()) ?></dt>
                 <dd><?php echo render_title($item->actor) ?></dd>
               <?php endif; ?>
               <?php if (null !== $item->getPlace()): ?>
                 <dt><?php echo __('Place') ?></dt>
-                <dd><?php echo $item->getPlace() ?></dd>
+                <dd><?php echo render_value_inline($item->getPlace()) ?></dd>
               <?php endif; ?>
               <?php if (0 < strlen($item->description)): ?>
                 <dt><?php echo __('Note') ?></dt>
-                <dd><?php echo $item->description ?></dd>
+                <dd><?php echo render_value_inline($item->description) ?></dd>
               <?php endif; ?>
             </dl>
 

--- a/apps/qubit/modules/informationobject/templates/_genreAccessPoints.php
+++ b/apps/qubit/modules/informationobject/templates/_genreAccessPoints.php
@@ -17,7 +17,7 @@
             <?php if (1 < $key): ?>
               &raquo;
             <?php endif; ?>
-            <?php echo link_to($subject->__toString(), array($subject, 'module' => 'term')) ?>
+            <?php echo link_to(render_title($subject), array($subject, 'module' => 'term')) ?>
           <?php endforeach; ?>
         </li>
       <?php endforeach; ?>

--- a/apps/qubit/modules/informationobject/templates/_nameAccessPoints.php
+++ b/apps/qubit/modules/informationobject/templates/_nameAccessPoints.php
@@ -14,7 +14,7 @@
         <?php $actorsShown = array(); ?>
         <?php foreach ($resource->getActorEvents() as $item): ?>
           <?php if (isset($item->actor) && !isset($actorsShown[$item->actor->id])): ?>
-            <li><?php echo link_to(render_title($item->actor), array($item->actor)) ?> <span class="note2">(<?php echo $item->type->getRole() ?>)</span></li>
+            <li><?php echo link_to(render_title($item->actor), array($item->actor)) ?> <span class="note2">(<?php echo render_value_inline($item->type->getRole()) ?>)</span></li>
             <?php $actorsShown[$item->actor->id] = true; ?>
           <?php endif; ?>
         <?php endforeach; ?>

--- a/apps/qubit/modules/informationobject/templates/_placeAccessPoints.php
+++ b/apps/qubit/modules/informationobject/templates/_placeAccessPoints.php
@@ -17,7 +17,7 @@
             <?php if (1 < $key): ?>
               &raquo;
             <?php endif; ?>
-            <?php echo link_to($place->__toString(), array($place, 'module' => 'term')) ?>
+            <?php echo link_to(render_title($place), array($place, 'module' => 'term')) ?>
           <?php endforeach; ?>
         </li>
       <?php endforeach; ?>

--- a/apps/qubit/modules/informationobject/templates/_relatedEvents.php
+++ b/apps/qubit/modules/informationobject/templates/_relatedEvents.php
@@ -26,17 +26,17 @@
           </div>
         </td><td>
           <div>
-            <?php echo $item->type ?>
+            <?php echo render_value_inline($item->type) ?>
           </div>
         </td><td>
           <div>
             <?php if (null !== $relation = QubitObjectTermRelation::getOneByObjectId($item->id)): ?>
-              <?php echo render_title($relation->term) ?>
+              <?php echo render_value_inline($relation->term) ?>
             <?php endif; ?>
           </div>
         </td><td>
           <div>
-            <?php echo Qubit::renderDateStartEnd($item->getDate(array('cultureFallback' => true)), $item->startDate, $item->endDate) ?>
+            <?php echo render_value_inline(Qubit::renderDateStartEnd($item->getDate(array('cultureFallback' => true)), $item->startDate, $item->endDate)) ?>
           </div>
         </td><td style="text-align: right">
           <input class="multiDelete" name="deleteEvents[]" type="checkbox" value="<?php echo url_for(array($item, 'module' => 'event')) ?>"/>

--- a/apps/qubit/modules/informationobject/templates/_subjectAccessPoints.php
+++ b/apps/qubit/modules/informationobject/templates/_subjectAccessPoints.php
@@ -17,7 +17,7 @@
             <?php if (1 < $key): ?>
               &raquo;
             <?php endif; ?>
-            <?php echo link_to($subject->__toString(), array($subject, 'module' => 'term')) ?>
+            <?php echo link_to(render_title($subject), array($subject, 'module' => 'term')) ?>
           <?php endforeach; ?>
         </li>
       <?php endforeach; ?>

--- a/apps/qubit/modules/informationobject/templates/autocompleteSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/autocompleteSuccess.php
@@ -4,7 +4,7 @@
       <?php $doc = $hit->getData() ?>
       <tr>
         <td>
-          <?php echo link_to(render_title(get_search_autocomplete_string($doc)), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?><?php if (isset($doc['publicationStatusId']) && QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $doc['publicationStatusId']): ?> <span class="publicationStatus"><?php echo QubitTerm::getById($doc['publicationStatusId'])->__toString() ?></span><?php endif; ?>
+          <?php echo link_to(render_value_inline(get_search_autocomplete_string($doc)), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?><?php if (isset($doc['publicationStatusId']) && QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $doc['publicationStatusId']): ?> <span class="publicationStatus"><?php echo render_value_inline(QubitTerm::getById($doc['publicationStatusId'])) ?></span><?php endif; ?>
         </td>
       </tr>
     <?php endforeach; ?>

--- a/apps/qubit/modules/informationobject/templates/boxLabelSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/boxLabelSuccess.php
@@ -41,16 +41,16 @@
           <td>
             <?php echo $row++ ?>
           </td><td>
-            <?php echo $item['referenceCode'] ?>
+            <?php echo render_value_inline($item['referenceCode']) ?>
           </td><td>
-            <?php echo $item['physicalObjectName'] ?>
+            <?php echo render_value_inline($item['physicalObjectName']) ?>
           </td><td>
-            <?php echo $item['title'] ?>
+            <?php echo render_value_inline($item['title']) ?>
           </td><td>
             <?php if ($item['creationDates']): ?>
               <ul>
                 <?php foreach (explode('|', $item['creationDates']) as $creationDate): ?>
-                  <li><?php echo $creationDate ?></li>
+                  <li><?php echo render_value_inline($creationDate) ?></li>
                 <?php endforeach; ?>
               </ul>
             <?php endif; ?>

--- a/apps/qubit/modules/informationobject/templates/browseSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/browseSuccess.php
@@ -22,12 +22,6 @@
   </div>
 <?php end_slot() ?>
 
-<?php if ($sf_user->hasFlash('notice')): ?>
-  <div class="messages">
-    <div><?php echo $sf_user->getFlash('notice', ESC_RAW) ?></div>
-  </div>
-<?php endif; ?>
-
 <?php if (isset($pager) && $pager->getNbResults() || sfConfig::get('app_enable_institutional_scoping')): ?>
 
   <?php slot('sidebar') ?>
@@ -144,7 +138,7 @@
 
     <?php if (isset($collection)): ?>
       <span class="search-filter">
-        <?php echo $collection->__toString() ?>
+        <?php echo render_title($collection) ?>
         <?php $params = $sf_data->getRaw('sf_request')->getGetParameters() ?>
         <?php unset($params['collection']) ?>
         <a href="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse') + $params) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
@@ -153,7 +147,7 @@
 
     <?php if (isset($creators)): ?>
       <span class="search-filter">
-        <?php echo $creators->__toString() ?>
+        <?php echo render_title($creators) ?>
         <?php $params = $sf_data->getRaw('sf_request')->getGetParameters() ?>
         <?php unset($params['creators']) ?>
         <a href="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse') + $params) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
@@ -162,7 +156,7 @@
 
     <?php if (isset($names)): ?>
       <span class="search-filter">
-        <?php echo $names->__toString() ?>
+        <?php echo render_title($names) ?>
         <?php $params = $sf_data->getRaw('sf_request')->getGetParameters() ?>
         <?php unset($params['names']) ?>
         <a href="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse') + $params) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
@@ -171,7 +165,7 @@
 
     <?php if (isset($places)): ?>
       <span class="search-filter">
-        <?php echo $places->__toString() ?>
+        <?php echo render_title($places) ?>
         <?php $params = $sf_data->getRaw('sf_request')->getGetParameters() ?>
         <?php unset($params['places']) ?>
         <a href="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse') + $params) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
@@ -180,7 +174,7 @@
 
     <?php if (isset($levels)): ?>
       <span class="search-filter">
-        <?php echo $levels->__toString() ?>
+        <?php echo render_title($levels) ?>
         <?php $params = $sf_data->getRaw('sf_request')->getGetParameters() ?>
         <?php unset($params['levels']) ?>
         <a href="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse') + $params) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
@@ -189,7 +183,7 @@
 
     <?php if (isset($subjects)): ?>
       <span class="search-filter">
-        <?php echo $subjects->__toString() ?>
+        <?php echo render_title($subjects) ?>
         <?php $params = $sf_data->getRaw('sf_request')->getGetParameters() ?>
         <?php unset($params['subjects']) ?>
         <a href="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse') + $params) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
@@ -198,7 +192,7 @@
 
     <?php if (isset($mediatypes)): ?>
       <span class="search-filter">
-        <?php echo $mediatypes->__toString() ?>
+        <?php echo render_title($mediatypes) ?>
         <?php $params = $sf_data->getRaw('sf_request')->getGetParameters() ?>
         <?php unset($params['mediatypes']) ?>
         <a href="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse') + $params) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
@@ -207,7 +201,7 @@
 
     <?php if (isset($copyrightStatus)): ?>
       <span class="search-filter">
-        <?php echo $copyrightStatus->__toString() ?>
+        <?php echo render_title($copyrightStatus) ?>
         <?php $params = $sf_data->getRaw('sf_request')->getGetParameters() ?>
         <?php unset($params['copyrightStatus']) ?>
         <a href="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse') + $params) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
@@ -216,7 +210,7 @@
 
     <?php if (isset($materialType)): ?>
       <span class="search-filter">
-        <?php echo $materialType->__toString() ?>
+        <?php echo render_title($materialType) ?>
         <?php $params = $sf_data->getRaw('sf_request')->getGetParameters() ?>
         <?php unset($params['materialType']) ?>
         <a href="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse') + $params) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
@@ -266,7 +260,7 @@
 
     <?php if (isset($findingAidStatusTag)): ?>
       <span class="search-filter">
-        <?php echo $findingAidStatusTag ?>
+        <?php echo render_value_inline($findingAidStatusTag) ?>
         <?php $params = $sf_data->getRaw('sf_request')->getGetParameters() ?>
         <?php unset($params['findingAidStatus']) ?>
         <a href="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse') + $params) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
@@ -275,7 +269,7 @@
 
     <?php if (isset($ancestor)): ?>
       <span class="search-filter">
-        <?php echo $ancestor->__toString() ?>
+        <?php echo render_title($ancestor) ?>
         <?php $params = $sf_data->getRaw('sf_request')->getGetParameters() ?>
         <?php unset($params['ancestor']) ?>
         <a href="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse') + $params) ?>" class="remove-filter"><i class="fa fa-times"></i></a>

--- a/apps/qubit/modules/informationobject/templates/inventorySuccess.php
+++ b/apps/qubit/modules/informationobject/templates/inventorySuccess.php
@@ -42,7 +42,7 @@
             <td>
               <?php echo $doc['identifier'] ?>
             </td>
-            <td><?php echo link_to(get_search_i18n($doc, 'title'), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?></td>
+            <td><?php echo link_to(render_value_inline(get_search_i18n($doc, 'title')), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?></td>
             <td>
               <?php $level = QubitTerm::getById($doc['levelOfDescriptionId']) ?>
               <?php if ($level !== null): ?>
@@ -50,7 +50,7 @@
               <?php endif; ?>
             </td>
             <td>
-              <?php echo render_search_result_date($doc['dates']) ?>
+              <?php echo render_value_inline(render_search_result_date($doc['dates'])) ?>
             </td>
             <td>
               <?php if ($doc['hasDigitalObject']): ?>

--- a/apps/qubit/modules/informationobject/templates/itemOrFileListSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/itemOrFileListSuccess.php
@@ -58,12 +58,12 @@
                 <?php endif; ?>
               </td>
             <?php endif; ?>
-            <td><?php echo $item['referenceCode'] ?></td>
-            <td><?php echo $item['title'] ?></td>
-            <td><?php echo $item['dates'] ?></td>
+            <td><?php echo render_value_inline($item['referenceCode']) ?></td>
+            <td><?php echo render_value_inline($item['title']) ?></td>
+            <td><?php echo render_value_inline($item['dates']) ?></td>
             <td><?php echo isset($item['accessConditions']) ? $item['accessConditions'] : $this->i18n->__('None') ?></td>
             <?php if (0 == sfConfig::get('app_generate_reports_as_pub_user', 1)): ?>
-              <td><?php echo $item['locations'] ?></td>
+              <td><?php echo render_value_inline($item['locations']) ?></td>
             <?php endif; ?>
           </tr>
         <?php endforeach; ?>

--- a/apps/qubit/modules/informationobject/templates/listSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/listSuccess.php
@@ -21,7 +21,7 @@
     <?php foreach ($informationObjects as $item): ?>
       <tr class="<?php echo 0 == @++$row % 2 ? 'even' : 'odd' ?>">
         <td>
-          <?php echo link_to(render_title($item), array($item, 'module' => 'informationobject')) ?><?php if (QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $item->getPublicationStatus()->status->id): ?> <span class="publicationStatus"><?php echo $item->getPublicationStatus()->status ?></span><?php endif; ?>
+          <?php echo link_to(render_title($item), array($item, 'module' => 'informationobject')) ?><?php if (QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $item->getPublicationStatus()->status->id): ?> <span class="publicationStatus"><?php echo render_title($item->getPublicationStatus()->status) ?></span><?php endif; ?>
         </td><td>
           <?php if (sfConfig::get('app_multi_repository')): ?>
             <?php if (isset($item->repository)): ?>

--- a/apps/qubit/modules/informationobject/templates/renameSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/renameSuccess.php
@@ -8,7 +8,7 @@
 
 <?php slot('title') ?>
 
-  <h1><?php echo $resource->title ?></h1>
+  <h1><?php echo render_title($resource) ?></h1>
 
 <?php end_slot() ?>
 
@@ -47,7 +47,7 @@
 
         <div class="rename-form-field-toggle"><input id="rename_enable_title" type="checkbox" checked="checked" /> <?php echo __('Update title') ?></div>
         <br />
- 
+
         <?php echo render_field($form->title
           ->label(__('Title'))
           ->help(__('Editing the description title will automatically update the slug field if the "Update slug" checkbox is selected - you can still edit it after.'))) ?>

--- a/apps/qubit/modules/informationobject/templates/storageLocationsSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/storageLocationsSuccess.php
@@ -17,7 +17,7 @@
   <h1 class="do-print"><?php echo $this->i18n->__('Physical storage locations') ?></h1>
 
   <h1 class="label">
-    <?php echo $resource->getTitle(array('cultureFallback' => true)) ?>
+    <?php echo render_title($resource) ?>
   </h1>
 
   <table class="sticky-enabled">
@@ -39,11 +39,11 @@
           <td>
             <?php echo $row++ ?>
           </td><td>
-            <?php echo link_to($item->name, sfConfig::get('app_siteBaseUrl').'/'.$item->slug) ?>
+            <?php echo link_to(render_title($item->name), sfConfig::get('app_siteBaseUrl').'/'.$item->slug) ?>
           </td><td>
-            <?php echo $item->location ?>
+            <?php echo render_value_inline($item->location) ?>
           </td><td>
-            <?php echo $item->type->__toString() ?>
+            <?php echo render_value_inline($item->type) ?>
           </td>
         </tr>
       <?php endforeach; ?>

--- a/apps/qubit/modules/informationobject/templates/updatePublicationStatusSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/updatePublicationStatusSuccess.php
@@ -8,7 +8,7 @@
 
 <?php slot('title') ?>
 
-  <h1><?php echo $resource->title ?></h1>
+  <h1><?php echo render_title($resource) ?></h1>
 
 <?php end_slot() ?>
 
@@ -25,11 +25,11 @@
         <legend><?php echo __('Update publication status') ?></legend>
 
         <?php echo $form->publicationStatus->label(__('Publication status'))->renderRow() ?>
-        
+
         <?php if ($resource->rgt - $resource->lft > 1): ?>
           <?php echo $form->updateDescendants->label(__('Update descendants'))->renderRow() ?>
         <?php endif; ?>
-        
+
       </fieldset>
 
     </div>

--- a/apps/qubit/modules/informationobject/templates/uploadFindingAidSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/uploadFindingAidSuccess.php
@@ -8,7 +8,7 @@
 
 <?php slot('title') ?>
 
-  <h1><?php echo $resource->title ?></h1>
+  <h1><?php echo render_title($resource) ?></h1>
 
 <?php end_slot() ?>
 
@@ -33,7 +33,7 @@
         <?php endif; ?>
 
         <?php echo $form->file->label(__('%1% file', array('%1%' => strtoupper($format))))->renderRow() ?>
-        
+
       </fieldset>
 
     </div>

--- a/apps/qubit/modules/jobs/templates/reportSuccess.php
+++ b/apps/qubit/modules/jobs/templates/reportSuccess.php
@@ -1,7 +1,7 @@
 <?php decorate_with('layout_1col') ?>
 
 <?php slot('title') ?>
-  <h1><?php echo render_title(__('Job report')) ?></h1>
+  <h1><?php echo __('Job report') ?></h1>
 <?php end_slot() ?>
 
 <section id="report-overview-area">

--- a/apps/qubit/modules/object/templates/importSelectSuccess.php
+++ b/apps/qubit/modules/object/templates/importSelectSuccess.php
@@ -13,14 +13,6 @@
 
 <?php slot('content') ?>
 
-
-  <?php if ($sf_user->hasFlash('error')): ?>
-    <div class="messages error">
-      <h3><?php echo __('Error encountered') ?></h3>
-      <div><?php echo $sf_user->getFlash('error', ESC_RAW) ?></div>
-    </div>
-  <?php endif; ?>
-
   <?php if (isset($resource)): ?>
     <?php echo $form->renderFormTag(url_for(array($resource, 'module' => 'object', 'action' => 'importSelect')), array('enctype' => 'multipart/form-data')) ?>
   <?php else: ?>

--- a/apps/qubit/modules/physicalobject/actions/autocompleteAction.class.php
+++ b/apps/qubit/modules/physicalobject/actions/autocompleteAction.class.php
@@ -34,7 +34,15 @@ class PhysicalObjectAutocompleteAction extends sfAction
     $criteria = new Criteria;
     $criteria->addJoin(QubitPhysicalObject::ID, QubitPhysicalObjectI18n::ID);
     $criteria->add(QubitPhysicalObjectI18n::CULTURE, $this->context->user->getCulture());
-    $criteria->add(QubitPhysicalObjectI18n::NAME, "$request->query%", Criteria::LIKE);
+
+    if (sfConfig::get('app_markdown_enabled', true))
+    {
+      $criteria->add(QubitPhysicalObjectI18n::NAME, "%$request->query%", Criteria::LIKE);
+    }
+    else
+    {
+      $criteria->add(QubitPhysicalObjectI18n::NAME, "$request->query%", Criteria::LIKE);
+    }
 
     $criteria->addAscendingOrderByColumn(QubitPhysicalObjectI18n::NAME);
 

--- a/apps/qubit/modules/physicalobject/templates/_contextMenu.php
+++ b/apps/qubit/modules/physicalobject/templates/_contextMenu.php
@@ -9,13 +9,13 @@
         <li>
 
           <?php if (isset($item->type)): ?>
-            <?php echo $item->type ?>:
+            <?php echo render_value_inline($item->type) ?>:
           <?php endif; ?>
 
           <?php echo link_to_if(QubitAcl::check($resource, 'update'), render_title($item), array($item, 'module' => 'physicalobject')) ?>
 
           <?php if (isset($item->location) && $sf_user->isAuthenticated()): ?>
-            - <?php echo $item->getLocation(array('cultureFallback' => 'true')) ?>
+            - <?php echo render_value_inline($item->getLocation(array('cultureFallback' => 'true'))) ?>
           <?php endif; ?>
 
         </li>

--- a/apps/qubit/modules/physicalobject/templates/boxListSuccess.php
+++ b/apps/qubit/modules/physicalobject/templates/boxListSuccess.php
@@ -28,14 +28,14 @@
     <?php foreach ($informationObjects as $item): ?>
       <tr class="<?php echo 0 == @++$row % 2 ? 'even' : 'odd' ?>">
         <td>
-          <?php $isad = new sfIsadPlugin($item); echo render_value($isad->referenceCode) ?>
+          <?php $isad = new sfIsadPlugin($item); echo render_value_inline($isad->referenceCode) ?>
         </td><td>
           <?php echo render_title($item) ?>
         </td><td>
           <ul>
             <?php foreach ($item->getDates() as $date): ?>
               <li>
-                <?php echo Qubit::renderDateStartEnd($date->getDate(array('cultureFallback' => true)), $date->startDate, $date->endDate) ?> (<?php echo $date->getType(array('cultureFallback' => true)) ?>)
+                <?php echo render_value_inline(Qubit::renderDateStartEnd($date->getDate(array('cultureFallback' => true)), $date->startDate, $date->endDate)) ?> (<?php echo $date->getType(array('cultureFallback' => true)) ?>)
                 <?php if (isset($date->actor)): ?>
                   <?php echo render_title($date->actor) ?>
                 <?php endif; ?>

--- a/apps/qubit/modules/physicalobject/templates/browseSuccess.php
+++ b/apps/qubit/modules/physicalobject/templates/browseSuccess.php
@@ -45,10 +45,10 @@
             <?php echo link_to(render_title($item), array($item, 'module' => 'physicalobject')) ?>
           </td>
           <td>
-            <?php echo $item->location ?>
+            <?php echo render_value_inline($item->location) ?>
           </td>
           <td>
-            <?php echo $item->type?>
+            <?php echo render_value_inline($item->type) ?>
           </td>
         </tr>
       <?php endforeach; ?>

--- a/apps/qubit/modules/physicalobject/templates/indexSuccess.php
+++ b/apps/qubit/modules/physicalobject/templates/indexSuccess.php
@@ -12,16 +12,16 @@
   <?php echo get_component('default', 'translationLinks', array('resource' => $resource)) ?>
 <?php end_slot() ?>
 
-<?php echo render_show(__('Type'), $resource->type) ?>
+<?php echo render_show(__('Type'), render_value($resource->type)) ?>
 
-<?php echo render_show(__('Location'), $resource->getLocation(array('cultureFallback' => true))) ?>
+<?php echo render_show(__('Location'), render_value($resource->getLocation(array('cultureFallback' => true)))) ?>
 
 <div class="field">
   <h3><?php echo __('Related resources') ?></h3>
   <div>
     <ul>
       <?php foreach (QubitRelation::getRelatedObjectsBySubjectId('QubitInformationObject', $resource->id, array('typeId' => QubitTerm::HAS_PHYSICAL_OBJECT_ID)) as $item): ?>
-        <li><?php echo link_to(esc_entities(render_title($item)), array($item, 'module' => 'informationobject')) ?></li>
+        <li><?php echo link_to(render_title($item), array($item, 'module' => 'informationobject')) ?></li>
       <?php endforeach; ?>
     </ul>
   </div>

--- a/apps/qubit/modules/repository/actions/autocompleteAction.class.php
+++ b/apps/qubit/modules/repository/actions/autocompleteAction.class.php
@@ -24,7 +24,16 @@ class RepositoryAutocompleteAction extends sfAction
     $criteria = new Criteria;
     $criteria->addJoin(QubitActor::ID, QubitActorI18n::ID);
     $criteria->add(QubitActor::PARENT_ID, QubitRepository::ROOT_ID);
-    $criteria->add(QubitActorI18n::AUTHORIZED_FORM_OF_NAME, "$request->query%", Criteria::LIKE);
+
+    if (sfConfig::get('app_markdown_enabled', true))
+    {
+      $criteria->add(QubitActorI18n::AUTHORIZED_FORM_OF_NAME, "%$request->query%", Criteria::LIKE);
+    }
+    else
+    {
+      $criteria->add(QubitActorI18n::AUTHORIZED_FORM_OF_NAME, "$request->query%", Criteria::LIKE);
+    }
+
     $criteria->addAscendingOrderByColumn('authorized_form_of_name');
     $criteria->setDistinct();
     $criteria->setLimit(sfConfig::get('app_hits_per_page', 10));

--- a/apps/qubit/modules/repository/actions/holdingsAction.class.php
+++ b/apps/qubit/modules/repository/actions/holdingsAction.class.php
@@ -54,7 +54,7 @@ class RepositoryHoldingsAction extends sfAction
       $doc = $item->getData();
       $results[] = array(
         'url' => url_for(array('module' => 'informationobject', 'slug' => $doc['slug'])),
-        'title' => get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture, 'cultureFallback' => true))
+        'title' => render_value_inline(get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture, 'cultureFallback' => true)))
       );
     }
 

--- a/apps/qubit/modules/repository/actions/maintainedActorsAction.class.php
+++ b/apps/qubit/modules/repository/actions/maintainedActorsAction.class.php
@@ -54,7 +54,7 @@ class RepositoryMaintainedActorsAction extends sfAction
       $doc = $item->getData();
       $results[] = array(
         'url' => url_for(array('module' => 'actor', 'slug' => $doc['slug'])),
-        'title' => get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false, 'culture' => $culture, 'cultureFallback' => true))
+        'title' => render_value_inline(get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false, 'culture' => $culture, 'cultureFallback' => true)))
       );
     }
 

--- a/apps/qubit/modules/repository/templates/_browseCardView.php
+++ b/apps/qubit/modules/repository/templates/_browseCardView.php
@@ -4,7 +4,7 @@
 
   <?php foreach ($pager->getResults() as $hit): ?>
     <?php $doc = $hit->getData() ?>
-    <?php $authorizedFormOfName = render_title(get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false, 'culture' => $selectedCulture))) ?>
+    <?php $authorizedFormOfName = get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false, 'culture' => $selectedCulture)) ?>
     <?php $hasLogo = file_exists(sfConfig::get('sf_upload_dir').'/r/'.$doc['slug'].'/conf/logo.png') ?>
     <?php if ($hasLogo): ?>
       <div class="brick">
@@ -14,14 +14,15 @@
       <a href="<?php echo url_for(array('module' => 'repository', 'slug' => $doc['slug'])) ?>">
         <?php if ($hasLogo): ?>
           <div class="preview">
-            <?php echo image_tag('/uploads/r/'.$doc['slug'].'/conf/logo.png', array('alt' => esc_entities(render_title(truncate_text(get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false, 'culture' => $selectedCulture)), 100))))) ?>
+            <?php echo image_tag('/uploads/r/'.$doc['slug'].'/conf/logo.png',
+                  array('alt' => truncate_text(strip_markdown($authorizedFormOfName), 100))) ?>
           </div>
         <?php else: ?>
-          <h4><?php echo $authorizedFormOfName ?></h4>
+          <h5><?php echo render_title($authorizedFormOfName) ?></h5>
         <?php endif; ?>
       </a>
       <div class="bottom">
-        <?php echo get_component('object', 'clipboardButton', array('slug' => $doc['slug'], 'wide' => false, 'repositoryOrDigitalObjBrowse' => true)) ?><?php echo $authorizedFormOfName ?>
+        <?php echo get_component('object', 'clipboardButton', array('slug' => $doc['slug'], 'wide' => false, 'repositoryOrDigitalObjBrowse' => true)) ?><?php echo render_title($authorizedFormOfName) ?>
       </div>
     </div>
   <?php endforeach; ?>

--- a/apps/qubit/modules/repository/templates/_browseTableView.php
+++ b/apps/qubit/modules/repository/templates/_browseTableView.php
@@ -59,16 +59,16 @@
       </td>
 
       <td>
-        <?php echo get_search_i18n($doc, 'region', array('allowEmpty' => true, 'culture' => $selectedCulture, 'cultureFallback' => true)) ?>
+        <?php echo render_value_inline(get_search_i18n($doc, 'region', array('allowEmpty' => true, 'culture' => $selectedCulture, 'cultureFallback' => true))) ?>
       </td>
       <td>
-        <?php echo get_search_i18n($doc, 'city', array('allowEmpty' => true, 'culture' => $selectedCulture, 'cultureFallback' => true)) ?>
+        <?php echo render_value_inline(get_search_i18n($doc, 'city', array('allowEmpty' => true, 'culture' => $selectedCulture, 'cultureFallback' => true))) ?>
       </td>
 
       <td>
         <?php if (isset($doc['thematicAreas'])): ?>
           <?php foreach ($doc['thematicAreas'] as $areaTerm): ?>
-            <li><?php echo render_value(QubitTerm::getById($areaTerm)) ?></li>
+            <li><?php echo render_value_inline(QubitTerm::getById($areaTerm)) ?></li>
           <?php endforeach; ?>
         <?php endif; ?>
       </td>

--- a/apps/qubit/modules/repository/templates/_contextMenu.php
+++ b/apps/qubit/modules/repository/templates/_contextMenu.php
@@ -1,4 +1,4 @@
-<?php if (isset($resource) && ($resource->getRawValue() instanceof QubitRepository) && sfConfig::get('app_enable_institutional_scoping')): ?>
+<?php if (isset($resource) && ($class === 'QubitRepository') && sfConfig::get('app_enable_institutional_scoping')): ?>
   <?php include_component('repository', 'holdingsInstitution', array('resource' => $resource)) ?>
   <?php include_component('repository', 'holdingsList', array('resource' => $resource)) ?>
   <?php if (QubitAcl::check($resource, 'update')): ?>
@@ -7,7 +7,7 @@
 <?php else: ?>
   <?php echo get_component('repository', 'logo') ?>
 
-  <?php if ($resource->getRawValue() instanceof QubitRepository): ?>
+  <?php if ($class === 'QubitRepository'): ?>
     <?php if (QubitAcl::check($resource, 'update')): ?>
       <?php include_component('repository', 'uploadLimit', array('resource' => $resource)) ?>
     <?php endif; ?>

--- a/apps/qubit/modules/repository/templates/_holdingsInstitution.php
+++ b/apps/qubit/modules/repository/templates/_holdingsInstitution.php
@@ -10,7 +10,9 @@
       <div class="repository-logo<?php echo $resource->existsLogo() ? '' : ' repository-logo-text' ?>">
         <a href="<?php echo url_for(array($resource, 'module' => 'repository')) ?>">
           <?php if ($resource->existsLogo()): ?>
-            <?php echo image_tag($resource->getLogoPath(), array('alt' => __('Go to %1%', array('%1%' => esc_entities(render_title(truncate_text($resource), 100)))))) ?>
+            <?php echo image_tag($resource->getLogoPath(),
+                  array('alt' => __('Go to %1%',
+                  array('%1%' => truncate_text(strip_markdown($resource), 100))))) ?>
           <?php else: ?>
             <h2><?php echo render_title($resource) ?></h2>
           <?php endif; ?>

--- a/apps/qubit/modules/repository/templates/_holdingsList.php
+++ b/apps/qubit/modules/repository/templates/_holdingsList.php
@@ -11,10 +11,9 @@
   <ul>
     <?php foreach ($pager->getResults() as $hit): ?>
       <?php $doc = $hit->getData() ?>
-      <li><?php echo link_to(get_search_i18n($doc, 'title', array('allowEmpty' => false)), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?></li>
+      <li><?php echo link_to(render_value_inline(get_search_i18n($doc, 'title', array('allowEmpty' => false))), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?></li>
     <?php endforeach; ?>
   </ul>
 
   <?php echo get_partial('default/sidebarPager', array('pager' => $pager)) ?>
 </section>
-

--- a/apps/qubit/modules/repository/templates/_logo.php
+++ b/apps/qubit/modules/repository/templates/_logo.php
@@ -3,7 +3,9 @@
 <div class="repository-logo<?php echo $resource->existsLogo() ? '' : ' repository-logo-text' ?>">
   <a href="<?php echo url_for(array($resource, 'module' => 'repository')) ?>">
     <?php if ($resource->existsLogo()): ?>
-      <?php echo image_tag($resource->getLogoPath(), array('alt' => __('Go to %1%', array('%1%' => esc_entities(render_title(truncate_text($resource), 100)))))) ?>
+      <?php echo image_tag($resource->getLogoPath(),
+            array('alt' => __('Go to %1%',
+            array('%1%' => truncate_text(strip_markdown($resource), 100))))) ?>
     <?php else: ?>
       <h2><?php echo render_title($resource) ?></h2>
     <?php endif; ?>

--- a/apps/qubit/modules/repository/templates/_maintainedActors.php
+++ b/apps/qubit/modules/repository/templates/_maintainedActors.php
@@ -17,7 +17,7 @@
   <ul>
     <?php foreach ($list['pager']->getResults() as $hit): ?>
       <?php $doc = $hit->getData() ?>
-      <li><?php echo link_to(get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false)), array('module' => 'actor', 'slug' => $doc['slug'])) ?></li>
+      <li><?php echo link_to(render_value_inline(get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false))), array('module' => 'actor', 'slug' => $doc['slug'])) ?></li>
     <?php endforeach; ?>
   </ul>
 

--- a/apps/qubit/modules/repository/templates/autocompleteSuccess.php
+++ b/apps/qubit/modules/repository/templates/autocompleteSuccess.php
@@ -3,7 +3,7 @@
     <?php foreach($repositories as $item): ?>
       <tr>
         <td>
-          <?php echo link_to($item->getAuthorizedFormOfName(array('cultureFallback' => true)), array($item, 'module' => 'repository')) ?>
+          <?php echo link_to(render_title($item->getAuthorizedFormOfName(array('cultureFallback' => true))), array($item, 'module' => 'repository')) ?>
         </td>
       </tr>
     <?php endforeach; ?>

--- a/apps/qubit/modules/rightsholder/actions/autocompleteAction.class.php
+++ b/apps/qubit/modules/rightsholder/actions/autocompleteAction.class.php
@@ -39,7 +39,14 @@ class RightsHolderAutocompleteAction extends sfAction
 
     if (isset($request->query))
     {
-      $criteria->add(QubitActorI18n::AUTHORIZED_FORM_OF_NAME, "$request->query%", Criteria::LIKE);
+      if (sfConfig::get('app_markdown_enabled', true))
+      {
+        $criteria->add(QubitActorI18n::AUTHORIZED_FORM_OF_NAME, "%$request->query%", Criteria::LIKE);
+      }
+      else
+      {
+        $criteria->add(QubitActorI18n::AUTHORIZED_FORM_OF_NAME, "$request->query%", Criteria::LIKE);
+      }
     }
 
     $this->pager = new QubitPager('QubitActor');

--- a/apps/qubit/modules/search/actions/indexAction.class.php
+++ b/apps/qubit/modules/search/actions/indexAction.class.php
@@ -71,9 +71,9 @@ class SearchIndexAction extends DefaultBrowseAction
 
       $result = array(
         'url' => url_for(array('module' => 'informationobject', 'slug' => $data['slug'])),
-        'title' => esc_specialchars(get_search_i18n($data, 'title', array('allowEmpty' => false))),
-        'identifier' => isset($data['identifier']) && !empty($data['identifier']) ? esc_specialchars($data['identifier']).' - ' : '',
-        'level' => null !== $levelOfDescription ? esc_specialchars($levelOfDescription->getName()) : '');
+        'title' => render_title(get_search_i18n($data, 'title', array('allowEmpty' => false))),
+        'identifier' => isset($data['identifier']) && !empty($data['identifier']) ? render_value_inline($data['identifier']).' - ' : '',
+        'level' => null !== $levelOfDescription ? render_value_inline($levelOfDescription) : '');
 
       $response['results'][] = $result;
     }

--- a/apps/qubit/modules/search/templates/_aggregation.php
+++ b/apps/qubit/modules/search/templates/_aggregation.php
@@ -24,7 +24,7 @@
           (!isset($filters[$name]) && $bucket['key'] == 'unique_language')) ?>
 
         <li <?php if ($active) echo 'class="active"' ?>>
-          <?php echo link_to(__($bucket['display']) . '<span>, ' . $bucket['doc_count'] . ' ' . __('results') . '</span>',
+          <?php echo link_to(__(render_value_inline($bucket['display'])) . '<span>, ' . $bucket['doc_count'] . ' ' . __('results') . '</span>',
             array('page' => null, $name => $bucket['key'] == 'unique_language' ? null : $bucket['key']) +
             $sf_data->getRaw('sf_request')->getParameterHolder()->getAll(), array('title' => '')) ?>
           <span class="facet-count" aria-hidden="true"><?php echo $bucket['doc_count'] ?></span>

--- a/apps/qubit/modules/search/templates/_box.php
+++ b/apps/qubit/modules/search/templates/_box.php
@@ -7,7 +7,7 @@
     <input type="hidden" name="topLod" value="0"/>
 
     <?php if (isset($repository) && !sfConfig::get('app_enable_institutional_scoping')): ?>
-      <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php echo $sf_request->query ?>" placeholder="<?php echo __('Search %1%', array('%1%' => render_title($repository))) ?>"/>
+      <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php echo $sf_request->query ?>" placeholder="<?php echo __('Search %1%', array('%1%' => strip_markdown($repository))) ?>"/>
     <?php else: ?>
       <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php if (!$sf_user->getAttribute('search-realm') || !sfConfig::get('app_enable_institutional_scoping')) echo $sf_request->query ?>" placeholder="<?php echo __('%1%', array('%1%' => sfConfig::get('app_ui_label_globalSearch'))) ?>"/>
     <?php endif; ?>
@@ -32,7 +32,7 @@
         <?php if (isset($repository)): ?>
           <div>
             <label>
-              <input name="repos" checked="checked" type="radio" value="<?php echo $repository->id ?>" data-placeholder="<?php echo __('Search %1%', array('%1%' => render_title($repository))) ?>"/>
+              <input name="repos" checked="checked" type="radio" value="<?php echo $repository->id ?>" data-placeholder="<?php echo __('Search %1%', array('%1%' => strip_markdown($repository))) ?>"/>
               <?php echo __('Search <span>%1%</span>', array('%1%' => render_title($repository))) ?>
             </label>
           </div>
@@ -41,7 +41,7 @@
         <?php if (isset($altRepository)): ?>
           <div>
             <label>
-              <input name="repos" type="radio" value="<?php echo $altRepository->id ?>" data-placeholder="<?php echo __('Search %1%', array('%1%' => render_title($altRepository))) ?>"/>
+              <input name="repos" type="radio" value="<?php echo $altRepository->id ?>" data-placeholder="<?php echo __('Search %1%', array('%1%' => strip_markdown($altRepository))) ?>"/>
               <?php echo __('Search <span>%1%</span>', array('%1%' => render_title($altRepository))) ?>
             </label>
           </div>

--- a/apps/qubit/modules/search/templates/_inlineSearch.php
+++ b/apps/qubit/modules/search/templates/_inlineSearch.php
@@ -18,7 +18,7 @@
         <div class="btn-group">
           <button class="btn dropdown-toggle" data-toggle="dropdown">
             <?php if (isset($sf_request->subqueryField) && 0 < strlen($sf_request->subqueryField)): ?>
-              <?php echo $fields->getRaw($sf_request->subqueryField) ?>
+              <?php echo $sf_data->getRaw('fields')[$sf_request->subqueryField] ?>
             <?php else: ?>
               <?php echo array_values($sf_data->getRaw('fields'))[0] ?>
             <?php endif; ?>

--- a/apps/qubit/modules/search/templates/_searchResult.php
+++ b/apps/qubit/modules/search/templates/_searchResult.php
@@ -15,10 +15,10 @@
                     QubitAcl::check(QubitInformationObject::getById($hit->getId()), 'readThumbnail') &&
                     QubitGrantedRight::checkPremis($hit->getId(), 'readThumb')): ?>
             <?php echo image_tag($doc['digitalObject']['thumbnailPath'],
-              array('alt' => esc_entities(render_title(truncate_text(get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture)), 100))))) ?>
+              array('alt' => truncate_text(strip_markdown(get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture))), 100))) ?>
           <?php else: ?>
             <?php echo image_tag(QubitDigitalObject::getGenericIconPathByMediaTypeId($doc['digitalObject']['mediaTypeId']),
-              array('alt' => esc_entities(render_title(truncate_text(get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture)), 100))))) ?>
+              array('alt' => truncate_text(strip_markdown(get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture))), 100))) ?>
           <?php endif; ?>
         </div>
       </a>
@@ -35,24 +35,24 @@
 
       <?php if ('1' == sfConfig::get('app_inherit_code_informationobject', 1)
         && isset($doc['referenceCode']) && !empty($doc['referenceCode'])) : ?>
-          <li class="reference-code"><?php echo $doc['referenceCode'] ?></li>
+          <li class="reference-code"><?php echo render_value_inline($doc['referenceCode']) ?></li>
       <?php elseif (isset($doc['identifier']) && !empty($doc['identifier'])) : ?>
-          <li class="reference-code"><?php echo $doc['identifier'] ?></li>
+          <li class="reference-code"><?php echo render_value_inline($doc['identifier']) ?></li>
       <?php endif; ?>
 
       <?php if (isset($doc['levelOfDescriptionId']) && !empty($doc['levelOfDescriptionId'])): ?>
-        <li class="level-description"><?php echo esc_specialchars(QubitCache::getLabel($doc['levelOfDescriptionId'], 'QubitTerm')) ?></li>
+        <li class="level-description"><?php echo render_value_inline(QubitCache::getLabel($doc['levelOfDescriptionId'], 'QubitTerm')) ?></li>
       <?php endif; ?>
 
       <?php if (isset($doc['dates'])): ?>
         <?php $date = render_search_result_date($doc['dates']) ?>
         <?php if (!empty($date)): ?>
-          <li class="dates"><?php echo $date ?></li>
+          <li class="dates"><?php echo render_value_inline($date) ?></li>
         <?php endif; ?>
       <?php endif; ?>
 
       <?php if (isset($doc['publicationStatusId']) && QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $doc['publicationStatusId']): ?>
-        <li class="publication-status"><?php echo QubitCache::getLabel($doc['publicationStatusId'], 'QubitTerm') ?></li>
+        <li class="publication-status"><?php echo render_value_inline(QubitCache::getLabel($doc['publicationStatusId'], 'QubitTerm')) ?></li>
       <?php endif; ?>
       <?php if (isset($doc['partOf'])): ?>
         <p><?php echo __('Part of '), link_to(render_title(get_search_i18n($doc['partOf'], 'title',
@@ -62,11 +62,11 @@
     </ul>
 
     <?php if (null !== $scopeAndContent = get_search_i18n($doc, 'scopeAndContent', array('culture' => $culture))): ?>
-      <p><?php echo truncate_text(strip_tags(render_value($scopeAndContent)), 250) ?></p>
+      <div class="scope-and-content"><?php echo render_value($scopeAndContent) ?></div>
     <?php endif; ?>
 
     <?php if (isset($doc['creators']) && null !== $creationDetails = get_search_creation_details($doc, $culture)): ?>
-      <p class="creation-details"><?php echo $creationDetails ?></p>
+      <p class="creation-details"><?php echo render_value_inline($creationDetails) ?></p>
     <?php endif; ?>
 
   </div>

--- a/apps/qubit/modules/search/templates/autocompleteSuccess.php
+++ b/apps/qubit/modules/search/templates/autocompleteSuccess.php
@@ -5,15 +5,15 @@
       <?php foreach ($descriptions->getResults() as $hit): ?>
         <?php $doc = $hit->getData() ?>
         <li>
-          <?php echo link_to(get_search_i18n($doc, 'title'), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?>
+          <?php echo link_to(render_title(get_search_i18n($doc, 'title')), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?>
           <?php $lodId = $doc['levelOfDescriptionId'] ?>
           <?php if (null !== $lodId): ?>
-            <?php echo $levelsOfDescription->get($lodId) ?>
+            <?php echo render_value_inline($levelsOfDescription[$lodId]) ?>
           <?php endif; ?>
         </li>
       <?php endforeach; ?>
       <?php if ($descriptions->getTotalHits() > 3): ?>
-        <li class="showall"><?php echo link_to(__('all matching descriptions'), array('module' => 'informationobject', 'action' => 'browse', 'topLod' => '0') + $allMatchingIoParams->getRawValue()) ?></li>
+        <li class="showall"><?php echo link_to(__('all matching descriptions'), array('module' => 'informationobject', 'action' => 'browse', 'topLod' => '0') + $sf_data->getRaw('allMatchingIoParams')) ?></li>
       <?php endif; ?>
     </ul>
   </section>
@@ -25,10 +25,10 @@
     <ul>
       <?php foreach ($repositories->getResults() as $hit): ?>
         <?php $doc = $hit->getData() ?>
-        <li><?php echo link_to(get_search_i18n($doc, 'authorizedFormOfName'), array('module' => 'repository', 'slug' => $doc['slug'])) ?></li>
+        <li><?php echo link_to(render_title(get_search_i18n($doc, 'authorizedFormOfName')), array('module' => 'repository', 'slug' => $doc['slug'])) ?></li>
       <?php endforeach; ?>
       <?php if ($repositories->getTotalHits() > 3): ?>
-        <li class="showall"><?php echo link_to(__('all matching institutions'), array('module' => 'repository', 'action' => 'browse') + $allMatchingParams->getRawValue()) ?></li>
+        <li class="showall"><?php echo link_to(__('all matching institutions'), array('module' => 'repository', 'action' => 'browse') + $sf_data->getRaw('allMatchingParams')) ?></li>
       <?php endif; ?>
     </ul>
   </section>
@@ -40,10 +40,10 @@
     <ul>
       <?php foreach ($actors->getResults() as $hit): ?>
         <?php $doc = $hit->getData() ?>
-        <li><?php echo link_to(get_search_i18n($doc, 'authorizedFormOfName'), array('module' => 'actor', 'slug' => $doc['slug'])) ?></li>
+        <li><?php echo link_to(render_title(get_search_i18n($doc, 'authorizedFormOfName')), array('module' => 'actor', 'slug' => $doc['slug'])) ?></li>
       <?php endforeach; ?>
       <?php if ($actors->getTotalHits() > 3): ?>
-        <li class="showall"><?php echo link_to(__('all matching people & organizations'), array('module' => 'actor', 'action' => 'browse') + $allMatchingParams->getRawValue()) ?></li>
+        <li class="showall"><?php echo link_to(__('all matching people & organizations'), array('module' => 'actor', 'action' => 'browse') + $sf_data->getRaw('allMatchingParams')) ?></li>
       <?php endif; ?>
     </ul>
   </section>
@@ -55,10 +55,10 @@
     <ul>
       <?php foreach ($places->getResults() as $hit): ?>
         <?php $doc = $hit->getData() ?>
-        <li><?php echo link_to(get_search_i18n($doc, 'name'), array('module' => 'term', 'slug' => $doc['slug'])) ?></li>
+        <li><?php echo link_to(render_title(get_search_i18n($doc, 'name')), array('module' => 'term', 'slug' => $doc['slug'])) ?></li>
       <?php endforeach; ?>
       <?php if ($places->getTotalHits() > 3): ?>
-        <li class="showall"><?php echo link_to(__('all matching places'), array('module' => 'taxonomy', 'action' => 'index', 'slug' => 'places', 'subqueryField' => 'allLabels') + $allMatchingParams->getRawValue()) ?></li>
+        <li class="showall"><?php echo link_to(__('all matching places'), array('module' => 'taxonomy', 'action' => 'index', 'slug' => 'places', 'subqueryField' => 'allLabels') + $sf_data->getRaw('allMatchingParams')) ?></li>
       <?php endif; ?>
     </ul>
   </section>
@@ -70,10 +70,10 @@
     <ul>
       <?php foreach ($subjects->getResults() as $hit): ?>
         <?php $doc = $hit->getData() ?>
-        <li><?php echo link_to(get_search_i18n($doc, 'name'), array('module' => 'term', 'slug' => $doc['slug'])) ?></li>
+        <li><?php echo link_to(render_title(get_search_i18n($doc, 'name')), array('module' => 'term', 'slug' => $doc['slug'])) ?></li>
       <?php endforeach; ?>
       <?php if ($subjects->getTotalHits() > 3): ?>
-        <li class="showall"><?php echo link_to(__('all matching subjects'), array('module' => 'taxonomy', 'action' => 'index', 'slug' => 'subjects', 'subqueryField' => 'allLabels') + $allMatchingParams->getRawValue()) ?></li>
+        <li class="showall"><?php echo link_to(__('all matching subjects'), array('module' => 'taxonomy', 'action' => 'index', 'slug' => 'subjects', 'subqueryField' => 'allLabels') + $sf_data->getRaw('allMatchingParams')) ?></li>
       <?php endif; ?>
     </ul>
   </section>

--- a/apps/qubit/modules/search/templates/descriptionUpdatesSuccess.php
+++ b/apps/qubit/modules/search/templates/descriptionUpdatesSuccess.php
@@ -108,28 +108,28 @@
 
               <?php if ('QubitInformationObject' == $className): ?>
 
-                <?php echo link_to(render_title(truncate_text(get_search_i18n($doc, 'title', array('allowEmpty' => false)), 100)), array('slug' => $doc['slug'], 'module' => 'informationobject')) ?>
+                <?php echo link_to(render_title(get_search_i18n($doc, 'title', array('allowEmpty' => false))), array('slug' => $doc['slug'], 'module' => 'informationobject')) ?>
                 <?php $status = (isset($doc['publicationStatusId'])) ? QubitTerm::getById($doc['publicationStatusId']) : null ?>
-                <?php if (isset($status) && $status->id == QubitTerm::PUBLICATION_STATUS_DRAFT_ID): ?><span class="note2"><?php echo ' ('.$status->name.')' ?></span><?php endif; ?>
+                <?php if (isset($status) && $status->id == QubitTerm::PUBLICATION_STATUS_DRAFT_ID): ?><span class="note2"><?php echo ' ('.render_value_inline($status).')' ?></span><?php endif; ?>
 
               <?php elseif ('QubitActor' == $className): ?>
 
-                <?php $name = render_title(truncate_text(get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false)), 100)) ?>
+                <?php $name = render_title(get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false))) ?>
                 <?php echo link_to($name, array('slug' => $doc['slug'], 'module' => 'actor')) ?>
 
               <?php elseif ('QubitFunction' == $className): ?>
 
-                <?php $name = render_title(truncate_text(get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false)), 100)) ?>
+                <?php $name = render_title(get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false))) ?>
                 <?php echo link_to($name, array('slug' => $doc['slug'], 'module' => 'function')) ?>
 
               <?php elseif ('QubitRepository' == $className): ?>
 
-                <?php $name = render_title(truncate_text(get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false)), 100)) ?>
+                <?php $name = render_title(get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false))) ?>
                 <?php echo link_to($name, array('slug' => $doc['slug'], 'module' => 'repository')) ?>
 
               <?php elseif ('QubitTerm' == $className): ?>
 
-                <?php $name = render_title(truncate_text(get_search_i18n($doc, 'name', array('allowEmpty' => false)), 100)) ?>
+                <?php $name = render_title(get_search_i18n($doc, 'name', array('allowEmpty' => false))) ?>
                 <?php echo link_to($name, array('slug' => $doc['slug'], 'module' => 'term')) ?>
 
               <?php endif; ?>
@@ -138,12 +138,12 @@
 
             <?php if ('QubitInformationObject' == $className && 0 < sfConfig::get('app_multi_repository')): ?>
               <td>
-                <?php if (null !== $repository = (isset($doc['repository'])) ? truncate_text(get_search_i18n($doc['repository'], 'authorizedFormOfName', array('allowEmpty' => false)), 100) : null): ?>
+                <?php if (null !== $repository = (isset($doc['repository'])) ? render_title(get_search_i18n($doc['repository'], 'authorizedFormOfName', array('allowEmpty' => false))) : null): ?>
                   <?php echo $repository ?>
                 <?php endif; ?>
               </td>
             <?php elseif('QubitTerm' == $className): ?>
-              <td><?php echo truncate_text(get_search_i18n($doc, 'name', array('allowEmpty' => false)), 100) ?></td>
+              <td><?php echo render_title(get_search_i18n($doc, 'name', array('allowEmpty' => false))) ?></td>
             <?php endif; ?>
 
             <td>

--- a/apps/qubit/modules/search/templates/globalReplaceSuccess.php
+++ b/apps/qubit/modules/search/templates/globalReplaceSuccess.php
@@ -1,6 +1,6 @@
 <?php use_helper('Text') ?>
 
-<h1><?php echo esc_entities($title) ?></h1>
+<h1><?php echo render_title($title) ?></h1>
 
 <?php if (isset($pager)): ?>
     <?php $form->pager = true; ?>

--- a/apps/qubit/modules/settings/actions/markdownAction.class.php
+++ b/apps/qubit/modules/settings/actions/markdownAction.class.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class SettingsMarkdownAction extends DefaultEditAction
+{
+  // Arrays not allowed in class constants
+  public static $NAMES = array('enabled');
+
+  protected function earlyExecute()
+  {
+    $this->i18n = sfContext::getInstance()->i18n;
+  }
+
+  protected function addField($name)
+  {
+    switch ($name)
+    {
+      case 'enabled':
+        $default = 1;
+        if (null !== $this->settingEnabled = QubitSetting::getByName('markdown_enabled'))
+        {
+          $default = $this->settingEnabled->getValue(array('sourceCulture' => true));
+        }
+
+        $this->form->setDefault($name, $default);
+        $this->form->setValidator($name, new sfValidatorInteger(array('required' => false)));
+        $this->form->setWidget($name, new sfWidgetFormSelectRadio(array('choices' => array(1 => 'yes', 0 => 'no')), array('class' => 'radio')));
+
+        break;
+    }
+  }
+
+  protected function processField($field)
+  {
+    switch ($field->getName())
+    {
+      case 'enabled':
+        if (null === $this->settingEnabled)
+        {
+          $this->settingEnabled = new QubitSetting;
+          $this->settingEnabled->name = 'markdown_enabled';
+          $this->settingEnabled->sourceCulture = 'en';
+        }
+
+        $this->settingEnabled->setValue($field->getValue(), array('culture' => 'en'));
+        $this->settingEnabled->save();
+
+        break;
+    }
+  }
+
+  public function execute($request)
+  {
+    parent::execute($request);
+
+    if ($request->isMethod('post'))
+    {
+      $this->form->bind($request->getPostParameters());
+
+      if ($this->form->isValid())
+      {
+        $this->processForm();
+
+        QubitCache::getInstance()->removePattern('settings:i18n:*');
+
+        $this->getUser()->setFlash('notice', $this->i18n->__('Markdown settings saved.'));
+
+        $this->redirect(array('module' => 'settings', 'action' => 'markdown'));
+      }
+    }
+  }
+}

--- a/apps/qubit/modules/settings/actions/menuComponent.class.php
+++ b/apps/qubit/modules/settings/actions/menuComponent.class.php
@@ -83,6 +83,10 @@ class SettingsMenuComponent extends sfComponent
       array(
         'label' => $i18n->__('Treeview'),
         'action' => 'treeview'
+      ),
+      array(
+        'label' => $i18n->__('Markdown'),
+        'action' => 'markdown'
       )
     );
 
@@ -106,5 +110,10 @@ class SettingsMenuComponent extends sfComponent
       // Active bool
       $node['active'] = $this->context->getActionName() === $node['action'];
     }
+
+    // Sort alphabetically
+    usort($this->nodes, function($el1, $el2) {
+      return strnatcmp( $el1['label'], $el2['label']);
+    });
   }
 }

--- a/apps/qubit/modules/settings/templates/markdownSuccess.php
+++ b/apps/qubit/modules/settings/templates/markdownSuccess.php
@@ -1,0 +1,51 @@
+<?php decorate_with('layout_2col.php') ?>
+
+<?php slot('sidebar') ?>
+
+  <?php echo get_component('settings', 'menu') ?>
+
+<?php end_slot() ?>
+
+<?php slot('title') ?>
+
+  <h1><?php echo __('Markdown') ?></h1>
+
+<?php end_slot() ?>
+
+<?php slot('content') ?>
+
+  <div class="alert alert-info">
+    <p><?php echo __('Please rebuild the search index if you are enabling/disabling Markdown support.') ?></p>
+    <pre>$ php symfony search:populate</pre>
+  </div>
+
+  <?php echo $form->renderFormTag(url_for(array('module' => 'settings', 'action' => 'markdown'))) ?>
+
+    <div id="content">
+
+      <table class="table sticky-enabled">
+        <thead>
+          <tr>
+            <th><?php echo __('Name')?></th>
+            <th><?php echo __('Value')?></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><?php echo $form->enabled->label(__('Enable Markdown support'))->renderLabel() ?></td>
+            <td><?php echo $form->enabled ?></td>
+          </tr>
+        </tbody>
+      </table>
+
+    </div>
+
+    <section class="actions">
+      <ul>
+        <li><input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Save') ?>"/></li>
+      </ul>
+    </section>
+
+  </form>
+
+<?php end_slot() ?>

--- a/apps/qubit/modules/staticpage/templates/homeSuccess.php
+++ b/apps/qubit/modules/staticpage/templates/homeSuccess.php
@@ -25,7 +25,7 @@
 <?php end_slot() ?>
 
 <div class="page">
-  <?php echo render_value($sf_data->getRaw('content')) ?>
+  <?php echo render_value_html($sf_data->getRaw('content')) ?>
 </div>
 
 <?php if (QubitAcl::check($resource, 'update')): ?>

--- a/apps/qubit/modules/staticpage/templates/indexSuccess.php
+++ b/apps/qubit/modules/staticpage/templates/indexSuccess.php
@@ -15,7 +15,7 @@
 <div class="page">
 
   <div>
-    <?php echo render_value($sf_data->getRaw('content')) ?>
+    <?php echo render_value_html($sf_data->getRaw('content')) ?>
   </div>
 
 </div>

--- a/apps/qubit/modules/taxonomy/actions/autocompleteAction.class.php
+++ b/apps/qubit/modules/taxonomy/actions/autocompleteAction.class.php
@@ -29,7 +29,14 @@ class TaxonomyAutocompleteAction extends sfAction
     // Narrow results by query
     if (0 < strlen($request->query))
     {
-      $criteria->add(QubitTaxonomyI18n::NAME, "$request->query%", Criteria::LIKE);
+      if (sfConfig::get('app_markdown_enabled', true))
+      {
+        $criteria->add(QubitTaxonomyI18n::NAME, "%$request->query%", Criteria::LIKE);
+      }
+      else
+      {
+        $criteria->add(QubitTaxonomyI18n::NAME, "$request->query%", Criteria::LIKE);
+      }
     }
 
     // Limit results by ACL

--- a/apps/qubit/modules/taxonomy/actions/indexAction.class.php
+++ b/apps/qubit/modules/taxonomy/actions/indexAction.class.php
@@ -211,7 +211,7 @@ class TaxonomyIndexAction extends sfAction
         return;
       }
 
-      sfContext::getInstance()->getConfiguration()->loadHelpers('Url');
+      sfContext::getInstance()->getConfiguration()->loadHelpers('Url', 'Qubit');
 
       $response = array('results' => array());
       foreach ($resultSet->getResults() as $item)
@@ -220,7 +220,7 @@ class TaxonomyIndexAction extends sfAction
 
         $result = array(
           'url' => url_for(array('module' => 'term', 'slug' => $data['slug'])),
-          'title' => $data['i18n'][$culture]['name'],
+          'title' => render_title(get_search_i18n($data, 'name')),
           'identifier' => '',
           'level' => '');
 

--- a/apps/qubit/modules/taxonomy/templates/indexSuccess.php
+++ b/apps/qubit/modules/taxonomy/templates/indexSuccess.php
@@ -66,9 +66,9 @@
         <tr>
           <td>
             <?php if ($doc['isProtected']): ?>
-              <?php echo link_to(get_search_i18n($doc, 'name', array('allowEmpty' => false)), array('module' => 'term', 'slug' => $doc['slug']), array('class' => 'readOnly')) ?>
+              <?php echo link_to(render_title(get_search_i18n($doc, 'name', array('allowEmpty' => false))), array('module' => 'term', 'slug' => $doc['slug']), array('class' => 'readOnly')) ?>
             <?php else: ?>
-              <?php echo link_to(get_search_i18n($doc, 'name', array('allowEmpty' => false)), array('module' => 'term', 'slug' => $doc['slug'])) ?>
+              <?php echo link_to(render_title(get_search_i18n($doc, 'name', array('allowEmpty' => false))), array('module' => 'term', 'slug' => $doc['slug'])) ?>
             <?php endif; ?>
 
             <?php if (0 < $doc['numberOfDescendants']): ?>
@@ -81,7 +81,7 @@
                 <?php echo __('Use for: ') ?>
 
                 <?php foreach ($doc['useFor'] as $label): ?>
-                  <?php $labels[] = get_search_i18n($label, 'name', array('allowEmpty' => false)) ?>
+                  <?php $labels[] = render_value_inline(get_search_i18n($label, 'name', array('allowEmpty' => false))) ?>
                 <?php endforeach; ?>
 
                 <?php echo implode(', ', $labels) ?>
@@ -92,7 +92,7 @@
             <?php if (isset($doc['scopeNotes']) && count($doc['scopeNotes']) > 0): ?>
               <ul>
                 <?php foreach ($doc['scopeNotes'] as $note): ?>
-                  <li><?php echo get_search_i18n($note, 'content') ?></li>
+                  <li><?php echo render_value_inline(get_search_i18n($note, 'content')) ?></li>
                 <?php endforeach; ?>
               </ul>
             <?php endif; ?>

--- a/apps/qubit/modules/taxonomy/templates/listSuccess.php
+++ b/apps/qubit/modules/taxonomy/templates/listSuccess.php
@@ -21,7 +21,7 @@
           <td>
             <?php echo link_to(render_title($item), array($item, 'module' => 'taxonomy')) ?>
           </td><td>
-            <?php echo $item->getNote(array('cultureFallback' => true)) ?>
+            <?php echo render_value_inline($item->getNote(array('cultureFallback' => true))) ?>
           </td>
         </tr>
       <?php endforeach; ?>

--- a/apps/qubit/modules/term/actions/autocompleteAction.class.php
+++ b/apps/qubit/modules/term/actions/autocompleteAction.class.php
@@ -57,7 +57,14 @@ class TermAutocompleteAction extends sfAction
       // Narrow results by query
       if (isset($request->query))
       {
-        $criteria->add(QubitTermI18n::NAME, "$request->query%", Criteria::LIKE);
+        if (sfConfig::get('app_markdown_enabled', true))
+        {
+          $criteria->add(QubitTermI18n::NAME, "%$request->query%", Criteria::LIKE);
+        }
+        else
+        {
+          $criteria->add(QubitTermI18n::NAME, "$request->query%", Criteria::LIKE);
+        }
       }
 
       // Sort by name

--- a/apps/qubit/modules/term/actions/indexAction.class.php
+++ b/apps/qubit/modules/term/actions/indexAction.class.php
@@ -156,7 +156,7 @@ class TermIndexAction extends DefaultBrowseAction
           return;
         }
 
-        sfContext::getInstance()->getConfiguration()->loadHelpers('Url');
+        sfContext::getInstance()->getConfiguration()->loadHelpers('Url', 'Qubit');
 
         $response = array('results' => array());
         foreach ($this->listResultSet->getResults() as $item)
@@ -165,7 +165,7 @@ class TermIndexAction extends DefaultBrowseAction
 
           $result = array(
             'url' => url_for(array('module' => 'term', 'slug' => $data['slug'])),
-            'title' => $data['i18n'][$this->culture]['name']);
+            'title' => render_title(get_search_i18n($data, 'name')));
 
           $response['results'][] = $result;
         }

--- a/apps/qubit/modules/term/templates/_treeView.php
+++ b/apps/qubit/modules/term/templates/_treeView.php
@@ -125,9 +125,9 @@
 
             <li>
               <?php if ($doc['isProtected']): ?>
-                <?php echo link_to(get_search_i18n($doc, 'name', array('allowEmpty' => false)), array('module' => 'term', 'slug' => $doc['slug']), array('class' => 'readOnly')) ?>
+                <?php echo link_to(render_title(get_search_i18n($doc, 'name', array('allowEmpty' => false))), array('module' => 'term', 'slug' => $doc['slug']), array('class' => 'readOnly')) ?>
               <?php else: ?>
-                <?php echo link_to(get_search_i18n($doc, 'name', array('allowEmpty' => false)), array('module' => 'term', 'slug' => $doc['slug'])) ?>
+                <?php echo link_to(render_title(get_search_i18n($doc, 'name', array('allowEmpty' => false))), array('module' => 'term', 'slug' => $doc['slug'])) ?>
               <?php endif; ?>
             </li>
 
@@ -175,7 +175,7 @@
 
       <form method="get" action="<?php echo url_for(array($resource->taxonomy, 'module' => 'taxonomy')) ?>" data-not-found="<?php echo __('No results found.') ?>">
         <div class="search-box">
-          <input type="text" name="query" placeholder="<?php echo __('Search %1%', array('%1%' => $resource->taxonomy)) ?>" />
+          <input type="text" name="query" placeholder="<?php echo __('Search %1%', array('%1%' => strip_markdown($resource->taxonomy))) ?>" />
           <button type="submit"><i class="fa fa-search"></i></button>
           <button id="treeview-search-settings" href="#"><i class="fa fa-cog"></i></button>
         </div>

--- a/apps/qubit/modules/term/templates/deleteSuccess.php
+++ b/apps/qubit/modules/term/templates/deleteSuccess.php
@@ -24,7 +24,7 @@
         <div class="delete-list">
           <ul>
             <?php foreach ($resource->events as $item): ?>
-              <li><?php echo Qubit::renderDateStartEnd($item->getDate(array('cultureFallback' => true)), $item->startDate, $item->endDate) ?> (<?php echo render_title($resource) ?>) <?php echo link_to(render_title($item->object), array($item->object, 'module' => 'informationobject')) ?></li>
+              <li><?php echo render_value_inline(Qubit::renderDateStartEnd($item->getDate(array('cultureFallback' => true)), $item->startDate, $item->endDate)) ?> (<?php echo render_title($resource) ?>) <?php echo link_to(render_title($item->object), array($item->object, 'module' => 'informationobject')) ?></li>
             <?php endforeach; ?>
           </ul>
         </div>

--- a/apps/qubit/modules/term/templates/indexSuccess.php
+++ b/apps/qubit/modules/term/templates/indexSuccess.php
@@ -112,7 +112,8 @@
         <?php echo $resource->code ?>
         <?php if (!empty($resource->code) && QubitTaxonomy::PLACE_ID == $resource->taxonomy->id): ?>
           <?php echo image_tag('https://maps.googleapis.com/maps/api/staticmap?zoom=13&size=300x300&sensor=false&center='.$resource->code,
-            array('class' => 'static-map', 'alt' => __('Map of %1%', array('%1%' => esc_entities(render_title(truncate_text($resource, 100))))))) ?>
+            array('class' => 'static-map', 'alt' => __('Map of %1%',
+            array('%1%' => truncate_text(strip_markdown($resource), 100))))) ?>
         <?php endif; ?>
       </div>
     </div>

--- a/apps/qubit/modules/user/templates/indexSuccess.php
+++ b/apps/qubit/modules/user/templates/indexSuccess.php
@@ -18,7 +18,7 @@
 
     <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('User details').'</h2>', array($resource, 'module' => 'user', 'action' => 'edit')) ?>
 
-    <?php echo render_show(__('User name'), $resource->username.($sf_user->user === $resource ? ' ('.__('you').')' : '')) ?>
+    <?php echo render_show(__('User name'), render_value($resource->username.($sf_user->user === $resource ? ' ('.__('you').')' : ''))) ?>
 
     <?php echo render_show(__('Email'), $resource->email) ?>
 

--- a/config/factories.yml
+++ b/config/factories.yml
@@ -16,7 +16,7 @@ test:
       session_path: %SF_TEST_CACHE_DIR%/sessions
 
   response:
-    class: sfWebResponse
+    class: QubitWebResponse
     param:
       send_http_headers: false
 
@@ -57,6 +57,9 @@ all:
           cache_dir: %SF_TEMPLATE_CACHE_DIR%
           lifetime: 86400
           prefix: %SF_APP_DIR%/template
+
+  response:
+    class: QubitWebResponse
 
   routing:
     class: QubitPatternRouting

--- a/js/fullWidthTreeView.js
+++ b/js/fullWidthTreeView.js
@@ -20,7 +20,7 @@
     var url  = '/informationobject/fullWidthTreeView';
     var $fwTreeView = $('<div id="fullwidth-treeview"></div>');
     var $fwTreeViewRow = $('<div id="fullwidth-treeview-row"></div>');
-    var $mainHeader = $('#main-column h1');
+    var $mainHeader = $('#main-column h1').first();
 
     // Add tree-view divs after main header, animate and allow resize
     $mainHeader.after(

--- a/js/qubit.js
+++ b/js/qubit.js
@@ -17,7 +17,7 @@ window.log = function()
 Drupal.behaviors.expander = {
   attach: function (context)
     {
-      jQuery('div.field:not(:has(div.field)) > div').each(function (index, element) {
+      jQuery('div.field:not(:has(div.field)) > div, article.search-result .scope-and-content').each(function (index, element) {
         var $element = jQuery(element);
         // Don't apply expander to fields with only one child, if that child is a list
         if ($element.children().length !== 1 || !$element.children().first().is('ul')) {

--- a/lib/QubitWebResponse.class.php
+++ b/lib/QubitWebResponse.class.php
@@ -17,16 +17,18 @@
  * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
  */
 
-class RepositoryContextMenuComponent extends sfComponent
-{
-  public function execute($request)
-  {
-    if (!isset($request->getAttribute('sf_route')->resource))
-    {
-      return sfView::NONE;
-    }
-
-    $this->resource = $request->getAttribute('sf_route')->resource;
-    $this->class = get_class($this->resource);
-  }
-}
+ class QubitWebResponse extends sfWebResponse
+ {
+   /**
+    * Sets title for the current web response.
+    *
+    * @param string  $title   Title name
+    * @param bool    $escape  true, for escaping the title
+    */
+   public function setTitle($title, $escape = true)
+   {
+     // Remove Markdown from title
+     $title = QubitMarkdown::getInstance()->strip($title);
+     $this->addMeta('title', $title, true, $escape);
+   }
+ }

--- a/lib/job/arBaseJob.class.php
+++ b/lib/job/arBaseJob.class.php
@@ -61,6 +61,7 @@ class arBaseJob extends Net_Gearman_Job_Common
     $this->i18n = $context->i18n;
     $this->user = $context->user;
     $this->dispatcher = $context->getEventDispatcher();
+    sfConfig::add(QubitSetting::getSettingsArray());
 
     $this->checkRequiredParameters($parameters);
 

--- a/lib/model/QubitContactInformation.php
+++ b/lib/model/QubitContactInformation.php
@@ -51,10 +51,10 @@ class QubitContactInformation extends BaseContactInformation
     sfContext::getInstance()->getConfiguration()->loadHelpers('Partial');
     $cf = array('cultureFallback' => true);
 
-    $string = ($this->getStreetAddress($cf)) ? esc_specialchars($this->getStreetAddress($cf)).'<br/>' : '';
+    $string = ($this->getStreetAddress($cf)) ? esc_specialchars($this->getStreetAddress($cf))."\n" : '';
     $string .= ($this->getCity($cf)) ? esc_specialchars($this->getCity($cf)) : '';
     $string .= ($this->getRegion($cf)) ? ', '.esc_specialchars($this->getRegion($cf)) : '';
-    $string .= ($this->getCountryCode($cf)) ? '<br/>'.esc_specialchars($this->getCountryCode($cf)) : '';
+    $string .= ($this->getCountryCode($cf)) ? "\n".esc_specialchars($this->getCountryCode($cf)) : '';
     $string .= ($this->getPostalCode($cf)) ? '   '.esc_specialchars($this->getPostalCode($cf)): '';
 
     return $string;

--- a/lib/model/QubitSetting.php
+++ b/lib/model/QubitSetting.php
@@ -103,6 +103,15 @@ class QubitSetting extends BaseSetting
       $settings[$key.'__source'] = $qubitSetting->value_source;
     }
 
+    // Disable Symfony escaping strategy if Markdown is enabled to allow
+    // parsing tags like blockquote ('>'). Parsedown is used in safe mode
+    // to escape the content while parsing when necesary in QubitMarkdown.
+    // Markdown is enabled by default if the setting doesn't exists.
+    if (!isset($settings['app_markdown_enabled']) || $settings['app_markdown_enabled'])
+    {
+      $settings['sf_escaping_strategy'] = false;
+    }
+
     return $settings;
   }
 

--- a/lib/task/migrate/arUpgradeSqlTask.class.php
+++ b/lib/task/migrate/arUpgradeSqlTask.class.php
@@ -222,6 +222,10 @@ EOF;
     // Store the milestone in settings, we're going to need that in further upgrades!
     // Use case: a user running 1.x for a long period after 2.x release, then upgrades
     $this->updateMilestone();
+
+    // Clear settings cache to reload them in sfConfig on the first request
+    // after the upgrade in QubitSettingsFilter.
+    QubitCache::getInstance()->removePattern('settings:i18n:*');
   }
 
   /**

--- a/lib/task/search/arPopulateTask.class.php
+++ b/lib/task/search/arPopulateTask.class.php
@@ -52,6 +52,7 @@ EOF;
   public function execute($arguments = array(), $options = array())
   {
     sfContext::createInstance($this->configuration);
+    sfConfig::add(QubitSetting::getSettingsArray());
 
     // If show-types flag set, show types available to index
     if (!empty($options['show-types']))

--- a/plugins/arArchivesCanadaPlugin/modules/search/templates/_box.php
+++ b/plugins/arArchivesCanadaPlugin/modules/search/templates/_box.php
@@ -7,7 +7,7 @@
     <div class="input-append">
 
       <?php if (isset($repository)): ?>
-        <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php echo $sf_request->query ?>" placeholder="<?php echo __('Search %1%', array('%1%' => render_title($repository))) ?>"/>
+        <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php echo $sf_request->query ?>" placeholder="<?php echo __('Search %1%', array('%1%' => strip_markdown($repository))) ?>"/>
       <?php else: ?>
         <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php echo $sf_request->query ?>" placeholder="<?php echo __('Search') ?>"/>
       <?php endif; ?>

--- a/plugins/arDacsPlugin/modules/arDacsPlugin/templates/indexSuccess.php
+++ b/plugins/arDacsPlugin/modules/arDacsPlugin/templates/indexSuccess.php
@@ -12,7 +12,8 @@
     <div class="messages error">
       <ul>
         <?php foreach ($errorSchema as $error): ?>
-          <li><?php echo $error->getMessage(ESC_RAW) ?></li>
+          <?php $error = sfOutputEscaper::unescape($error) ?>
+          <li><?php echo $error->getMessage() ?></li>
         <?php endforeach; ?>
       </ul>
     </div>
@@ -72,7 +73,7 @@
       <ul>
         <?php foreach ($resource->getDates() as $item): ?>
           <li>
-            <?php echo Qubit::renderDateStartEnd($item->getDate(array('cultureFallback' => true)), $item->startDate, $item->endDate) ?> (<?php echo $item->getType(array('cultureFallback' => true)) ?>)
+            <?php echo render_value_inline(Qubit::renderDateStartEnd($item->getDate(array('cultureFallback' => true)), $item->startDate, $item->endDate)) ?> (<?php echo $item->getType(array('cultureFallback' => true)) ?>)
           </li>
         <?php endforeach; ?>
       </ul>
@@ -201,7 +202,7 @@
       <div>
         <ul>
           <?php foreach ($resource->getNotesByTaxonomy(array('taxonomyId' => QubitTaxonomy::DACS_NOTE_ID)) as $item): ?>
-            <li><?php echo $item->type ?>: <?php echo $item->getContent(array('cultureFallback' => true)) ?></li>
+            <li><?php echo render_value_inline($item->type) ?>: <?php echo render_value_inline($item->getContent(array('cultureFallback' => true))) ?></li>
           <?php endforeach; ?>
         </ul>
       </div>

--- a/plugins/arDominionPlugin/css/less/scaffolding.less
+++ b/plugins/arDominionPlugin/css/less/scaffolding.less
@@ -767,7 +767,12 @@ div#content > table.table {
   .box-shadow(0 1px 1px rgba(0, 0, 0, .2));
 
   // Section title
-  h2 {
+  .section > h2,
+  .section > a > h2,
+  .section > span > h2,
+  section > h2,
+  section > a > h2,
+  section > span > h2 {
     font-size: @baseFontSize * 1.10;
     line-height: 38px;
     color: @orange;
@@ -1173,7 +1178,7 @@ section .vcard:last-child > .field:last-child > div {
   .creation-details {
     color: @grayLight;
     font-size: @baseFontSize * 0.90;
-    margin-top: -10px !important;
+    margin-top: 10px;
   }
 
   // List of details
@@ -1827,4 +1832,10 @@ body.login #content {
   &+ .multiline-header {
     margin-top: 45px;
   }
+}
+
+// Maintain font size in blockquotes
+
+blockquote p {
+  font-size: inherit;
 }

--- a/plugins/arDominionPlugin/css/less/search.less
+++ b/plugins/arDominionPlugin/css/less/search.less
@@ -474,11 +474,6 @@ h1 {
     border-bottom: 1px solid @grayLighter;
   }
 
-  em {
-    color: @orange;
-    font-style: normal;
-  }
-
   .showall a {
     font-style: oblique;
     color: @grayDark !important;

--- a/plugins/arElasticSearchPlugin/config/search.yml
+++ b/plugins/arElasticSearchPlugin/config/search.yml
@@ -222,6 +222,22 @@ all:
             type: stop
             stopwords: _turkish_
 
+
+        char_filter:
+
+          # This char_filter is added to all analyzers when the index
+          # is created in arElasticSearchPlugin initialize when the
+          # app_markdown_enabled setting is set to true. Ideally, the
+          # Markdown tags should be removed with several regex like
+          # in this example: https://github.com/stiang/remove-markdown.
+          # But processing all those regex could run very slowly, so
+          # we're replacing the following punctuation chars by spaces:
+          #     *_#![]()->`+\~:|^=
+          strip_md:
+            type: pattern_replace
+            pattern: '[\*_#!\[\]\(\)\->`\+\\~:\|\^=]'
+            replacement: ' '
+
       # Disable dynamic creation of mappings for unmapped types
       mapper:
         dynamic: false

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPlugin.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPlugin.class.php
@@ -170,6 +170,16 @@ class arElasticSearchPlugin extends QubitSearchEngine
       // If the index has not been initialized, create it
       if ($e instanceof \Elastica\Exception\ResponseException)
       {
+        // Based on the markdown_enabled setting, add a new filter to strip Markdown tags
+        if (sfConfig::get('app_markdown_enabled', true)
+          && isset($this->config['index']['configuration']['analysis']['char_filter']['strip_md']))
+        {
+          foreach ($this->config['index']['configuration']['analysis']['analyzer'] as $key => $analyzer)
+          {
+            $this->config['index']['configuration']['analysis']['analyzer'][$key]['char_filter'] = array('strip_md');
+          }
+        }
+
         $this->index->create($this->config['index']['configuration'],
           array('recreate' => true));
       }

--- a/plugins/qbAclPlugin/modules/aclGroup/templates/indexSuccess.php
+++ b/plugins/qbAclPlugin/modules/aclGroup/templates/indexSuccess.php
@@ -8,11 +8,11 @@
 
     <?php echo link_to_if(QubitAcl::check($group, 'update'), '<h2>'.__('Group details').'</h2>', array($group, 'module' => 'aclGroup', 'action' => 'edit')) ?>
 
-    <?php echo render_show(__('Name'), $group->name) ?>
+    <?php echo render_show(__('Name'), render_value($group->name)) ?>
 
-    <?php echo render_show(__('Description'), $group->description) ?>
+    <?php echo render_show(__('Description'), render_value($group->description)) ?>
 
-    <?php echo render_show(__('Translate'), __($translate)) ?>
+    <?php echo render_show(__('Translate'), render_value(__($translate))) ?>
 
   </section>
 

--- a/plugins/qtAccessionPlugin/modules/accession/templates/browseSuccess.php
+++ b/plugins/qtAccessionPlugin/modules/accession/templates/browseSuccess.php
@@ -47,7 +47,7 @@
         <?php $doc = $hit->getData() ?>
         <tr>
           <td width="20%">
-            <?php echo link_to($doc['identifier'], array('module' => 'accession', 'slug' => $doc['slug'])) ?>
+            <?php echo link_to(render_value_inline($doc['identifier']), array('module' => 'accession', 'slug' => $doc['slug'])) ?>
           </td>
           <td>
             <?php echo link_to(render_title(get_search_i18n($doc, 'title')), array('module' => 'accession', 'slug' => $doc['slug'])) ?>

--- a/plugins/qtAccessionPlugin/modules/accession/templates/indexSuccess.php
+++ b/plugins/qtAccessionPlugin/modules/accession/templates/indexSuccess.php
@@ -78,7 +78,7 @@
       <ul>
         <?php foreach ($resource->getDates() as $item): ?>
           <li>
-            <?php echo Qubit::renderDateStartEnd($item->getDate(array('cultureFallback' => true)), $item->startDate, $item->endDate) ?> (<?php echo $item->getType(array('cultureFallback' => true)) ?>)
+            <?php echo render_value_inline(Qubit::renderDateStartEnd($item->getDate(array('cultureFallback' => true)), $item->startDate, $item->endDate)) ?> (<?php echo $item->getType(array('cultureFallback' => true)) ?>)
           </li>
         <?php endforeach; ?>
       </ul>

--- a/plugins/qtAccessionPlugin/modules/deaccession/templates/indexSuccess.php
+++ b/plugins/qtAccessionPlugin/modules/deaccession/templates/indexSuccess.php
@@ -26,7 +26,7 @@
 <div class="field">
   <h3>Accession record</h3>
   <div class="value">
-    <?php echo link_to($resource->accession->__toString(), array($resource->accession, 'module' => 'accession')) ?>
+    <?php echo link_to(render_title($resource->accession), array($resource->accession, 'module' => 'accession')) ?>
   </div>
 </div>
 

--- a/plugins/qtAccessionPlugin/modules/donor/actions/autocompleteAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/donor/actions/autocompleteAction.class.php
@@ -40,7 +40,14 @@ class DonorAutocompleteAction extends sfAction
 
     if (isset($request->query))
     {
-      $criteria->add(QubitActorI18n::AUTHORIZED_FORM_OF_NAME, "$request->query%", Criteria::LIKE);
+      if (sfConfig::get('app_markdown_enabled', true))
+      {
+        $criteria->add(QubitActorI18n::AUTHORIZED_FORM_OF_NAME, "%$request->query%", Criteria::LIKE);
+      }
+      else
+      {
+        $criteria->add(QubitActorI18n::AUTHORIZED_FORM_OF_NAME, "$request->query%", Criteria::LIKE);
+      }
     }
 
     $this->pager = new QubitPager('QubitDonor');

--- a/plugins/qtSwordPlugin/modules/qtSwordPlugin/templates/depositSuccess.xml.php
+++ b/plugins/qtSwordPlugin/modules/qtSwordPlugin/templates/depositSuccess.xml.php
@@ -3,7 +3,7 @@
 <entry xmlns="http://www.w3.org/2005/Atom"
        xmlns:sword="http://purl.org/net/sword/">
 
-  <title><?php echo render_title($informationObject, false) ?></title>
+  <title><?php echo strip_tags(render_title($informationObject)) ?></title>
 
   <?php
     // For unknown reasons the type of the createdAt property is not always a DateTime but a string

--- a/plugins/sfDcPlugin/modules/sfDcPlugin/templates/_dcNames.php
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/templates/_dcNames.php
@@ -27,7 +27,7 @@
               </div>
             </td><td>
               <div class="animateNicely">
-                <?php echo $item->getType(array('cultureFallback' => true)) ?>
+                <?php echo render_value_inline($item->type) ?>
               </div>
             </td>
           </tr>

--- a/plugins/sfDcPlugin/modules/sfDcPlugin/templates/indexSuccess.php
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/templates/indexSuccess.php
@@ -12,7 +12,8 @@
     <div class="messages error">
       <ul>
         <?php foreach ($errorSchema as $error): ?>
-          <li><?php echo $error->getMessage(ESC_RAW) ?></li>
+          <?php $error = sfOutputEscaper::unescape($error) ?>
+          <li><?php echo $error->getMessage() ?></li>
         <?php endforeach; ?>
       </ul>
     </div>
@@ -94,13 +95,13 @@
   <?php echo get_partial('informationobject/dates', array('resource' => $resource)) ?>
 
   <?php foreach ($resource->getSubjectAccessPoints() as $item): ?>
-    <?php echo render_show(__('Subject'), link_to($item->term, array($item->term, 'module' => 'term'))) ?>
+    <?php echo render_show(__('Subject'), link_to(render_title($item->term), array($item->term, 'module' => 'term'))) ?>
   <?php endforeach; ?>
 
   <?php echo render_show(__('Description'), render_value($resource->getScopeAndContent(array('cultureFallback' => true)))) ?>
 
   <?php foreach ($dc->type as $item): ?>
-    <?php echo render_show(__('Type'), $item) ?>
+    <?php echo render_show(__('Type'), render_value($item)) ?>
   <?php endforeach; ?>
 
   <?php foreach ($dc->format as $item): ?>

--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/_event.php
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/_event.php
@@ -28,9 +28,9 @@
           <td>
             <?php echo render_title($item->object) ?>
           </td><td>
-            <?php echo $item->type ?>
+            <?php echo render_value_inline($item->type) ?>
           </td><td>
-            <?php echo Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate) ?>
+            <?php echo render_value_inline(Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate)) ?>
           </td><td style="text-align: right">
             <input class="multiDelete" name="deleteEvents[]" type="checkbox" value="<?php echo url_for(array($item, 'module' => 'event')) ?>"/>
           </td>

--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/_relatedAuthorityRecord.php
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/_relatedAuthorityRecord.php
@@ -37,22 +37,22 @@
             <?php endif; ?>
           </td><td>
             <?php if ($item->type->parentId == QubitTerm::ROOT_ID): ?>
-              <?php echo $item->type ?>
+              <?php echo render_value_inline($item->type) ?>
             <?php else: ?>
-              <?php echo $item->type->parent ?>
+              <?php echo render_title($item->type->parent) ?>
             <?php endif; ?>
           </td><td>
             <?php if ($item->type->parentId != QubitTerm::ROOT_ID): ?>
               <?php if ($resource->id != $item->objectId): ?>
-                <?php echo $item->type.' '.render_title($resource) ?>
+                <?php echo render_title($item->type).' '.render_title($resource) ?>
               <?php elseif (0 < count($converseTerms = QubitRelation::getBySubjectOrObjectId($item->type->id, array('typeId' => QubitTerm::CONVERSE_TERM_ID)))): ?>
-                <?php echo $converseTerms[0]->getOpposedObject($item->type).' '.render_title($resource) ?>
+                <?php echo render_title($converseTerms[0]->getOpposedObject($item->type)).' '.render_title($resource) ?>
               <?php endif; ?>
             <?php endif; ?>
           </td><td>
-            <?php echo Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate) ?>
+            <?php echo render_value_inline(Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate)) ?>
           </td><td>
-            <?php echo $item->description ?>
+            <?php echo render_value_inline($item->description) ?>
           </td><td style="text-align: center">
             <input class="multiDelete" name="deleteRelations[]" type="checkbox" value="<?php echo url_for(array($item, 'module' => 'relation')) ?>"/>
           </td>

--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/indexSuccess.php
@@ -12,7 +12,8 @@
     <div class="messages error">
       <ul>
         <?php foreach ($errorSchema as $error): ?>
-          <li><?php echo $error->getMessage(ESC_RAW) ?></li>
+          <?php $error = sfOutputEscaper::unescape($error) ?>
+          <li><?php echo $error->getMessage() ?></li>
         <?php endforeach; ?>
       </ul>
     </div>
@@ -150,7 +151,7 @@
           <?php endif; ?>
         <?php endif; ?>
 
-        <?php echo render_show(__('Dates of the relationship'), Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate)) ?>
+        <?php echo render_show(__('Dates of the relationship'), render_value_inline(Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate))) ?>
 
         <?php echo render_show(__('Description of relationship'), render_value($item->description)) ?>
 

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/editSuccess.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/editSuccess.php
@@ -36,7 +36,7 @@
 
         <legend><?php echo __('Identity area') ?></legend>
 
-        <?php echo render_show(__('Reference code'), $isad->referenceCode) ?>
+        <?php echo render_show(__('Reference code'), render_value($isad->referenceCode)) ?>
 
         <?php echo $form->identifier
           ->help(__('Provide a specific local reference code, control number, or other unique identifier. The country and repository code will be automatically added from the linked repository record to form a full reference code. (ISAD 3.1.1)'))

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/fileListSuccess.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/fileListSuccess.php
@@ -19,14 +19,14 @@
     <?php foreach ($informationObjects as $item): ?>
       <tr class="<?php echo 0 == @++$row % 2 ? 'even' : 'odd' ?>">
         <td>
-          <?php $isad = new sfIsadPlugin($item); echo render_value($isad->referenceCode) ?>
+          <?php $isad = new sfIsadPlugin($item); echo render_value_inline($isad->referenceCode) ?>
         </td><td>
           <?php echo link_to(render_title($item), array($item, 'module' => 'informationobject')) ?>
         </td><td>
           <ul>
             <?php foreach ($item->getDates() as $date): ?>
               <li>
-                <?php echo Qubit::renderDateStartEnd($date->getDate(array('cultureFallback' => true)), $date->startDate, $date->endDate) ?> (<?php echo $date->getType(array('cultureFallback' => true)) ?>)
+                <?php echo render_value_inline(Qubit::renderDateStartEnd($date->getDate(array('cultureFallback' => true)), $date->startDate, $date->endDate)) ?> (<?php echo $date->getType(array('cultureFallback' => true)) ?>)
                 <?php if (isset($date->actor)): ?>
                   <?php echo link_to(render_title($date->actor), array($date->actor, 'module' => 'actor')) ?>
                 <?php endif; ?>
@@ -34,7 +34,7 @@
             <?php endforeach; ?>
           </ul>
         </td><td>
-          <?php echo render_value($item->getAccessConditions(array('cultureFallback' => true))) ?>
+          <?php echo render_value_inline($item->getAccessConditions(array('cultureFallback' => true))) ?>
         </td>
       </tr>
     <?php endforeach; ?>

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/indexSuccess.php
@@ -12,7 +12,8 @@
     <div class="messages error">
       <ul>
         <?php foreach ($errorSchema as $error): ?>
-          <li><?php echo $error->getMessage(ESC_RAW) ?></li>
+          <?php $error = sfOutputEscaper::unescape($error) ?>
+          <li><?php echo $error->getMessage() ?></li>
         <?php endforeach; ?>
       </ul>
     </div>
@@ -62,7 +63,7 @@
 
   <?php echo render_show(__('Reference code'), render_value($isad->referenceCode), array('fieldLabel' => 'referenceCode')) ?>
 
-  <?php echo render_show(__('Title'), render_value($resource->getTitle(array('cultureFallback' => true))), array('fieldLabel' => 'title')) ?>
+  <?php echo render_show(__('Title'), render_title($resource), array('fieldLabel' => 'title')) ?>
 
   <div class="field">
     <h3><?php echo __('Date(s)') ?></h3>
@@ -70,7 +71,7 @@
       <ul>
         <?php foreach ($resource->getDates() as $item): ?>
           <li>
-            <?php echo Qubit::renderDateStartEnd($item->getDate(array('cultureFallback' => true)), $item->startDate, $item->endDate) ?> (<?php echo $item->getType(array('cultureFallback' => true)) ?>)
+            <?php echo render_value_inline(Qubit::renderDateStartEnd($item->getDate(array('cultureFallback' => true)), $item->startDate, $item->endDate)) ?> (<?php echo $item->getType(array('cultureFallback' => true)) ?>)
           </li>
         <?php endforeach; ?>
       </ul>

--- a/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/templates/_relatedAuthorityRecord.php
+++ b/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/templates/_relatedAuthorityRecord.php
@@ -28,9 +28,9 @@
           <td>
             <?php echo render_title($item->object) ?>
           </td><td>
-            <?php echo $item->description ?>
+            <?php echo render_value_inline($item->description) ?>
           </td><td>
-            <?php echo Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate) ?>
+            <?php echo render_value_inline(Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate)) ?>
           </td><td style="text-align: center">
             <input class="multiDelete" name="deleteRelations[]" type="checkbox" value="<?php echo url_for(array($item, 'module' => 'relation')) ?>"/>
           </td>

--- a/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/templates/_relatedFunction.php
+++ b/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/templates/_relatedFunction.php
@@ -34,11 +34,11 @@
               <?php echo render_title($item->object) ?>
             <?php endif; ?>
           </td><td>
-            <?php echo $item->type ?>
+            <?php echo render_value_inline($item->type) ?>
           </td><td>
-            <?php echo $item->description ?>
+            <?php echo render_value_inline($item->description) ?>
           </td><td>
-            <?php echo Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate) ?>
+            <?php echo render_value_inline(Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate)) ?>
           </td><td style="text-align: center">
             <input class="multiDelete" name="deleteRelations[]" type="checkbox" value="<?php echo url_for(array($item, 'module' => 'relation')) ?>"/>
           </td>

--- a/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/templates/_relatedResource.php
+++ b/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/templates/_relatedResource.php
@@ -28,9 +28,9 @@
           <td>
             <?php echo render_title($item->object) ?>
           </td><td>
-            <?php echo $item->description ?>
+            <?php echo render_value_inline($item->description) ?>
           </td><td>
-            <?php echo Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate) ?>
+            <?php echo render_value_inline(Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate)) ?>
           </td><td style="text-align: center">
             <input class="multiDelete" name="deleteRelations[]" type="checkbox" value="<?php echo url_for(array($item, 'module' => 'relation')) ?>"/>
           </td>

--- a/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/templates/indexSuccess.php
@@ -13,7 +13,8 @@
     <div class="messages error">
       <ul>
         <?php foreach ($errorSchema as $error): ?>
-          <li><?php echo $error->getMessage(ESC_RAW) ?></li>
+          <?php $error = sfOutputEscaper::unescape($error) ?>
+          <li><?php echo $error->getMessage() ?></li>
         <?php endforeach; ?>
       </ul>
     </div>
@@ -82,7 +83,7 @@
 
         <?php echo render_show(__('Authorized form of name'), link_to(render_title($item->getOpposedObject($resource->id)), array($item->getOpposedObject($resource->id), 'module' => 'function'))) ?>
 
-        <?php echo render_show(__('Identifier'), $item->getOpposedObject($resource->id)->getDescriptionIdentifier(array('cultureFallback' => true))) ?>
+        <?php echo render_show(__('Identifier'), render_value($item->getOpposedObject($resource->id)->getDescriptionIdentifier(array('cultureFallback' => true)))) ?>
 
         <?php echo render_show(__('Type'), render_value($item->getOpposedObject($resource->id)->type)) ?>
 
@@ -90,7 +91,7 @@
 
         <?php echo render_show(__('Description of relationship'), render_value($item->description)) ?>
 
-        <?php echo render_show(__('Dates of relationship'), Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate)) ?>
+        <?php echo render_show(__('Dates of relationship'), render_value_inline(Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate))) ?>
 
       </div>
     </div>
@@ -109,7 +110,7 @@
           <?php echo render_show(__('Nature of relationship'), render_value($item->description)) ?>
         <?php endif; ?>
 
-        <?php echo render_show(__('Dates of the relationship'), Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate)) ?>
+        <?php echo render_show(__('Dates of the relationship'), render_value_inline(Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate))) ?>
 
       </div>
     </div>
@@ -123,13 +124,13 @@
 
         <?php echo render_show(__('Title'), link_to(render_title($item->object->getTitle(array('cultureFallback' => true))), array($item->object, 'module' => 'informationobject'))) ?>
 
-        <?php $isad = new sfIsadPlugin($item->object); echo render_show(__('Identifier'), $isad->referenceCode) ?>
+        <?php $isad = new sfIsadPlugin($item->object); echo render_show(__('Identifier'), render_value($isad->referenceCode)) ?>
 
         <?php if (null !== $item->description): ?>
           <?php echo render_show(__('Nature of relationship'), render_value($item->description)) ?>
         <?php endif; ?>
 
-        <?php echo render_show(__('Dates of the relationship'), Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate)) ?>
+        <?php echo render_show(__('Dates of the relationship'), render_value_inline(Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate))) ?>
 
       </div>
     </div>

--- a/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
@@ -13,7 +13,8 @@
     <div class="messages error">
       <ul>
         <?php foreach ($errorSchema as $error): ?>
-          <li><?php echo $error->getMessage(ESC_RAW) ?></li>
+          <?php $error = sfOutputEscaper::unescape($error) ?>
+          <li><?php echo $error->getMessage() ?></li>
         <?php endforeach; ?>
       </ul>
     </div>
@@ -57,7 +58,7 @@
   <?php if (isset($primaryContact)): ?>
     <section id="primary-contact">
       <h4><?php echo __('Primary contact') ?></h4>
-      <?php echo $sf_data->getRaw('primaryContact')->getContactInformationString(array('simple' => true)) ?>
+      <?php echo render_value($sf_data->getRaw('primaryContact')->getContactInformationString(array('simple' => true))) ?>
       <div class="context-actions">
         <?php if (null !== $website = $primaryContact->getWebsite()): ?>
           <?php if (null === parse_url($website, PHP_URL_SCHEME)): ?>
@@ -230,10 +231,10 @@
     <div>
       <ul>
         <?php foreach ($resource->getTermRelations(QubitTaxonomy::THEMATIC_AREA_ID) as $item): ?>
-          <li><?php echo __(render_value($item->term)) ?> (Thematic area)</li>
+          <li><?php echo __(render_value_inline($item->term)) ?> (Thematic area)</li>
         <?php endforeach; ?>
         <?php foreach ($resource->getTermRelations(QubitTaxonomy::GEOGRAPHIC_SUBREGION_ID) as $item): ?>
-          <li><?php echo __(render_value($item->term)) ?> (Geographic subregion)</li>
+          <li><?php echo __(render_value_inline($item->term)) ?> (Geographic subregion)</li>
         <?php endforeach; ?>
       </ul>
     </div>

--- a/plugins/sfModsPlugin/modules/sfModsPlugin/templates/indexSuccess.php
+++ b/plugins/sfModsPlugin/modules/sfModsPlugin/templates/indexSuccess.php
@@ -12,7 +12,8 @@
     <div class="messages error">
       <ul>
         <?php foreach ($errorSchema as $error): ?>
-          <li><?php echo $error->getMessage(ESC_RAW) ?></li>
+          <?php $error = sfOutputEscaper::unescape($error) ?>
+          <li><?php echo $error->getMessage() ?></li>
         <?php endforeach; ?>
       </ul>
     </div>
@@ -63,7 +64,7 @@
   <?php echo get_partial('informationobject/dates', array('resource' => $resource)) ?>
 
   <?php foreach ($mods->typeOfResource as $item): ?>
-    <?php echo render_show(__('Type of resource'), $item->term) ?>
+    <?php echo render_show(__('Type of resource'), render_value($item->term)) ?>
   <?php endforeach; ?>
 
   <?php foreach ($resource->language as $code): ?>
@@ -71,7 +72,7 @@
   <?php endforeach; ?>
 
   <?php if (0 < count($resource->digitalObjects)): ?>
-    <?php echo render_show(__('Internet media type'), $resource->digitalObjects[0]->mimeType) ?>
+    <?php echo render_show(__('Internet media type'), render_value($resource->digitalObjects[0]->mimeType)) ?>
   <?php endif; ?>
 
   <?php echo get_partial('informationobject/subjectAccessPoints', array('resource' => $resource, 'mods' => true)) ?>
@@ -92,7 +93,7 @@
       <?php if (isset($resource->repository)): ?>
 
         <?php if (isset($resource->repository->identifier)): ?>
-          <?php echo $resource->repository->identifier ?> -
+          <?php echo render_value_inline($resource->repository->identifier) ?> -
         <?php endif; ?>
 
         <?php echo link_to(render_title($resource->repository), array($resource->repository, 'module' => 'repository')) ?>
@@ -100,11 +101,11 @@
         <?php if (null !== $contact = $resource->repository->getPrimaryContact()): ?>
 
           <?php if (isset($contact->city)): ?>
-            <?php echo $contact->city ?>
+            <?php echo render_value_inline($contact->city) ?>
           <?php endif; ?>
 
           <?php if (isset($contact->region)): ?>
-            <?php echo $contact->region ?>
+            <?php echo render_value_inline($contact->region) ?>
           <?php endif; ?>
 
           <?php if (isset($contact->countryCode)): ?>

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/templates/editSuccess.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/templates/editSuccess.php
@@ -84,7 +84,7 @@
         <?php echo get_partial('informationobject/identifierOptions', array('mask' => $mask)) ?>
         <?php echo get_partial('informationobject/alternativeIdentifiers', $sf_data->getRaw('alternativeIdentifiersComponent')->getVarHolder()->getAll()) ?>
 
-        <?php echo render_show(__('Reference code'), $rad->referenceCode) ?>
+        <?php echo render_show(__('Reference code'), render_value($rad->referenceCode)) ?>
 
       </fieldset> <!-- #titleAndStatementOfResponsibilityArea -->
 

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
@@ -12,7 +12,8 @@
     <div class="messages error">
       <ul>
         <?php foreach ($errorSchema as $error): ?>
-          <li><?php echo $error->getMessage(ESC_RAW) ?></li>
+          <?php $error = sfOutputEscaper::unescape($error) ?>
+          <li><?php echo $error->getMessage() ?></li>
         <?php endforeach; ?>
       </ul>
     </div>
@@ -67,7 +68,7 @@
     <div class="generalMaterialDesignation">
       <ul>
         <?php foreach ($resource->getMaterialTypes() as $materialType): ?>
-          <li><?php echo $materialType->term ?></li>
+          <li><?php echo render_value_inline($materialType->term) ?></li>
         <?php endforeach; ?>
       </ul>
     </div>
@@ -85,7 +86,7 @@
     <div class="titleNotes">
       <ul>
         <?php foreach ($resource->getNotesByTaxonomy(array('taxonomyId' => QubitTaxonomy::RAD_TITLE_NOTE_ID)) as $item): ?>
-          <li><?php echo $item->type ?>: <?php echo $item->getContent(array('cultureFallback' => true)) ?></li>
+          <li><?php echo render_value_inline($item->type) ?>: <?php echo render_value_inline($item->getContent(array('cultureFallback' => true))) ?></li>
         <?php endforeach; ?>
       </ul>
     </div>
@@ -268,7 +269,7 @@
     <?php endif; ?>
 
     <div class="field">
-      <h3><?php echo __($item->type) ?></h3>
+      <h3><?php echo __(render_value_inline($item->type)) ?></h3>
       <div class="radNote">
         <?php echo render_value($item->getContent(array('cultureFallback' => true))) ?>
       </div>

--- a/vendor/parsedown/Parsedown.php
+++ b/vendor/parsedown/Parsedown.php
@@ -1,0 +1,1679 @@
+<?php
+
+#
+#
+# Parsedown
+# http://parsedown.org
+#
+# (c) Emanuil Rusev
+# http://erusev.com
+#
+# For the full license information, view the LICENSE file that was distributed
+# with this source code.
+#
+#
+
+class Parsedown
+{
+    # ~
+
+    const version = '1.7.1';
+
+    # ~
+
+    function text($text)
+    {
+        # make sure no definitions are set
+        $this->DefinitionData = array();
+
+        # standardize line breaks
+        $text = str_replace(array("\r\n", "\r"), "\n", $text);
+
+        # remove surrounding line breaks
+        $text = trim($text, "\n");
+
+        # split text into lines
+        $lines = explode("\n", $text);
+
+        # iterate through lines to identify blocks
+        $markup = $this->lines($lines);
+
+        # trim line breaks
+        $markup = trim($markup, "\n");
+
+        return $markup;
+    }
+
+    #
+    # Setters
+    #
+
+    function setBreaksEnabled($breaksEnabled)
+    {
+        $this->breaksEnabled = $breaksEnabled;
+
+        return $this;
+    }
+
+    protected $breaksEnabled;
+
+    function setMarkupEscaped($markupEscaped)
+    {
+        $this->markupEscaped = $markupEscaped;
+
+        return $this;
+    }
+
+    protected $markupEscaped;
+
+    function setUrlsLinked($urlsLinked)
+    {
+        $this->urlsLinked = $urlsLinked;
+
+        return $this;
+    }
+
+    protected $urlsLinked = true;
+
+    function setSafeMode($safeMode)
+    {
+        $this->safeMode = (bool) $safeMode;
+
+        return $this;
+    }
+
+    protected $safeMode;
+
+    protected $safeLinksWhitelist = array(
+        'http://',
+        'https://',
+        'ftp://',
+        'ftps://',
+        'mailto:',
+        'data:image/png;base64,',
+        'data:image/gif;base64,',
+        'data:image/jpeg;base64,',
+        'irc:',
+        'ircs:',
+        'git:',
+        'ssh:',
+        'news:',
+        'steam:',
+    );
+
+    #
+    # Lines
+    #
+
+    protected $BlockTypes = array(
+        '#' => array('Header'),
+        '*' => array('Rule', 'List'),
+        '+' => array('List'),
+        '-' => array('SetextHeader', 'Table', 'Rule', 'List'),
+        '0' => array('List'),
+        '1' => array('List'),
+        '2' => array('List'),
+        '3' => array('List'),
+        '4' => array('List'),
+        '5' => array('List'),
+        '6' => array('List'),
+        '7' => array('List'),
+        '8' => array('List'),
+        '9' => array('List'),
+        ':' => array('Table'),
+        '<' => array('Comment', 'Markup'),
+        '=' => array('SetextHeader'),
+        '>' => array('Quote'),
+        '[' => array('Reference'),
+        '_' => array('Rule'),
+        '`' => array('FencedCode'),
+        '|' => array('Table'),
+        '~' => array('FencedCode'),
+    );
+
+    # ~
+
+    protected $unmarkedBlockTypes = array(
+        'Code',
+    );
+
+    #
+    # Blocks
+    #
+
+    protected function lines(array $lines)
+    {
+        $CurrentBlock = null;
+
+        foreach ($lines as $line)
+        {
+            if (chop($line) === '')
+            {
+                if (isset($CurrentBlock))
+                {
+                    $CurrentBlock['interrupted'] = true;
+                }
+
+                continue;
+            }
+
+            if (strpos($line, "\t") !== false)
+            {
+                $parts = explode("\t", $line);
+
+                $line = $parts[0];
+
+                unset($parts[0]);
+
+                foreach ($parts as $part)
+                {
+                    $shortage = 4 - mb_strlen($line, 'utf-8') % 4;
+
+                    $line .= str_repeat(' ', $shortage);
+                    $line .= $part;
+                }
+            }
+
+            $indent = 0;
+
+            while (isset($line[$indent]) and $line[$indent] === ' ')
+            {
+                $indent ++;
+            }
+
+            $text = $indent > 0 ? substr($line, $indent) : $line;
+
+            # ~
+
+            $Line = array('body' => $line, 'indent' => $indent, 'text' => $text);
+
+            # ~
+
+            if (isset($CurrentBlock['continuable']))
+            {
+                $Block = $this->{'block'.$CurrentBlock['type'].'Continue'}($Line, $CurrentBlock);
+
+                if (isset($Block))
+                {
+                    $CurrentBlock = $Block;
+
+                    continue;
+                }
+                else
+                {
+                    if ($this->isBlockCompletable($CurrentBlock['type']))
+                    {
+                        $CurrentBlock = $this->{'block'.$CurrentBlock['type'].'Complete'}($CurrentBlock);
+                    }
+                }
+            }
+
+            # ~
+
+            $marker = $text[0];
+
+            # ~
+
+            $blockTypes = $this->unmarkedBlockTypes;
+
+            if (isset($this->BlockTypes[$marker]))
+            {
+                foreach ($this->BlockTypes[$marker] as $blockType)
+                {
+                    $blockTypes []= $blockType;
+                }
+            }
+
+            #
+            # ~
+
+            foreach ($blockTypes as $blockType)
+            {
+                $Block = $this->{'block'.$blockType}($Line, $CurrentBlock);
+
+                if (isset($Block))
+                {
+                    $Block['type'] = $blockType;
+
+                    if ( ! isset($Block['identified']))
+                    {
+                        $Blocks []= $CurrentBlock;
+
+                        $Block['identified'] = true;
+                    }
+
+                    if ($this->isBlockContinuable($blockType))
+                    {
+                        $Block['continuable'] = true;
+                    }
+
+                    $CurrentBlock = $Block;
+
+                    continue 2;
+                }
+            }
+
+            # ~
+
+            if (isset($CurrentBlock) and ! isset($CurrentBlock['type']) and ! isset($CurrentBlock['interrupted']))
+            {
+                $CurrentBlock['element']['text'] .= "\n".$text;
+            }
+            else
+            {
+                $Blocks []= $CurrentBlock;
+
+                $CurrentBlock = $this->paragraph($Line);
+
+                $CurrentBlock['identified'] = true;
+            }
+        }
+
+        # ~
+
+        if (isset($CurrentBlock['continuable']) and $this->isBlockCompletable($CurrentBlock['type']))
+        {
+            $CurrentBlock = $this->{'block'.$CurrentBlock['type'].'Complete'}($CurrentBlock);
+        }
+
+        # ~
+
+        $Blocks []= $CurrentBlock;
+
+        unset($Blocks[0]);
+
+        # ~
+
+        $markup = '';
+
+        foreach ($Blocks as $Block)
+        {
+            if (isset($Block['hidden']))
+            {
+                continue;
+            }
+
+            $markup .= "\n";
+            $markup .= isset($Block['markup']) ? $Block['markup'] : $this->element($Block['element']);
+        }
+
+        $markup .= "\n";
+
+        # ~
+
+        return $markup;
+    }
+
+    protected function isBlockContinuable($Type)
+    {
+        return method_exists($this, 'block'.$Type.'Continue');
+    }
+
+    protected function isBlockCompletable($Type)
+    {
+        return method_exists($this, 'block'.$Type.'Complete');
+    }
+
+    #
+    # Code
+
+    protected function blockCode($Line, $Block = null)
+    {
+        if (isset($Block) and ! isset($Block['type']) and ! isset($Block['interrupted']))
+        {
+            return;
+        }
+
+        if ($Line['indent'] >= 4)
+        {
+            $text = substr($Line['body'], 4);
+
+            $Block = array(
+                'element' => array(
+                    'name' => 'pre',
+                    'handler' => 'element',
+                    'text' => array(
+                        'name' => 'code',
+                        'text' => $text,
+                    ),
+                ),
+            );
+
+            return $Block;
+        }
+    }
+
+    protected function blockCodeContinue($Line, $Block)
+    {
+        if ($Line['indent'] >= 4)
+        {
+            if (isset($Block['interrupted']))
+            {
+                $Block['element']['text']['text'] .= "\n";
+
+                unset($Block['interrupted']);
+            }
+
+            $Block['element']['text']['text'] .= "\n";
+
+            $text = substr($Line['body'], 4);
+
+            $Block['element']['text']['text'] .= $text;
+
+            return $Block;
+        }
+    }
+
+    protected function blockCodeComplete($Block)
+    {
+        $text = $Block['element']['text']['text'];
+
+        $Block['element']['text']['text'] = $text;
+
+        return $Block;
+    }
+
+    #
+    # Comment
+
+    protected function blockComment($Line)
+    {
+        if ($this->markupEscaped or $this->safeMode)
+        {
+            return;
+        }
+
+        if (isset($Line['text'][3]) and $Line['text'][3] === '-' and $Line['text'][2] === '-' and $Line['text'][1] === '!')
+        {
+            $Block = array(
+                'markup' => $Line['body'],
+            );
+
+            if (preg_match('/-->$/', $Line['text']))
+            {
+                $Block['closed'] = true;
+            }
+
+            return $Block;
+        }
+    }
+
+    protected function blockCommentContinue($Line, array $Block)
+    {
+        if (isset($Block['closed']))
+        {
+            return;
+        }
+
+        $Block['markup'] .= "\n" . $Line['body'];
+
+        if (preg_match('/-->$/', $Line['text']))
+        {
+            $Block['closed'] = true;
+        }
+
+        return $Block;
+    }
+
+    #
+    # Fenced Code
+
+    protected function blockFencedCode($Line)
+    {
+        if (preg_match('/^['.$Line['text'][0].']{3,}[ ]*([^`]+)?[ ]*$/', $Line['text'], $matches))
+        {
+            $Element = array(
+                'name' => 'code',
+                'text' => '',
+            );
+
+            if (isset($matches[1]))
+            {
+                $class = 'language-'.$matches[1];
+
+                $Element['attributes'] = array(
+                    'class' => $class,
+                );
+            }
+
+            $Block = array(
+                'char' => $Line['text'][0],
+                'element' => array(
+                    'name' => 'pre',
+                    'handler' => 'element',
+                    'text' => $Element,
+                ),
+            );
+
+            return $Block;
+        }
+    }
+
+    protected function blockFencedCodeContinue($Line, $Block)
+    {
+        if (isset($Block['complete']))
+        {
+            return;
+        }
+
+        if (isset($Block['interrupted']))
+        {
+            $Block['element']['text']['text'] .= "\n";
+
+            unset($Block['interrupted']);
+        }
+
+        if (preg_match('/^'.$Block['char'].'{3,}[ ]*$/', $Line['text']))
+        {
+            $Block['element']['text']['text'] = substr($Block['element']['text']['text'], 1);
+
+            $Block['complete'] = true;
+
+            return $Block;
+        }
+
+        $Block['element']['text']['text'] .= "\n".$Line['body'];
+
+        return $Block;
+    }
+
+    protected function blockFencedCodeComplete($Block)
+    {
+        $text = $Block['element']['text']['text'];
+
+        $Block['element']['text']['text'] = $text;
+
+        return $Block;
+    }
+
+    #
+    # Header
+
+    protected function blockHeader($Line)
+    {
+        if (isset($Line['text'][1]))
+        {
+            $level = 1;
+
+            while (isset($Line['text'][$level]) and $Line['text'][$level] === '#')
+            {
+                $level ++;
+            }
+
+            if ($level > 6)
+            {
+                return;
+            }
+
+            $text = trim($Line['text'], '# ');
+
+            $Block = array(
+                'element' => array(
+                    'name' => 'h' . min(6, $level),
+                    'text' => $text,
+                    'handler' => 'line',
+                ),
+            );
+
+            return $Block;
+        }
+    }
+
+    #
+    # List
+
+    protected function blockList($Line)
+    {
+        list($name, $pattern) = $Line['text'][0] <= '-' ? array('ul', '[*+-]') : array('ol', '[0-9]+[.]');
+
+        if (preg_match('/^('.$pattern.'[ ]+)(.*)/', $Line['text'], $matches))
+        {
+            $Block = array(
+                'indent' => $Line['indent'],
+                'pattern' => $pattern,
+                'element' => array(
+                    'name' => $name,
+                    'handler' => 'elements',
+                ),
+            );
+
+            if($name === 'ol')
+            {
+                $listStart = stristr($matches[0], '.', true);
+
+                if($listStart !== '1')
+                {
+                    $Block['element']['attributes'] = array('start' => $listStart);
+                }
+            }
+
+            $Block['li'] = array(
+                'name' => 'li',
+                'handler' => 'li',
+                'text' => array(
+                    $matches[2],
+                ),
+            );
+
+            $Block['element']['text'] []= & $Block['li'];
+
+            return $Block;
+        }
+    }
+
+    protected function blockListContinue($Line, array $Block)
+    {
+        if ($Block['indent'] === $Line['indent'] and preg_match('/^'.$Block['pattern'].'(?:[ ]+(.*)|$)/', $Line['text'], $matches))
+        {
+            if (isset($Block['interrupted']))
+            {
+                $Block['li']['text'] []= '';
+
+                $Block['loose'] = true;
+
+                unset($Block['interrupted']);
+            }
+
+            unset($Block['li']);
+
+            $text = isset($matches[1]) ? $matches[1] : '';
+
+            $Block['li'] = array(
+                'name' => 'li',
+                'handler' => 'li',
+                'text' => array(
+                    $text,
+                ),
+            );
+
+            $Block['element']['text'] []= & $Block['li'];
+
+            return $Block;
+        }
+
+        if ($Line['text'][0] === '[' and $this->blockReference($Line))
+        {
+            return $Block;
+        }
+
+        if ( ! isset($Block['interrupted']))
+        {
+            $text = preg_replace('/^[ ]{0,4}/', '', $Line['body']);
+
+            $Block['li']['text'] []= $text;
+
+            return $Block;
+        }
+
+        if ($Line['indent'] > 0)
+        {
+            $Block['li']['text'] []= '';
+
+            $text = preg_replace('/^[ ]{0,4}/', '', $Line['body']);
+
+            $Block['li']['text'] []= $text;
+
+            unset($Block['interrupted']);
+
+            return $Block;
+        }
+    }
+
+    protected function blockListComplete(array $Block)
+    {
+        if (isset($Block['loose']))
+        {
+            foreach ($Block['element']['text'] as &$li)
+            {
+                if (end($li['text']) !== '')
+                {
+                    $li['text'] []= '';
+                }
+            }
+        }
+
+        return $Block;
+    }
+
+    #
+    # Quote
+
+    protected function blockQuote($Line)
+    {
+        if (preg_match('/^>[ ]?(.*)/', $Line['text'], $matches))
+        {
+            $Block = array(
+                'element' => array(
+                    'name' => 'blockquote',
+                    'handler' => 'lines',
+                    'text' => (array) $matches[1],
+                ),
+            );
+
+            return $Block;
+        }
+    }
+
+    protected function blockQuoteContinue($Line, array $Block)
+    {
+        if ($Line['text'][0] === '>' and preg_match('/^>[ ]?(.*)/', $Line['text'], $matches))
+        {
+            if (isset($Block['interrupted']))
+            {
+                $Block['element']['text'] []= '';
+
+                unset($Block['interrupted']);
+            }
+
+            $Block['element']['text'] []= $matches[1];
+
+            return $Block;
+        }
+
+        if ( ! isset($Block['interrupted']))
+        {
+            $Block['element']['text'] []= $Line['text'];
+
+            return $Block;
+        }
+    }
+
+    #
+    # Rule
+
+    protected function blockRule($Line)
+    {
+        if (preg_match('/^(['.$Line['text'][0].'])([ ]*\1){2,}[ ]*$/', $Line['text']))
+        {
+            $Block = array(
+                'element' => array(
+                    'name' => 'hr'
+                ),
+            );
+
+            return $Block;
+        }
+    }
+
+    #
+    # Setext
+
+    protected function blockSetextHeader($Line, array $Block = null)
+    {
+        if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
+        {
+            return;
+        }
+
+        if (chop($Line['text'], $Line['text'][0]) === '')
+        {
+            $Block['element']['name'] = $Line['text'][0] === '=' ? 'h1' : 'h2';
+
+            return $Block;
+        }
+    }
+
+    #
+    # Markup
+
+    protected function blockMarkup($Line)
+    {
+        if ($this->markupEscaped or $this->safeMode)
+        {
+            return;
+        }
+
+        if (preg_match('/^<(\w[\w-]*)(?:[ ]*'.$this->regexHtmlAttribute.')*[ ]*(\/)?>/', $Line['text'], $matches))
+        {
+            $element = strtolower($matches[1]);
+
+            if (in_array($element, $this->textLevelElements))
+            {
+                return;
+            }
+
+            $Block = array(
+                'name' => $matches[1],
+                'depth' => 0,
+                'markup' => $Line['text'],
+            );
+
+            $length = strlen($matches[0]);
+
+            $remainder = substr($Line['text'], $length);
+
+            if (trim($remainder) === '')
+            {
+                if (isset($matches[2]) or in_array($matches[1], $this->voidElements))
+                {
+                    $Block['closed'] = true;
+
+                    $Block['void'] = true;
+                }
+            }
+            else
+            {
+                if (isset($matches[2]) or in_array($matches[1], $this->voidElements))
+                {
+                    return;
+                }
+
+                if (preg_match('/<\/'.$matches[1].'>[ ]*$/i', $remainder))
+                {
+                    $Block['closed'] = true;
+                }
+            }
+
+            return $Block;
+        }
+    }
+
+    protected function blockMarkupContinue($Line, array $Block)
+    {
+        if (isset($Block['closed']))
+        {
+            return;
+        }
+
+        if (preg_match('/^<'.$Block['name'].'(?:[ ]*'.$this->regexHtmlAttribute.')*[ ]*>/i', $Line['text'])) # open
+        {
+            $Block['depth'] ++;
+        }
+
+        if (preg_match('/(.*?)<\/'.$Block['name'].'>[ ]*$/i', $Line['text'], $matches)) # close
+        {
+            if ($Block['depth'] > 0)
+            {
+                $Block['depth'] --;
+            }
+            else
+            {
+                $Block['closed'] = true;
+            }
+        }
+
+        if (isset($Block['interrupted']))
+        {
+            $Block['markup'] .= "\n";
+
+            unset($Block['interrupted']);
+        }
+
+        $Block['markup'] .= "\n".$Line['body'];
+
+        return $Block;
+    }
+
+    #
+    # Reference
+
+    protected function blockReference($Line)
+    {
+        if (preg_match('/^\[(.+?)\]:[ ]*<?(\S+?)>?(?:[ ]+["\'(](.+)["\')])?[ ]*$/', $Line['text'], $matches))
+        {
+            $id = strtolower($matches[1]);
+
+            $Data = array(
+                'url' => $matches[2],
+                'title' => null,
+            );
+
+            if (isset($matches[3]))
+            {
+                $Data['title'] = $matches[3];
+            }
+
+            $this->DefinitionData['Reference'][$id] = $Data;
+
+            $Block = array(
+                'hidden' => true,
+            );
+
+            return $Block;
+        }
+    }
+
+    #
+    # Table
+
+    protected function blockTable($Line, array $Block = null)
+    {
+        if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
+        {
+            return;
+        }
+
+        if (strpos($Block['element']['text'], '|') !== false and chop($Line['text'], ' -:|') === '')
+        {
+            $alignments = array();
+
+            $divider = $Line['text'];
+
+            $divider = trim($divider);
+            $divider = trim($divider, '|');
+
+            $dividerCells = explode('|', $divider);
+
+            foreach ($dividerCells as $dividerCell)
+            {
+                $dividerCell = trim($dividerCell);
+
+                if ($dividerCell === '')
+                {
+                    continue;
+                }
+
+                $alignment = null;
+
+                if ($dividerCell[0] === ':')
+                {
+                    $alignment = 'left';
+                }
+
+                if (substr($dividerCell, - 1) === ':')
+                {
+                    $alignment = $alignment === 'left' ? 'center' : 'right';
+                }
+
+                $alignments []= $alignment;
+            }
+
+            # ~
+
+            $HeaderElements = array();
+
+            $header = $Block['element']['text'];
+
+            $header = trim($header);
+            $header = trim($header, '|');
+
+            $headerCells = explode('|', $header);
+
+            foreach ($headerCells as $index => $headerCell)
+            {
+                $headerCell = trim($headerCell);
+
+                $HeaderElement = array(
+                    'name' => 'th',
+                    'text' => $headerCell,
+                    'handler' => 'line',
+                );
+
+                if (isset($alignments[$index]))
+                {
+                    $alignment = $alignments[$index];
+
+                    $HeaderElement['attributes'] = array(
+                        'style' => 'text-align: '.$alignment.';',
+                    );
+                }
+
+                $HeaderElements []= $HeaderElement;
+            }
+
+            # ~
+
+            $Block = array(
+                'alignments' => $alignments,
+                'identified' => true,
+                'element' => array(
+                    'name' => 'table',
+                    'handler' => 'elements',
+                ),
+            );
+
+            $Block['element']['text'] []= array(
+                'name' => 'thead',
+                'handler' => 'elements',
+            );
+
+            $Block['element']['text'] []= array(
+                'name' => 'tbody',
+                'handler' => 'elements',
+                'text' => array(),
+            );
+
+            $Block['element']['text'][0]['text'] []= array(
+                'name' => 'tr',
+                'handler' => 'elements',
+                'text' => $HeaderElements,
+            );
+
+            return $Block;
+        }
+    }
+
+    protected function blockTableContinue($Line, array $Block)
+    {
+        if (isset($Block['interrupted']))
+        {
+            return;
+        }
+
+        if ($Line['text'][0] === '|' or strpos($Line['text'], '|'))
+        {
+            $Elements = array();
+
+            $row = $Line['text'];
+
+            $row = trim($row);
+            $row = trim($row, '|');
+
+            preg_match_all('/(?:(\\\\[|])|[^|`]|`[^`]+`|`)+/', $row, $matches);
+
+            foreach ($matches[0] as $index => $cell)
+            {
+                $cell = trim($cell);
+
+                $Element = array(
+                    'name' => 'td',
+                    'handler' => 'line',
+                    'text' => $cell,
+                );
+
+                if (isset($Block['alignments'][$index]))
+                {
+                    $Element['attributes'] = array(
+                        'style' => 'text-align: '.$Block['alignments'][$index].';',
+                    );
+                }
+
+                $Elements []= $Element;
+            }
+
+            $Element = array(
+                'name' => 'tr',
+                'handler' => 'elements',
+                'text' => $Elements,
+            );
+
+            $Block['element']['text'][1]['text'] []= $Element;
+
+            return $Block;
+        }
+    }
+
+    #
+    # ~
+    #
+
+    protected function paragraph($Line)
+    {
+        $Block = array(
+            'element' => array(
+                'name' => 'p',
+                'text' => $Line['text'],
+                'handler' => 'line',
+            ),
+        );
+
+        return $Block;
+    }
+
+    #
+    # Inline Elements
+    #
+
+    protected $InlineTypes = array(
+        '"' => array('SpecialCharacter'),
+        '!' => array('Image'),
+        '&' => array('SpecialCharacter'),
+        '*' => array('Emphasis'),
+        ':' => array('Url'),
+        '<' => array('UrlTag', 'EmailTag', 'Markup', 'SpecialCharacter'),
+        '>' => array('SpecialCharacter'),
+        '[' => array('Link'),
+        '_' => array('Emphasis'),
+        '`' => array('Code'),
+        '~' => array('Strikethrough'),
+        '\\' => array('EscapeSequence'),
+    );
+
+    # ~
+
+    protected $inlineMarkerList = '!"*_&[:<>`~\\';
+
+    #
+    # ~
+    #
+
+    public function line($text, $nonNestables=array())
+    {
+        $markup = '';
+
+        # $excerpt is based on the first occurrence of a marker
+
+        while ($excerpt = strpbrk($text, $this->inlineMarkerList))
+        {
+            $marker = $excerpt[0];
+
+            $markerPosition = strpos($text, $marker);
+
+            $Excerpt = array('text' => $excerpt, 'context' => $text);
+
+            foreach ($this->InlineTypes[$marker] as $inlineType)
+            {
+                # check to see if the current inline type is nestable in the current context
+
+                if ( ! empty($nonNestables) and in_array($inlineType, $nonNestables))
+                {
+                    continue;
+                }
+
+                $Inline = $this->{'inline'.$inlineType}($Excerpt);
+
+                if ( ! isset($Inline))
+                {
+                    continue;
+                }
+
+                # makes sure that the inline belongs to "our" marker
+
+                if (isset($Inline['position']) and $Inline['position'] > $markerPosition)
+                {
+                    continue;
+                }
+
+                # sets a default inline position
+
+                if ( ! isset($Inline['position']))
+                {
+                    $Inline['position'] = $markerPosition;
+                }
+
+                # cause the new element to 'inherit' our non nestables
+
+                foreach ($nonNestables as $non_nestable)
+                {
+                    $Inline['element']['nonNestables'][] = $non_nestable;
+                }
+
+                # the text that comes before the inline
+                $unmarkedText = substr($text, 0, $Inline['position']);
+
+                # compile the unmarked text
+                $markup .= $this->unmarkedText($unmarkedText);
+
+                # compile the inline
+                $markup .= isset($Inline['markup']) ? $Inline['markup'] : $this->element($Inline['element']);
+
+                # remove the examined text
+                $text = substr($text, $Inline['position'] + $Inline['extent']);
+
+                continue 2;
+            }
+
+            # the marker does not belong to an inline
+
+            $unmarkedText = substr($text, 0, $markerPosition + 1);
+
+            $markup .= $this->unmarkedText($unmarkedText);
+
+            $text = substr($text, $markerPosition + 1);
+        }
+
+        $markup .= $this->unmarkedText($text);
+
+        return $markup;
+    }
+
+    #
+    # ~
+    #
+
+    protected function inlineCode($Excerpt)
+    {
+        $marker = $Excerpt['text'][0];
+
+        if (preg_match('/^('.$marker.'+)[ ]*(.+?)[ ]*(?<!'.$marker.')\1(?!'.$marker.')/s', $Excerpt['text'], $matches))
+        {
+            $text = $matches[2];
+            $text = preg_replace("/[ ]*\n/", ' ', $text);
+
+            return array(
+                'extent' => strlen($matches[0]),
+                'element' => array(
+                    'name' => 'code',
+                    'text' => $text,
+                ),
+            );
+        }
+    }
+
+    protected function inlineEmailTag($Excerpt)
+    {
+        if (strpos($Excerpt['text'], '>') !== false and preg_match('/^<((mailto:)?\S+?@\S+?)>/i', $Excerpt['text'], $matches))
+        {
+            $url = $matches[1];
+
+            if ( ! isset($matches[2]))
+            {
+                $url = 'mailto:' . $url;
+            }
+
+            return array(
+                'extent' => strlen($matches[0]),
+                'element' => array(
+                    'name' => 'a',
+                    'text' => $matches[1],
+                    'attributes' => array(
+                        'href' => $url,
+                    ),
+                ),
+            );
+        }
+    }
+
+    protected function inlineEmphasis($Excerpt)
+    {
+        if ( ! isset($Excerpt['text'][1]))
+        {
+            return;
+        }
+
+        $marker = $Excerpt['text'][0];
+
+        if ($Excerpt['text'][1] === $marker and preg_match($this->StrongRegex[$marker], $Excerpt['text'], $matches))
+        {
+            $emphasis = 'strong';
+        }
+        elseif (preg_match($this->EmRegex[$marker], $Excerpt['text'], $matches))
+        {
+            $emphasis = 'em';
+        }
+        else
+        {
+            return;
+        }
+
+        return array(
+            'extent' => strlen($matches[0]),
+            'element' => array(
+                'name' => $emphasis,
+                'handler' => 'line',
+                'text' => $matches[1],
+            ),
+        );
+    }
+
+    protected function inlineEscapeSequence($Excerpt)
+    {
+        if (isset($Excerpt['text'][1]) and in_array($Excerpt['text'][1], $this->specialCharacters))
+        {
+            return array(
+                'markup' => $Excerpt['text'][1],
+                'extent' => 2,
+            );
+        }
+    }
+
+    protected function inlineImage($Excerpt)
+    {
+        if ( ! isset($Excerpt['text'][1]) or $Excerpt['text'][1] !== '[')
+        {
+            return;
+        }
+
+        $Excerpt['text']= substr($Excerpt['text'], 1);
+
+        $Link = $this->inlineLink($Excerpt);
+
+        if ($Link === null)
+        {
+            return;
+        }
+
+        $Inline = array(
+            'extent' => $Link['extent'] + 1,
+            'element' => array(
+                'name' => 'img',
+                'attributes' => array(
+                    'src' => $Link['element']['attributes']['href'],
+                    'alt' => $Link['element']['text'],
+                ),
+            ),
+        );
+
+        $Inline['element']['attributes'] += $Link['element']['attributes'];
+
+        unset($Inline['element']['attributes']['href']);
+
+        return $Inline;
+    }
+
+    protected function inlineLink($Excerpt)
+    {
+        $Element = array(
+            'name' => 'a',
+            'handler' => 'line',
+            'nonNestables' => array('Url', 'Link'),
+            'text' => null,
+            'attributes' => array(
+                'href' => null,
+                'title' => null,
+            ),
+        );
+
+        $extent = 0;
+
+        $remainder = $Excerpt['text'];
+
+        if (preg_match('/\[((?:[^][]++|(?R))*+)\]/', $remainder, $matches))
+        {
+            $Element['text'] = $matches[1];
+
+            $extent += strlen($matches[0]);
+
+            $remainder = substr($remainder, $extent);
+        }
+        else
+        {
+            return;
+        }
+
+        if (preg_match('/^[(]\s*+((?:[^ ()]++|[(][^ )]+[)])++)(?:[ ]+("[^"]*"|\'[^\']*\'))?\s*[)]/', $remainder, $matches))
+        {
+            $Element['attributes']['href'] = $matches[1];
+
+            if (isset($matches[2]))
+            {
+                $Element['attributes']['title'] = substr($matches[2], 1, - 1);
+            }
+
+            $extent += strlen($matches[0]);
+        }
+        else
+        {
+            if (preg_match('/^\s*\[(.*?)\]/', $remainder, $matches))
+            {
+                $definition = strlen($matches[1]) ? $matches[1] : $Element['text'];
+                $definition = strtolower($definition);
+
+                $extent += strlen($matches[0]);
+            }
+            else
+            {
+                $definition = strtolower($Element['text']);
+            }
+
+            if ( ! isset($this->DefinitionData['Reference'][$definition]))
+            {
+                return;
+            }
+
+            $Definition = $this->DefinitionData['Reference'][$definition];
+
+            $Element['attributes']['href'] = $Definition['url'];
+            $Element['attributes']['title'] = $Definition['title'];
+        }
+
+        return array(
+            'extent' => $extent,
+            'element' => $Element,
+        );
+    }
+
+    protected function inlineMarkup($Excerpt)
+    {
+        if ($this->markupEscaped or $this->safeMode or strpos($Excerpt['text'], '>') === false)
+        {
+            return;
+        }
+
+        if ($Excerpt['text'][1] === '/' and preg_match('/^<\/\w[\w-]*[ ]*>/s', $Excerpt['text'], $matches))
+        {
+            return array(
+                'markup' => $matches[0],
+                'extent' => strlen($matches[0]),
+            );
+        }
+
+        if ($Excerpt['text'][1] === '!' and preg_match('/^<!---?[^>-](?:-?[^-])*-->/s', $Excerpt['text'], $matches))
+        {
+            return array(
+                'markup' => $matches[0],
+                'extent' => strlen($matches[0]),
+            );
+        }
+
+        if ($Excerpt['text'][1] !== ' ' and preg_match('/^<\w[\w-]*(?:[ ]*'.$this->regexHtmlAttribute.')*[ ]*\/?>/s', $Excerpt['text'], $matches))
+        {
+            return array(
+                'markup' => $matches[0],
+                'extent' => strlen($matches[0]),
+            );
+        }
+    }
+
+    protected function inlineSpecialCharacter($Excerpt)
+    {
+        if ($Excerpt['text'][0] === '&' and ! preg_match('/^&#?\w+;/', $Excerpt['text']))
+        {
+            return array(
+                'markup' => '&amp;',
+                'extent' => 1,
+            );
+        }
+
+        $SpecialCharacter = array('>' => 'gt', '<' => 'lt', '"' => 'quot');
+
+        if (isset($SpecialCharacter[$Excerpt['text'][0]]))
+        {
+            return array(
+                'markup' => '&'.$SpecialCharacter[$Excerpt['text'][0]].';',
+                'extent' => 1,
+            );
+        }
+    }
+
+    protected function inlineStrikethrough($Excerpt)
+    {
+        if ( ! isset($Excerpt['text'][1]))
+        {
+            return;
+        }
+
+        if ($Excerpt['text'][1] === '~' and preg_match('/^~~(?=\S)(.+?)(?<=\S)~~/', $Excerpt['text'], $matches))
+        {
+            return array(
+                'extent' => strlen($matches[0]),
+                'element' => array(
+                    'name' => 'del',
+                    'text' => $matches[1],
+                    'handler' => 'line',
+                ),
+            );
+        }
+    }
+
+    protected function inlineUrl($Excerpt)
+    {
+        if ($this->urlsLinked !== true or ! isset($Excerpt['text'][2]) or $Excerpt['text'][2] !== '/')
+        {
+            return;
+        }
+
+        if (preg_match('/\bhttps?:[\/]{2}[^\s<]+\b\/*/ui', $Excerpt['context'], $matches, PREG_OFFSET_CAPTURE))
+        {
+            $url = $matches[0][0];
+
+            $Inline = array(
+                'extent' => strlen($matches[0][0]),
+                'position' => $matches[0][1],
+                'element' => array(
+                    'name' => 'a',
+                    'text' => $url,
+                    'attributes' => array(
+                        'href' => $url,
+                    ),
+                ),
+            );
+
+            return $Inline;
+        }
+    }
+
+    protected function inlineUrlTag($Excerpt)
+    {
+        if (strpos($Excerpt['text'], '>') !== false and preg_match('/^<(\w+:\/{2}[^ >]+)>/i', $Excerpt['text'], $matches))
+        {
+            $url = $matches[1];
+
+            return array(
+                'extent' => strlen($matches[0]),
+                'element' => array(
+                    'name' => 'a',
+                    'text' => $url,
+                    'attributes' => array(
+                        'href' => $url,
+                    ),
+                ),
+            );
+        }
+    }
+
+    # ~
+
+    protected function unmarkedText($text)
+    {
+        if ($this->breaksEnabled)
+        {
+            $text = preg_replace('/[ ]*\n/', "<br />\n", $text);
+        }
+        else
+        {
+            $text = preg_replace('/(?:[ ][ ]+|[ ]*\\\\)\n/', "<br />\n", $text);
+            $text = str_replace(" \n", "\n", $text);
+        }
+
+        return $text;
+    }
+
+    #
+    # Handlers
+    #
+
+    protected function element(array $Element)
+    {
+        if ($this->safeMode)
+        {
+            $Element = $this->sanitiseElement($Element);
+        }
+
+        $markup = '<'.$Element['name'];
+
+        if (isset($Element['attributes']))
+        {
+            foreach ($Element['attributes'] as $name => $value)
+            {
+                if ($value === null)
+                {
+                    continue;
+                }
+
+                $markup .= ' '.$name.'="'.self::escape($value).'"';
+            }
+        }
+
+        if (isset($Element['text']))
+        {
+            $markup .= '>';
+
+            if (!isset($Element['nonNestables'])) 
+            {
+                $Element['nonNestables'] = array();
+            }
+
+            if (isset($Element['handler']))
+            {
+                $markup .= $this->{$Element['handler']}($Element['text'], $Element['nonNestables']);
+            }
+            else
+            {
+                $markup .= self::escape($Element['text'], true);
+            }
+
+            $markup .= '</'.$Element['name'].'>';
+        }
+        else
+        {
+            $markup .= ' />';
+        }
+
+        return $markup;
+    }
+
+    protected function elements(array $Elements)
+    {
+        $markup = '';
+
+        foreach ($Elements as $Element)
+        {
+            $markup .= "\n" . $this->element($Element);
+        }
+
+        $markup .= "\n";
+
+        return $markup;
+    }
+
+    # ~
+
+    protected function li($lines)
+    {
+        $markup = $this->lines($lines);
+
+        $trimmedMarkup = trim($markup);
+
+        if ( ! in_array('', $lines) and substr($trimmedMarkup, 0, 3) === '<p>')
+        {
+            $markup = $trimmedMarkup;
+            $markup = substr($markup, 3);
+
+            $position = strpos($markup, "</p>");
+
+            $markup = substr_replace($markup, '', $position, 4);
+        }
+
+        return $markup;
+    }
+
+    #
+    # Deprecated Methods
+    #
+
+    function parse($text)
+    {
+        $markup = $this->text($text);
+
+        return $markup;
+    }
+
+    protected function sanitiseElement(array $Element)
+    {
+        static $goodAttribute = '/^[a-zA-Z0-9][a-zA-Z0-9-_]*+$/';
+        static $safeUrlNameToAtt  = array(
+            'a'   => 'href',
+            'img' => 'src',
+        );
+
+        if (isset($safeUrlNameToAtt[$Element['name']]))
+        {
+            $Element = $this->filterUnsafeUrlInAttribute($Element, $safeUrlNameToAtt[$Element['name']]);
+        }
+
+        if ( ! empty($Element['attributes']))
+        {
+            foreach ($Element['attributes'] as $att => $val)
+            {
+                # filter out badly parsed attribute
+                if ( ! preg_match($goodAttribute, $att))
+                {
+                    unset($Element['attributes'][$att]);
+                }
+                # dump onevent attribute
+                elseif (self::striAtStart($att, 'on'))
+                {
+                    unset($Element['attributes'][$att]);
+                }
+            }
+        }
+
+        return $Element;
+    }
+
+    protected function filterUnsafeUrlInAttribute(array $Element, $attribute)
+    {
+        foreach ($this->safeLinksWhitelist as $scheme)
+        {
+            if (self::striAtStart($Element['attributes'][$attribute], $scheme))
+            {
+                return $Element;
+            }
+        }
+
+        $Element['attributes'][$attribute] = str_replace(':', '%3A', $Element['attributes'][$attribute]);
+
+        return $Element;
+    }
+
+    #
+    # Static Methods
+    #
+
+    protected static function escape($text, $allowQuotes = false)
+    {
+        return htmlspecialchars($text, $allowQuotes ? ENT_NOQUOTES : ENT_QUOTES, 'UTF-8');
+    }
+
+    protected static function striAtStart($string, $needle)
+    {
+        $len = strlen($needle);
+
+        if ($len > strlen($string))
+        {
+            return false;
+        }
+        else
+        {
+            return strtolower(substr($string, 0, $len)) === strtolower($needle);
+        }
+    }
+
+    static function instance($name = 'default')
+    {
+        if (isset(self::$instances[$name]))
+        {
+            return self::$instances[$name];
+        }
+
+        $instance = new static();
+
+        self::$instances[$name] = $instance;
+
+        return $instance;
+    }
+
+    private static $instances = array();
+
+    #
+    # Fields
+    #
+
+    protected $DefinitionData;
+
+    #
+    # Read-Only
+
+    protected $specialCharacters = array(
+        '\\', '`', '*', '_', '{', '}', '[', ']', '(', ')', '>', '#', '+', '-', '.', '!', '|',
+    );
+
+    protected $StrongRegex = array(
+        '*' => '/^[*]{2}((?:\\\\\*|[^*]|[*][^*]*[*])+?)[*]{2}(?![*])/s',
+        '_' => '/^__((?:\\\\_|[^_]|_[^_]*_)+?)__(?!_)/us',
+    );
+
+    protected $EmRegex = array(
+        '*' => '/^[*]((?:\\\\\*|[^*]|[*][*][^*]+?[*][*])+?)[*](?![*])/s',
+        '_' => '/^_((?:\\\\_|[^_]|__[^_]*__)+?)_(?!_)\b/us',
+    );
+
+    protected $regexHtmlAttribute = '[a-zA-Z_:][\w:.-]*(?:\s*=\s*(?:[^"\'=<>`\s]+|"[^"]*"|\'[^\']*\'))?';
+
+    protected $voidElements = array(
+        'area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source',
+    );
+
+    protected $textLevelElements = array(
+        'a', 'br', 'bdo', 'abbr', 'blink', 'nextid', 'acronym', 'basefont',
+        'b', 'em', 'big', 'cite', 'small', 'spacer', 'listing',
+        'i', 'rp', 'del', 'code',          'strike', 'marquee',
+        'q', 'rt', 'ins', 'font',          'strong',
+        's', 'tt', 'kbd', 'mark',
+        'u', 'xm', 'sub', 'nobr',
+                   'sup', 'ruby',
+                   'var', 'span',
+                   'wbr', 'time',
+    );
+}

--- a/vendor/parsedown/ParsedownExtra.php
+++ b/vendor/parsedown/ParsedownExtra.php
@@ -1,0 +1,526 @@
+<?php
+
+#
+#
+# Parsedown Extra
+# https://github.com/erusev/parsedown-extra
+#
+# (c) Emanuil Rusev
+# http://erusev.com
+#
+# For the full license information, view the LICENSE file that was distributed
+# with this source code.
+#
+#
+
+class ParsedownExtra extends Parsedown
+{
+    # ~
+
+    const version = '0.7.0';
+
+    # ~
+
+    function __construct()
+    {
+        if (parent::version < '1.5.0')
+        {
+            throw new Exception('ParsedownExtra requires a later version of Parsedown');
+        }
+
+        $this->BlockTypes[':'] []= 'DefinitionList';
+        $this->BlockTypes['*'] []= 'Abbreviation';
+
+        # identify footnote definitions before reference definitions
+        array_unshift($this->BlockTypes['['], 'Footnote');
+
+        # identify footnote markers before before links
+        array_unshift($this->InlineTypes['['], 'FootnoteMarker');
+    }
+
+    #
+    # ~
+
+    function text($text)
+    {
+        $markup = parent::text($text);
+
+        # merge consecutive dl elements
+
+        $markup = preg_replace('/<\/dl>\s+<dl>\s+/', '', $markup);
+
+        # add footnotes
+
+        if (isset($this->DefinitionData['Footnote']))
+        {
+            $Element = $this->buildFootnoteElement();
+
+            $markup .= "\n" . $this->element($Element);
+        }
+
+        return $markup;
+    }
+
+    #
+    # Blocks
+    #
+
+    #
+    # Abbreviation
+
+    protected function blockAbbreviation($Line)
+    {
+        if (preg_match('/^\*\[(.+?)\]:[ ]*(.+?)[ ]*$/', $Line['text'], $matches))
+        {
+            $this->DefinitionData['Abbreviation'][$matches[1]] = $matches[2];
+
+            $Block = array(
+                'hidden' => true,
+            );
+
+            return $Block;
+        }
+    }
+
+    #
+    # Footnote
+
+    protected function blockFootnote($Line)
+    {
+        if (preg_match('/^\[\^(.+?)\]:[ ]?(.*)$/', $Line['text'], $matches))
+        {
+            $Block = array(
+                'label' => $matches[1],
+                'text' => $matches[2],
+                'hidden' => true,
+            );
+
+            return $Block;
+        }
+    }
+
+    protected function blockFootnoteContinue($Line, $Block)
+    {
+        if ($Line['text'][0] === '[' and preg_match('/^\[\^(.+?)\]:/', $Line['text']))
+        {
+            return;
+        }
+
+        if (isset($Block['interrupted']))
+        {
+            if ($Line['indent'] >= 4)
+            {
+                $Block['text'] .= "\n\n" . $Line['text'];
+
+                return $Block;
+            }
+        }
+        else
+        {
+            $Block['text'] .= "\n" . $Line['text'];
+
+            return $Block;
+        }
+    }
+
+    protected function blockFootnoteComplete($Block)
+    {
+        $this->DefinitionData['Footnote'][$Block['label']] = array(
+            'text' => $Block['text'],
+            'count' => null,
+            'number' => null,
+        );
+
+        return $Block;
+    }
+
+    #
+    # Definition List
+
+    protected function blockDefinitionList($Line, $Block)
+    {
+        if ( ! isset($Block) or isset($Block['type']))
+        {
+            return;
+        }
+
+        $Element = array(
+            'name' => 'dl',
+            'handler' => 'elements',
+            'text' => array(),
+        );
+
+        $terms = explode("\n", $Block['element']['text']);
+
+        foreach ($terms as $term)
+        {
+            $Element['text'] []= array(
+                'name' => 'dt',
+                'handler' => 'line',
+                'text' => $term,
+            );
+        }
+
+        $Block['element'] = $Element;
+
+        $Block = $this->addDdElement($Line, $Block);
+
+        return $Block;
+    }
+
+    protected function blockDefinitionListContinue($Line, array $Block)
+    {
+        if ($Line['text'][0] === ':')
+        {
+            $Block = $this->addDdElement($Line, $Block);
+
+            return $Block;
+        }
+        else
+        {
+            if (isset($Block['interrupted']) and $Line['indent'] === 0)
+            {
+                return;
+            }
+
+            if (isset($Block['interrupted']))
+            {
+                $Block['dd']['handler'] = 'text';
+                $Block['dd']['text'] .= "\n\n";
+
+                unset($Block['interrupted']);
+            }
+
+            $text = substr($Line['body'], min($Line['indent'], 4));
+
+            $Block['dd']['text'] .= "\n" . $text;
+
+            return $Block;
+        }
+    }
+
+    #
+    # Header
+
+    protected function blockHeader($Line)
+    {
+        $Block = parent::blockHeader($Line);
+
+        if (preg_match('/[ #]*{('.$this->regexAttribute.'+)}[ ]*$/', $Block['element']['text'], $matches, PREG_OFFSET_CAPTURE))
+        {
+            $attributeString = $matches[1][0];
+
+            $Block['element']['attributes'] = $this->parseAttributeData($attributeString);
+
+            $Block['element']['text'] = substr($Block['element']['text'], 0, $matches[0][1]);
+        }
+
+        return $Block;
+    }
+
+    #
+    # Markup
+
+    protected function blockMarkupComplete($Block)
+    {
+        if ( ! isset($Block['void']))
+        {
+            $Block['markup'] = $this->processTag($Block['markup']);
+        }
+
+        return $Block;
+    }
+
+    #
+    # Setext
+
+    protected function blockSetextHeader($Line, array $Block = null)
+    {
+        $Block = parent::blockSetextHeader($Line, $Block);
+
+        if (preg_match('/[ ]*{('.$this->regexAttribute.'+)}[ ]*$/', $Block['element']['text'], $matches, PREG_OFFSET_CAPTURE))
+        {
+            $attributeString = $matches[1][0];
+
+            $Block['element']['attributes'] = $this->parseAttributeData($attributeString);
+
+            $Block['element']['text'] = substr($Block['element']['text'], 0, $matches[0][1]);
+        }
+
+        return $Block;
+    }
+
+    #
+    # Inline Elements
+    #
+
+    #
+    # Footnote Marker
+
+    protected function inlineFootnoteMarker($Excerpt)
+    {
+        if (preg_match('/^\[\^(.+?)\]/', $Excerpt['text'], $matches))
+        {
+            $name = $matches[1];
+
+            if ( ! isset($this->DefinitionData['Footnote'][$name]))
+            {
+                return;
+            }
+
+            $this->DefinitionData['Footnote'][$name]['count'] ++;
+
+            if ( ! isset($this->DefinitionData['Footnote'][$name]['number']))
+            {
+                $this->DefinitionData['Footnote'][$name]['number'] = ++ $this->footnoteCount; # » &
+            }
+
+            $Element = array(
+                'name' => 'sup',
+                'attributes' => array('id' => 'fnref'.$this->DefinitionData['Footnote'][$name]['count'].':'.$name),
+                'handler' => 'element',
+                'text' => array(
+                    'name' => 'a',
+                    'attributes' => array('href' => '#fn:'.$name, 'class' => 'footnote-ref'),
+                    'text' => $this->DefinitionData['Footnote'][$name]['number'],
+                ),
+            );
+
+            return array(
+                'extent' => strlen($matches[0]),
+                'element' => $Element,
+            );
+        }
+    }
+
+    private $footnoteCount = 0;
+
+    #
+    # Link
+
+    protected function inlineLink($Excerpt)
+    {
+        $Link = parent::inlineLink($Excerpt);
+
+        $remainder = substr($Excerpt['text'], $Link['extent']);
+
+        if (preg_match('/^[ ]*{('.$this->regexAttribute.'+)}/', $remainder, $matches))
+        {
+            $Link['element']['attributes'] += $this->parseAttributeData($matches[1]);
+
+            $Link['extent'] += strlen($matches[0]);
+        }
+
+        return $Link;
+    }
+
+    #
+    # ~
+    #
+
+    protected function unmarkedText($text)
+    {
+        $text = parent::unmarkedText($text);
+
+        if (isset($this->DefinitionData['Abbreviation']))
+        {
+            foreach ($this->DefinitionData['Abbreviation'] as $abbreviation => $meaning)
+            {
+                $pattern = '/\b'.preg_quote($abbreviation, '/').'\b/';
+
+                $text = preg_replace($pattern, '<abbr title="'.$meaning.'">'.$abbreviation.'</abbr>', $text);
+            }
+        }
+
+        return $text;
+    }
+
+    #
+    # Util Methods
+    #
+
+    protected function addDdElement(array $Line, array $Block)
+    {
+        $text = substr($Line['text'], 1);
+        $text = trim($text);
+
+        unset($Block['dd']);
+
+        $Block['dd'] = array(
+            'name' => 'dd',
+            'handler' => 'line',
+            'text' => $text,
+        );
+
+        if (isset($Block['interrupted']))
+        {
+            $Block['dd']['handler'] = 'text';
+
+            unset($Block['interrupted']);
+        }
+
+        $Block['element']['text'] []= & $Block['dd'];
+
+        return $Block;
+    }
+
+    protected function buildFootnoteElement()
+    {
+        $Element = array(
+            'name' => 'div',
+            'attributes' => array('class' => 'footnotes'),
+            'handler' => 'elements',
+            'text' => array(
+                array(
+                    'name' => 'hr',
+                ),
+                array(
+                    'name' => 'ol',
+                    'handler' => 'elements',
+                    'text' => array(),
+                ),
+            ),
+        );
+
+        uasort($this->DefinitionData['Footnote'], 'self::sortFootnotes');
+
+        foreach ($this->DefinitionData['Footnote'] as $definitionId => $DefinitionData)
+        {
+            if ( ! isset($DefinitionData['number']))
+            {
+                continue;
+            }
+
+            $text = $DefinitionData['text'];
+
+            $text = parent::text($text);
+
+            $numbers = range(1, $DefinitionData['count']);
+
+            $backLinksMarkup = '';
+
+            foreach ($numbers as $number)
+            {
+                $backLinksMarkup .= ' <a href="#fnref'.$number.':'.$definitionId.'" rev="footnote" class="footnote-backref">&#8617;</a>';
+            }
+
+            $backLinksMarkup = substr($backLinksMarkup, 1);
+
+            if (substr($text, - 4) === '</p>')
+            {
+                $backLinksMarkup = '&#160;'.$backLinksMarkup;
+
+                $text = substr_replace($text, $backLinksMarkup.'</p>', - 4);
+            }
+            else
+            {
+                $text .= "\n".'<p>'.$backLinksMarkup.'</p>';
+            }
+
+            $Element['text'][1]['text'] []= array(
+                'name' => 'li',
+                'attributes' => array('id' => 'fn:'.$definitionId),
+                'text' => "\n".$text."\n",
+            );
+        }
+
+        return $Element;
+    }
+
+    # ~
+
+    protected function parseAttributeData($attributeString)
+    {
+        $Data = array();
+
+        $attributes = preg_split('/[ ]+/', $attributeString, - 1, PREG_SPLIT_NO_EMPTY);
+
+        foreach ($attributes as $attribute)
+        {
+            if ($attribute[0] === '#')
+            {
+                $Data['id'] = substr($attribute, 1);
+            }
+            else # "."
+            {
+                $classes []= substr($attribute, 1);
+            }
+        }
+
+        if (isset($classes))
+        {
+            $Data['class'] = implode(' ', $classes);
+        }
+
+        return $Data;
+    }
+
+    # ~
+
+    protected function processTag($elementMarkup) # recursive
+    {
+        # http://stackoverflow.com/q/1148928/200145
+        libxml_use_internal_errors(true);
+
+        $DOMDocument = new DOMDocument;
+
+        # http://stackoverflow.com/q/11309194/200145
+        $elementMarkup = mb_convert_encoding($elementMarkup, 'HTML-ENTITIES', 'UTF-8');
+
+        # http://stackoverflow.com/q/4879946/200145
+        $DOMDocument->loadHTML($elementMarkup);
+        $DOMDocument->removeChild($DOMDocument->doctype);
+        $DOMDocument->replaceChild($DOMDocument->firstChild->firstChild->firstChild, $DOMDocument->firstChild);
+
+        $elementText = '';
+
+        if ($DOMDocument->documentElement->getAttribute('markdown') === '1')
+        {
+            foreach ($DOMDocument->documentElement->childNodes as $Node)
+            {
+                $elementText .= $DOMDocument->saveHTML($Node);
+            }
+
+            $DOMDocument->documentElement->removeAttribute('markdown');
+
+            $elementText = "\n".$this->text($elementText)."\n";
+        }
+        else
+        {
+            foreach ($DOMDocument->documentElement->childNodes as $Node)
+            {
+                $nodeMarkup = $DOMDocument->saveHTML($Node);
+
+                if ($Node instanceof DOMElement and ! in_array($Node->nodeName, $this->textLevelElements))
+                {
+                    $elementText .= $this->processTag($nodeMarkup);
+                }
+                else
+                {
+                    $elementText .= $nodeMarkup;
+                }
+            }
+        }
+
+        # because we don't want for markup to get encoded
+        $DOMDocument->documentElement->nodeValue = 'placeholder\x1A';
+
+        $markup = $DOMDocument->saveHTML($DOMDocument->documentElement);
+        $markup = str_replace('placeholder\x1A', $elementText, $markup);
+
+        return $markup;
+    }
+
+    # ~
+
+    protected function sortFootnotes($A, $B) # callback
+    {
+        return $A['number'] - $B['number'];
+    }
+
+    #
+    # Fields
+    #
+
+    protected $regexAttribute = '(?:[#.][-\w]+[ ]*)';
+}


### PR DESCRIPTION
Add a new setting to enable/disable Markdown support. When it's enabled
Markdown content will be parsed and stripped where needed using the
Parsedown and ParsedownExtra libraries, included in this changes. Added
this setting in a new page to add and make clear a notice about the need of
rebuilding the search index after this setting changes.

The Markdown support conflicts with the Symfony escaping strategy so, when
Markdown is enabled the escaping strategy is disabled and we rely in the safe
mode of Parsedown to escape all special chars after parsing the content. The
main consequence of this changes is that now the data can be found scaped
or not in the templates and it needs to be accessed with methods that work in
both sfOutputEscaperObjectDecorator/sfOutputEscaperArrayDecorator and 
objects/arrays.

QubitMarkdown has been converted to an instantiable class for Markdown
operations using Parsedown, it contains parse and strip methods that are being
called from the render helpers in QubitHelper. It is important to use the following
helpers while displaying data that may contain Markdown syntax:

- render_value: uses Parsedown text method in safe mode (adds paragraphs).
- render_value_inline: uses Parsedown line method in safe mode.
- render_value_html: uses Parsedown text method in unsafe mode (for HTML).
- render_title: returns 'Untitled' if render_value_inline returns and empty string. 
- strip_markdown: removes Markdown and HTML tags.

To strip Markdown in the response title meta, QubitWebResponse has been
created extending sfWebResponse and being used in factories.yml.

The new setting will also determine the behavior on the EAD import, converting
`emph` tags to Markdown when it's enabled or just removing them when it's not.

In the Elasticsearch index, the data is stored with the Markdown tags but, to
avoid issues while searching over content like '__test value__', a new char filter
is being added to all analyzers (only if the new setting is enabled). This char
filter replaces the following punctuation chars by spaces: *_#![]()->`+\~:|^=

For the same reason, autocomplete queries executed over the ORM now use two
wildcards ('%query%') instead of only one ('query%'), only when the setting
is enabled.

Parsed Markdown creates HTML and it can break the page look if it's truncated.
To avoid that, the IOs scope and content field in the search results and the links
in the card view of repos and IOs (when no DO/logo exists) are no longer being
truncated. For that reason, the links use now a level five header instead of four
and the scope and content field uses now the same JS expandable method used
in the index pages. Other truncated text added to HTML attributes is passed through
the strip_markdown helper to remove Markdown and HTML tags before it's truncated.

This changes also include:

- Styling fixes to avoid global rules to apply to parsed Markdown.
- Removal of the duplication of flash notices in some pages.
- Order of the setting menu alphabetically.
- sfConfig settings reload on job execution.
- Clear settings cache after upgrade.