### PR TITLE
Prevent UI access to lock taxonomies, refs #12421

### DIFF
--- a/apps/qubit/modules/taxonomy/actions/indexAction.class.php
+++ b/apps/qubit/modules/taxonomy/actions/indexAction.class.php
@@ -38,6 +38,13 @@ class TaxonomyIndexAction extends sfAction
       $this->resource = $this->getRoute()->resource;
     }
 
+    // Disallow access to locked taxonomies
+    if (in_array($this->resource->id, QubitTaxonomy::$lockedTaxonomies))
+    {
+      $this->getResponse()->setStatusCode(403);
+      return sfView::NONE;
+    }
+
     if (!$this->resource instanceof QubitTaxonomy)
     {
       $this->redirect(array('module' => 'taxonomy', 'action' => 'list'));

--- a/apps/qubit/modules/term/actions/indexAction.class.php
+++ b/apps/qubit/modules/term/actions/indexAction.class.php
@@ -99,6 +99,13 @@ class TermIndexAction extends DefaultBrowseAction
       $this->forward404();
     }
 
+    // Disallow access to locked taxonomies
+    if (in_array($this->resource->taxonomyId, QubitTaxonomy::$lockedTaxonomies))
+    {
+      $this->getResponse()->setStatusCode(403);
+      return sfView::NONE;
+    }
+
     if (sfConfig::get('app_enable_institutional_scoping'))
     {
       // Remove search-realm


### PR DESCRIPTION
Prevent users from viewing the index pages for locked taxonomies and terms
within them.