### PR TITLE
Digital object file delete check, refs #11449

### DIFF
--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -1248,7 +1248,16 @@ class QubitDigitalObject extends BaseDigitalObject
       // Delete digital asset
       if (file_exists($this->getAbsolutePath()))
       {
-        unlink($this->getAbsolutePath());
+        // Check, before deleting file, to make sure it's not also used by
+        // another digital object
+        $criteria = new Criteria;
+        $criteria->add(QubitDigitalObject::PATH, $this->path);
+        $criteria->add(QubitDigitalObject::NAME, $this->name);
+
+        if (count(QubitDigitalObject::get($criteria)) <= 1)
+        {
+          unlink($this->getAbsolutePath());
+        }
       }
 
       // Prune asset directory, if empty


### PR DESCRIPTION
Added check to make sure, before deleting a digital object file asset, that
the same file isn't also used by another digital object.