### PR TITLE
Delete finding aid when IO's deleted, refs #10059

### DIFF
--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -372,6 +372,12 @@ class QubitInformationObject extends BaseInformationObject
     // Delete any keymap entries
     $this->removeKeymapEntries();
 
+    // Delete finding aid
+    if (null !== $path = arFindingAidJob::getFindingAidPathForDownload($this->id))
+    {
+      unlink($path);
+    }
+
     QubitSearch::getInstance()->delete($this);
 
     parent::delete($connection);


### PR DESCRIPTION
Added logic to, when an information object is deleted, delete any finding aids
generated or uploaded for it.