### PR TITLE
Show ElasticSearch config. in status, refs #12627

### DIFF
--- a/lib/task/search/arSearchStatusTask.class.php
+++ b/lib/task/search/arSearchStatusTask.class.php
@@ -45,9 +45,18 @@ EOF;
   {
     parent::execute($arguments, $options);
 
-    $this->log("Document indexing status:");
+    // Displaying Elasticsearch server configuration
+    $config = arElasticSearchPluginConfiguration::$config;
+
+    $this->log("Elasticsearch server information:");
+    $this->log(sprintf(" - Host: %s", $config['server']['host']));
+    $this->log(sprintf(" - port: %s", $config['server']['port']));
+    $this->log(sprintf(" - Index name: %s", $config['index']['name']));
+    $this->log();
 
     // Display how many objects are indexed versus how many are available
+    $this->log("Document indexing status:");
+
     foreach ($this->availableDocumentTypes() as $docType)
     {
       $docTypeDescription = sfInflector::humanize(sfInflector::underscore($docType));


### PR DESCRIPTION
Display ElasticSearch configuration information (host, port, and index
name) in the search:status task.