### PR TITLE
Reuse upload handling in D.O. upload, refs #10438

### DIFF
--- a/apps/qubit/modules/informationobject/actions/multiFileUploadAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/multiFileUploadAction.class.php
@@ -87,8 +87,6 @@ class InformationObjectMultiFileUploadAction extends sfAction
   public function processForm()
   {
     $tmpPath = sfConfig::get('sf_upload_dir').'/tmp';
-    // Original file in PHP temp dir.
-    $phpTmpPath = sys_get_temp_dir();
 
     // Upload files
     $i = 0;
@@ -122,13 +120,13 @@ class InformationObjectMultiFileUploadAction extends sfAction
       // Save description
       $informationObject->save();
 
-      if (file_exists("$phpTmpPath/$file[tmpName]"))
+      if (file_exists("$tmpPath/$file[tmpName]"))
       {
         // Upload asset and create digital object
         $digitalObject = new QubitDigitalObject;
         $digitalObject->informationObject = $informationObject;
         $digitalObject->usageId = QubitTerm::MASTER_ID;
-        $digitalObject->assets[] = new QubitAsset($file['name'], file_get_contents("$phpTmpPath/$file[tmpName]"));
+        $digitalObject->assets[] = new QubitAsset($file['name'], file_get_contents("$tmpPath/$file[tmpName]"));
 
         $digitalObject->save();
       }
@@ -136,9 +134,9 @@ class InformationObjectMultiFileUploadAction extends sfAction
       $thumbnailIsGeneric = (bool) strstr($file['thumb'], 'generic-icons');
 
       // Clean up temp files
-      if (file_exists("$phpTmpPath/$file[tmpName]"))
+      if (file_exists("$tmpPath/$file[tmpName]"))
       {
-        unlink("$phpTmpPath/$file[tmpName]");
+        unlink("$tmpPath/$file[tmpName]");
       }
       if (!$thumbnailIsGeneric && file_exists("$tmpPath/$file[thumb]"))
       {

--- a/lib/Qubit.class.php
+++ b/lib/Qubit.class.php
@@ -368,12 +368,17 @@ class Qubit
     Qubit::createUploadDirsIfNeeded();
     $tmpDir = sfConfig::get('sf_upload_dir').'/tmp';
 
+    // Get file extension (or filename if no extension exists)
+    $extension = substr($file['name'], strrpos($file['name'], '.'));
+
     // Get a unique file name (to avoid clashing file names).
     do
     {
       $uniqueString = substr(md5(time().$file['name']), 0, 8);
       $tmpFileName = "TMP$uniqueString";
-      $tmpFilePath = "$tmpDir/$tmpFileName";
+
+      // Add temp filename, preserving extension (if any)
+      $tmpFilePath = "$tmpDir/$tmpFileName$extension";
     }
     while (file_exists($tmpFilePath));
 


### PR DESCRIPTION
The Qubit::moveUploadFile had functionality that the digital object
upload functionality wasn't reusing. Also added preservation of file
extensions to the moveUploadFile handler so the extensions can be used
to detect MIME types, etc.