### PR TITLE
Fix siblings order on CSV import, refs #12183

### DIFF
--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -32,13 +32,14 @@ class QubitFlatfileImport
   public $displayProgress = true;    // display progress by default
   public $rowsUntilProgressDisplay;  // optional display progress every n rows
 
-  public $searchIndexingDisabled = true;  // disable per-object search indexing by default
-  public $matchAndUpdate         = false; // Match existing records & update them
-  public $deleteAndReplace       = false; // Delete matching records & replace them
-  public $skipMatched            = false; // Skip creating new record if matching one is found
-  public $skipUnmatched          = false; // Skip creating new record if matching one is not found
-  public $keepDigitalObjects     = false; // Skip deletion of DOs when set. Works when --update set.
-  public $limitToId              = 0;     // Id of repository or TLD to limit our update matching under
+  public $searchIndexingDisabled   = true;  // disable per-object search indexing by default
+  public $disableNestedSetUpdating = false; // update nested set on object creation
+  public $matchAndUpdate           = false; // match existing records & update them
+  public $deleteAndReplace         = false; // delete matching records & replace them
+  public $skipMatched              = false; // skip creating new record if matching one is found
+  public $skipUnmatched            = false; // skip creating new record if matching one is not found
+  public $keepDigitalObjects       = false; // skip deletion of DOs when set. Works when --update set.
+  public $limitToId                = 0;     // id of repository or TLD to limit our update matching under
   public $status          = array(); // place to store data related to overall import
   public $rowStatusVars   = array(); // place to store data related to current row
 
@@ -774,7 +775,7 @@ class QubitFlatfileImport
 
       if (property_exists(get_class($this->object), 'disableNestedSetUpdating'))
       {
-        $this->object->disableNestedSetUpdating = $this->searchIndexingDisabled;
+        $this->object->disableNestedSetUpdating = $this->disableNestedSetUpdating;
       }
     }
     else

--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -999,8 +999,9 @@ EOF;
       }
     ));
 
-
     $import->searchIndexingDisabled = ($options['index']) ? false : true;
+    $import->disableNestedSetUpdating = ($options['skip-nested-set-build']) ? true : false;
+
     $import->setUpdateOptions($options);
 
     // Convert content with | characters to a bulleted list
@@ -1044,15 +1045,6 @@ EOF;
     });
 
     $import->csv($fh, $skipRows);
-
-    // Build nested set if desired
-    if (!$options['skip-nested-set-build'])
-    {
-      $buildNestedSet = new propelBuildNestedSetTask($this->dispatcher, $this->formatter);
-      $buildNestedSet->setCommandApplication($this->commandApplication);
-      $buildNestedSet->setConfiguration($this->configuration);
-      $ret = $buildNestedSet->run();
-    }
   }
 
   /**


### PR DESCRIPTION
Disabling the nested set update on IO creation in the CSV import process
doesn't maintain the order of the siblings from the CSV file. Moreover,
this is disabled based on the `index` option, when it should be using
the `skip-nested-set-build` option.

The `skip-nested-set-build` was only used to not run the build nested
set task at the end of the import, a task that is only needed when the
nested set is not being updated on creation, which doesn't make sense.

The build nested set task execution has been removed from the end of the
import and it should be executed manually after the import task if the
`skip-nested-set-build` option was used.