### PR TITLE
Change port config in Docker compose, refs #12111

### DIFF
--- a/docker/bootstrap.php
+++ b/docker/bootstrap.php
@@ -51,6 +51,7 @@ $CONFIG = array(
   'atom.mysql_dsn'          => getenv_or_fail('ATOM_MYSQL_DSN'),
   'atom.mysql_username'     => getenv_or_fail('ATOM_MYSQL_USERNAME'),
   'atom.mysql_password'     => getenv_or_fail('ATOM_MYSQL_PASSWORD'),
+  'atom.debug_ip'           => getenv_default('ATOM_DEBUG_IP', ''),
   'php.max_execution_time'  => getenv_default('ATOM_PHP_MAX_EXECUTION_TIME', '120'),
   'php.max_input_time'      => getenv_default('ATOM_PHP_MAX_INPUT_TIME', '120'),
   'php.memory_limit'        => getenv_default('ATOM_PHP_MEMORY_LIMIT', '512M'),
@@ -290,6 +291,7 @@ pm.max_children = 5
 pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+env[ATOM_DEBUG_IP] = ${CONFIG['atom.debug_ip']}
 
 EOT;
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -30,6 +30,10 @@ services:
         soft: -1
         hard: -1
     mem_limit: 1g
+    ports:
+      - "63002:9200"
+    expose:
+      - "9300"
     volumes:
       - "elasticsearch_data:/usr/share/elasticsearch/data"
     networks:
@@ -88,6 +92,7 @@ services:
       - "ATOM_MYSQL_DSN=mysql:host=percona;port=3306;dbname=atom;charset=utf8"
       - "ATOM_MYSQL_USERNAME=atom"
       - "ATOM_MYSQL_PASSWORD=atom_12345"
+      - "ATOM_DEBUG_IP=172.22.0.1"
 
   atom_worker:
     build:
@@ -113,7 +118,7 @@ services:
   nginx:
     image: "nginx:latest"
     ports:
-      - "80"
+      - "63001:80"
     volumes:
       - "../:/atom/src:ro"
       - "./etc/nginx/prod.conf:/etc/nginx/nginx.conf:ro"


### PR DESCRIPTION
Map Nginx and Elasticsearch 9200 to fixed ports in the host and expose
Elasticsearch 9300. Allow setting the ATOM_DEBUG_IP env. variable in
the PHP-FPM pool.