### PR TITLE
Fix permission settings form, refs 12434

### DIFF
--- a/apps/qubit/modules/settings/actions/permissionsAction.class.php
+++ b/apps/qubit/modules/settings/actions/permissionsAction.class.php
@@ -91,6 +91,12 @@ class SettingsPermissionsAction extends sfAction
         foreach ($values as $key => $value)
         {
           $setting = QubitSetting::getByNameAndScope($key, 'access_statement');
+          if (null === $setting)
+          {
+            $setting = new QubitSetting;
+            $setting->name = $key;
+            $setting->scope = 'access_statement';
+          }
           $setting->setValue($value);
           $setting->save();
         }


### PR DESCRIPTION
Create `access_statement` settings for new Rights Basis terms when
they are don't exists before setting their value.