### PR TITLE
Remove repos actor autocomplete, refs# 12322

### DIFF
--- a/apps/qubit/modules/actor/actions/autocompleteAction.class.php
+++ b/apps/qubit/modules/actor/actions/autocompleteAction.class.php
@@ -32,7 +32,7 @@ class ActorAutocompleteAction extends sfAction
     $criteria->addJoin(QubitActor::ID, QubitObject::ID);
 
     // Filter out non-authority Actors
-    $filteredObjects = array('QubitUser', 'QubitDonor', 'QubitRightsHolder');
+    $filteredObjects = array('QubitUser', 'QubitDonor', 'QubitRightsHolder', 'QubitRepository');
     $criteria->add(QubitObject::CLASS_NAME, $filteredObjects, Criteria::NOT_IN);
 
     // Sort alphabetically by name


### PR DESCRIPTION
Do not list repositories in the actor autocomplete. This was occurring
when adding creators to descriptions and when linking actors to one
another. Autocomplete was not filtering types of QubitRepository.