### PR TITLE
Fix clipboard clear page HTTP 500, refs #12619

### DIFF
--- a/apps/qubit/modules/user/actions/clipboardClearAction.class.php
+++ b/apps/qubit/modules/user/actions/clipboardClearAction.class.php
@@ -38,16 +38,23 @@ class UserClipboardClearAction extends sfAction
     }
 
     $allSlugs = $this->context->user->getClipboard()->getAllByClassName();
-    $slugs = $allSlugs[$this->type];
-    $this->typeLabel = $this->getTypeLabel();
+    $slugs = (isset($allSlugs[$this->type])) ? $allSlugs[$this->type] : array();
 
     // Redirect to clipboard page if the clipboard is empty
     if (count($slugs) == 0)
     {
+      if (empty($this->type))
+      {
+        $message = $this->context->i18n->__("No entity type specified.");
+        $this->context->getUser()->setFlash('error', $message);
+      }
+
       $this->redirect(array('module' => 'user', 'action' => 'clipboard'));
     }
 
-    // Get all descriptions added to the clipboard
+    // Determine label for type and get data about all entities added to the clipboard
+    $this->typeLabel = $this->getTypeLabel();
+
     $query = new \Elastica\Query;
     $queryTerms = new \Elastica\Query\Terms('slug', $slugs);
     $queryBool = new \Elastica\Query\BoolQuery;

--- a/apps/qubit/modules/user/templates/clipboardSuccess.php
+++ b/apps/qubit/modules/user/templates/clipboardSuccess.php
@@ -46,13 +46,13 @@
 
   <?php echo get_partial('default/pager', array('pager' => $pager)) ?>
 
-  <section class="actions">
-    <ul>
-      <li><?php echo link_to(__('Clear %1 clipboard', array('%1' => lcfirst($uiLabels[$type]))), array('module' => 'user', 'action' => 'clipboardClear', 'type' => $entityType), array('class' => 'c-btn c-btn-delete')) ?></li>
-      <?php if (isset($pager) && $pager->getNbResults()): ?>
+  <?php if (isset($pager) && $pager->getNbResults()): ?>
+    <section class="actions">
+      <ul>
+        <li><?php echo link_to(__('Clear %1 clipboard', array('%1' => lcfirst($uiLabels[$type]))), array('module' => 'user', 'action' => 'clipboardClear', 'type' => $entityType), array('class' => 'c-btn c-btn-delete')) ?></li>
         <li><?php echo link_to(__('Save'), array('module' => 'user', 'action' => 'clipboardSave'), array('class' => 'c-btn')) ?></li>
         <li><?php echo link_to(__('Export'), array('module' => 'object', 'action' => 'export', 'objectType' => $type), array('class' => 'c-btn')) ?></li>
-      <?php endif; ?>
-    </ul>
-  </section>
+      </ul>
+    </section>
+  <?php endif; ?>
 <?php end_slot() ?>


### PR DESCRIPTION
Prevent clipboard clearing page from being accessed without an entity
type specified, redirecting to the clipboard page and showing an
error notification.

Hide link to clipboard clearing page if the clipboard is empty for the
active entity type.