### PR TITLE
Add GA repository dimension, refs #12209

### DIFF
--- a/apps/qubit/modules/object/actions/gaInstitutionsDimensionComponent.class.php
+++ b/apps/qubit/modules/object/actions/gaInstitutionsDimensionComponent.class.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class ObjectGaInstitutionsDimensionComponent extends sfComponent
+{
+  public function execute($request)
+  {
+    $this->dimensionIndex = sfConfig::get('app_google_analytics_institutions_dimension_index', '');
+
+    if (empty($this->dimensionIndex))
+    {
+      return sfView::NONE;
+    }
+
+    switch (get_class($this->resource))
+    {
+      case 'QubitInformationObject':
+        $this->repository = $this->resource->getRepository(array('inherit' => true));
+        break;
+
+      case 'QubitActor':
+        $this->repository = $this->resource->getMaintainingRepository();
+        break;
+
+      case 'QubitRepository':
+        $this->repository = $this->resource;
+        break;
+
+      default:
+        $this->repository = null;
+        break;
+    }
+
+    if (!isset($this->repository))
+    {
+      return sfView::NONE;
+    }
+  }
+}

--- a/apps/qubit/modules/object/templates/_gaInstitutionsDimension.php
+++ b/apps/qubit/modules/object/templates/_gaInstitutionsDimension.php
@@ -1,0 +1,3 @@
+<?php slot('google_analytics') ?>
+  ga('set', 'dimension<?php echo $dimensionIndex ?>', '<?php echo $repository->getAuthorizedFormOfName(array('sourceCulture' => true)) ?>');
+<?php end_slot() ?>

--- a/apps/qubit/templates/_footer.php
+++ b/apps/qubit/templates/_footer.php
@@ -12,16 +12,13 @@
 
 </footer>
 
-<?php if (null !== $gaKey = sfConfig::get('app_google_analytics_api_key')): ?>
-  <script type="text/javascript">
-    var _gaq = _gaq || [];
-    _gaq.push(['_setAccount', '<?php echo $gaKey ?>']);
-    _gaq.push(['_trackPageview']);
+<?php $gaKey = sfConfig::get('app_google_analytics_api_key', '') ?>
+<?php if (!empty($gaKey)): ?>
+  <script>
+    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+    ga('create', '<?php echo $gaKey ?>', 'auto');
     <?php include_slot('google_analytics') ?>
-    (function() {
-      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-    })();
+    ga('send', 'pageview');
   </script>
+  <script async src='https://www.google-analytics.com/analytics.js'></script>
 <?php endif; ?>

--- a/config/app.yml
+++ b/config/app.yml
@@ -20,8 +20,15 @@ all:
   # by and environment variable called "ATOM_READ_ONLY"
   read_only: false
 
-  # Google Analitycs
-  # google_analytics_api_key: ...
+  # Google Analitycs:
+  # Set a GA property API key to track page view hits.
+  # E.g.: UA-1234567-89
+  google_analytics_api_key:
+  # Set a GA custom dimension index numver (from the same property)
+  # to track the repository name as a dimension in page view hits
+  # of IOs, actors and repos index pages.
+  # E.g.: 1
+  google_analytics_institutions_dimension_index:
 
   # htmlpurifier is used in static pages, disabled by default
   htmlpurifier_enabled: false

--- a/plugins/arDacsPlugin/modules/arDacsPlugin/templates/indexSuccess.php
+++ b/plugins/arDacsPlugin/modules/arDacsPlugin/templates/indexSuccess.php
@@ -282,3 +282,5 @@
 <?php slot('after-content') ?>
   <?php echo get_partial('informationobject/actions', array('resource' => $resource, 'renameForm' => $renameForm)) ?>
 <?php end_slot() ?>
+
+<?php echo get_component('object', 'gaInstitutionsDimension', array('resource' => $resource)) ?>

--- a/plugins/sfDcPlugin/modules/sfDcPlugin/templates/indexSuccess.php
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/templates/indexSuccess.php
@@ -156,3 +156,5 @@
 <?php slot('after-content') ?>
   <?php echo get_partial('informationobject/actions', array('resource' => $resource, 'renameForm' => $renameForm)) ?>
 <?php end_slot() ?>
+
+<?php echo get_component('object', 'gaInstitutionsDimension', array('resource' => $resource)) ?>

--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/indexSuccess.php
@@ -256,3 +256,5 @@
   </section>
 
 <?php end_slot() ?>
+
+<?php echo get_component('object', 'gaInstitutionsDimension', array('resource' => $resource)) ?>

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/indexSuccess.php
@@ -348,3 +348,5 @@
 <?php slot('after-content') ?>
   <?php echo get_partial('informationobject/actions', array('resource' => $resource, 'renameForm' => $renameForm)) ?>
 <?php end_slot() ?>
+
+<?php echo get_component('object', 'gaInstitutionsDimension', array('resource' => $resource)) ?>

--- a/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
@@ -5,10 +5,6 @@
   <?php include_component('repository', 'maintainedActors', array('resource' => $resource)) ?>
 <?php end_slot() ?>
 
-<?php slot('google_analytics') ?>
-  _gaq.push(['_setCustomVar', 1, 'repository', '<?php echo $resource->slug ?>']);
-<?php end_slot() ?>
-
 <?php slot('title') ?>
 
   <h1><?php echo render_title($resource) ?></h1>
@@ -272,3 +268,5 @@
   <?php end_slot() ?>
 
 <?php endif; ?>
+
+<?php echo get_component('object', 'gaInstitutionsDimension', array('resource' => $resource)) ?>

--- a/plugins/sfModsPlugin/modules/sfModsPlugin/templates/indexSuccess.php
+++ b/plugins/sfModsPlugin/modules/sfModsPlugin/templates/indexSuccess.php
@@ -154,3 +154,5 @@
 <?php slot('after-content') ?>
   <?php echo get_partial('informationobject/actions', array('resource' => $resource, 'renameForm' => $renameForm)) ?>
 <?php end_slot() ?>
+
+<?php echo get_component('object', 'gaInstitutionsDimension', array('resource' => $resource)) ?>

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
@@ -413,3 +413,5 @@
 <?php slot('after-content') ?>
   <?php echo get_partial('informationobject/actions', array('resource' => $resource, 'renameForm' => $renameForm)) ?>
 <?php end_slot() ?>
+
+<?php echo get_component('object', 'gaInstitutionsDimension', array('resource' => $resource)) ?>


### PR DESCRIPTION
- Add config setting in 'app.yml' for repository dimension index:

Added explanatory comments and un-commented the GA settings for a
better understanding.

- Upgrade to Universal Analytics:

Custom dimensions are not available in 'ga.js', which is already
deprecated. See: https://support.google.com/analytics/answer/3450662

- Add GA repository dimension component:

Called from the index pages of IOs, repos and actors, checks the new
config setting, gets the resource's related repository and sets it's
source culture authorized form of name as the value of the dimension
before sending the page view hit.