### PR TITLE
Improve identifier fields in ES, refs #9290

### DIFF
--- a/apps/qubit/modules/actor/actions/browseAction.class.php
+++ b/apps/qubit/modules/actor/actions/browseAction.class.php
@@ -128,7 +128,7 @@ class ActorBrowseAction extends DefaultBrowseAction
         break;
 
       case 'identifier':
-        $this->search->query->setSort(array('descriptionIdentifier' => $request->sortDir));
+        $this->search->query->setSort(array('descriptionIdentifier.untouched' => $request->sortDir));
 
         break;
 

--- a/apps/qubit/modules/informationobject/actions/autocompleteAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/autocompleteAction.class.php
@@ -40,7 +40,7 @@ class InformationObjectAutocompleteAction extends sfAction
     $this->query->setSize($request->limit);
     $this->query->setSort(array(
       'levelOfDescriptionId' => 'asc',
-      'identifier' => 'asc',
+      'identifier.untouched' => 'asc',
       'i18n.'.$culture.'.title.untouched' => 'asc'));
 
     $this->queryBool = new \Elastica\Query\BoolQuery;

--- a/apps/qubit/modules/informationobject/actions/browseAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/browseAction.class.php
@@ -543,7 +543,7 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
         break;
 
       case 'identifier':
-        $this->search->query->addSort(array('identifier' => $request->sortDir));
+        $this->search->query->addSort(array('identifier.untouched' => $request->sortDir));
 
         break;
 

--- a/apps/qubit/modules/informationobject/actions/inventoryAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/inventoryAction.class.php
@@ -115,7 +115,7 @@ class InformationObjectInventoryAction extends DefaultBrowseAction
     switch ($sort)
     {
       case 'identifierDown':
-        $query->setSort(array('identifier' => 'desc'));
+        $query->setSort(array('identifier.untouched' => 'desc'));
 
         break;
 
@@ -159,7 +159,7 @@ class InformationObjectInventoryAction extends DefaultBrowseAction
 
       case 'identifierUp':
       default:
-        $query->setSort(array('identifier' => 'asc'));
+        $query->setSort(array('identifier.untouched' => 'asc'));
     }
 
     QubitAclSearch::filterDrafts($queryBool);

--- a/apps/qubit/modules/repository/actions/browseAction.class.php
+++ b/apps/qubit/modules/repository/actions/browseAction.class.php
@@ -158,7 +158,7 @@ class RepositoryBrowseAction extends DefaultBrowseAction
         break;
 
       case 'identifier':
-        $this->search->query->addSort(array('identifier' => $request->sortDir));
+        $this->search->query->addSort(array('identifier.untouched' => $request->sortDir));
       case 'alphabetic':
         $this->search->query->addSort(array($i18n.'authorizedFormOfName.untouched' => $request->sortDir));
 

--- a/apps/qubit/modules/user/actions/clipboardAction.class.php
+++ b/apps/qubit/modules/user/actions/clipboardAction.class.php
@@ -127,7 +127,7 @@ class UserClipboardAction extends DefaultBrowseAction
         break;
 
       case 'identifier':
-        $this->search->query->addSort(array('identifier' => $request->sortDir));
+        $this->search->query->addSort(array('identifier.untouched' => $request->sortDir));
 
         break;
 

--- a/lib/job/arActorXmlExportJob.class.php
+++ b/lib/job/arActorXmlExportJob.class.php
@@ -19,7 +19,7 @@
 
 /**
  * A worker to, given the HTTP GET parameters sent to advanced search,
- * replicate the search and export the resulting decriptions to CSV.
+ * replicate the search and export the resulting descriptions to CSV.
  *
  * @package    symfony
  * @subpackage jobs

--- a/lib/job/arInformationObjectCsvExportJob.class.php
+++ b/lib/job/arInformationObjectCsvExportJob.class.php
@@ -19,7 +19,7 @@
 
 /**
  * A worker to, given the HTTP GET parameters sent to advanced search,
- * replicate the search and export the resulting decriptions to CSV.
+ * replicate the search and export the resulting descriptions to CSV.
  *
  * @package    symfony
  * @subpackage jobs

--- a/lib/job/arInformationObjectXmlExportJob.class.php
+++ b/lib/job/arInformationObjectXmlExportJob.class.php
@@ -19,7 +19,7 @@
 
 /**
  * A worker to, given the HTTP GET parameters sent to advanced search,
- * replicate the search and export the resulting decriptions to CSV.
+ * replicate the search and export the resulting descriptions to CSV.
  *
  * @package    symfony
  * @subpackage jobs

--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -342,7 +342,11 @@ mapping:
     dynamic: strict
     properties:
       slug: { type: keyword }
-      description_identifier: { type: keyword }
+      description_identifier:
+        type: text
+        fields:
+          untouched:
+            type: keyword
       corporate_body_identifiers: { type: keyword }
       entity_type_id: { type: integer, include_in_all: false }
       maintaining_repository_id: { type: integer, include_in_all: false }
@@ -356,7 +360,11 @@ mapping:
     dynamic: strict
     properties:
       slug: { type: keyword }
-      identifier: { type: keyword }
+      identifier:
+        type: text
+        fields:
+          untouched:
+            type: keyword
       date: { type: date, include_in_all: false }
 
   repository:
@@ -373,7 +381,11 @@ mapping:
     dynamic: strict
     properties:
       slug: { type: keyword }
-      identifier: { type: keyword }
+      identifier:
+        type: text
+        fields:
+          untouched:
+            type: keyword
       types: { type: integer, include_in_all: false }
       geographic_subregions: { type: integer, include_in_all: false }
       thematic_areas: { type: integer, include_in_all: false }
@@ -390,9 +402,13 @@ mapping:
     dynamic: strict
     properties:
       slug: { type: keyword }
-      decriptionStatusId: { type: integer }
-      decriptionDetailId: { type: integer }
-      decriptionIdentifier: { type: keyword }
+      description_status_id: { type: integer }
+      description_detail_id: { type: integer }
+      description_identifier:
+        type: text
+        fields:
+          untouched:
+            type: keyword
 
   information_object:
     _attributes:
@@ -453,7 +469,11 @@ mapping:
     dynamic: strict
     properties:
       slug: { type: keyword }
-      identifier: { type: keyword }
+      identifier:
+        type: text
+        fields:
+          untouched:
+            type: keyword
       reference_code_without_country_and_repo: { type: keyword }
       level_of_description_id: { type: integer }
       lft: { type: integer }
@@ -484,7 +504,7 @@ mapping:
         type: object
         properties:
           label: { type: text }
-          identifier: { type: keyword }
+          identifier: { type: text }
       reference_code:
         type: text
         fields:

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchFunctionPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchFunctionPdo.class.php
@@ -114,9 +114,9 @@ class arElasticSearchFunctionPdo
 
     $serialized['id'] = $this->id;
     $serialized['slug'] = $this->slug;
-    $serialized['decriptionStatusId'] = $this->description_status_id;
-    $serialized['decriptionDetailId'] = $this->description_detail_id;
-    $serialized['decriptionIdentifier'] = $this->description_identifier;
+    $serialized['descriptionStatusId'] = $this->description_status_id;
+    $serialized['descriptionDetailId'] = $this->description_detail_id;
+    $serialized['descriptionIdentifier'] = $this->description_identifier;
 
     $sql = 'SELECT id, source_culture FROM '.QubitOtherName::TABLE_NAME.' WHERE object_id = ? AND type_id = ?';
     foreach (QubitPdo::fetchAll($sql, array($this->id, QubitTerm::OTHER_FORM_OF_NAME_ID)) as $item)

--- a/plugins/qtAccessionPlugin/modules/accession/actions/browseAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/browseAction.class.php
@@ -94,6 +94,7 @@ class AccessionBrowseAction extends sfAction
     else
     {
       $queryString = new \Elastica\Query\QueryString(arElasticSearchPluginUtil::escapeTerm($request->subquery));
+      $queryString->setDefaultOperator('AND');
 
       $boost = array(
         'donors.i18n.%s.authorizedFormOfName' => 10,
@@ -135,7 +136,7 @@ class AccessionBrowseAction extends sfAction
     {
       case 'identifier': // For backward compatibility
       case 'accessionNumber':
-        $this->query->setSort(array('identifier' => $request->sortDir));
+        $this->query->setSort(array('identifier.untouched' => $request->sortDir));
 
         break;
 


### PR DESCRIPTION
- Use a text type field for identifiers to improve searches and add a
  keyword sub-field for sorting.
- Fix `description` fields in QubitFunction mapping.
- Use `AND` operator in Accessions string query.
- Fix typos.