### PR TITLE
Don't show cached OAI DC if disabled, refs #12272

### DIFF
--- a/plugins/arOaiPlugin/lib/arOaiPluginComponent.class.php
+++ b/plugins/arOaiPlugin/lib/arOaiPluginComponent.class.php
@@ -148,6 +148,12 @@ abstract class arOaiPluginComponent extends sfComponent
     return file_exists(QubitInformationObjectXmlCache::resourceExportFilePath($resource, $format, true));
   }
 
+  public static function checkDisplayCachedMetadata($resource, $metadataPrefix)
+  {
+    $xmlCachingEnabled = sfConfig::get('app_cache_xml_on_save', false);
+    return $xmlCachingEnabled && self::cachedMetadataExists($resource, $metadataPrefix);
+  }
+
   public static function includeCachedMetadata($resource, $metadataPrefix)
   {
     $format = self::parseXmlFormatFromMetadataPrefix($metadataPrefix);

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_getRecord.xml.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_getRecord.xml.php
@@ -10,7 +10,7 @@
           <setSpec><?php echo $record->getCollectionRoot()->getOaiIdentifier()?></setSpec>
         </header>
         <metadata>
-          <?php if ($metadataPrefix == 'oai_dc' && !arOaiPluginComponent::cachedMetadataExists($record, $metadataPrefix)): ?>
+          <?php if ($metadataPrefix == 'oai_dc' && !arOaiPluginComponent::checkDisplayCachedMetadata($record, $metadataPrefix)): ?>
             <?php echo get_component('sfDcPlugin', 'dc', array('resource' => $record)) ?>
           <?php else: ?>
             <?php arOaiPluginComponent::includeCachedMetadata($record, $metadataPrefix) ?>

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_listRecords.xml.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_listRecords.xml.php
@@ -11,7 +11,7 @@
           <setSpec><?php echo $record->getCollectionRoot()->getOaiIdentifier()?></setSpec>
         </header>
         <metadata>
-          <?php if ($metadataPrefix == 'oai_dc' && !arOaiPluginComponent::cachedMetadataExists($record, $metadataPrefix)): ?>
+          <?php if ($metadataPrefix == 'oai_dc' && !arOaiPluginComponent::checkDisplayCachedMetadata($record, $metadataPrefix)): ?>
             <?php echo get_component('sfDcPlugin', 'dc', array('resource' => $record)) ?>
           <?php else: ?>
             <?php arOaiPluginComponent::includeCachedMetadata($record, $metadataPrefix) ?>


### PR DESCRIPTION
Added check to see if XML caching is enabled before showing cached results.