### PR TITLE
Allow empty paths in top-level menus, refs #8406

### DIFF
--- a/apps/qubit/modules/menu/actions/editAction.class.php
+++ b/apps/qubit/modules/menu/actions/editAction.class.php
@@ -53,7 +53,8 @@ class MenuEditAction extends sfAction
 
       case 'path':
         $this->form->setDefault($name, $this->menu[$name]);
-        $this->form->setValidator($name, new sfValidatorString(array('required' => true)));
+        $pathRequired = ($this->menu->parentId == QubitMenu::ROOT_ID) ? false : true;
+        $this->form->setValidator($name, new sfValidatorString(array('required' => $pathRequired)));
         $this->form->setWidget($name, new sfWidgetFormInput);
 
         break;


### PR DESCRIPTION
By default, our top-level menu nodes have the path field empty. If the user
tries to edit a menu node, e.g. change the label of the staticPagesMenu node,
the form won't validate unless the user introduces a path. A workaround is to
type in a slash (/), but the validator should be tweaked in order to allow
empty values for top-level nodes.