### PR TITLE
Index ISAD archivists' notes, refs #12023

### DIFF
--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -421,6 +421,7 @@ mapping:
         - conservationNotes.content
         - physicalDescriptionNotes.content
         - continuationOfTitleNotes.content
+        - archivistsNotes.content
     _partial_foreign_types:
       part_of:
         _i18nFields: [title]
@@ -448,6 +449,7 @@ mapping:
       conservation_notes: note
       physical_description_notes: note
       continuation_of_title_notes: note
+      archivists_notes: note
     dynamic: strict
     properties:
       slug: { type: keyword }

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
@@ -1338,6 +1338,14 @@ class arElasticSearchInformationObjectPdo
       }
     }
 
+    if (null !== $termId = $this->getTermIdByNameAndTaxonomy("Archivist's note", QubitTaxonomy::NOTE_TYPE_ID))
+    {
+      foreach ($this->getNotesByType($termId) as $item)
+      {
+        $serialized['archivistsNotes'][] = arElasticSearchNote::serialize($item);
+      }
+    }
+
     if (false !== $item = $this->getProperty('titleStatementOfResponsibility'))
     {
       $serialized['titleStatementOfResponsibility'] = arElasticSearchProperty::serialize($item);


### PR DESCRIPTION
ISAD archivists' notes weren't getting indexed, even though, by default, they
are displayed to unauthorized users. Added to index mapping/logic.