### PR TITLE
Change digital object DB column type, refs #12488

### DIFF
--- a/config/schema.yml
+++ b/config/schema.yml
@@ -105,7 +105,7 @@ propel:
     name: { type: varchar(1024), required: true }
     path: { type: varchar(1024), required: true }
     sequence: integer
-    byte_size: integer
+    byte_size: bigint
     checksum: varchar(255)
     checksum_type: type: varchar(50)
     parent_id: { type: integer, foreignTable: digital_object, foreignReference: id }
@@ -282,7 +282,7 @@ propel:
     filename: varchar(1024)
     last_modified: timestamp
     date_ingested: bu_date
-    size: integer
+    size: bigint
     mime_type: varchar(255)
 
   property:

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 166
+    value: 167
   milestone:
     name: milestone
     editable: 0

--- a/data/sql/lib.model.schema.sql
+++ b/data/sql/lib.model.schema.sql
@@ -322,7 +322,7 @@ CREATE TABLE `digital_object`
 	`name` VARCHAR(1024)  NOT NULL,
 	`path` VARCHAR(1024)  NOT NULL,
 	`sequence` INTEGER,
-	`byte_size` INTEGER,
+	`byte_size` BIGINT,
 	`checksum` VARCHAR(255),
 	`checksum_type` VARCHAR(50),
 	`parent_id` INTEGER,
@@ -916,7 +916,7 @@ CREATE TABLE `premis_object`
 	`filename` VARCHAR(1024),
 	`last_modified` DATETIME,
 	`date_ingested` DATE,
-	`size` INTEGER,
+	`size` BIGINT,
 	`mime_type` VARCHAR(255),
 	PRIMARY KEY (`id`),
 	CONSTRAINT `premis_object_FK_1`

--- a/lib/model/map/DigitalObjectTableMap.php
+++ b/lib/model/map/DigitalObjectTableMap.php
@@ -44,7 +44,7 @@ class DigitalObjectTableMap extends TableMap {
 		$this->addColumn('NAME', 'name', 'VARCHAR', true, 1024, null);
 		$this->addColumn('PATH', 'path', 'VARCHAR', true, 1024, null);
 		$this->addColumn('SEQUENCE', 'sequence', 'INTEGER', false, null, null);
-		$this->addColumn('BYTE_SIZE', 'byteSize', 'INTEGER', false, null, null);
+		$this->addColumn('BYTE_SIZE', 'byteSize', 'BIGINT', false, null, null);
 		$this->addColumn('CHECKSUM', 'checksum', 'VARCHAR', false, 255, null);
 		$this->addColumn('CHECKSUM_TYPE', 'checksumType', 'VARCHAR', false, 50, null);
 		$this->addForeignKey('PARENT_ID', 'parentId', 'INTEGER', 'digital_object', 'ID', false, null, null);

--- a/lib/model/map/PremisObjectTableMap.php
+++ b/lib/model/map/PremisObjectTableMap.php
@@ -42,7 +42,7 @@ class PremisObjectTableMap extends TableMap {
 		$this->addColumn('FILENAME', 'filename', 'VARCHAR', false, 1024, null);
 		$this->addColumn('LAST_MODIFIED', 'lastModified', 'TIMESTAMP', false, null, null);
 		$this->addColumn('DATE_INGESTED', 'dateIngested', 'DATE', false, null, null);
-		$this->addColumn('SIZE', 'size', 'INTEGER', false, null, null);
+		$this->addColumn('SIZE', 'size', 'BIGINT', false, null, null);
 		$this->addColumn('MIME_TYPE', 'mimeType', 'VARCHAR', false, 255, null);
 		// validators
 	} // initialize()

--- a/lib/task/migrate/migrations/arMigration0167.class.php
+++ b/lib/task/migrate/migrations/arMigration0167.class.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Change digital and PREMIS object byte size columns to allow larger file sizes
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0167
+{
+  const
+    VERSION = 167, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  public function up($configuration)
+  {
+    // Change digital object table's byte_size column to BIGINT
+    $sql = "ALTER TABLE `digital_object` CHANGE `byte_size` `byte_size` BIGINT";
+    QubitPdo::modify($sql);
+
+    // Change premis_object table's size column to BIGINT
+    $sql = "ALTER TABLE `premis_object` CHANGE `size` `size` BIGINT";
+    QubitPdo::modify($sql);
+
+    return true;
+  }
+}


### PR DESCRIPTION
The MySQL database digital object table column for recording the size
of digital object files, in bytes, only allowed for a maximum of 2 GB.
Changed to a BIGINT column.