### PR TITLE
Dev/issue 12650 actor linked digital object

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/deleteAction.class.php
+++ b/apps/qubit/modules/digitalobject/actions/deleteAction.class.php
@@ -37,19 +37,19 @@ class DigitalObjectDeleteAction extends sfAction
     $parent = $this->resource->parent;
     if (isset($parent))
     {
-      $this->informationObject = $parent->informationObject;
+      $this->object = $parent->object;
     }
     else
     {
-      $this->informationObject = $this->resource->informationObject;
-      if (!isset($this->informationObject))
+      $this->object = $this->resource->object;
+      if (!isset($this->object))
       {
         $this->forward404();
       }
     }
 
     // Check user authorization
-    if (!QubitAcl::check($this->informationObject, 'delete'))
+    if (!QubitAcl::check($this->object, 'delete'))
     {
       QubitAcl::forwardUnauthorized();
     }
@@ -58,8 +58,8 @@ class DigitalObjectDeleteAction extends sfAction
     {
       // Delete the digital object record from the database
       $this->resource->delete();
-      QubitSearch::getInstance()->update($this->informationObject);
-      $this->informationObject->updateXmlExports();
+      QubitSearch::getInstance()->update($this->object);
+      $this->object->updateXmlExports();
 
       // Redirect to edit page for parent Info Object
       if (isset($parent))
@@ -68,7 +68,7 @@ class DigitalObjectDeleteAction extends sfAction
       }
       else
       {
-        $this->redirect(array($this->informationObject, 'module' => 'informationobject'));
+        $this->redirect(array($this->object, 'module' => 'informationobject'));
       }
     }
   }

--- a/apps/qubit/modules/digitalobject/actions/editAction.class.php
+++ b/apps/qubit/modules/digitalobject/actions/editAction.class.php
@@ -48,7 +48,7 @@ class DigitalObjectEditAction extends sfAction
     $this->showCompoundObjectToggle = false;
     foreach ($this->object->getChildren() as $item)
     {
-      if (null !== $item->getDigitalObjectRelatedByobjectId())   //digitalObjectRelatedByobjectId
+      if (null !== $item->getDigitalObjectRelatedByobjectId())
       {
         $this->showCompoundObjectToggle = true;
 

--- a/apps/qubit/modules/digitalobject/actions/editAction.class.php
+++ b/apps/qubit/modules/digitalobject/actions/editAction.class.php
@@ -46,9 +46,9 @@ class DigitalObjectEditAction extends sfAction
     // Only display "compound digital object" toggle if we have a child with a
     // digital object
     $this->showCompoundObjectToggle = false;
-    foreach ($this->informationObject->getChildren() as $item)
+    foreach ($this->object->getChildren() as $item)
     {
-      if (null !== $item->getDigitalObject())
+      if (null !== $item->getDigitalObjectRelatedByobjectId())   //digitalObjectRelatedByobjectId
       {
         $this->showCompoundObjectToggle = true;
 
@@ -132,10 +132,10 @@ class DigitalObjectEditAction extends sfAction
       $this->forward404();
     }
 
-    $this->informationObject = $this->resource->informationObject;
+    $this->object = $this->resource->object;
 
     // Check user authorization
-    if (!QubitAcl::check($this->informationObject, 'update') && !$this->getUser()->hasGroup(QubitAclGroup::EDITOR_ID))
+    if (!QubitAcl::check($this->object, 'update') && !$this->getUser()->hasGroup(QubitAclGroup::EDITOR_ID))
     {
       QubitAcl::forwardUnauthorized();
     }
@@ -162,9 +162,9 @@ class DigitalObjectEditAction extends sfAction
         $this->processForm();
 
         $this->resource->save();
-        $this->informationObject->updateXmlExports();
+        $this->object->updateXmlExports();
 
-        $this->redirect(array($this->informationObject, 'module' => 'informationobject'));
+        $this->redirect(array($this->object, 'module' => 'informationobject'));
       }
     }
   }

--- a/apps/qubit/modules/digitalobject/actions/imageflowComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/imageflowComponent.class.php
@@ -65,8 +65,8 @@ class DigitalObjectImageflowComponent extends sfComponent
       else
       {
         // Ensure the user has permissions to see a thumbnail
-        if (!QubitAcl::check($item->informationObject, 'readThumbnail') ||
-            !QubitGrantedRight::checkPremis($item->informationObject->id, 'readThumb'))
+        if (!QubitAcl::check($item->object, 'readThumbnail') ||
+            !QubitGrantedRight::checkPremis($item->object->id, 'readThumb'))
         {
           $thumbnail = QubitDigitalObject::getGenericRepresentation($item->mimeType);
           $thumbnail->setParent($item);

--- a/apps/qubit/modules/digitalobject/actions/imageflowComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/imageflowComponent.class.php
@@ -43,7 +43,7 @@ class DigitalObjectImageflowComponent extends sfComponent
 
     // Add thumbs
     $criteria = new Criteria;
-    $criteria->addJoin(QubitInformationObject::ID, QubitDigitalObject::INFORMATION_OBJECT_ID);
+    $criteria->addJoin(QubitInformationObject::ID, QubitDigitalObject::OBJECT_ID);
     $criteria->add(QubitInformationObject::LFT, $this->resource->lft, Criteria::GREATER_THAN);
     $criteria->add(QubitInformationObject::RGT, $this->resource->rgt, Criteria::LESS_THAN);
 

--- a/apps/qubit/modules/digitalobject/actions/metadataComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/metadataComponent.class.php
@@ -45,11 +45,11 @@ class DigitalObjectMetadataComponent extends sfComponent
     $this->googleMapsApiKey = sfConfig::get('app_google_maps_api_key');
 
     // Provide latitude to template
-    $latitudeProperty = $this->infoObj->digitalObjects[0]->getPropertyByName('latitude');
+    $latitudeProperty = $this->infoObj->digitalObjectsRelatedByobjectId[0]->getPropertyByName('latitude');
     $this->latitude = $latitudeProperty->value;
 
     // Provide longitude to template
-    $longitudeProperty = $this->infoObj->digitalObjects[0]->getPropertyByName('longitude');
+    $longitudeProperty = $this->infoObj->digitalObjectsRelatedByobjectId[0]->getPropertyByName('longitude');
     $this->longitude = $longitudeProperty->value;
   }
 }

--- a/apps/qubit/modules/digitalobject/actions/showComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/showComponent.class.php
@@ -41,7 +41,7 @@ class DigitalObjectShowComponent extends sfComponent
       $this->usageType = QubitTerm::THUMBNAIL_ID;
     }
 
-    if (QubitTerm::MASTER_ID == $this->usageType && !QubitAcl::check($this->resource->informationObject, 'readMaster'))
+    if (QubitTerm::MASTER_ID == $this->usageType && !QubitAcl::check($this->resource->object, 'readMaster'))
     {
       return sfView::NONE;
     }

--- a/apps/qubit/modules/digitalobject/actions/showComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/showComponent.class.php
@@ -77,7 +77,7 @@ class DigitalObjectShowComponent extends sfComponent
   private function checkShowGenericIcon()
   {
     $curUser = sfContext::getInstance()->getUser();
-    $curInfoObjectId = $this->resource->informationObject->id;
+    $curInfoObjectId = $this->resource->object->id;
 
     switch ($this->usageType)
     {
@@ -89,10 +89,10 @@ class DigitalObjectShowComponent extends sfComponent
         }
 
         // Authenticated, check regular ACL rules...
-        return !QubitAcl::check($this->resource->informationObject, 'readReference');
+        return !QubitAcl::check($this->resource->object, 'readReference');
 
       case QubitTerm::THUMBNAIL_ID:
-        return !QubitAcl::check($this->resource->informationObject, 'readThumbnail');
+        return !QubitAcl::check($this->resource->object, 'readThumbnail');
     }
   }
 
@@ -102,11 +102,11 @@ class DigitalObjectShowComponent extends sfComponent
    */
   private function getAccessWarning()
   {
-    $curInfoObjectId = $this->resource->informationObject->id;
+    $curInfoObjectId = $this->resource->object->id;
     $denyReason = '';
 
     if (!QubitGrantedRight::checkPremis($curInfoObjectId, 'readReference', $denyReason) ||
-        !QubitAcl::check($this->resource->informationObject, 'readReference'))
+        !QubitAcl::check($this->resource->object, 'readReference'))
     {
       return $denyReason;
     }

--- a/apps/qubit/modules/digitalobject/actions/showCompoundComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/showCompoundComponent.class.php
@@ -35,7 +35,7 @@ class DigitalObjectShowCompoundComponent extends sfComponent
   {
     // Find all digital objects of child information objects
     $criteria = new Criteria;
-    $criteria->add(QubitInformationObject::PARENT_ID, $this->resource->informationObject->id);
+    $criteria->add(QubitInformationObject::PARENT_ID, $this->resource->object->id);
     $criteria->addJoin(QubitInformationObject::ID, QubitDigitalObject::OBJECT_ID);
 
     // Show two results on page with pager

--- a/apps/qubit/modules/digitalobject/actions/showCompoundComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/showCompoundComponent.class.php
@@ -36,7 +36,7 @@ class DigitalObjectShowCompoundComponent extends sfComponent
     // Find all digital objects of child information objects
     $criteria = new Criteria;
     $criteria->add(QubitInformationObject::PARENT_ID, $this->resource->informationObject->id);
-    $criteria->addJoin(QubitInformationObject::ID, QubitDigitalObject::INFORMATION_OBJECT_ID);
+    $criteria->addJoin(QubitInformationObject::ID, QubitDigitalObject::OBJECT_ID);
 
     // Show two results on page with pager
     $this->pager = new QubitPager('QubitDigitalObject');

--- a/apps/qubit/modules/digitalobject/actions/showDownloadComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/showDownloadComponent.class.php
@@ -60,7 +60,7 @@ class DigitalObjectShowDownloadComponent extends sfComponent
     // Build a fully qualified URL to this digital object asset
     if ((QubitTerm::IMAGE_ID != $this->resource->mediaTypeId || QubitTerm::REFERENCE_ID == $this->usageType)
         && $this->resource->usageId != QubitTerm::OFFLINE_ID
-        && QubitAcl::check($this->resource->informationObject, 'readMaster'))
+        && QubitAcl::check($this->resource->object, 'readMaster'))
     {
       $this->link = $this->resource->getPublicPath();
     }

--- a/apps/qubit/modules/digitalobject/actions/showGenericIconComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/showGenericIconComponent.class.php
@@ -35,6 +35,6 @@ class DigitalObjectShowGenericIconComponent extends sfComponent
   public function execute($request)
   {
     $this->representation = QubitDigitalObject::getGenericRepresentation($this->resource->mimeType, $this->resource->usageId);
-    $this->canReadMaster = QubitAcl::check($this->resource->informationObject, 'readMaster');
+    $this->canReadMaster = QubitAcl::check($this->resource->object, 'readMaster');
   }
 }

--- a/apps/qubit/modules/digitalobject/actions/updateAction.class.php
+++ b/apps/qubit/modules/digitalobject/actions/updateAction.class.php
@@ -32,7 +32,7 @@ class DigitalObjectUpdateAction extends sfAction
     $this->resource = $this->getRoute()->resource;
 
     // Check user authorization
-    if (!QubitAcl::check($this->resource->informationObject, 'update'))
+    if (!QubitAcl::check($this->resource->object, 'update'))
     {
       QubitAcl::forwardUnauthorized();
     }

--- a/apps/qubit/modules/digitalobject/actions/uploadAction.class.php
+++ b/apps/qubit/modules/digitalobject/actions/uploadAction.class.php
@@ -28,15 +28,15 @@ class DigitalObjectUploadAction extends sfAction
     $uploadFiles = array();
     $warning = null;
 
-    $this->informationObject = QubitInformationObject::getById($request->informationObjectId);
+    $this->object = QubitInformationObject::getById($request->objectId);
 
-    if (!isset($this->informationObject))
+    if (!isset($this->object))
     {
       $this->forward404();
     }
 
     // Check user authorization
-    if (!QubitAcl::check($this->informationObject, 'update'))
+    if (!QubitAcl::check($this->object, 'update'))
     {
       throw new sfException;
     }
@@ -47,7 +47,7 @@ class DigitalObjectUploadAction extends sfAction
       QubitAcl::forwardToSecureAction();
     }
 
-    $repo = $this->informationObject->getRepository(array('inherit' => true));
+    $repo = $this->object->getRepository(array('inherit' => true));
 
     if (isset($repo))
     {

--- a/apps/qubit/modules/digitalobject/templates/_imageflow.php
+++ b/apps/qubit/modules/digitalobject/templates/_imageflow.php
@@ -4,7 +4,7 @@
 
   <div class="imageflow clearfix" id="imageflow">
     <?php foreach ($thumbnails as $item): ?>
-      <?php echo image_tag($item->getFullPath(), array('longdesc' => url_for(array($item->parent->informationObject, 'module' => 'informationobject')), 'alt' => truncate_text(strip_markdown($item->parent->informationObject), 100))) ?>
+      <?php echo image_tag($item->getFullPath(), array('longdesc' => url_for(array($item->parent->object, 'module' => 'informationobject')), 'alt' => truncate_text(strip_markdown($item->parent->object), 100))) ?>
     <?php endforeach; ?>
   </div>
 

--- a/apps/qubit/modules/digitalobject/templates/_metadata.php
+++ b/apps/qubit/modules/digitalobject/templates/_metadata.php
@@ -8,7 +8,7 @@
     <div id="front-map" class="simple-map" data-key="<?php echo $googleMapsApiKey ?>" data-latitude="<?php echo $latitude ?>" data-longitude="<?php echo $longitude ?>"></div>
   <?php endif; ?>
 
-  <?php if (!QubitAcl::check($resource->informationObject, 'readReference')): ?>
+  <?php if (!QubitAcl::check($resource->object, 'readReference')): ?>
     <?php echo render_show(__('Access'), __('Restricted')) ?>
   <?php endif; ?>
 
@@ -44,12 +44,12 @@
   <?php endif; ?>
 
   <?php if ($sf_user->isAuthenticated()): ?>
-    <?php echo render_show(__('Object UUID'), render_value($resource->informationObject->objectUUID), array('fieldLabel' => 'objectUUID')) ?>
-    <?php echo render_show(__('AIP UUID'), render_value($resource->informationObject->aipUUID), array('fieldLabel' => 'aipUUID')) ?>
-    <?php echo render_show(__('Format name'), render_value($resource->informationObject->formatName), array('fieldLabel' => 'formatName')) ?>
-    <?php echo render_show(__('Format version'), render_value($resource->informationObject->formatVersion), array('fieldLabel' => 'formatVersion')) ?>
-    <?php echo render_show(__('Format registry key'), render_value($resource->informationObject->formatRegistryKey), array('fieldLabel' => 'formatRegistryKey')) ?>
-    <?php echo render_show(__('Format registry name'), render_value($resource->informationObject->formatRegistryName), array('fieldLabel' => 'formatRegistryName')) ?>
+    <?php echo render_show(__('Object UUID'), render_value($resource->object->objectUUID), array('fieldLabel' => 'objectUUID')) ?>
+    <?php echo render_show(__('AIP UUID'), render_value($resource->object->aipUUID), array('fieldLabel' => 'aipUUID')) ?>
+    <?php echo render_show(__('Format name'), render_value($resource->object->formatName), array('fieldLabel' => 'formatName')) ?>
+    <?php echo render_show(__('Format version'), render_value($resource->object->formatVersion), array('fieldLabel' => 'formatVersion')) ?>
+    <?php echo render_show(__('Format registry key'), render_value($resource->object->formatRegistryKey), array('fieldLabel' => 'formatRegistryKey')) ?>
+    <?php echo render_show(__('Format registry name'), render_value($resource->object->formatRegistryName), array('fieldLabel' => 'formatRegistryName')) ?>
   <?php endif; ?>
 
 </section>

--- a/apps/qubit/modules/digitalobject/templates/_showAudio.php
+++ b/apps/qubit/modules/digitalobject/templates/_showAudio.php
@@ -10,7 +10,7 @@
     </div>
   <?php endif;?>
 
-  <?php if (isset($link) && QubitAcl::check($resource->informationObject, 'readMaster')): ?>
+  <?php if (isset($link) && QubitAcl::check($resource->object, 'readMaster')): ?>
     <?php echo link_to(__('Download audio'), $link, array('class' => 'download')) ?>
   <?php endif; ?>
 

--- a/apps/qubit/modules/informationobject/actions/addDigitalObjectAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/addDigitalObjectAction.class.php
@@ -63,7 +63,7 @@ class InformationObjectAddDigitalObjectAction extends sfAction
     }
 
     // Check if already exists a digital object
-    if (null !== $digitalObject = $this->resource->getDigitalObject())
+    if (null !== $digitalObject = $this->resource->getDigitalObjectRelatedByobjectId())
     {
       $this->redirect(array($digitalObject, 'module' => 'digitalobject', 'action' => 'edit'));
     }
@@ -131,6 +131,6 @@ class InformationObjectAddDigitalObjectAction extends sfAction
       }
     }
 
-    $this->resource->digitalObjects[] = $digitalObject;
+    $this->resource->digitalObjectsRelatedByobjectId[] = $digitalObject;
   }
 }

--- a/apps/qubit/modules/informationobject/actions/multiFileUploadAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/multiFileUploadAction.class.php
@@ -124,7 +124,7 @@ class InformationObjectMultiFileUploadAction extends sfAction
       {
         // Upload asset and create digital object
         $digitalObject = new QubitDigitalObject;
-        $digitalObject->informationObject = $informationObject;
+        $digitalObject->object = $informationObject;
         $digitalObject->usageId = QubitTerm::MASTER_ID;
         $digitalObject->assets[] = new QubitAsset($file['name'], file_get_contents("$tmpPath/$file[tmpName]"));
 

--- a/apps/qubit/modules/informationobject/actions/renameAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/renameAction.class.php
@@ -43,7 +43,7 @@ class InformationObjectRenameAction extends DefaultEditAction
     {
       if ($name == 'filename')
       {
-        $this->form->setDefault($name, $this->resource->digitalObjects[0]->name);
+        $this->form->setDefault($name, $this->resource->digitalObjectsRelatedByobjectId[0]->name);
       }
       else
       {
@@ -124,13 +124,13 @@ class InformationObjectRenameAction extends DefaultEditAction
     }
 
     // Update digital object filename, if filename sent
-    if ((null !== $postedFilename) && count($this->resource->digitalObjects))
+    if ((null !== $postedFilename) && count($this->resource->digitalObjectsRelatedByobjectId))
     {
       // Parse filename so special characters can be removed
       $fileParts = pathinfo($postedFilename);
       $filename = QubitSlug::slugify($fileParts['filename']) .'.'. QubitSlug::slugify($fileParts['extension']);
 
-      $digitalObject = $this->resource->digitalObjects[0];
+      $digitalObject = $this->resource->digitalObjectsRelatedByobjectId[0];
 
       // Rename master file
       $basePath = sfConfig::get('sf_web_dir') . $digitalObject->path;

--- a/apps/qubit/modules/informationobject/templates/_actions.php
+++ b/apps/qubit/modules/informationobject/templates/_actions.php
@@ -40,8 +40,8 @@
 
               <li class="divider"></li>
 
-              <?php if (0 < count($resource->digitalObjects) && QubitDigitalObject::isUploadAllowed()): ?>
-                <li><?php echo link_to(__('Edit %1%', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))), array($resource->digitalObjects[0], 'module' => 'digitalobject', 'action' => 'edit')) ?></li>
+              <?php if (0 < count($resource->digitalObjectsRelatedByobjectId) && QubitDigitalObject::isUploadAllowed()): ?>
+                <li><?php echo link_to(__('Edit %1%', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))), array($resource->digitalObjectsRelatedByobjectId[0], 'module' => 'digitalobject', 'action' => 'edit')) ?></li>
               <?php elseif (QubitDigitalObject::isUploadAllowed()): ?>
                 <li><?php echo link_to(__('Link %1%', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))), array($resource, 'module' => 'informationobject', 'action' => 'addDigitalObject')) ?></li>
               <?php endif; // has digital object ?>

--- a/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php
@@ -124,7 +124,7 @@ YAHOO.widget.Uploader.SWFURL = '$uploadSwfPath';
 Qubit.multiFileUpload.maxUploadSize = '$maxUploadSize';
 Qubit.multiFileUpload.uploadTmpDir = '$uploadTmpDir';
 Qubit.multiFileUpload.uploadResponsePath = '$uploadResponsePath';
-Qubit.multiFileUpload.informationObjectId = '$resource->id';
+Qubit.multiFileUpload.objectId = '$resource->id';
 Qubit.multiFileUpload.thumbWidth = 150;
 
 Qubit.multiFileUpload.i18nUploading = '{$sf_context->i18n->__('Uploading...')}';

--- a/apps/qubit/modules/informationobject/templates/renameSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/renameSuccess.php
@@ -63,7 +63,7 @@
 
         <p><?php echo __('Original slug') ?>: <em><?php echo $resource->slug ?></em></p>
 
-        <?php if (count($resource->digitalObjects) > 0): ?>
+        <?php if (count($resource->digitalObjectsRelatedByobjectId) > 0): ?>
 
           <div class="rename-form-field-toggle"><input id="rename_enable_filename" type="checkbox" /> <?php echo __('Update filename') ?></div>
           <br />
@@ -72,7 +72,7 @@
           ->label(__('Filename'))
           ->help(__('Do not use any special characters or spaces in the filename - only lower case alphanumeric characters (a-z, 0-9) and dashes (-) will be saved. Other characters will be stripped out or replaced. Editing the filename will not automatically update the other fields.')), $resource) ?>
 
-          <p><?php echo __('Original filename') ?>: <em><?php echo $resource->digitalObjects[0]->name ?></em></p>
+          <p><?php echo __('Original filename') ?>: <em><?php echo $resource->digitalObjectsRelatedByobjectId[0]->name ?></em></p>
 
         <?php endif; ?>
 

--- a/config/schema.yml
+++ b/config/schema.yml
@@ -98,7 +98,7 @@ propel:
 
   digital_object:
     id: { type: integer, required: true, primaryKey: true, foreignTable: object, foreignReference: id, onDelete: cascade, inheritanceKey: true }
-    information_object_id:
+    object_id: { type: integer, foreignTable: object, foreignReference: id, onDelete: cascade }
     usage_id: { type: integer, foreignTable: term, foreignReference: id, onDelete: setnull }
     mime_type: varchar(255)
     media_type_id: { type: integer, foreignTable: term, foreignReference: id, onDelete: setnull }

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 168
+    value: 169
   milestone:
     name: milestone
     editable: 0

--- a/data/sql/lib.model.schema.sql
+++ b/data/sql/lib.model.schema.sql
@@ -315,7 +315,7 @@ DROP TABLE IF EXISTS `digital_object`;
 CREATE TABLE `digital_object`
 (
 	`id` INTEGER  NOT NULL,
-	`information_object_id` INTEGER,
+	`object_id` INTEGER,
 	`usage_id` INTEGER,
 	`mime_type` VARCHAR(255),
 	`media_type_id` INTEGER,
@@ -332,10 +332,11 @@ CREATE TABLE `digital_object`
 		FOREIGN KEY (`id`)
 		REFERENCES `object` (`id`)
 		ON DELETE CASCADE,
-	INDEX `digital_object_FI_2` (`information_object_id`),
+	INDEX `digital_object_FI_2` (`object_id`),
 	CONSTRAINT `digital_object_FK_2`
-		FOREIGN KEY (`information_object_id`)
-		REFERENCES `information_object` (`id`),
+		FOREIGN KEY (`object_id`)
+		REFERENCES `object` (`id`)
+		ON DELETE CASCADE,
 	INDEX `digital_object_FI_3` (`usage_id`),
 	CONSTRAINT `digital_object_FK_3`
 		FOREIGN KEY (`usage_id`)

--- a/js/multiFileUpload.js
+++ b/js/multiFileUpload.js
@@ -101,7 +101,7 @@
               var fileId = parseHtmlId($(this).closest('.multiFileUploadItem').attr('id'));
 
               // Upload it
-              uploader.upload('file' + fileId, Qubit.multiFileUpload.uploadResponsePath, 'POST', { informationObjectId: Qubit.multiFileUpload.informationObjectId });
+              uploader.upload('file' + fileId, Qubit.multiFileUpload.uploadResponsePath, 'POST', { objectId: Qubit.multiFileUpload.objectId });
 
               return false;
             });
@@ -209,7 +209,7 @@
                 uploader.setSimUploadLimit(1);
 
                 // Start upload!
-                uploader.uploadAll(Qubit.multiFileUpload.uploadResponsePath, 'POST', { informationObjectId: Qubit.multiFileUpload.informationObjectId });
+                uploader.uploadAll(Qubit.multiFileUpload.uploadResponsePath, 'POST', { objectId: Qubit.multiFileUpload.objectId });
               }
             });
 
@@ -349,4 +349,3 @@
         }
     }
   })(jQuery);
-

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -1817,15 +1817,12 @@ class QubitDigitalObject extends BaseDigitalObject
    */
   public function getAssetPath($checksum)
   {
-    sfContext::getInstance()->getLogger()->err('SBSBSB A: '.$checksum);
     if (isset($this->object))
     {
-      sfContext::getInstance()->getLogger()->err('SBSBSB B');
       $object = $this->object;
     }
     else if (isset($this->parent))
     {
-      sfContext::getInstance()->getLogger()->err('SBSBSB C');
       $object = $this->parent->object;
     }
 

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -1391,7 +1391,7 @@ class QubitInformationObject extends BaseInformationObject
    */
   public function getDigitalObject()
   {
-    $digitalObjects = $this->getDigitalObjects();
+    $digitalObjects = $this->getDigitalObjectRelatedByobjectId();
     if (count($digitalObjects) > 0)
     {
       return $digitalObjects[0];
@@ -1409,7 +1409,7 @@ class QubitInformationObject extends BaseInformationObject
    */
   public function getDigitalObjectChecksum()
   {
-    if (null !== $do = $this->getDigitalObject())
+    if (null !== $do = $this->getDigitalObjectRelatedByobjectId())
     {
       return $do->getChecksum();
     }

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -254,12 +254,12 @@ class QubitInformationObject extends BaseInformationObject
 
     // Save new digital objects
     // TODO Allow adding additional digital objects as derivatives
-    foreach ($this->digitalObjects as $item)
+    foreach ($this->digitalObjectsRelatedByobjectId as $item)
     {
       $item->indexOnSave = false;
 
       // TODO Needed if $this is new, should be transparent
-      $item->informationObject = $this;
+      $item->object = $this;
       $item->save($connection);
 
       break; // Save only one digital object per information object
@@ -324,7 +324,7 @@ class QubitInformationObject extends BaseInformationObject
   public function delete($connection = null)
   {
     // Delete related digitalObjects
-    foreach ($this->digitalObjects as $digitalObject)
+    foreach ($this->digitalObjectsRelatedByobjectId as $digitalObject)
     {
       // Set IO to null to avoid ES document update
       $digitalObject->informationObjectId = null;
@@ -1425,7 +1425,7 @@ class QubitInformationObject extends BaseInformationObject
   {
     $sql = '
       SELECT COUNT(d.id) FROM information_object i
-      INNER JOIN digital_object d ON i.id=d.information_object_id
+      INNER JOIN digital_object d ON i.id=d.object_id
       WHERE i.lft > ? and i.rgt < ?
     ';
 
@@ -1442,7 +1442,7 @@ class QubitInformationObject extends BaseInformationObject
   public function getDigitalObjectPublicUrl()
   {
     // Set digital object URL
-    $do = $this->digitalObjects[0];
+    $do = $this->digitalObjectsRelatedByobjectId[0];
     if (!isset($do))
     {
       return;
@@ -1517,7 +1517,7 @@ class QubitInformationObject extends BaseInformationObject
           continue;
         }
 
-        $infoObject->digitalObjects[] = $digitalObject;
+        $infoObject->digitalObjectsRelatedByobjectId[] = $digitalObject;
         $infoObject->title = $digitalObject->name;
 
         if (isset($pubStatus))
@@ -1541,7 +1541,7 @@ class QubitInformationObject extends BaseInformationObject
       try
       {
         $digitalObject->importFromUri($uris);
-        $this->digitalObjects[] = $digitalObject;
+        $this->digitalObjectsRelatedByobjectId[] = $digitalObject;
       }
       catch (sfException $e)
       {
@@ -1567,7 +1567,7 @@ class QubitInformationObject extends BaseInformationObject
     $digitalObject->usageId = QubitTerm::MASTER_ID;
     $digitalObject->importFromBase64($encodedString, $filename);
 
-    $this->digitalObjects[] = $digitalObject;
+    $this->digitalObjectsRelatedByobjectId[] = $digitalObject;
   }
 
   public function setRepositoryByName($name)
@@ -3190,12 +3190,12 @@ class QubitInformationObject extends BaseInformationObject
    */
   public function getDigitalObjectLink()
   {
-    if (count($this->digitalObjects) <= 0)
+    if (count($this->digitalObjectsRelatedByobjectId) <= 0)
     {
       return;
     }
 
-    $digitalObject = $this->digitalObjects[0];
+    $digitalObject = $this->digitalObjectsRelatedByobjectId[0];
     if (QubitTerm::OFFLINE_ID == $digitalObject->usageId)
     {
       return;

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -327,7 +327,7 @@ class QubitInformationObject extends BaseInformationObject
     foreach ($this->digitalObjectsRelatedByobjectId as $digitalObject)
     {
       // Set IO to null to avoid ES document update
-      $digitalObject->informationObjectId = null;
+      $digitalObject->objectId = null;
       $digitalObject->delete();
     }
 

--- a/lib/model/QubitObject.php
+++ b/lib/model/QubitObject.php
@@ -339,6 +339,15 @@ class QubitObject extends BaseObject implements Zend_Acl_Resource_Interface
     return QubitNote::get($criteria);
   }
 
+  public function getDigitalObjectRelatedByobjectId()
+  {
+    $digitalObjects = $this->getDigitalObjectsRelatedByobjectId();
+    if (0 < count($digitalObjects))
+    {
+      return $digitalObjects[0];
+    }
+  }
+
   /********************
        Other names
   *********************/

--- a/lib/model/map/ActorTableMap.php
+++ b/lib/model/map/ActorTableMap.php
@@ -60,7 +60,6 @@ class ActorTableMap extends TableMap {
     $this->addRelation('termRelatedBydescriptionStatusId', 'term', RelationMap::MANY_TO_ONE, array('description_status_id' => 'id', ), 'SET NULL', null);
     $this->addRelation('termRelatedBydescriptionDetailId', 'term', RelationMap::MANY_TO_ONE, array('description_detail_id' => 'id', ), 'SET NULL', null);
     $this->addRelation('actorRelatedByparentId', 'actor', RelationMap::MANY_TO_ONE, array('parent_id' => 'id', ), null, null);
-    $this->addRelation('donor', 'donor', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('actorRelatedByparentId', 'actor', RelationMap::ONE_TO_MANY, array('id' => 'parent_id', ), null, null);
     $this->addRelation('actorI18n', 'actorI18n', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('contactInformation', 'contactInformation', RelationMap::ONE_TO_MANY, array('id' => 'actor_id', ), 'CASCADE', null);
@@ -69,6 +68,7 @@ class ActorTableMap extends TableMap {
     $this->addRelation('rights', 'rights', RelationMap::ONE_TO_MANY, array('id' => 'rights_holder_id', ), 'SET NULL', null);
     $this->addRelation('rightsHolder', 'rightsHolder', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('user', 'user', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
+    $this->addRelation('donor', 'donor', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
 	} // buildRelations()
 
 } // ActorTableMap

--- a/lib/model/map/DigitalObjectTableMap.php
+++ b/lib/model/map/DigitalObjectTableMap.php
@@ -37,7 +37,7 @@ class DigitalObjectTableMap extends TableMap {
 		$this->setUseIdGenerator(false);
 		// columns
 		$this->addForeignPrimaryKey('ID', 'id', 'INTEGER' , 'object', 'ID', true, null, null);
-		$this->addForeignKey('INFORMATION_OBJECT_ID', 'informationObjectId', 'INTEGER', 'information_object', 'ID', false, null, null);
+		$this->addForeignKey('OBJECT_ID', 'objectId', 'INTEGER', 'object', 'ID', false, null, null);
 		$this->addForeignKey('USAGE_ID', 'usageId', 'INTEGER', 'term', 'ID', false, null, null);
 		$this->addColumn('MIME_TYPE', 'mimeType', 'VARCHAR', false, 255, null);
 		$this->addForeignKey('MEDIA_TYPE_ID', 'mediaTypeId', 'INTEGER', 'term', 'ID', false, null, null);
@@ -56,8 +56,8 @@ class DigitalObjectTableMap extends TableMap {
 	 */
 	public function buildRelations()
 	{
-    $this->addRelation('object', 'object', RelationMap::MANY_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
-    $this->addRelation('informationObject', 'informationObject', RelationMap::MANY_TO_ONE, array('information_object_id' => 'id', ), null, null);
+    $this->addRelation('objectRelatedByid', 'object', RelationMap::MANY_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
+    $this->addRelation('objectRelatedByobjectId', 'object', RelationMap::MANY_TO_ONE, array('object_id' => 'id', ), 'CASCADE', null);
     $this->addRelation('termRelatedByusageId', 'term', RelationMap::MANY_TO_ONE, array('usage_id' => 'id', ), 'SET NULL', null);
     $this->addRelation('termRelatedBymediaTypeId', 'term', RelationMap::MANY_TO_ONE, array('media_type_id' => 'id', ), 'SET NULL', null);
     $this->addRelation('digitalObjectRelatedByparentId', 'digitalObject', RelationMap::MANY_TO_ONE, array('parent_id' => 'id', ), null, null);

--- a/lib/model/map/InformationObjectTableMap.php
+++ b/lib/model/map/InformationObjectTableMap.php
@@ -67,7 +67,6 @@ class InformationObjectTableMap extends TableMap {
     $this->addRelation('termRelatedBydescriptionStatusId', 'term', RelationMap::MANY_TO_ONE, array('description_status_id' => 'id', ), 'SET NULL', null);
     $this->addRelation('termRelatedBydescriptionDetailId', 'term', RelationMap::MANY_TO_ONE, array('description_detail_id' => 'id', ), 'SET NULL', null);
     $this->addRelation('termRelatedBydisplayStandardId', 'term', RelationMap::MANY_TO_ONE, array('display_standard_id' => 'id', ), 'SET NULL', null);
-    $this->addRelation('digitalObject', 'digitalObject', RelationMap::ONE_TO_MANY, array('id' => 'information_object_id', ), null, null);
     $this->addRelation('informationObjectRelatedByparentId', 'informationObject', RelationMap::ONE_TO_MANY, array('id' => 'parent_id', ), null, null);
     $this->addRelation('informationObjectI18n', 'informationObjectI18n', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('premisObject', 'premisObject', RelationMap::ONE_TO_MANY, array('id' => 'information_object_id', ), null, null);

--- a/lib/model/map/ObjectTableMap.php
+++ b/lib/model/map/ObjectTableMap.php
@@ -49,8 +49,7 @@ class ObjectTableMap extends TableMap {
 	 */
 	public function buildRelations()
 	{
-    $this->addRelation('accession', 'accession', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
-    $this->addRelation('deaccession', 'deaccession', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
+    $this->addRelation('aclPermission', 'aclPermission', RelationMap::ONE_TO_MANY, array('id' => 'object_id', ), 'CASCADE', null);
     $this->addRelation('accessLog', 'accessLog', RelationMap::ONE_TO_MANY, array('id' => 'object_id', ), 'CASCADE', null);
     $this->addRelation('actor', 'actor', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('aipRelatedByid', 'aip', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
@@ -58,7 +57,8 @@ class ObjectTableMap extends TableMap {
     $this->addRelation('auditLog', 'auditLog', RelationMap::ONE_TO_MANY, array('id' => 'object_id', ), 'CASCADE', null);
     $this->addRelation('jobRelatedByid', 'job', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('jobRelatedByobjectId', 'job', RelationMap::ONE_TO_MANY, array('id' => 'object_id', ), 'SET NULL', null);
-    $this->addRelation('digitalObject', 'digitalObject', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
+    $this->addRelation('digitalObjectRelatedByid', 'digitalObject', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
+    $this->addRelation('digitalObjectRelatedByobjectId', 'digitalObject', RelationMap::ONE_TO_MANY, array('id' => 'object_id', ), 'CASCADE', null);
     $this->addRelation('eventRelatedByid', 'event', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('eventRelatedByobjectId', 'event', RelationMap::ONE_TO_MANY, array('id' => 'object_id', ), 'CASCADE', null);
     $this->addRelation('function', 'function', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
@@ -79,7 +79,8 @@ class ObjectTableMap extends TableMap {
     $this->addRelation('status', 'status', RelationMap::ONE_TO_MANY, array('id' => 'object_id', ), 'CASCADE', null);
     $this->addRelation('taxonomy', 'taxonomy', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('term', 'term', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
-    $this->addRelation('aclPermission', 'aclPermission', RelationMap::ONE_TO_MANY, array('id' => 'object_id', ), 'CASCADE', null);
+    $this->addRelation('accession', 'accession', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
+    $this->addRelation('deaccession', 'deaccession', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
 	} // buildRelations()
 
 } // ObjectTableMap

--- a/lib/model/map/TermTableMap.php
+++ b/lib/model/map/TermTableMap.php
@@ -54,11 +54,6 @@ class TermTableMap extends TableMap {
     $this->addRelation('object', 'object', RelationMap::MANY_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('taxonomy', 'taxonomy', RelationMap::MANY_TO_ONE, array('taxonomy_id' => 'id', ), 'CASCADE', null);
     $this->addRelation('termRelatedByparentId', 'term', RelationMap::MANY_TO_ONE, array('parent_id' => 'id', ), null, null);
-    $this->addRelation('accessionRelatedByacquisitionTypeId', 'accession', RelationMap::ONE_TO_MANY, array('id' => 'acquisition_type_id', ), 'SET NULL', null);
-    $this->addRelation('accessionRelatedByprocessingPriorityId', 'accession', RelationMap::ONE_TO_MANY, array('id' => 'processing_priority_id', ), 'SET NULL', null);
-    $this->addRelation('accessionRelatedByprocessingStatusId', 'accession', RelationMap::ONE_TO_MANY, array('id' => 'processing_status_id', ), 'SET NULL', null);
-    $this->addRelation('accessionRelatedByresourceTypeId', 'accession', RelationMap::ONE_TO_MANY, array('id' => 'resource_type_id', ), 'SET NULL', null);
-    $this->addRelation('deaccession', 'deaccession', RelationMap::ONE_TO_MANY, array('id' => 'scope_id', ), 'SET NULL', null);
     $this->addRelation('actorRelatedByentityTypeId', 'actor', RelationMap::ONE_TO_MANY, array('id' => 'entity_type_id', ), 'SET NULL', null);
     $this->addRelation('actorRelatedBydescriptionStatusId', 'actor', RelationMap::ONE_TO_MANY, array('id' => 'description_status_id', ), 'SET NULL', null);
     $this->addRelation('actorRelatedBydescriptionDetailId', 'actor', RelationMap::ONE_TO_MANY, array('id' => 'description_detail_id', ), 'SET NULL', null);
@@ -91,6 +86,11 @@ class TermTableMap extends TableMap {
     $this->addRelation('statusRelatedBystatusId', 'status', RelationMap::ONE_TO_MANY, array('id' => 'status_id', ), 'CASCADE', null);
     $this->addRelation('termRelatedByparentId', 'term', RelationMap::ONE_TO_MANY, array('id' => 'parent_id', ), null, null);
     $this->addRelation('termI18n', 'termI18n', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null);
+    $this->addRelation('accessionRelatedByacquisitionTypeId', 'accession', RelationMap::ONE_TO_MANY, array('id' => 'acquisition_type_id', ), 'SET NULL', null);
+    $this->addRelation('accessionRelatedByprocessingPriorityId', 'accession', RelationMap::ONE_TO_MANY, array('id' => 'processing_priority_id', ), 'SET NULL', null);
+    $this->addRelation('accessionRelatedByprocessingStatusId', 'accession', RelationMap::ONE_TO_MANY, array('id' => 'processing_status_id', ), 'SET NULL', null);
+    $this->addRelation('accessionRelatedByresourceTypeId', 'accession', RelationMap::ONE_TO_MANY, array('id' => 'resource_type_id', ), 'SET NULL', null);
+    $this->addRelation('deaccession', 'deaccession', RelationMap::ONE_TO_MANY, array('id' => 'scope_id', ), 'SET NULL', null);
 	} // buildRelations()
 
 } // TermTableMap

--- a/lib/model/map/UserTableMap.php
+++ b/lib/model/map/UserTableMap.php
@@ -51,12 +51,12 @@ class UserTableMap extends TableMap {
 	public function buildRelations()
 	{
     $this->addRelation('actor', 'actor', RelationMap::MANY_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
-    $this->addRelation('auditLog', 'auditLog', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'SET NULL', null);
-    $this->addRelation('job', 'job', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'SET NULL', null);
-    $this->addRelation('note', 'note', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), null, null);
     $this->addRelation('aclPermission', 'aclPermission', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'CASCADE', null);
     $this->addRelation('aclUserGroup', 'aclUserGroup', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'CASCADE', null);
+    $this->addRelation('auditLog', 'auditLog', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'SET NULL', null);
+    $this->addRelation('job', 'job', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'SET NULL', null);
     $this->addRelation('clipboardSave', 'clipboardSave', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'SET NULL', null);
+    $this->addRelation('note', 'note', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), null, null);
 	} // buildRelations()
 
 } // UserTableMap

--- a/lib/model/om/BaseDigitalObject.php
+++ b/lib/model/om/BaseDigitalObject.php
@@ -8,7 +8,7 @@ abstract class BaseDigitalObject extends QubitObject implements ArrayAccess
     TABLE_NAME = 'digital_object',
 
     ID = 'digital_object.ID',
-    INFORMATION_OBJECT_ID = 'digital_object.INFORMATION_OBJECT_ID',
+    OBJECT_ID = 'digital_object.OBJECT_ID',
     USAGE_ID = 'digital_object.USAGE_ID',
     MIME_TYPE = 'digital_object.MIME_TYPE',
     MEDIA_TYPE_ID = 'digital_object.MEDIA_TYPE_ID',
@@ -27,7 +27,7 @@ abstract class BaseDigitalObject extends QubitObject implements ArrayAccess
     $criteria->addJoin(QubitDigitalObject::ID, QubitObject::ID);
 
     $criteria->addSelectColumn(QubitDigitalObject::ID);
-    $criteria->addSelectColumn(QubitDigitalObject::INFORMATION_OBJECT_ID);
+    $criteria->addSelectColumn(QubitDigitalObject::OBJECT_ID);
     $criteria->addSelectColumn(QubitDigitalObject::USAGE_ID);
     $criteria->addSelectColumn(QubitDigitalObject::MIME_TYPE);
     $criteria->addSelectColumn(QubitDigitalObject::MEDIA_TYPE_ID);
@@ -142,9 +142,9 @@ abstract class BaseDigitalObject extends QubitObject implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
-  public static function addJoininformationObjectCriteria(Criteria $criteria)
+  public static function addJoinobjectCriteria(Criteria $criteria)
   {
-    $criteria->addJoin(QubitDigitalObject::INFORMATION_OBJECT_ID, QubitInformationObject::ID);
+    $criteria->addJoin(QubitDigitalObject::OBJECT_ID, QubitObject::ID);
 
     return $criteria;
   }

--- a/lib/model/om/BaseInformationObject.php
+++ b/lib/model/om/BaseInformationObject.php
@@ -125,11 +125,6 @@ abstract class BaseInformationObject extends QubitObject implements ArrayAccess
     {
     }
 
-    if ('digitalObjects' == $name)
-    {
-      return true;
-    }
-
     if ('informationObjectsRelatedByparentId' == $name)
     {
       return true;
@@ -187,23 +182,6 @@ abstract class BaseInformationObject extends QubitObject implements ArrayAccess
     }
     catch (sfException $e)
     {
-    }
-
-    if ('digitalObjects' == $name)
-    {
-      if (!isset($this->refFkValues['digitalObjects']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['digitalObjects'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['digitalObjects'] = self::getdigitalObjectsById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['digitalObjects'];
     }
 
     if ('informationObjectsRelatedByparentId' == $name)
@@ -518,26 +496,6 @@ abstract class BaseInformationObject extends QubitObject implements ArrayAccess
     $criteria->addJoin(QubitInformationObject::DISPLAY_STANDARD_ID, QubitTerm::ID);
 
     return $criteria;
-  }
-
-  public static function adddigitalObjectsCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitDigitalObject::INFORMATION_OBJECT_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getdigitalObjectsById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::adddigitalObjectsCriteriaById($criteria, $id);
-
-    return QubitDigitalObject::get($criteria, $options);
-  }
-
-  public function adddigitalObjectsCriteria(Criteria $criteria)
-  {
-    return self::adddigitalObjectsCriteriaById($criteria, $this->id);
   }
 
   public static function addinformationObjectsRelatedByparentIdCriteriaById(Criteria $criteria, $id)

--- a/lib/model/om/BaseObject.php
+++ b/lib/model/om/BaseObject.php
@@ -185,6 +185,11 @@ abstract class BaseObject implements ArrayAccess
       }
     }
 
+    if ('aclPermissions' == $name)
+    {
+      return true;
+    }
+
     if ('accessLogs' == $name)
     {
       return true;
@@ -201,6 +206,11 @@ abstract class BaseObject implements ArrayAccess
     }
 
     if ('jobsRelatedByobjectId' == $name)
+    {
+      return true;
+    }
+
+    if ('digitalObjectsRelatedByobjectId' == $name)
     {
       return true;
     }
@@ -250,11 +260,6 @@ abstract class BaseObject implements ArrayAccess
       return true;
     }
 
-    if ('aclPermissions' == $name)
-    {
-      return true;
-    }
-
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
@@ -294,6 +299,23 @@ abstract class BaseObject implements ArrayAccess
 
         $offset++;
       }
+    }
+
+    if ('aclPermissions' == $name)
+    {
+      if (!isset($this->refFkValues['aclPermissions']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['aclPermissions'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['aclPermissions'] = self::getaclPermissionsById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['aclPermissions'];
     }
 
     if ('accessLogs' == $name)
@@ -362,6 +384,23 @@ abstract class BaseObject implements ArrayAccess
       }
 
       return $this->refFkValues['jobsRelatedByobjectId'];
+    }
+
+    if ('digitalObjectsRelatedByobjectId' == $name)
+    {
+      if (!isset($this->refFkValues['digitalObjectsRelatedByobjectId']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['digitalObjectsRelatedByobjectId'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['digitalObjectsRelatedByobjectId'] = self::getdigitalObjectsRelatedByobjectIdById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['digitalObjectsRelatedByobjectId'];
     }
 
     if ('eventsRelatedByobjectId' == $name)
@@ -515,23 +554,6 @@ abstract class BaseObject implements ArrayAccess
       }
 
       return $this->refFkValues['statuss'];
-    }
-
-    if ('aclPermissions' == $name)
-    {
-      if (!isset($this->refFkValues['aclPermissions']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['aclPermissions'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['aclPermissions'] = self::getaclPermissionsById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['aclPermissions'];
     }
 
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
@@ -860,6 +882,26 @@ abstract class BaseObject implements ArrayAccess
 		$this->setid($key);
 	}
 
+  public static function addaclPermissionsCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitAclPermission::OBJECT_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getaclPermissionsById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addaclPermissionsCriteriaById($criteria, $id);
+
+    return QubitAclPermission::get($criteria, $options);
+  }
+
+  public function addaclPermissionsCriteria(Criteria $criteria)
+  {
+    return self::addaclPermissionsCriteriaById($criteria, $this->id);
+  }
+
   public static function addaccessLogsCriteriaById(Criteria $criteria, $id)
   {
     $criteria->add(QubitAccessLog::OBJECT_ID, $id);
@@ -938,6 +980,26 @@ abstract class BaseObject implements ArrayAccess
   public function addjobsRelatedByobjectIdCriteria(Criteria $criteria)
   {
     return self::addjobsRelatedByobjectIdCriteriaById($criteria, $this->id);
+  }
+
+  public static function adddigitalObjectsRelatedByobjectIdCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitDigitalObject::OBJECT_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getdigitalObjectsRelatedByobjectIdById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::adddigitalObjectsRelatedByobjectIdCriteriaById($criteria, $id);
+
+    return QubitDigitalObject::get($criteria, $options);
+  }
+
+  public function adddigitalObjectsRelatedByobjectIdCriteria(Criteria $criteria)
+  {
+    return self::adddigitalObjectsRelatedByobjectIdCriteriaById($criteria, $this->id);
   }
 
   public static function addeventsRelatedByobjectIdCriteriaById(Criteria $criteria, $id)
@@ -1118,26 +1180,6 @@ abstract class BaseObject implements ArrayAccess
   public function addstatussCriteria(Criteria $criteria)
   {
     return self::addstatussCriteriaById($criteria, $this->id);
-  }
-
-  public static function addaclPermissionsCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitAclPermission::OBJECT_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getaclPermissionsById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::addaclPermissionsCriteriaById($criteria, $id);
-
-    return QubitAclPermission::get($criteria, $options);
-  }
-
-  public function addaclPermissionsCriteria(Criteria $criteria)
-  {
-    return self::addaclPermissionsCriteriaById($criteria, $this->id);
   }
 
   public function __call($name, $args)

--- a/lib/model/om/BaseTerm.php
+++ b/lib/model/om/BaseTerm.php
@@ -109,31 +109,6 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
     {
     }
 
-    if ('accessionsRelatedByacquisitionTypeId' == $name)
-    {
-      return true;
-    }
-
-    if ('accessionsRelatedByprocessingPriorityId' == $name)
-    {
-      return true;
-    }
-
-    if ('accessionsRelatedByprocessingStatusId' == $name)
-    {
-      return true;
-    }
-
-    if ('accessionsRelatedByresourceTypeId' == $name)
-    {
-      return true;
-    }
-
-    if ('deaccessions' == $name)
-    {
-      return true;
-    }
-
     if ('actorsRelatedByentityTypeId' == $name)
     {
       return true;
@@ -294,6 +269,31 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
       return true;
     }
 
+    if ('accessionsRelatedByacquisitionTypeId' == $name)
+    {
+      return true;
+    }
+
+    if ('accessionsRelatedByprocessingPriorityId' == $name)
+    {
+      return true;
+    }
+
+    if ('accessionsRelatedByprocessingStatusId' == $name)
+    {
+      return true;
+    }
+
+    if ('accessionsRelatedByresourceTypeId' == $name)
+    {
+      return true;
+    }
+
+    if ('deaccessions' == $name)
+    {
+      return true;
+    }
+
     try
     {
       if (!$value = call_user_func_array(array($this->getCurrenttermI18n($options), '__isset'), $args) && !empty($options['cultureFallback']))
@@ -336,91 +336,6 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
     }
     catch (sfException $e)
     {
-    }
-
-    if ('accessionsRelatedByacquisitionTypeId' == $name)
-    {
-      if (!isset($this->refFkValues['accessionsRelatedByacquisitionTypeId']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['accessionsRelatedByacquisitionTypeId'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['accessionsRelatedByacquisitionTypeId'] = self::getaccessionsRelatedByacquisitionTypeIdById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['accessionsRelatedByacquisitionTypeId'];
-    }
-
-    if ('accessionsRelatedByprocessingPriorityId' == $name)
-    {
-      if (!isset($this->refFkValues['accessionsRelatedByprocessingPriorityId']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['accessionsRelatedByprocessingPriorityId'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['accessionsRelatedByprocessingPriorityId'] = self::getaccessionsRelatedByprocessingPriorityIdById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['accessionsRelatedByprocessingPriorityId'];
-    }
-
-    if ('accessionsRelatedByprocessingStatusId' == $name)
-    {
-      if (!isset($this->refFkValues['accessionsRelatedByprocessingStatusId']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['accessionsRelatedByprocessingStatusId'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['accessionsRelatedByprocessingStatusId'] = self::getaccessionsRelatedByprocessingStatusIdById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['accessionsRelatedByprocessingStatusId'];
-    }
-
-    if ('accessionsRelatedByresourceTypeId' == $name)
-    {
-      if (!isset($this->refFkValues['accessionsRelatedByresourceTypeId']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['accessionsRelatedByresourceTypeId'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['accessionsRelatedByresourceTypeId'] = self::getaccessionsRelatedByresourceTypeIdById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['accessionsRelatedByresourceTypeId'];
-    }
-
-    if ('deaccessions' == $name)
-    {
-      if (!isset($this->refFkValues['deaccessions']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['deaccessions'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['deaccessions'] = self::getdeaccessionsById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['deaccessions'];
     }
 
     if ('actorsRelatedByentityTypeId' == $name)
@@ -967,6 +882,91 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
       return $this->refFkValues['termI18ns'];
     }
 
+    if ('accessionsRelatedByacquisitionTypeId' == $name)
+    {
+      if (!isset($this->refFkValues['accessionsRelatedByacquisitionTypeId']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['accessionsRelatedByacquisitionTypeId'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['accessionsRelatedByacquisitionTypeId'] = self::getaccessionsRelatedByacquisitionTypeIdById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['accessionsRelatedByacquisitionTypeId'];
+    }
+
+    if ('accessionsRelatedByprocessingPriorityId' == $name)
+    {
+      if (!isset($this->refFkValues['accessionsRelatedByprocessingPriorityId']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['accessionsRelatedByprocessingPriorityId'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['accessionsRelatedByprocessingPriorityId'] = self::getaccessionsRelatedByprocessingPriorityIdById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['accessionsRelatedByprocessingPriorityId'];
+    }
+
+    if ('accessionsRelatedByprocessingStatusId' == $name)
+    {
+      if (!isset($this->refFkValues['accessionsRelatedByprocessingStatusId']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['accessionsRelatedByprocessingStatusId'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['accessionsRelatedByprocessingStatusId'] = self::getaccessionsRelatedByprocessingStatusIdById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['accessionsRelatedByprocessingStatusId'];
+    }
+
+    if ('accessionsRelatedByresourceTypeId' == $name)
+    {
+      if (!isset($this->refFkValues['accessionsRelatedByresourceTypeId']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['accessionsRelatedByresourceTypeId'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['accessionsRelatedByresourceTypeId'] = self::getaccessionsRelatedByresourceTypeIdById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['accessionsRelatedByresourceTypeId'];
+    }
+
+    if ('deaccessions' == $name)
+    {
+      if (!isset($this->refFkValues['deaccessions']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['deaccessions'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['deaccessions'] = self::getdeaccessionsById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['deaccessions'];
+    }
+
     try
     {
       if (1 > strlen($value = call_user_func_array(array($this->getCurrenttermI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
@@ -1193,106 +1193,6 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
     $criteria->addJoin(QubitTerm::PARENT_ID, QubitTerm::ID);
 
     return $criteria;
-  }
-
-  public static function addaccessionsRelatedByacquisitionTypeIdCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitAccession::ACQUISITION_TYPE_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getaccessionsRelatedByacquisitionTypeIdById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::addaccessionsRelatedByacquisitionTypeIdCriteriaById($criteria, $id);
-
-    return QubitAccession::get($criteria, $options);
-  }
-
-  public function addaccessionsRelatedByacquisitionTypeIdCriteria(Criteria $criteria)
-  {
-    return self::addaccessionsRelatedByacquisitionTypeIdCriteriaById($criteria, $this->id);
-  }
-
-  public static function addaccessionsRelatedByprocessingPriorityIdCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitAccession::PROCESSING_PRIORITY_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getaccessionsRelatedByprocessingPriorityIdById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::addaccessionsRelatedByprocessingPriorityIdCriteriaById($criteria, $id);
-
-    return QubitAccession::get($criteria, $options);
-  }
-
-  public function addaccessionsRelatedByprocessingPriorityIdCriteria(Criteria $criteria)
-  {
-    return self::addaccessionsRelatedByprocessingPriorityIdCriteriaById($criteria, $this->id);
-  }
-
-  public static function addaccessionsRelatedByprocessingStatusIdCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitAccession::PROCESSING_STATUS_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getaccessionsRelatedByprocessingStatusIdById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::addaccessionsRelatedByprocessingStatusIdCriteriaById($criteria, $id);
-
-    return QubitAccession::get($criteria, $options);
-  }
-
-  public function addaccessionsRelatedByprocessingStatusIdCriteria(Criteria $criteria)
-  {
-    return self::addaccessionsRelatedByprocessingStatusIdCriteriaById($criteria, $this->id);
-  }
-
-  public static function addaccessionsRelatedByresourceTypeIdCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitAccession::RESOURCE_TYPE_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getaccessionsRelatedByresourceTypeIdById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::addaccessionsRelatedByresourceTypeIdCriteriaById($criteria, $id);
-
-    return QubitAccession::get($criteria, $options);
-  }
-
-  public function addaccessionsRelatedByresourceTypeIdCriteria(Criteria $criteria)
-  {
-    return self::addaccessionsRelatedByresourceTypeIdCriteriaById($criteria, $this->id);
-  }
-
-  public static function adddeaccessionsCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitDeaccession::SCOPE_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getdeaccessionsById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::adddeaccessionsCriteriaById($criteria, $id);
-
-    return QubitDeaccession::get($criteria, $options);
-  }
-
-  public function adddeaccessionsCriteria(Criteria $criteria)
-  {
-    return self::adddeaccessionsCriteriaById($criteria, $this->id);
   }
 
   public static function addactorsRelatedByentityTypeIdCriteriaById(Criteria $criteria, $id)
@@ -1933,6 +1833,106 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
   public function addtermI18nsCriteria(Criteria $criteria)
   {
     return self::addtermI18nsCriteriaById($criteria, $this->id);
+  }
+
+  public static function addaccessionsRelatedByacquisitionTypeIdCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitAccession::ACQUISITION_TYPE_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getaccessionsRelatedByacquisitionTypeIdById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addaccessionsRelatedByacquisitionTypeIdCriteriaById($criteria, $id);
+
+    return QubitAccession::get($criteria, $options);
+  }
+
+  public function addaccessionsRelatedByacquisitionTypeIdCriteria(Criteria $criteria)
+  {
+    return self::addaccessionsRelatedByacquisitionTypeIdCriteriaById($criteria, $this->id);
+  }
+
+  public static function addaccessionsRelatedByprocessingPriorityIdCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitAccession::PROCESSING_PRIORITY_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getaccessionsRelatedByprocessingPriorityIdById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addaccessionsRelatedByprocessingPriorityIdCriteriaById($criteria, $id);
+
+    return QubitAccession::get($criteria, $options);
+  }
+
+  public function addaccessionsRelatedByprocessingPriorityIdCriteria(Criteria $criteria)
+  {
+    return self::addaccessionsRelatedByprocessingPriorityIdCriteriaById($criteria, $this->id);
+  }
+
+  public static function addaccessionsRelatedByprocessingStatusIdCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitAccession::PROCESSING_STATUS_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getaccessionsRelatedByprocessingStatusIdById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addaccessionsRelatedByprocessingStatusIdCriteriaById($criteria, $id);
+
+    return QubitAccession::get($criteria, $options);
+  }
+
+  public function addaccessionsRelatedByprocessingStatusIdCriteria(Criteria $criteria)
+  {
+    return self::addaccessionsRelatedByprocessingStatusIdCriteriaById($criteria, $this->id);
+  }
+
+  public static function addaccessionsRelatedByresourceTypeIdCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitAccession::RESOURCE_TYPE_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getaccessionsRelatedByresourceTypeIdById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addaccessionsRelatedByresourceTypeIdCriteriaById($criteria, $id);
+
+    return QubitAccession::get($criteria, $options);
+  }
+
+  public function addaccessionsRelatedByresourceTypeIdCriteria(Criteria $criteria)
+  {
+    return self::addaccessionsRelatedByresourceTypeIdCriteriaById($criteria, $this->id);
+  }
+
+  public static function adddeaccessionsCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitDeaccession::SCOPE_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getdeaccessionsById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::adddeaccessionsCriteriaById($criteria, $id);
+
+    return QubitDeaccession::get($criteria, $options);
+  }
+
+  public function adddeaccessionsCriteria(Criteria $criteria)
+  {
+    return self::adddeaccessionsCriteriaById($criteria, $this->id);
   }
 
   public function getCurrenttermI18n(array $options = array())

--- a/lib/model/om/BaseUser.php
+++ b/lib/model/om/BaseUser.php
@@ -84,6 +84,16 @@ abstract class BaseUser extends QubitActor implements ArrayAccess
     {
     }
 
+    if ('aclPermissions' == $name)
+    {
+      return true;
+    }
+
+    if ('aclUserGroups' == $name)
+    {
+      return true;
+    }
+
     if ('auditLogs' == $name)
     {
       return true;
@@ -100,16 +110,6 @@ abstract class BaseUser extends QubitActor implements ArrayAccess
     }
 
     if ('notes' == $name)
-    {
-      return true;
-    }
-
-    if ('aclPermissions' == $name)
-    {
-      return true;
-    }
-
-    if ('aclUserGroups' == $name)
     {
       return true;
     }
@@ -133,6 +133,40 @@ abstract class BaseUser extends QubitActor implements ArrayAccess
     }
     catch (sfException $e)
     {
+    }
+
+    if ('aclPermissions' == $name)
+    {
+      if (!isset($this->refFkValues['aclPermissions']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['aclPermissions'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['aclPermissions'] = self::getaclPermissionsById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['aclPermissions'];
+    }
+
+    if ('aclUserGroups' == $name)
+    {
+      if (!isset($this->refFkValues['aclUserGroups']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['aclUserGroups'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['aclUserGroups'] = self::getaclUserGroupsById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['aclUserGroups'];
     }
 
     if ('auditLogs' == $name)
@@ -203,41 +237,47 @@ abstract class BaseUser extends QubitActor implements ArrayAccess
       return $this->refFkValues['notes'];
     }
 
-    if ('aclPermissions' == $name)
-    {
-      if (!isset($this->refFkValues['aclPermissions']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['aclPermissions'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['aclPermissions'] = self::getaclPermissionsById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['aclPermissions'];
-    }
-
-    if ('aclUserGroups' == $name)
-    {
-      if (!isset($this->refFkValues['aclUserGroups']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['aclUserGroups'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['aclUserGroups'] = self::getaclUserGroupsById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['aclUserGroups'];
-    }
-
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
+  }
+
+  public static function addaclPermissionsCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitAclPermission::USER_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getaclPermissionsById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addaclPermissionsCriteriaById($criteria, $id);
+
+    return QubitAclPermission::get($criteria, $options);
+  }
+
+  public function addaclPermissionsCriteria(Criteria $criteria)
+  {
+    return self::addaclPermissionsCriteriaById($criteria, $this->id);
+  }
+
+  public static function addaclUserGroupsCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitAclUserGroup::USER_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getaclUserGroupsById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addaclUserGroupsCriteriaById($criteria, $id);
+
+    return QubitAclUserGroup::get($criteria, $options);
+  }
+
+  public function addaclUserGroupsCriteria(Criteria $criteria)
+  {
+    return self::addaclUserGroupsCriteriaById($criteria, $this->id);
   }
 
   public static function addauditLogsCriteriaById(Criteria $criteria, $id)
@@ -318,45 +358,5 @@ abstract class BaseUser extends QubitActor implements ArrayAccess
   public function addnotesCriteria(Criteria $criteria)
   {
     return self::addnotesCriteriaById($criteria, $this->id);
-  }
-
-  public static function addaclPermissionsCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitAclPermission::USER_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getaclPermissionsById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::addaclPermissionsCriteriaById($criteria, $id);
-
-    return QubitAclPermission::get($criteria, $options);
-  }
-
-  public function addaclPermissionsCriteria(Criteria $criteria)
-  {
-    return self::addaclPermissionsCriteriaById($criteria, $this->id);
-  }
-
-  public static function addaclUserGroupsCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitAclUserGroup::USER_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getaclUserGroupsById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::addaclUserGroupsCriteriaById($criteria, $id);
-
-    return QubitAclUserGroup::get($criteria, $options);
-  }
-
-  public function addaclUserGroupsCriteria(Criteria $criteria)
-  {
-    return self::addaclUserGroupsCriteriaById($criteria, $this->id);
   }
 }

--- a/lib/task/digitalobject/digitalObjectDeleteTask.class.php
+++ b/lib/task/digitalobject/digitalObjectDeleteTask.class.php
@@ -74,7 +74,7 @@ EOF;
                         ++$nDeleted, count($ios), $io->getTitle(array('cultureFallback' => true))));
 
       // Remove appropriate digital object files, empty directories left behind, and db entries
-      foreach ($io->digitalObjects as $do)
+      foreach ($io->digitalObjectsRelatedByobjectId as $do)
       {
         $this->deleteDigitalObjectFiles($do);
         QubitDigitalObject::pruneEmptyDirs(dirname($do->getAbsolutePath()));

--- a/lib/task/digitalobject/digitalObjectLoadTask.class.php
+++ b/lib/task/digitalobject/digitalObjectLoadTask.class.php
@@ -157,7 +157,7 @@ EOF;
 
     // Set up prepared query based on identifier type
     $sql = 'SELECT io.id, do.id FROM '.QubitInformationObject::TABLE_NAME.' io
-      LEFT JOIN '.QubitDigitalObject::TABLE_NAME.' do ON io.id = do.information_object_id';
+      LEFT JOIN '.QubitDigitalObject::TABLE_NAME.' do ON io.id = do.object_id';
 
     if ($idType == 'id')
     {

--- a/lib/task/digitalobject/digitalObjectLoadTask.class.php
+++ b/lib/task/digitalobject/digitalObjectLoadTask.class.php
@@ -232,7 +232,7 @@ EOF;
     }
   }
 
-  protected function addDigitalObject($ioId, $path, $options = array())
+  protected function addDigitalObject($objectId, $path, $options = array())
   {
     $this->curObjNum++;
 
@@ -264,7 +264,7 @@ EOF;
 
     // Create digital object
     $do = new QubitDigitalObject;
-    $do->informationObjectId = $ioId;
+    $do->objectId = $objectId;
     $do->usageId = QubitTerm::MASTER_ID;
     $do->assets[] = new QubitAsset($filename, $content);
     $do->save($options['conn']);

--- a/lib/task/digitalobject/digitalObjectRegenDerivativesTask.class.php
+++ b/lib/task/digitalobject/digitalObjectRegenDerivativesTask.class.php
@@ -82,7 +82,7 @@ EOF;
 
     // Get all master digital objects
     $query = 'SELECT do.id
-      FROM digital_object do JOIN information_object io ON do.information_object_id = io.id';
+      FROM digital_object do JOIN information_object io ON do.object_id = io.id';
 
     // Limit to a branch
     if ($options['slug'])

--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -978,7 +978,7 @@ EOF;
           && null === $self->object->getDigitalObject())
         {
           $do = new QubitDigitalObject;
-          $do->informationObject = $self->object;
+          $do->object = $self->object;
 
           if ($self->status['options']['skip-derivatives'])
           {
@@ -1076,7 +1076,7 @@ EOF;
 
     $do = new QubitDigitalObject;
     $do->usageId = QubitTerm::MASTER_ID;
-    $do->informationObject = $self->object;
+    $do->object = $self->object;
 
     // Don't create derivatives (reference, thumb)
     if ($self->status['options']['skip-derivatives'])

--- a/lib/task/import/importDipObjectsTask.class.php
+++ b/lib/task/import/importDipObjectsTask.class.php
@@ -143,7 +143,7 @@ EOF;
       throw new sfException('You must specify a DIP directory');
     }
 
-    // If undo log directory specified, make sure it's a valid directory 
+    // If undo log directory specified, make sure it's a valid directory
     if (!empty($options['undo-log-dir']) && !is_dir($options['undo-log-dir']))
     {
       throw new sfException('Undo log directory does not exist.');
@@ -465,7 +465,7 @@ EOF;
     $do->assets[] = new QubitAsset($filepath);
 
     // Add digital object to information object
-    $informationObject->digitalObjects[] = $do;
+    $informationObject->digitalObjectsRelatedByobjectId[] = $do;
 
     // Add DIP UUID as aipUUID information object property
     if (null !== $dipUUID = $this->getUUID(basename($this->dipDir)))

--- a/lib/task/migrate/migrations/arMigration0169.class.php
+++ b/lib/task/migrate/migrations/arMigration0169.class.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add new term to the levels of description taxonomy
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0169
+{
+  const
+    VERSION = 169, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  public function up($configuration)
+  {
+    // Add object_id to digital_object with fk relationship
+    $sql = <<<sql
+
+ALTER TABLE `atom`.`digital_object`
+DROP FOREIGN KEY `digital_object_FK_2`;
+ALTER TABLE `atom`.`digital_object`
+CHANGE COLUMN `information_object_id` `object_id` INT(11) NULL DEFAULT NULL ;
+ALTER TABLE `atom`.`digital_object`
+ADD CONSTRAINT `digital_object_FK_2`
+  FOREIGN KEY (`object_id`)
+  REFERENCES `atom`.`information_object` (`id`);
+
+sql;
+
+    QubitPdo::modify($sql);
+
+    return true;
+  }
+}

--- a/lib/task/migrate/migrations/arMigration0169.class.php
+++ b/lib/task/migrate/migrations/arMigration0169.class.php
@@ -18,7 +18,11 @@
  */
 
 /*
- * Add new term to the levels of description taxonomy
+ * Change Digital Object fk relationship.
+ *
+ * Historically, digital objects were related to the information object table
+ * directly. This change alters the FK relationship such that DO's can be
+ * linked to any object type via fk linking to the object table.
  *
  * @package    AccesstoMemory
  * @subpackage migration

--- a/plugins/arDacsPlugin/modules/arDacsPlugin/templates/indexSuccess.php
+++ b/plugins/arDacsPlugin/modules/arDacsPlugin/templates/indexSuccess.php
@@ -51,8 +51,8 @@
 
 <?php end_slot() ?>
 
-<?php if (0 < count($resource->digitalObjects)): ?>
-  <?php echo get_component('digitalobject', 'show', array('link' => $digitalObjectLink, 'resource' => $resource->digitalObjects[0], 'usageType' => QubitTerm::REFERENCE_ID)) ?>
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)): ?>
+  <?php echo get_component('digitalobject', 'show', array('link' => $digitalObjectLink, 'resource' => $resource->digitalObjectsRelatedByobjectId[0], 'usageType' => QubitTerm::REFERENCE_ID)) ?>
 <?php endif; ?>
 
 <section id="identityArea">
@@ -264,11 +264,11 @@
 
 <?php endif; ?>
 
-<?php if (0 < count($resource->digitalObjects)): ?>
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)): ?>
 
-  <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjects[0], 'infoObj' => $resource)) ?>
+  <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjectsRelatedByobjectId[0], 'infoObj' => $resource)) ?>
 
-  <?php echo get_partial('digitalobject/rights', array('resource' => $resource->digitalObjects[0])) ?>
+  <?php echo get_partial('digitalobject/rights', array('resource' => $resource->digitalObjectsRelatedByobjectId[0])) ?>
 
 <?php endif; ?>
 

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchAipPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchAipPdo.class.php
@@ -108,7 +108,7 @@ class arElasticSearchAipPdo
                 obj.updated_at';
     $sql .= ' FROM '.QubitDigitalObject::TABLE_NAME.' do';
     $sql .= ' JOIN '.QubitRelation::TABLE_NAME.' relation
-                ON do.information_object_id = relation.object_id';
+                ON do.object_id = relation.object_id';
     $sql .= ' JOIN '.QubitObject::TABLE_NAME.' obj
                 ON do.id = obj.id';
     $sql .= ' WHERE relation.subject_id = ?

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
@@ -154,7 +154,7 @@ class arElasticSearchInformationObjectPdo
        JOIN '.QubitStatus::TABLE_NAME.' pubstat
          ON io.id = pubstat.object_id
        LEFT JOIN '.QubitDigitalObject::TABLE_NAME.' do
-         ON io.id = do.information_object_id
+         ON io.id = do.object_id
        WHERE io.id = :id';
 
       self::$statements['informationObject'] = self::$conn->prepare($sql);

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_about.xml.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_about.xml.php
@@ -1,7 +1,7 @@
-      <?php if (count($record->digitalObjects)): ?>
+      <?php if (count($record->digitalObjectsRelatedByobjectId)): ?>
         <about>
           <feed xmlns="http://www.w3.org/2005/Atom">
-            <?php foreach ($record->digitalObjects as $digitalObject): ?>
+            <?php foreach ($record->digitalObjectsRelatedByobjectId as $digitalObject): ?>
               <?php if ($digitalObject->usageId == QubitTerm::OFFLINE_ID): ?>
                 <?php continue; ?>
               <?php endif; ?>

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_getRecord.xml.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_getRecord.xml.php
@@ -16,7 +16,7 @@
             <?php arOaiPluginComponent::includeCachedMetadata($record, $metadataPrefix) ?>
           <?php endif; ?>
         </metadata>
-        <?php if (count($record->digitalObjects)): ?>
+        <?php if (count($record->digitalObjectsRelatedByobjectId)): ?>
           <?php include('_about.xml.php') ?>
         <?php endif; ?>
       </record>

--- a/plugins/arRestApiPlugin/modules/api/actions/digitalobjectsBrowseAction.class.php
+++ b/plugins/arRestApiPlugin/modules/api/actions/digitalobjectsBrowseAction.class.php
@@ -75,7 +75,7 @@ class ApiDigitalObjectsBrowseAction extends QubitApiAction
       {
         $criteria = new Criteria;
         $criteria->add(QubitProperty::NAME, $propertyName);
-        $criteria->add(QubitProperty::OBJECT_ID, $do->informationObjectId);
+        $criteria->add(QubitProperty::OBJECT_ID, $do->objectId);
 
         if (null !== ($uuidProperty = QubitProperty::getOne($criteria))) { $fields[$apiFieldLabel] = $uuidProperty->value; }
       }

--- a/plugins/arRestApiPlugin/modules/api/actions/digitalobjectsCreateAction.class.php
+++ b/plugins/arRestApiPlugin/modules/api/actions/digitalobjectsCreateAction.class.php
@@ -46,7 +46,7 @@ class ApiDigitalObjectsCreateAction extends QubitApiAction
     }
 
     // Associate properties with information object
-    if (!empty($this->do->informationObjectId))
+    if (!empty($this->do->objectId))
     {
       $props = array(
         'file_uuid' => 'objectUUID',
@@ -65,7 +65,7 @@ class ApiDigitalObjectsCreateAction extends QubitApiAction
         }
 
         $property = new QubitProperty;
-        $property->objectId = $this->do->informationObjectId;
+        $property->objectId = $this->do->objectId;
         $property->name = $pval;
         $property->value = $payload->$pkey;
         $property->save();
@@ -101,7 +101,7 @@ class ApiDigitalObjectsCreateAction extends QubitApiAction
 
         if (null !== $slug)
         {
-          $this->do->informationObjectId = $slug->objectId;
+          $this->do->objectId = $slug->objectId;
         }
         break;
 
@@ -115,7 +115,7 @@ class ApiDigitalObjectsCreateAction extends QubitApiAction
         $io->setLevelOfDescriptionByName('item');
         $io->save();
 
-        $this->do->informationObjectId = $io->id;
+        $this->do->objectId = $io->id;
         break;
 
       case 'media_type':

--- a/plugins/arRestApiPlugin/modules/api/actions/informationobjectsReadAction.class.php
+++ b/plugins/arRestApiPlugin/modules/api/actions/informationobjectsReadAction.class.php
@@ -118,7 +118,7 @@ class ApiInformationObjectsReadAction extends QubitApiAction
         {
           $this->addItemToArray($ioData, 'repository', $ancestor->repository->getAuthorizedFormOfName(array('cultureFallback' => true)));
           $this->addItemToArray($ioData, 'repository_inherited_from', $ancestor->getTitle(array('cultureFallback' => true)));
-        
+
           break;
         }
       }
@@ -193,7 +193,7 @@ class ApiInformationObjectsReadAction extends QubitApiAction
         $relatedDescriptions[] = $item->subject->getTitle(array('cultureFallback' => true));
       }
     }
-    
+
     $this->addItemToArray($ioData, 'related_descriptions', $relatedDescriptions);
 
     $publicationNotes = array();
@@ -201,7 +201,7 @@ class ApiInformationObjectsReadAction extends QubitApiAction
     {
       $publicationNotes[] = $item->getContent(array('cultureFallback' => true));
     }
-    
+
     $this->addItemToArray($ioData, 'publication_notes', $publicationNotes);
 
     if (sfConfig::get('app_element_visibility_isad_notes', false))
@@ -211,7 +211,7 @@ class ApiInformationObjectsReadAction extends QubitApiAction
       {
         $notes[] = $item->getContent(array('cultureFallback' => true));
       }
-      
+
       $this->addItemToArray($ioData, 'notes', $notes);
     }
 
@@ -316,8 +316,8 @@ class ApiInformationObjectsReadAction extends QubitApiAction
       {
         $archivistsNotes[] = $item->getContent(array('cultureFallback' => true));
       }
-      
-      $this->addItemToArray($ioData, 'archivists_notes', $archivistsNotes);      
+
+      $this->addItemToArray($ioData, 'archivists_notes', $archivistsNotes);
     }
 
     $rights = array();
@@ -328,10 +328,10 @@ class ApiInformationObjectsReadAction extends QubitApiAction
 
       if (isset($right->basis))
       {
-        $this->addItemToArray($rightData, 'basis', $right->basis->getName(array('cultureFallback' => true)));      
+        $this->addItemToArray($rightData, 'basis', $right->basis->getName(array('cultureFallback' => true)));
       }
 
-      $this->addItemToArray($rightData, 'start_date', $right->startDate);      
+      $this->addItemToArray($rightData, 'start_date', $right->startDate);
       $this->addItemToArray($rightData, 'end_date', $right->endDate);
       $this->addItemToArray($rightData, 'documentation_identifier_type', $right->getIdentifierType(array('cultureFallback' => true)));
       $this->addItemToArray($rightData, 'documentation_identifier_value', $right->getIdentifierValue(array('cultureFallback' => true)));
@@ -339,7 +339,7 @@ class ApiInformationObjectsReadAction extends QubitApiAction
 
       if (isset($right->rightsHolder))
       {
-        $this->addItemToArray($rightData, 'rights_holder', $right->rightsHolder->getAuthorizedFormOfName(array('cultureFallback' => true)));      
+        $this->addItemToArray($rightData, 'rights_holder', $right->rightsHolder->getAuthorizedFormOfName(array('cultureFallback' => true)));
       }
 
       $this->addItemToArray($rightData, 'rights_note', $right->getRightsNote(array('cultureFallback' => true)));
@@ -349,7 +349,7 @@ class ApiInformationObjectsReadAction extends QubitApiAction
       {
         if (isset($right->copyrightStatus))
         {
-          $this->addItemToArray($rightData, 'copyright_status', $right->copyrightStatus->getName(array('cultureFallback' => true)));      
+          $this->addItemToArray($rightData, 'copyright_status', $right->copyrightStatus->getName(array('cultureFallback' => true)));
         }
 
         $this->addItemToArray($rightData, 'copyright_status_date', $right->copyrightStatusDate);
@@ -368,7 +368,7 @@ class ApiInformationObjectsReadAction extends QubitApiAction
 
         if (isset($right->statuteCitation))
         {
-          $this->addItemToArray($rightData, 'statute_citation', $right->statuteCitation->getName(array('cultureFallback' => true)));      
+          $this->addItemToArray($rightData, 'statute_citation', $right->statuteCitation->getName(array('cultureFallback' => true)));
         }
 
         $this->addItemToArray($rightData, 'statute_determination_date', $right->statuteDeterminationDate);
@@ -382,10 +382,10 @@ class ApiInformationObjectsReadAction extends QubitApiAction
 
         if (isset($grantedRight->act))
         {
-          $this->addItemToArray($grantedRightData, 'act', $grantedRight->act->getName(array('cultureFallback' => true)));      
+          $this->addItemToArray($grantedRightData, 'act', $grantedRight->act->getName(array('cultureFallback' => true)));
         }
 
-        $this->addItemToArray($grantedRightData, 'restriction', QubitGrantedRight::getRestrictionString($grantedRight->restriction));      
+        $this->addItemToArray($grantedRightData, 'restriction', QubitGrantedRight::getRestrictionString($grantedRight->restriction));
         $this->addItemToArray($grantedRightData, 'start_date', $grantedRight->startDate);
         $this->addItemToArray($grantedRightData, 'end_date', $grantedRight->endDate);
         $this->addItemToArray($grantedRightData, 'notes', $grantedRight->notes);
@@ -398,11 +398,11 @@ class ApiInformationObjectsReadAction extends QubitApiAction
       $rights[] = $rightData;
     }
 
-    $this->addItemToArray($ioData, 'rights', $rights);      
+    $this->addItemToArray($ioData, 'rights', $rights);
 
-    if (0 < count($this->resource->digitalObjects))
+    if (0 < count($this->resource->digitalObjectsRelatedByobjectId))
     {
-      $digitalObject = $this->resource->digitalObjects[0];
+      $digitalObject = $this->resource->digitalObjectsRelatedByobjectId[0];
       $doData = array();
 
       if (sfConfig::get('app_element_visibility_digital_object_file_name', false))

--- a/plugins/arRestApiPlugin/modules/api/actions/informationobjectsReadAction.class.php
+++ b/plugins/arRestApiPlugin/modules/api/actions/informationobjectsReadAction.class.php
@@ -430,8 +430,8 @@ class ApiInformationObjectsReadAction extends QubitApiAction
         $this->addItemToArray($doData, 'uploaded_at', format_date($digitalObject->createdAt, 'f'));
       }
 
-      $this->addItemToArray($doData, 'object_uuid', $digitalObject->informationObject->objectUUID);
-      $this->addItemToArray($doData, 'aip_uuid', $digitalObject->informationObject->aipUUID);
+      $this->addItemToArray($doData, 'object_uuid', $digitalObject->object->objectUUID);
+      $this->addItemToArray($doData, 'aip_uuid', $digitalObject->object->aipUUID);
 
       if (sfConfig::get('app_element_visibility_digital_object_url', false))
       {

--- a/plugins/qtSwordPlugin/lib/qtPackageExtractorMETSArchivematicaDIP.class.php
+++ b/plugins/qtSwordPlugin/lib/qtPackageExtractorMETSArchivematicaDIP.class.php
@@ -56,7 +56,7 @@ class qtPackageExtractorMETSArchivematicaDIP extends qtPackageExtractorBase
     // Initialice METS parser, used in addDigitalObjects to add
     // the required data from the METS file to the digital objects
     $this->metsParser = new QubitMetsParser($this->document);
-    
+
     // Stop if there isn't a proper structMap
     if (null === $structMap = $this->metsParser->getStructMap())
     {
@@ -226,7 +226,7 @@ class qtPackageExtractorMETSArchivematicaDIP extends qtPackageExtractorBase
         $digitalObject = new QubitDigitalObject;
         $digitalObject->assets[] = new QubitAsset($data['absolutePathWithinDip']);
         $digitalObject->usageId = QubitTerm::MASTER_ID;
-        $child->digitalObjects[] = $digitalObject;
+        $child->digitalObjectsRelatedByobjectId[] = $digitalObject;
       }
 
       // Create relation with AIP
@@ -305,7 +305,7 @@ class qtPackageExtractorMETSArchivematicaDIP extends qtPackageExtractorBase
           $digitalObject = new QubitDigitalObject;
           $digitalObject->assets[] = new QubitAsset($absolutePathWithinDip);
           $digitalObject->usageId = QubitTerm::MASTER_ID;
-          $child->digitalObjects[] = $digitalObject;
+          $child->digitalObjectsRelatedByobjectId[] = $digitalObject;
         }
 
         // Process metatadata from METS file

--- a/plugins/sfDcPlugin/modules/sfDcPlugin/templates/indexSuccess.php
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/templates/indexSuccess.php
@@ -49,8 +49,8 @@
 
 <?php end_slot() ?>
 
-<?php if (0 < count($resource->digitalObjects)): ?>
-  <?php echo get_component('digitalobject', 'show', array('link' => $digitalObjectLink, 'resource' => $resource->digitalObjects[0], 'usageType' => QubitTerm::REFERENCE_ID)) ?>
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)): ?>
+  <?php echo get_component('digitalobject', 'show', array('link' => $digitalObjectLink, 'resource' => $resource->digitalObjectsRelatedByobjectId[0], 'usageType' => QubitTerm::REFERENCE_ID)) ?>
 <?php endif; ?>
 
 <section id="elementsArea">
@@ -138,11 +138,11 @@
 
 <?php endif; ?>
 
-<?php if (0 < count($resource->digitalObjects)): ?>
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)): ?>
 
-  <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjects[0], 'infoObj' => $resource)) ?>
+  <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjectsRelatedByobjectId[0], 'infoObj' => $resource)) ?>
 
-  <?php echo get_partial('digitalobject/rights', array('resource' => $resource->digitalObjects[0])) ?>
+  <?php echo get_partial('digitalobject/rights', array('resource' => $resource->digitalObjectsRelatedByobjectId[0])) ?>
 
 <?php endif; ?>
 

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
@@ -180,7 +180,7 @@
     <materialspec type='philatelic' <?php if (0 < strlen($encoding = $ead->getMetadataParameter('philatelic'))): ?>encodinganalog="<?php echo $encoding ?>"<?php endif; ?>><?php echo escape_dc(esc_specialchars($value)) ?></materialspec>
   <?php endif; ?>
 
-  <?php if (null !== $digitalObject = $$resourceVar->digitalObjects[0]): ?>
+  <?php if (null !== $digitalObject = $$resourceVar->digitalObjectsRelatedByobjectId[0]): ?>
     <?php if (QubitTerm::OFFLINE_ID != $digitalObject->usageId): ?>
       <?php if (QubitAcl::check($$resourceVar, 'readMaster') && 0 < strlen($url = QubitTerm::EXTERNAL_URI_ID == $digitalObject->usageId ? $digitalObject->getPath() : $ead->getAssetPath($digitalObject))): ?>
         <dao linktype="simple" href="<?php echo $url ?>" role="master" actuate="onrequest" show="embed"/>

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/indexSuccess.php
@@ -51,8 +51,8 @@
 
 <?php end_slot() ?>
 
-<?php if (0 < count($resource->digitalObjects)): ?>
-  <?php echo get_component('digitalobject', 'show', array('link' => $digitalObjectLink, 'resource' => $resource->digitalObjects[0], 'usageType' => QubitTerm::REFERENCE_ID)) ?>
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)): ?>
+  <?php echo get_component('digitalobject', 'show', array('link' => $digitalObjectLink, 'resource' => $resource->digitalObjectsRelatedByobjectId[0], 'usageType' => QubitTerm::REFERENCE_ID)) ?>
 <?php endif; ?>
 
 <section id="identityArea">
@@ -324,14 +324,14 @@
 
 <?php endif; ?>
 
-<?php if (0 < count($resource->digitalObjects)): ?>
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)): ?>
 
   <div class="digitalObjectMetadata">
-    <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjects[0], 'infoObj' => $resource)) ?>
+    <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjectsRelatedByobjectId[0], 'infoObj' => $resource)) ?>
   </div>
 
   <div class="digitalObjectRights">
-    <?php echo get_partial('digitalobject/rights', array('resource' => $resource->digitalObjects[0])) ?>
+    <?php echo get_partial('digitalobject/rights', array('resource' => $resource->digitalObjectsRelatedByobjectId[0])) ?>
   </div>
 
 <?php endif; ?>

--- a/plugins/sfModsPlugin/modules/sfModsPlugin/templates/indexSuccess.php
+++ b/plugins/sfModsPlugin/modules/sfModsPlugin/templates/indexSuccess.php
@@ -53,8 +53,8 @@
 
   <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Elements area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'mainArea', 'title' => __('Edit elements area'))) ?>
 
-  <?php if (0 < count($resource->digitalObjects)): ?>
-    <?php echo get_component('digitalobject', 'show', array('link' => $digitalObjectLink, 'resource' => $resource->digitalObjects[0], 'usageType' => QubitTerm::REFERENCE_ID)) ?>
+  <?php if (0 < count($resource->digitalObjectsRelatedByobjectId)): ?>
+    <?php echo get_component('digitalobject', 'show', array('link' => $digitalObjectLink, 'resource' => $resource->digitalObjectsRelatedByobjectId[0], 'usageType' => QubitTerm::REFERENCE_ID)) ?>
   <?php endif; ?>
 
   <?php echo render_show(__('Identifier'), render_value($resource->identifier)) ?>
@@ -71,8 +71,8 @@
     <?php echo render_show(__('Language'), format_language($code)) ?>
   <?php endforeach; ?>
 
-  <?php if (0 < count($resource->digitalObjects)): ?>
-    <?php echo render_show(__('Internet media type'), render_value($resource->digitalObjects[0]->mimeType)) ?>
+  <?php if (0 < count($resource->digitalObjectsRelatedByobjectId)): ?>
+    <?php echo render_show(__('Internet media type'), render_value($resource->digitalObjectsRelatedByobjectId[0]->mimeType)) ?>
   <?php endif; ?>
 
   <?php echo get_partial('object/subjectAccessPoints', array('resource' => $resource, 'mods' => true)) ?>
@@ -83,7 +83,7 @@
 
   <?php echo render_show(__('Access condition'), render_value($resource->getAccessConditions(array('cultureFallback' => true)))) ?>
 
-  <?php if (0 < count($resource->digitalObjects)): ?>
+  <?php if (0 < count($resource->digitalObjectsRelatedByobjectId)): ?>
     <?php echo render_show(__('URL'), link_to(null, $resource->getDigitalObjectPublicUrl())) ?>
   <?php endif; ?>
 
@@ -136,11 +136,11 @@
 
 <?php endif; ?>
 
-<?php if (0 < count($resource->digitalObjects)): ?>
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)): ?>
 
-  <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjects[0], 'infoObj' => $resource)) ?>
+  <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjectsRelatedByobjectId[0], 'infoObj' => $resource)) ?>
 
-  <?php echo get_partial('digitalobject/rights', array('resource' => $resource->digitalObjects[0])) ?>
+  <?php echo get_partial('digitalobject/rights', array('resource' => $resource->digitalObjectsRelatedByobjectId[0])) ?>
 
 <?php endif; ?>
 

--- a/plugins/sfModsPlugin/modules/sfModsPlugin/templates/indexSuccess.xml.php
+++ b/plugins/sfModsPlugin/modules/sfModsPlugin/templates/indexSuccess.xml.php
@@ -56,9 +56,9 @@
     <?php endforeach; ?>
   <?php endif; ?>
 
-  <?php if (isset($resource->digitalObjects[0]->mimeType)): ?>
+  <?php if (isset($resource->digitalObjectsRelatedByobjectId[0]->mimeType)): ?>
     <physicalDescription>
-      <internetMediaType><?php echo $resource->digitalObjects[0]->mimeType ?></internetMediaType>
+      <internetMediaType><?php echo $resource->digitalObjectsRelatedByobjectId[0]->mimeType ?></internetMediaType>
     </physicalDescription>
   <?php endif; ?>
 
@@ -113,7 +113,7 @@
     <accessCondition type="use and reproduction"></accessCondition>
   <?php endif; ?>
 
-  <?php if (isset($resource->digitalObjects[0])): ?>
+  <?php if (isset($resource->digitalObjectsRelatedByobjectId[0])): ?>
     <location>
       <holdingSimple>
         <copyInformation>

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
@@ -51,8 +51,8 @@
 
 <?php end_slot() ?>
 
-<?php if (0 < count($resource->digitalObjects)): ?>
-  <?php echo get_component('digitalobject', 'show', array('link' => $digitalObjectLink, 'resource' => $resource->digitalObjects[0], 'usageType' => QubitTerm::REFERENCE_ID)) ?>
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)): ?>
+  <?php echo get_component('digitalobject', 'show', array('link' => $digitalObjectLink, 'resource' => $resource->digitalObjectsRelatedByobjectId[0], 'usageType' => QubitTerm::REFERENCE_ID)) ?>
 <?php endif; ?>
 
 <section id="titleAndStatementOfResponsibilityArea">
@@ -393,12 +393,12 @@
 
 <?php endif; ?>
 
-<?php if (0 < count($resource->digitalObjects)): ?>
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)): ?>
   <div class="digitalObjectMetadata">
-    <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjects[0], 'infoObj' => $resource)) ?>
+    <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjectsRelatedByobjectId[0], 'infoObj' => $resource)) ?>
   </div>
   <div class="digitalObjectRights">
-    <?php echo get_partial('digitalobject/rights', array('resource' => $resource->digitalObjects[0])) ?>
+    <?php echo get_partial('digitalobject/rights', array('resource' => $resource->digitalObjectsRelatedByobjectId[0])) ?>
   </div>
 <?php endif; ?>
 


### PR DESCRIPTION
This PR changes the relationship between the digital object table and the information object table.  Historically there was a 1 to 1 direct relationship between these two tables.  To support adding a digital object to other types of objects I have changed the linking of digital objects so that they now link through to the object table.

Former relationship: digital_object.information_object_id 1->1 information_object.id
New relationship: digital_object.object_id 1->1 object.id

All commits here support this database change and include the required refactoring.  There are no new features added in the pull request - AtoM's existing digital object functionality should appear identical to the user before and after this work.