### PR TITLE
Add descendant date calculation, refs #12115

### DIFF
--- a/apps/qubit/config/routing.yml
+++ b/apps/qubit/config/routing.yml
@@ -51,7 +51,7 @@ informationobject/action:
   class: QubitResourceRoute
   param:
     module: informationobject
-    action: { pattern: 'addDigitalObject|fileList|multiFileUpload|rename|reports|slugPreview|modifications' }
+    action: { pattern: 'addDigitalObject|fileList|multiFileUpload|rename|reports|slugPreview|modifications|calculateDates' }
 
 oai:
   url: /;oai

--- a/apps/qubit/modules/informationobject/actions/calculateDatesAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/calculateDatesAction.class.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class InformationObjectCalculateDatesAction extends DefaultEditAction
+{
+  // Arrays not allowed in class constants
+  public static
+    $NAMES = array(
+      'eventId');
+
+  protected function addField($name)
+  {
+    switch ($name)
+    {
+      case 'eventId':
+        if (count($this->events) == 1)
+        {
+          // If there's only one event with data range data, display its description
+          // via the form label and relay its ID via a hidden field
+          $this->form->setDefault($name, key($this->events));
+          $this->form->setWidget($name, new sfWidgetFormInputHidden);
+          $label = current($this->events);
+        }
+        else
+        {
+          // Otherwise, display the events using a SELECT element
+          $this->form->setWidget($name, new sfWidgetFormSelect(array('choices' => $this->events)));
+          $label = $this->i18n->__('Event');
+        }
+
+        $this->form->setValidator($name, new sfValidatorInteger);
+        $this->form->getWidgetSchema()->$name->setLabel($label);
+
+        break;
+    }
+  }
+
+  protected function processField($field)
+  {
+    switch ($name = $field->getName())
+    {
+      case 'eventId':
+        $this->eventId = $field->getValue();
+
+        break;
+    }
+  }
+
+  protected function earlyExecute()
+  {
+    $this->i18n = $this->context->i18n;
+    $this->resource = $this->getRoute()->resource;
+    $this->events = self::getResourceEventsWithDateRangeSet($this->resource);
+  }
+
+  public function execute($request)
+  {
+    parent::execute($request);
+
+    // Redirect if unauthorized
+    if (!QubitAcl::check($this->resource, 'update'))
+    {
+      QubitAcl::forwardUnauthorized();
+    }
+
+    // Set response to 403 forbidden if attempting to calculate dates using
+    // non-existant descendants
+    if (!count($this->resource->descendants))
+    {
+      $this->getResponse()->setStatusCode(403);
+      return sfView::NONE;
+    }
+
+    if ($request->isMethod('post'))
+    {
+      $this->form->bind($request->getPostParameters());
+
+      if ($this->form->isValid())
+      {
+        $this->processForm();
+        $this->beginDateCalculation();
+        $this->redirect(array($this->resource, 'module' => 'informationobject'));
+      }
+    }
+
+    $message = $this->i18n->__('Warning: Selected date range for the specified event will be overwritten.');
+    $this->getUser()->setFlash('notice', $message);
+  }
+
+  protected function beginDateCalculation()
+  {
+    // Specify parameters for job
+    $params = array(
+      'objectId' => $this->resource->id,
+      'eventId' => $this->eventId
+    );
+
+    // Catch no Gearman worker available exception
+    // and others to show alert with exception message
+    try
+    {
+      QubitJob::runJob('arCalculateDescendantDatesJob', $params);
+
+      $message = $this->i18n->__('Date calculation started.');
+      $this->context->user->setFlash('info', $message);
+    }
+    catch (Exception $e)
+    {
+      $message = $this->i18n->__('Calculation failed') .': '. $this->i18n->__($e->getMessage());
+      $this->context->user->setFlash('error', $message);
+    }
+  }
+
+  static public function getResourceEventsWithDateRangeSet($resource)
+  {
+    $events = array();
+
+    $criteria = new Criteria;
+    $criteria->add(QubitEvent::OBJECT_ID, $resource->id);
+
+    // Assemble array of descriptions for any events containing date information
+    foreach(QubitEvent::get($criteria) as $event)
+    {
+      if ((!empty($event->date) || !empty($event->startDate) || !empty($event->endDate)) && null !== $event->typeId)
+      {
+        $eventTypeName = $event->type->getName(array('cultureFallback' => true));
+        $eventRange = Qubit::renderDateStartEnd($event->getDate(array('cultureFallback' => true)), $event->startDate, $event->endDate);
+        $events[$event->id] = sprintf('%s [%s]', $eventRange, $eventTypeName);
+      }
+    }
+
+    return $events;
+  }
+}

--- a/apps/qubit/modules/informationobject/actions/calculateDatesLinkComponent.class.php
+++ b/apps/qubit/modules/informationobject/actions/calculateDatesLinkComponent.class.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class InformationObjectCalculateDatesLinkComponent extends sfComponent
+{
+  public function execute($request)
+  {
+    $i18n = $this->context->i18n;
+
+    // Get events for the information object
+    $this->events = InformationObjectCalculateDatesAction::getResourceEventsWithDateRangeSet($this->resource);
+
+    // Determine when, or if, the date calculation job was last run
+    $criteria = new Criteria;
+    $criteria->add(QubitJob::NAME, 'arCalculateDescendantDatesJob');
+    $criteria->add(QubitJob::OBJECT_ID, $this->resource->id);
+    $criteria->addDescendingOrderByColumn(QubitJob::ID);
+
+    $lastJobRan = QubitJob::getOne($criteria);
+
+    if ($lastJobRan === null)
+    {
+      $this->lastRun = $i18n->__('Never');
+    }
+    else if($lastJobRan->statusId == QubitTerm::JOB_STATUS_IN_PROGRESS_ID)
+    {
+      $this->lastRun = $i18n->__('In progress');
+    }
+    else
+    {
+      $this->lastRun = $lastJobRan->completedAt;
+    }
+  }
+}

--- a/apps/qubit/modules/informationobject/templates/_actionIcons.php
+++ b/apps/qubit/modules/informationobject/templates/_actionIcons.php
@@ -106,5 +106,6 @@
 
     <?php echo get_component('informationobject', 'findingAid', array('resource' => $resource)) ?>
 
+    <?php echo get_component('informationobject', 'calculateDatesLink', array('resource' => $resource)) ?>
   </ul>
 </section>

--- a/apps/qubit/modules/informationobject/templates/_calculateDatesLink.php
+++ b/apps/qubit/modules/informationobject/templates/_calculateDatesLink.php
@@ -1,0 +1,13 @@
+<?php if (QubitAcl::check($resource, 'update') && count($resource->descendants) && count($events)): ?>
+  <li class="separator"><h4><?php echo __('Tasks') ?></h4></li>
+
+  <li>
+    <a href="<?php echo url_for(array($resource, 'module' => 'informationobject', 'action' => 'calculateDates')) ?>">
+      <i class="fa fa-calendar"></i>
+      <?php echo __('Calculate dates') ?>
+    </a>
+  </li>
+  <li>
+    <?php echo __('Last run:') ?> <?php echo $lastRun ?>
+  </li>
+<?php endif; ?>

--- a/apps/qubit/modules/informationobject/templates/calculateDatesSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/calculateDatesSuccess.php
@@ -1,0 +1,45 @@
+<?php decorate_with('layout_2col') ?>
+
+<?php slot('sidebar') ?>
+  <?php include_component('informationobject', 'contextMenu') ?>
+<?php end_slot() ?>
+
+<?php slot('title') ?>
+
+  <h1><?php echo __('Calculate dates') ?></h1>
+
+<?php end_slot() ?>
+
+<?php slot('content') ?>
+
+  <?php echo $form->renderFormTag(url_for(array($resource, 'module' => 'informationobject', 'action' => 'calculateDates'))) ?>
+
+    <div id="content">
+
+      <fieldset class="collapsible">
+        <div class="fieldset-wrapper">
+
+          <?php echo $form->eventId->renderRow() ?>
+
+          <h6>
+            <?php echo __('Note: While the date range update is running, the selected description should not be edited.') ?>
+            <?php echo __('You can check the job page to determine the current status of the update job.') ?>
+          </h6>
+
+        </div>
+      </fieldset>
+
+    </div>
+
+    <section class="actions">
+      <ul>
+        <li><?php echo link_to(__('Cancel'), array($resource, 'module' => 'informationobject'), array('class' => 'c-btn')) ?></li>
+      </ul>
+      <ul>
+        <li><input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Continue') ?>"/></li>
+      </ul>
+    </section>
+
+  </form>
+
+<?php end_slot() ?>

--- a/config/gearman.yml
+++ b/config/gearman.yml
@@ -7,6 +7,8 @@ all:
       - arFindingAidJob
     acl:
       - arInheritRightsJob
+    calculate_dates:
+      - arCalculateDescendantDatesJob
     move:
       - arObjectMoveJob
     search_csv_export:

--- a/lib/job/arCalculateDescendantDatesJob.class.php
+++ b/lib/job/arCalculateDescendantDatesJob.class.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A job to calculate, for a given information object and event type, the
+ * earliest start date and latest end date
+ *
+ * @package    symfony
+ * @subpackage jobs
+ */
+
+class arCalculateDescendantDatesJob extends arBaseJob
+{
+  /**
+   * @see arBaseJob::$requiredParameters
+   */
+  protected $extraRequiredParameters = array('objectId', 'eventId');
+
+  public function runJob($parameters)
+  {
+    $this->info($this->i18n->__(
+      'Calculating dates for information object (ID: %1, event ID: %2)',
+      array('%1' => $parameters['objectId'], '%2' => $parameters['eventId'])
+    ));
+
+    // Load related objects
+    $io = QubitInformationObject::getById($parameters['objectId']);
+    $event = QubitEvent::getById($parameters['eventId']);
+
+    // Describe original dates
+    $this->info($this->i18n->__(
+      'Original start date of event is %1 and end date is %2.',
+      array('%1' => $this->describeDate($event->startDate), '%2' => $this->describeDate($event->endDate))
+    ));
+
+    // Determine earliest start date and lastest end date of descendent events
+    // sharing type with provided event
+    //
+    // Note: if NULL is present as a start or end date then it'll be considered
+    //       the minimum or maximum respectively (for open-ended date ranges)
+    $sql = "SELECT
+      COUNT(*) AS found,
+      IF (MAX(e.start_date IS NULL), NULL, MIN(e.start_date)) AS min,
+      IF (MAX(e.end_date IS NULL), NULL, MAX(e.end_date)) as max
+      FROM
+        information_object i
+        INNER JOIN event e ON i.id=e.object_id
+      WHERE
+        i.lft > :lft
+        AND i.rgt < :rgt
+        AND e.type_id=:eventType
+        AND (e.start_date IS NOT NULL OR e.end_date IS NOT NULL)";
+
+    $params = array(
+      ':lft' => $io->lft,
+      ':rgt' => $io->rgt,
+      ':eventType' => $event->typeId
+    );
+
+    $eventData = QubitPdo::fetchOne($sql, $params, array('fetchMode' => PDO::FETCH_ASSOC));
+
+    // Update event with start and end dates if descendant events were found
+    if ($eventData->found)
+    {
+      // Describe new dates
+      $this->info($this->i18n->__(
+        'Changing start date of event to %1 and end date to %2.',
+        array('%1' => $this->describeDate($eventData->min), '%2' => $this->describeDate($eventData->max))
+      ));
+
+      $event->startDate = $eventData->min;
+      $event->endDate = $eventData->max;
+      $event->save();
+    }
+
+    // Mark job as completed
+    $this->info('Date calculation completed.');
+    $this->job->setStatusCompleted();
+    $this->job->save();
+
+    return true;
+  }
+
+  private function describeDate($date)
+  {
+    return ($date !== null) ? $date : $this->i18n->__('[open ended]');
+  }
+}


### PR DESCRIPTION
This adds functionality that lets you specify an event, associated with an
information object, and calculate a start and end date based on the earliest
and latest, respectively, start and end date of events, of the same type,
associated with descendant information objects.

* Add new job type ("arCalculateDescendantDatesJob"): this job will, given
  the ID of an information object and the ID of an event associated with that
  information object, do the aforementioned date calculation
* Add link, on description viewing pages, that opens a dialog that allows the
  user to select an event whose dates should be replaced then trigger date
  calculation
* Under this link show the last time a date calculation was run for the
  information object