### PR TITLE
Pass user to CSV import and sign in, refs #12083

### DIFF
--- a/lib/QubitCsvImport.class.php
+++ b/lib/QubitCsvImport.class.php
@@ -98,6 +98,9 @@ class QubitCsvImport
     // Figure out whether indexing flag should be added to command.
     $commandIndexFlag = ($taskClassName != 'csv:event-import' && $this->indexDuringImport) ? '--index' : '';
 
+    // Figure out whether user option should be added to command
+    $commandUser = ($taskClassName == 'csv:import') ? sprintf('--user-id="%s"', sfContext::getInstance()->getUser()->getUserId()) : '';
+
     if ('' !== $this->updateType)
     {
       switch ($this->updateType)
@@ -123,7 +126,7 @@ class QubitCsvImport
     if (isset($this->parent))
     {
       // Example: php symfony csv:import --default-parent-slug="$sourceName" /tmp/foobar
-      $command = sprintf('php %s %s %s %s %s %s %s --quiet --source-name=%s --default-parent-slug=%s %s',
+      $command = sprintf('php %s %s %s %s %s %s %s --quiet --source-name=%s %s --default-parent-slug=%s %s',
         escapeshellarg(sfConfig::get('sf_root_dir').DIRECTORY_SEPARATOR.'symfony'),
         escapeshellarg($taskClassName),
         $commandIndexFlag,
@@ -131,6 +134,7 @@ class QubitCsvImport
         $commandUpdate,
         $commandSkipUnmatched,
         $commandSkipMatched,
+        $commandUser,
         escapeshellarg($csvOrigFileName),
         escapeshellarg($this->parent->slug),
         escapeshellarg($transformedFile ? $transformedFile : $csvFile));
@@ -138,7 +142,7 @@ class QubitCsvImport
     else
     {
       // Example: php symfony csv:import /tmp/foobar
-      $command = sprintf('php %s %s %s %s %s %s %s --quiet --source-name=%s %s',
+      $command = sprintf('php %s %s %s %s %s %s %s --quiet %s --source-name=%s %s',
         escapeshellarg(sfConfig::get('sf_root_dir').DIRECTORY_SEPARATOR.'symfony'),
         escapeshellarg($taskClassName),
         $commandIndexFlag,
@@ -146,6 +150,7 @@ class QubitCsvImport
         $commandUpdate,
         $commandSkipUnmatched,
         $commandSkipMatched,
+        $commandUser,
         escapeshellarg($csvOrigFileName),
         escapeshellarg($transformedFile ? $transformedFile : $csvFile));
     }

--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -103,6 +103,13 @@ EOF;
         'Limit --update matching to under a specified top level description or repository via slug.'
       ),
       new sfCommandOption(
+        'user-id',
+        null,
+        sfCommandOption::PARAMETER_OPTIONAL,
+        'User ID to run import as',
+        null
+      ),
+      new sfCommandOption(
         'keep-digital-objects',
         null,
         sfCommandOption::PARAMETER_NONE,
@@ -144,6 +151,11 @@ EOF;
       throw new sfException('You must specify a valid filename');
     }
 
+    if (!empty($options['user-id']) && (null !== $user = QubitUser::getById($options['user-id'])))
+    {
+      $this->context->getUser()->signIn($user);
+    }
+
     $skipRows = $options['skip-rows'] ?: 0;
     $sourceName = $options['source-name'] ?: basename($arguments['filename']);
     $defaultStatusId = sfConfig::get('app_defaultPubStatus', QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID);
@@ -165,7 +177,7 @@ EOF;
     // Define import
     $import = new QubitFlatfileImport(array(
       // Pass context
-      'context' => sfContext::createInstance($this->configuration),
+      'context' => $this->context,
 
       // What type of object are we importing?
       'className' => 'QubitInformationObject',


### PR DESCRIPTION
Fixed issue where, when doing a CSV import from the web UI, via an asynchronous
job, information object audit logging wasn't noting the user that created the
job.

Added --user-id option to task for CSV import of information objects, and corresponding logic, to sign the user in before import.

Added, to QubitCsvImport, the relaying of the current logged-in user to to the import task as a CLI option (if information objects are being imported).
