### PR TITLE
CLI SKOS plugin activation issue, refs #12364

### DIFF
--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -1344,6 +1344,8 @@ class QubitXmlImport
 
     $includes = array(
       '/plugins/sfSkosPlugin/lib/sfSkosPlugin.class.php',
+      '/plugins/sfSkosPlugin/lib/sfSkosPluginException.class.php',
+      '/plugins/sfSkosPlugin/lib/sfSkosUniqueRelations.class.php',
     );
 
     foreach ($includes as $include)


### PR DESCRIPTION
If the SKOS plugin is turned off, and a purge is performed from the
CLI, importing SKOS files from the CLI import:bulk task will fail.

Errors have to do with the SKOS plugin class sfSkosUniqueRelations
not being available.

This change manually loads the classes req so the CLI task will not
fail. The SKOS plugin activation setting is respected.