### PR TITLE
Fix search box ampersand key handling, refs #11944

### DIFF
--- a/js/dominion.js
+++ b/js/dominion.js
@@ -507,8 +507,12 @@
             break;
 
           case 38: // Up arrow
-            e.preventDefault();
-            this.move(-1);
+            // If charCode is 38 then, in Chrome, it's an ampersand
+            if (e.charCode == 0)
+            {
+              e.preventDefault();
+              this.move(-1);
+            }
             break;
 
           case 40: // Down arrow


### PR DESCRIPTION
Fixed issue with Chrome interpreting a press of the ampersand key, in
the global search field, as a press of the up arrow key.