### PR TITLE
Fixed /private redirect in viewAction.class.php

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/viewAction.class.php
+++ b/apps/qubit/modules/digitalobject/actions/viewAction.class.php
@@ -125,7 +125,8 @@ class DigitalObjectViewAction extends sfAction
     // Using X-Accel-Redirect (Nginx) unless ATOM_XSENDFILE is set
     if (false === filter_var($_SERVER['ATOM_XSENDFILE'], FILTER_VALIDATE_BOOLEAN))
     {
-      $this->response->setHttpHeader('X-Accel-Redirect', '/private'.$this->resource->getFullPath());
+      $urlPath = preg_replace('\/?[^\/]+\.php$', '', $_SERVER['SCRIPT_NAME']);
+      $this->response->setHttpHeader('X-Accel-Redirect', $urlPath . '/private' . $this->resource->getFullPath());
     }
     else
     {


### PR DESCRIPTION
When AtoM is not installed in the default location, but is instead being served from a sub-directory of the root, it will have a URL like the following (rather the usual http://example.com/)

- http://example.com/path/to/atom/

In cases like this, when accessing an image/file in the "`uploads/r/`" folder however, the setResponseHeaders() method in viewAction.class.php will redirect to the absolute URL

- http://example.com/private/uploads/r/blah/blah/blah.jpg

instead of 

- http://example.com/path/to/atom/private/uploads/r/blah/blah/blah.jpg

That is, portion of the URL path leading to the location of the installed AtoM instance ("/path/to/atom") is lost.  This will result in a 404 error.

This commit fixes the issue with setResponseHeaders() and ensures the URL path portion is retained. At this point, `$_SERVER['SCRIPT_NAME']` will be `/path/to/atom/index.php`. The fix works by removing the trailing filename (`/index.php`) and using the remainder to construct the correct URL for the `/private` folder.