### PR TITLE
Physical Location report enhancement, refs #12255

### DIFF
--- a/apps/qubit/modules/informationobject/templates/boxLabelSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/boxLabelSuccess.php
@@ -1,5 +1,6 @@
 <html>
 <head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <style>
     table, thead {
       border-collapse: collapse;

--- a/apps/qubit/modules/informationobject/templates/storageLocationsSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/storageLocationsSuccess.php
@@ -40,11 +40,11 @@
           <td>
             <?php echo $row++ ?>
           </td><td>
-            <?php echo link_to(render_title($item['name']), sfConfig::get('app_siteBaseUrl').'/'.$item['slug']) ?>
+            <?php echo link_to(render_title($item->getName(array('cultureFallback' => true))), sfConfig::get('app_siteBaseUrl').'/'.$item->slug) ?>
           </td><td>
-            <?php echo render_value_inline($item['location']) ?>
+            <?php echo render_value_inline($item->getLocation(array('cultureFallback' => true))) ?>
           </td><td>
-            <?php echo render_value_inline($item['type']) ?>
+            <?php echo render_value_inline($item->getType(array('cultureFallback' => true))) ?>
           </td>
         </tr>
       <?php endforeach; ?>

--- a/apps/qubit/modules/informationobject/templates/storageLocationsSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/storageLocationsSuccess.php
@@ -1,5 +1,6 @@
 <html>
 <head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <style>
     table, thead {
       border-collapse: collapse;
@@ -39,11 +40,11 @@
           <td>
             <?php echo $row++ ?>
           </td><td>
-            <?php echo link_to(render_title($item->name), sfConfig::get('app_siteBaseUrl').'/'.$item->slug) ?>
+            <?php echo link_to(render_title($item['name']), sfConfig::get('app_siteBaseUrl').'/'.$item['slug']) ?>
           </td><td>
-            <?php echo render_value_inline($item->location) ?>
+            <?php echo render_value_inline($item['location']) ?>
           </td><td>
-            <?php echo render_value_inline($item->type) ?>
+            <?php echo render_value_inline($item['type']) ?>
           </td>
         </tr>
       <?php endforeach; ?>

--- a/lib/job/arGenerateReportJob.class.php
+++ b/lib/job/arGenerateReportJob.class.php
@@ -155,19 +155,7 @@ class arGenerateReportJob extends arBaseJob
     $criteria->addJoin(QubitRelation::OBJECT_ID, QubitInformationObject::ID);
     $criteria->addJoin(QubitRelation::SUBJECT_ID, QubitPhysicalObject::ID);
 
-    $storageLocations = QubitPhysicalObject::get($criteria);
-    $results = array();
-
-    foreach($storageLocations as $item)
-    {
-      $results[] = array(
-        'name' => isset($item->name) ? $item->getName(array('cultureFallback' => true)) : '',
-        'slug' => isset($item->slug) ? $item->slug : '',
-        'location' => isset($item->location) ? $item->getLocation(array('cultureFallback' => true)) : '',
-        'type' => isset($item->type) ? $item->type : '',
-      );
-    }
-    return $results;
+    return QubitPhysicalObject::get($criteria);
   }
 
   /**

--- a/lib/job/arGenerateReportJob.class.php
+++ b/lib/job/arGenerateReportJob.class.php
@@ -155,7 +155,19 @@ class arGenerateReportJob extends arBaseJob
     $criteria->addJoin(QubitRelation::OBJECT_ID, QubitInformationObject::ID);
     $criteria->addJoin(QubitRelation::SUBJECT_ID, QubitPhysicalObject::ID);
 
-    return QubitPhysicalObject::get($criteria);
+    $storageLocations = QubitPhysicalObject::get($criteria);
+    $results = array();
+
+    foreach($storageLocations as $item)
+    {
+      $results[] = array(
+        'name' => isset($item->name) ? $item->getName(array('cultureFallback' => true)) : '',
+        'slug' => isset($item->slug) ? $item->slug : '',
+        'location' => isset($item->location) ? $item->getLocation(array('cultureFallback' => true)) : '',
+        'type' => isset($item->type) ? $item->type : '',
+      );
+    }
+    return $results;
   }
 
   /**


### PR DESCRIPTION
This commit corrects a couple issues with the physical location report:

- When physical object records had null values in the type_id field,
or other fields, the report would crash. This should no longer occur.
- Fields for which there was no current translation would be blank.
This should no longer occur.
- Characters with diacritics that occurred in the report title would
be garbled. This has been corrected.
- The box label report was having similar display issues of characters
with diacritics - this should also be fixed.