### PR TITLE
Hide full treeview paging buttons, refs #12695

### DIFF
--- a/plugins/arDominionPlugin/css/less/buttons.less
+++ b/plugins/arDominionPlugin/css/less/buttons.less
@@ -267,3 +267,7 @@ a.clipboard-print {
   margin-top: 20px;
   margin-bottom: 10px;
 }
+
+#fullwidth-treeview-reset-button, #fullwidth-treeview-more-button {
+  display: none;
+}


### PR DESCRIPTION
Added CSS change to hide full treeview paging buttons when they're not
in use.