### PR TITLE
New EAD import field mappings, refs #12172

### DIFF
--- a/apps/qubit/modules/object/config/import/ead.yml
+++ b/apps/qubit/modules/object/config/import/ead.yml
@@ -451,7 +451,7 @@ information_object:
       Parameters: ["$options = array('note' => $nodeValue, 'noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID)"]
 
     archivistnote:
-      XPath:  "../eadheader/filedesc/titlestmt/author[@encodinganalog='creator']"
+      XPath:  "(../eadheader/filedesc/titlestmt/author[@encodinganalog='creator'] | ../eadheader/filedesc/titlestmt/author[@encodinganalog='245$c'] | ../eadheader/filedesc/publicationstmt/p)"
       Method: importEadNote
       Parameters: ["$options = array('note' => $nodeValue, 'noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID)"]
       Filters:


### PR DESCRIPTION
Add new mappings of EAD fields to Archivist's Notes.

EAD import nodes being added to ead.yml (map to Archivist's Notes):
- filedesc/titlestmt/author[@encodinganalog='245$c']
- filedesc/publicationstmt/p