### PR TITLE
Don't append to existing CSV export, refs #8387

### DIFF
--- a/lib/flatfile/QubitFlatfileExport.class.php
+++ b/lib/flatfile/QubitFlatfileExport.class.php
@@ -394,6 +394,12 @@ class QubitFlatfileExport
     else
     {
       $filePath = $this->path;
+
+      // Replace file if it already exists, yet we haven't exported any rows
+      if (file_exists($filePath) && !$this->rowsExported)
+      {
+        unlink($filePath);
+      }
     }
 
     // If file doesn't yet exist, write headers


### PR DESCRIPTION
Replace CSV export file if it already exists, yet the export writer hasn't
exported any rows.

This fixes unexpected CSV export writer behavior where, if an export with the
same filename already exists before the writer has exported anything, the
writer will append to it rather than replace it.