### PR TITLE
Correct EAD import mapping, refs #12172

### DIFF
--- a/apps/qubit/modules/object/config/import/ead.yml
+++ b/apps/qubit/modules/object/config/import/ead.yml
@@ -451,7 +451,7 @@ information_object:
       Parameters: ["$options = array('note' => $nodeValue, 'noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID)"]
 
     archivistnote:
-      XPath:  "(../eadheader/filedesc/titlestmt/author[@encodinganalog='creator'] | ../eadheader/filedesc/titlestmt/author[@encodinganalog='245$c'] | ../eadheader/filedesc/publicationstmt/p)"
+      XPath:  "(../eadheader/filedesc/titlestmt/author[@encodinganalog='creator'] | ../eadheader/filedesc/titlestmt/author | ../eadheader/filedesc/publicationstmt/p)"
       Method: importEadNote
       Parameters: ["$options = array('note' => $nodeValue, 'noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID)"]
       Filters:


### PR DESCRIPTION
Correcting previous commit where filedesc/titlestmt/author was mapped
to Archivist Note: Encodinganalog='245$c' needed to be removed as it
was incorrect.