### PR TITLE
Add results column to genre taxonomy, refs #12332

### DIFF
--- a/apps/qubit/modules/taxonomy/actions/indexAction.class.php
+++ b/apps/qubit/modules/taxonomy/actions/indexAction.class.php
@@ -135,6 +135,11 @@ class TaxonomyIndexAction extends sfAction
         $this->addResultsColumn = true;
 
         break;
+
+      case QubitTaxonomy::GENRE_ID:
+        $this->addResultsColumn = true;
+
+        break;
     }
 
     $culture = $this->context->user->getCulture();


### PR DESCRIPTION
The page for browsing genre terms didn't, unlike the subject and place access
point browse pages, have a results column. Added.