### PR TITLE
Fix site title escaping in OAI XML, refs #12622

### DIFF
--- a/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_identify.xml.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_identify.xml.php
@@ -1,5 +1,5 @@
   <Identify>
-    <repositoryName><?php echo $title ?></repositoryName>
+    <repositoryName><?php echo esc_specialchars($title) ?></repositoryName>
     <baseURL><?php echo QubitOai::getBaseUrl() ?></baseURL>
     <protocolVersion><?php echo $protocolVersion ?></protocolVersion>
     <?php foreach ($adminEmails as $email): ?>


### PR DESCRIPTION
The site title wasn't being escaped and caused errors if it contained
special characters.