### PR TITLE
Re-implemented menu locking to fix issue, refs #11186

### DIFF
--- a/apps/qubit/modules/menu/actions/editAction.class.php
+++ b/apps/qubit/modules/menu/actions/editAction.class.php
@@ -39,6 +39,18 @@ class MenuEditAction extends sfAction
     switch ($name)
     {
       case 'name':
+        // Don't allow locked menus to be renamed
+        if ($this->menu->isProtected())
+        {
+          break;
+        }
+
+        $this->form->setDefault($name, $this->menu[$name]);
+        $this->form->setValidator($name, new QubitValidatorMenuName(array('required' => true, 'resource' => $this->menu)));
+        $this->form->setWidget($name, new sfWidgetFormInput);
+
+        break;
+
       case 'path':
         $this->form->setDefault($name, $this->menu[$name]);
         $this->form->setValidator($name, new sfValidatorString(array('required' => true)));
@@ -98,11 +110,13 @@ class MenuEditAction extends sfAction
         break;
 
       default:
-        // Don't allow non-renameable menus to be renamed
-        if ($name != 'name' || $this->menu->renameable)
+        // Don't allow locked menus to be renamed
+        if ($name == 'name' && $this->menu->isProtected())
         {
-          $this->menu[$field->getName()] = $this->form->getValue($field->getName());
+          break;
         }
+
+        $this->menu[$field->getName()] = $this->form->getValue($field->getName());
     }
   }
 

--- a/apps/qubit/modules/menu/templates/editSuccess.php
+++ b/apps/qubit/modules/menu/templates/editSuccess.php
@@ -31,7 +31,7 @@
           <?php echo __('Main area') ?>
         </legend>
 
-        <?php if ($menu->renameable): ?>
+        <?php if (!$menu->isProtected()): ?>
           <div class="form-item">
             <?php echo $form->name
               ->help(__('Provide an internal menu name.  This is not visible to users.'))

--- a/config/schema.yml
+++ b/config/schema.yml
@@ -202,8 +202,6 @@ propel:
     parent_id: { type: integer, foreignTable: menu, foreignReference: id, onDelete: cascade }
     name: varchar(255)
     path: varchar(255)
-    renameable: { type: boolean, default: true }
-    deleteable: { type: boolean, default: true }
     lft: { type: integer, required: true, nestedSetLeftKey: true }
     rgt: { type: integer, required: true, nestedSetRightKey: true }
     created_at:

--- a/data/fixtures/menus.yml
+++ b/data/fixtures/menus.yml
@@ -1,22 +1,16 @@
 QubitMenu:
   QubitMenu_root:
     id: 1
-    renameable: false
-    deleteable: false
   QubitMenu_mainmenu:
     id: 2
     parent_id: QubitMenu_root
     source_culture: en
     name: mainMenu
-    renameable: false
-    deleteable: false
   QubitMenu_quicklinks:
     id: 3
     parent_id: QubitMenu_root
     source_culture: en
     name: quickLinks
-    renameable: false
-    deleteable: false
   QubitMenu_browse:
     id: 4
     parent_id: QubitMenu_root
@@ -56,8 +50,6 @@ QubitMenu:
     parent_id: QubitMenu_mainmenu
     source_culture: en
     name: add
-    renameable: false
-    deleteable: false
     label:
       ca: Afegeix
       ca@valencia: Agregar
@@ -390,8 +382,6 @@ QubitMenu:
     parent_id: QubitMenu_mainmenu
     source_culture: en
     name: admin
-    renameable: false
-    deleteable: false
     label:
       ca: Administrador
       ca@valencia: Administrador
@@ -1504,8 +1494,6 @@ QubitMenu:
     parent_id: QubitMenu_quicklinks
     source_culture: en
     name: myProfile
-    renameable: false
-    deleteable: false
     label:
       ca: 'El meu perfil'
       ca@valencia: 'El meu perfil'

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -1201,3 +1201,10 @@ QubitSetting:
     source_culture: en
     value:
       en: 0
+  Qubit_Settings_menu_locking_info:
+    name: menu_locking_info
+    editable: 0
+    deleteable: 0
+    source_culture: en
+    value:
+      en: 'a:2:{s:6:"byName";a:18:{i:0;s:10:"accessions";i:1;s:20:"browseDigitalObjects";i:2;s:17:"browseInstitution";i:3;s:14:"browseSubjects";i:4;s:9:"clipboard";i:5;s:13:"globalReplace";i:6;s:6:"groups";i:7;s:10:"importSkos";i:8;s:4:"jobs";i:9;s:5:"login";i:10;s:6:"logout";i:11;s:9:"myProfile";i:12;s:7:"plugins";i:13;s:7:"privacy";i:14;s:8:"settings";i:15;s:15:"staticPagesMenu";i:16;s:10:"taxonomies";i:17;s:5:"users";}s:4:"byId";a:8:{i:0;i:1;i:1;i:4;i:2;i:7;i:3;i:2;i:4;i:10;i:5;i:3;i:6;i:5;i:7;i:9;}}'

--- a/data/sql/lib.model.schema.sql
+++ b/data/sql/lib.model.schema.sql
@@ -617,8 +617,6 @@ CREATE TABLE `menu`
 	`parent_id` INTEGER,
 	`name` VARCHAR(255),
 	`path` VARCHAR(255),
-	`renameable` TINYINT default 1,
-	`deleteable` TINYINT default 1,
 	`lft` INTEGER  NOT NULL,
 	`rgt` INTEGER  NOT NULL,
 	`created_at` DATETIME  NOT NULL,

--- a/lib/model/QubitMenu.php
+++ b/lib/model/QubitMenu.php
@@ -121,7 +121,22 @@ class QubitMenu extends BaseMenu
    */
   public function isProtected()
   {
-    return !$this->deleteable;
+    if (!isset($this->id))
+    {
+      return false;
+    }
+
+    $lockInfo = unserialize(sfConfig::get('app_menu_locking_info', array()));
+
+    // If lock info isn't empty and the menu's ID or name indicates it should be locked, then lock it
+    if (count($lockInfo) && (in_array($this->id, $lockInfo['byId']) || in_array($this->name, $lockInfo['byName'])))
+    {
+      return true;
+    }
+    else
+    {
+      return false;
+    }
   }
 
   /**

--- a/lib/model/map/MenuTableMap.php
+++ b/lib/model/map/MenuTableMap.php
@@ -39,8 +39,6 @@ class MenuTableMap extends TableMap {
 		$this->addForeignKey('PARENT_ID', 'parentId', 'INTEGER', 'menu', 'ID', false, null, null);
 		$this->addColumn('NAME', 'name', 'VARCHAR', false, 255, null);
 		$this->addColumn('PATH', 'path', 'VARCHAR', false, 255, null);
-		$this->addColumn('RENAMEABLE', 'renameable', 'BOOLEAN', false, null, true);
-		$this->addColumn('DELETEABLE', 'deleteable', 'BOOLEAN', false, null, true);
 		$this->addColumn('LFT', 'lft', 'INTEGER', true, null, null);
 		$this->addColumn('RGT', 'rgt', 'INTEGER', true, null, null);
 		$this->addColumn('CREATED_AT', 'createdAt', 'TIMESTAMP', true, null, null);

--- a/lib/model/om/BaseMenu.php
+++ b/lib/model/om/BaseMenu.php
@@ -10,8 +10,6 @@ abstract class BaseMenu implements ArrayAccess
     PARENT_ID = 'menu.PARENT_ID',
     NAME = 'menu.NAME',
     PATH = 'menu.PATH',
-    RENAMEABLE = 'menu.RENAMEABLE',
-    DELETEABLE = 'menu.DELETEABLE',
     LFT = 'menu.LFT',
     RGT = 'menu.RGT',
     CREATED_AT = 'menu.CREATED_AT',
@@ -25,8 +23,6 @@ abstract class BaseMenu implements ArrayAccess
     $criteria->addSelectColumn(QubitMenu::PARENT_ID);
     $criteria->addSelectColumn(QubitMenu::NAME);
     $criteria->addSelectColumn(QubitMenu::PATH);
-    $criteria->addSelectColumn(QubitMenu::RENAMEABLE);
-    $criteria->addSelectColumn(QubitMenu::DELETEABLE);
     $criteria->addSelectColumn(QubitMenu::LFT);
     $criteria->addSelectColumn(QubitMenu::RGT);
     $criteria->addSelectColumn(QubitMenu::CREATED_AT);
@@ -48,7 +44,7 @@ abstract class BaseMenu implements ArrayAccess
   public static function getFromRow(array $row)
   {
     $keys = array();
-    $keys['id'] = $row[10];
+    $keys['id'] = $row[8];
 
     $key = serialize($keys);
     if (!isset(self::$menus[$key]))

--- a/lib/validator/QubitValidatorMenuName.class.php
+++ b/lib/validator/QubitValidatorMenuName.class.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class QubitValidatorMenuName extends sfValidatorBase
+{
+  protected function configure($options = array(), $messages = array())
+  {
+    parent::configure($options, $messages);
+
+    $this->addRequiredOption('resource');
+  }
+
+  protected function doClean($value)
+  {
+    // Before allowing use of proposed identifier, make sure it's available for use
+    if (self::nameCanBeUsed($value, $this->getOption('resource')))
+    {
+      return $value;
+    }
+
+    throw new sfValidatorError($this, sfContext::getInstance()->i18n->__('This name is already in use.'), array('value' => $value));
+  }
+
+  public static function nameCanBeUsed($name, $menu = null)
+  {
+    // Only do this check for new menu items or menu items that can be renamed
+    if ($menu->isProtected())
+    {
+      return true;
+    }
+
+    $criteria = new Criteria;
+    $criteria->add(QubitMenu::NAME, $name);
+
+    // Name is valid if it isn't yet used or if it's used by the menu item being edited
+    $nameIsValid = (null === $foundMenu = QubitMenu::getOne($criteria)) || ($menu->id == $foundMenu->id);
+
+    return $nameIsValid;
+  }
+}


### PR DESCRIPTION
Implemented menu locking, preventing renaming and deletion, differerently to
avoid migration-related complications related to adding a column to the
QubitMenu model.