### PR TITLE
Allow date calc job to create events, refs #12082

### DIFF
--- a/apps/qubit/modules/informationobject/templates/_calculateDatesLink.php
+++ b/apps/qubit/modules/informationobject/templates/_calculateDatesLink.php
@@ -1,4 +1,4 @@
-<?php if (QubitAcl::check($resource, 'update') && count($resource->descendants) && count($events)): ?>
+<?php if (QubitAcl::check($resource, 'update') && count($resource->descendants)): ?>
   <li class="separator"><h4><?php echo __('Tasks') ?></h4></li>
 
   <li>

--- a/apps/qubit/modules/informationobject/templates/calculateDatesSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/calculateDatesSuccess.php
@@ -19,7 +19,11 @@
       <fieldset class="collapsible">
         <div class="fieldset-wrapper">
 
-          <?php echo $form->eventId->renderRow() ?>
+          <?php if (count($events)): ?>
+            <?php echo $form->eventId->renderRow() ?>
+          <?php else: ?>
+            <?php echo $form->eventTypeId->renderRow() ?>
+          <?php endif; ?>
 
           <h6>
             <?php echo __('Note: While the date range update is running, the selected description should not be edited.') ?>


### PR DESCRIPTION
Added support, in the UI and date calculation job, for a new job parameter,
event type ID, that allows an information object with no events to have one
created for it (rather than replacing date data in an existing event).