### PR TITLE
Increase default ES fields limit, refs #12282

### DIFF
--- a/plugins/arElasticSearchPlugin/config/search.yml
+++ b/plugins/arElasticSearchPlugin/config/search.yml
@@ -29,7 +29,7 @@ all:
 
       number_of_shards: 4
       number_of_replicas: 1
-      index.mapping.total_fields.limit: 2000
+      index.mapping.total_fields.limit: 3000
 
       analysis:
 


### PR DESCRIPTION
New fields have been added to the index in f1cba27 and maybe in another
changes. This will increase the default value to 3000 until we found a
better solution to set this value dinamically on index creation.