### PR TITLE
Permissive slug uri display, refs #11761

### DIFF
--- a/lib/routing/QubitMetadataRoute.class.php
+++ b/lib/routing/QubitMetadataRoute.class.php
@@ -17,7 +17,7 @@
  * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
  */
 
-class QubitMetadataRoute extends sfRoute
+class QubitMetadataRoute extends QubitRoute
 {
   public static
 


### PR DESCRIPTION
The previous commit to ensure the characters * : @ = , are represented
as literals in the browser address bar when 'Permissive Slugs' setting
is activated had an issue where the class QubitMetadataRoute does need
to extend QubitRoute. This commit corrects this.