### PR TITLE
Populate search index using slug, refs #9250

### DIFF
--- a/lib/task/search/arPopulateTask.class.php
+++ b/lib/task/search/arPopulateTask.class.php
@@ -30,6 +30,8 @@ class arSearchPopulateTask extends sfBaseTask
     $this->addOptions(array(
       new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', 'qubit'),
       new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
+      new sfCommandOption('slug', null, sfCommandOption::PARAMETER_OPTIONAL, 'Slug of resource to index (ignoring exclude-types option).'),
+      new sfCommandOption('ignore-descendants', null, sfCommandOption::PARAMETER_NONE, "Don't index resource's descendants (applies to --slug option only)."),
       new sfCommandOption('exclude-types', null, sfCommandOption::PARAMETER_OPTIONAL, 'Exclude document type(s) (command-separated) from indexing'),
       new sfCommandOption('show-types', null, sfCommandOption::PARAMETER_NONE, 'Show available document type(s), that can be excluded, before indexing')));
 
@@ -63,9 +65,18 @@ EOF;
 
     new sfDatabaseManager($this->configuration);
 
-    $excludeTypes = (!empty($options['exclude-types'])) ? explode(',', strtolower($options['exclude-types'])) : null;
+    // Index by slug, if specified, or all indexable resources except those with an excluded type
+    if ($options['slug'])
+    {
+      $logMessage = (false !== $this->attemptIndexBySlug($options)) ? 'Slug indexed.' : 'Slug not found.';
+      $this->log($logMessage);
+    }
+    else
+    {
+      $excludeTypes = (!empty($options['exclude-types'])) ? explode(',', strtolower($options['exclude-types'])) : null;
 
-    QubitSearch::getInstance()->populate($excludeTypes);
+      QubitSearch::getInstance()->populate($excludeTypes);
+    }
   }
 
   private function availableDocumentTypes()
@@ -73,5 +84,25 @@ EOF;
     $types = array_keys(QubitSearch::getInstance()->loadMappings()->asArray());
     sort($types);
     return $types;
+  }
+
+  private function attemptIndexBySlug($options)
+  {
+    // Abort if resource doesn't exist for the provided slug
+    if (null == $resource = QubitObject::getBySlug($options['slug']))
+    {
+      return false;
+    }
+
+    // For information objects, allow optional skipping of descendants
+    if ($resource instanceOf QubitInformationObject)
+    {
+      $options = array('updateDescendants' => !$options['ignore-descendants']);
+      QubitSearch::getInstance()->update($resource, $options);
+    }
+    else
+    {
+      QubitSearch::getInstance()->update($resource);
+    }
   }
 }


### PR DESCRIPTION
Added --slug and --ignore-descendants options to search:populate task to allow
CLI users to index individual resources if need be.