### PR TITLE
Optimize phys. object normalization, refs #12713

### DIFF
--- a/lib/task/physicalobject/physicalObjectDeleteUnlinkedTask.class.php
+++ b/lib/task/physicalobject/physicalObjectDeleteUnlinkedTask.class.php
@@ -156,7 +156,9 @@ EOF;
   {
     $toDelete = array();
 
-    foreach(QubitPhysicalObject::getAll() as $physicalObject)
+    $sql = "SELECT id FROM physical_object";
+
+    foreach (QubitPdo::fetchAll($sql) as $physicalObject)
     {
       // Get relations to physical object
       $relations = QubitRelation::getRelationsBySubjectId($physicalObject->id, array('typeId' => QubitTerm::HAS_PHYSICAL_OBJECT_ID));


### PR DESCRIPTION
Changed the physical object normalization task to use SQL rather than
the ORM. Also made similar optimization to the task for deleting
unlinked physical objects.