### PR TITLE
Clear libxml errors between imports, refs #12370

### DIFF
--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -747,7 +747,8 @@ class QubitXmlImport
   protected function loadXML($xmlFile, $options = array())
   {
     libxml_use_internal_errors(true);
-
+    libxml_clear_errors();
+    
     // FIXME: trap possible load validation errors (just suppress for now)
     $err_level = error_reporting(0);
     $doc = new DOMDocument('1.0', 'UTF-8');


### PR DESCRIPTION
When an XML import job is run, either from the WebUI or from the shell via 'php symfony import:bulk', libxml errors buffer was not cleared between executions (WebUI) or files (shell).

This commit attempts to fix the problem by calling libxml_clear_errors() before loading an XML document, therefore, previous libxml errors are not carried into the error log of the new import.