### PR TITLE
Login/logout/profile display labels, refs #12167

### DIFF
--- a/apps/qubit/modules/menu/actions/userMenuComponent.class.php
+++ b/apps/qubit/modules/menu/actions/userMenuComponent.class.php
@@ -48,5 +48,9 @@ class MenuUserMenuComponent extends sfComponent
         25,
         urlencode(public_path('/images/gravatar-anonymous.png', false)));
     }
+
+    $this->logInMenu = QubitMenu::getByName('login');
+    $this->logOutMenu = QubitMenu::getByName('logout');
+    $this->profileMenu = QubitMenu::getByName('myProfile');
   }
 }

--- a/apps/qubit/modules/menu/templates/_userMenu.php
+++ b/apps/qubit/modules/menu/templates/_userMenu.php
@@ -3,7 +3,7 @@
   <div id="user-menu">
 
     <?php if ($sf_user->isAuthenticated() || check_field_visibility('app_element_visibility_global_login_button')): ?>
-    <button class="top-item top-dropdown" data-toggle="dropdown" data-target="#" aria-expanded="false"><?php echo __('Log in') ?></button>
+    <button class="top-item top-dropdown" data-toggle="dropdown" data-target="#" aria-expanded="false"><?php echo $logInMenu->getLabel(array('cultureFallback' => true)) ?></button>
     <?php endif; ?>
 
     <div class="top-dropdown-container">
@@ -26,7 +26,7 @@
 
           <?php echo $form->password->renderRow(array('autocomplete' => 'off')) ?>
 
-          <button type="submit"><?php echo __('Log in') ?></button>
+          <button type="submit"><?php echo $logInMenu->getLabel(array('cultureFallback' => true)) ?></button>
 
         </form>
 
@@ -60,8 +60,8 @@
       <div class="top-dropdown-body">
 
         <ul>
-          <li><?php echo link_to(__('Profile'), array($sf_user->user, 'module' => 'user')) ?></li>
-          <li><?php echo link_to(__('Log out'), array('module' => 'user', 'action' => 'logout')) ?></li>
+          <li><?php echo link_to($profileMenu->getLabel(array('cultureFallback' => true)), array($sf_user->user, 'module' => 'user')) ?></li>
+          <li><?php echo link_to($logOutMenu->getLabel(array('cultureFallback' => true)), array('module' => 'user', 'action' => 'logout')) ?></li>
         </ul>
 
       </div>


### PR DESCRIPTION
Got rid of hardcoded text for "Log in", "Log out", and "Profile" and replaced
with display labels.