### PR TITLE
Improve date calculation, refs #12082

### DIFF
--- a/apps/qubit/modules/informationobject/actions/calculateDatesLinkComponent.class.php
+++ b/apps/qubit/modules/informationobject/actions/calculateDatesLinkComponent.class.php
@@ -24,7 +24,7 @@ class InformationObjectCalculateDatesLinkComponent extends sfComponent
     $i18n = $this->context->i18n;
 
     // Get events for the information object
-    $this->events = InformationObjectCalculateDatesAction::getResourceEventsWithDateRangeSet($this->resource);
+    $this->descendantEventTypes = InformationObjectCalculateDatesAction::getDescendantDateTypes($this->resource);
 
     // Determine when, or if, the date calculation job was last run
     $criteria = new Criteria;

--- a/apps/qubit/modules/informationobject/templates/_calculateDatesLink.php
+++ b/apps/qubit/modules/informationobject/templates/_calculateDatesLink.php
@@ -1,4 +1,4 @@
-<?php if (QubitAcl::check($resource, 'update') && count($resource->descendants)): ?>
+<?php if (QubitAcl::check($resource, 'update') && count($descendantEventTypes)): ?>
   <li class="separator"><h4><?php echo __('Tasks') ?></h4></li>
 
   <li>

--- a/apps/qubit/modules/informationobject/templates/calculateDatesSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/calculateDatesSuccess.php
@@ -20,8 +20,12 @@
         <div class="fieldset-wrapper">
 
           <?php if (count($events)): ?>
+            <p>Please select either an event or an event type:</p>
+
             <?php echo $form->eventId->renderRow() ?>
-          <?php else: ?>
+          <?php endif; ?>
+
+          <?php if (count($eventTypes)): ?>
             <?php echo $form->eventTypeId->renderRow() ?>
           <?php endif; ?>
 


### PR DESCRIPTION
* Added logic so event types are derived from the types present in descendant
  information object's events

* Removed automatic selection of single events (so their dates can be replaced)
  given there is now an option to add a new event with dates calculated from
  descendant dates

* Changed logic determining whether a date calculation link should be shown so
  it's not shown if no events exist in descendent events