### PR TITLE
Accession task keymap records, refs #12739

### DIFF
--- a/lib/task/import/csvAccessionImportTask.class.php
+++ b/lib/task/import/csvAccessionImportTask.class.php
@@ -320,6 +320,12 @@ EOF;
             }
           }
         }
+
+        // Add keymap entry
+        if (!empty($self->rowStatusVars['accessionNumber']))
+        {
+          $self->createKeymapEntry($self->getStatus('sourceName'), $self->rowStatusVars['accessionNumber']);
+        }
       }
     ));
 


### PR DESCRIPTION
Add logic to create keymap records when importing accession records
with the accession import CLI task. These are already being created
when new accessions are created using the descriptions import task.