### PR TITLE
Trim CSV import elements, refs #12067

### DIFF
--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -179,11 +179,11 @@ class QubitFlatfileImport
   {
     if ($this->contentFilterLogic)
     {
-      return call_user_func_array($this->contentFilterLogic, array($text));
+      return trim(call_user_func_array($this->contentFilterLogic, array($text)));
     }
     else
     {
-      return $text;
+      return trim($text);
     }
   }
 
@@ -225,7 +225,7 @@ class QubitFlatfileImport
     {
       if ($value === false)
       {
-        return $this->status['row'][$columnIndex];
+        return trim($this->status['row'][$columnIndex]);
       }
       else
       {
@@ -1119,6 +1119,9 @@ class QubitFlatfileImport
     // process import columns that don't produce child data
     $this->forEachRowColumn($row, function(&$self, $index, $columnName, $value)
     {
+      // Trim whitespace
+      $value = trim($value);
+
       if (
         isset($self->columnNames[$index])
         && in_array($self->columnNames[$index], $self->variableColumns)
@@ -1204,6 +1207,9 @@ class QubitFlatfileImport
   {
     $this->forEachRowColumn($row, function(&$self, $index, $columnName, $value)
     {
+      // Trim whitespace
+      $value = trim($value);
+
       // Create/relate terms
       if (isset($self->termRelations) && isset($self->termRelations[$columnName]) && $value)
       {
@@ -1380,7 +1386,7 @@ class QubitFlatfileImport
   {
     if ($value)
     {
-      $this->rowStatusVars[$column] = explode($delimiter, $value);
+      $this->rowStatusVars[$column] = array_map('trim', explode($delimiter, $value));
     }
   }
 

--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -510,7 +510,7 @@ EOF;
         {
           $pubStatusTermId = array_search_case_insensitive(
             $self->rowStatusVars['publicationStatus'],
-            $self->status['pubStatusTypes'][$self->columnValue('culture')]
+            $self->status['pubStatusTypes'][trim($self->columnValue('culture'))]
           );
 
           if (!$pubStatusTermId)
@@ -1011,7 +1011,7 @@ EOF;
 
     $import->addColumnHandler('levelOfDescription', function($self, $data)
     {
-      $self->object->setLevelOfDescriptionByName($data);
+      $self->object->setLevelOfDescriptionByName(trim($data));
     });
 
     // Map value to taxonomy term name and take note of taxonomy term's ID
@@ -1019,7 +1019,7 @@ EOF;
     {
       if ($data)
       {
-        $data = explode('|', $data);
+        $data = array_map('trim', explode('|', $data));
 
         foreach ($data as $value)
         {


### PR DESCRIPTION
This change trims all pipe separated elements contained in an import
CSV file. This was not occurring previously and extra leading and
trailing spaces were appearing in the import, and in some cases,
preventing correct matching when match is based off these fields.

Additionally I have added code to ensure culture and other fields are
trimmed. If these fields has leading or trailing spaces in the csv, they
where previously not being trimmed, and the term lookups would fail.

Custom column handlers had a similar issue and require trimming of
values to ensure leading and trailing spaces in the csv field do not
affect the import.