### PR TITLE
Accessions save deletes relations, refs #12662

### DIFF
--- a/plugins/qtAccessionPlugin/modules/accession/actions/editAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/editAction.class.php
@@ -330,6 +330,7 @@ class AccessionEditAction extends DefaultEditAction
           $relation = new QubitRelation;
           $relation->subject = $item;
           $relation->typeId = QubitTerm::ACCESSION_ID;
+          $relation->indexOnSave = false;
 
           $this->resource->relationsRelatedByobjectId[] = $relation;
         }

--- a/plugins/qtAccessionPlugin/modules/accession/actions/editAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/editAction.class.php
@@ -315,9 +315,9 @@ class AccessionEditAction extends DefaultEditAction
 
         foreach ($this->informationObjects as $item)
         {
-          if (isset($value[$item->objectId]))
+          if (isset($value[$item->subjectId]))
           {
-            unset($filtered[$item->objectId]);
+            unset($filtered[$item->subjectId]);
           }
           else
           {


### PR DESCRIPTION
All relations are being deleted and re-added every time a change to an
accession is saved regardless of which field is updated. This is causing
all related information objects to be reindexed when an accession is
saved - this can be quite slow if many descriptions are linked.

These lines should be comparing the relation "subjectId" and not
"objectId" - objectId contains the accession.id, subjectId contains the
info_obj.id.