### PR TITLE
Add advanced authority record search, refs #12651

### DIFF
--- a/apps/qubit/modules/actor/config/view.yml
+++ b/apps/qubit/modules/actor/config/view.yml
@@ -1,4 +1,7 @@
 browseSuccess:
+  stylesheets:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/ui/ui.all.css:
   javascripts:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/ui/ui.datepicker.js:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/jquery.once.js:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/tableheader:

--- a/apps/qubit/modules/actor/templates/_advancedSearch.php
+++ b/apps/qubit/modules/actor/templates/_advancedSearch.php
@@ -1,0 +1,138 @@
+<section class="advanced-search-section">
+
+  <a href="#" class="advanced-search-toggle <?php echo $show ? 'open' : '' ?>" aria-expanded="<?php echo $show ? 'true' : 'false' ?>"><?php echo __('Advanced search options') ?></a>
+
+  <div class="advanced-search animateNicely" <?php echo !$show ? 'style="display: none;"' : '' ?>>
+
+    <?php echo $form->renderFormTag(url_for(array('module' => 'actor', 'action' => 'browse')), array('name' => 'advanced-search-form', 'method' => 'get')) ?>
+
+      <?php foreach ($hiddenFields as $name => $value): ?>
+        <input type="hidden" name="<?php echo $name ?>" value="<?php echo $value ?>"/>
+      <?php endforeach; ?>
+
+      <p><?php echo __('Find results with:') ?></p>
+
+      <div class="criteria">
+
+        <?php if (isset($criteria)): ?>
+
+          <?php foreach ($criteria as $key => $item): ?>
+
+            <div class="criterion">
+
+              <select class="boolean" name="so<?php echo $key ?>">
+                <option value="and"<?php echo $item['operator'] == 'and' ? ' selected="selected"' : '' ?>><?php echo __('and') ?></option>
+                <option value="or"<?php echo $item['operator'] == 'or' ? ' selected="selected"' : '' ?>><?php echo __('or') ?></option>
+                <option value="not"<?php echo $item['operator'] == 'not' ? ' selected="selected"' : '' ?>><?php echo __('not') ?></option>
+              </select>
+
+              <input class="query" type="text" placeholder="<?php echo __('Search') ?>" name="sq<?php echo $key ?>" value="<?php echo $item['query'] ?>"/>
+
+              <span><?php echo __('in') ?></span>
+
+              <select class="field" name="sf<?php echo $key ?>">
+                <option value=""<?php echo $item['field'] == '' ? ' selected="selected"' : '' ?>><?php echo __('Any field') ?></option>
+                <?php foreach($fieldOptions as $name => $label): ?>
+                  <option value="<?php echo $name; ?>"<?php echo $item['field'] == $name ? ' selected="selected"' : '' ?>><?php echo $label ?></option>
+                <?php endforeach; ?>
+              </select>
+
+              <a href="#" class="delete-criterion"><i class="fa fa-times"></i></a>
+
+            </div>
+
+          <?php endforeach; ?>
+
+        <?php endif; ?>
+
+        <?php $count = isset($key) ? $key++ : 0 ?>
+
+        <div class="criterion">
+
+          <select class="boolean" name="so<?php echo $count ?>">
+            <option value="and"><?php echo __('and') ?></option>
+            <option value="or"><?php echo __('or') ?></option>
+            <option value="not"><?php echo __('not') ?></option>
+          </select>
+
+          <input class="query" type="text" placeholder="<?php echo __('Search') ?>" name="sq<?php echo $count?>"/>
+
+          <span><?php echo __('in') ?></span>
+
+          <select class="field" name="sf<?php echo $count ?>">
+            <option value=""><?php echo __('Any field') ?></option>
+            <?php foreach ($fieldOptions as $name => $label): ?>
+              <option value="<?php echo $name; ?>"><?php echo $label ?></option>
+            <?php endforeach; ?>
+          </select>
+
+          <a href="#" class="delete-criterion"><i class="fa fa-times"></i></a>
+
+        </div>
+
+        <div class="add-new-criteria">
+          <div class="btn-group">
+            <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+              <?php echo __('Add new criteria') ?><span class="caret"></span>
+            </a>
+            <ul class="dropdown-menu">
+              <li><a href="#" id="add-criterion-and"><?php echo __('And') ?></a></li>
+              <li><a href="#" id="add-criterion-or"><?php echo __('Or') ?></a></li>
+              <li><a href="#" id="add-criterion-not"><?php echo __('Not') ?></a></li>
+            </ul>
+          </div>
+        </div>
+
+      </div>
+      <p><?php echo __('Limit results to:') ?></p>
+
+      <?php if (sfConfig::get('app_multi_repository')): ?>
+        <div class="criteria">
+
+          <div class="filter-row">
+            <div class="filter">
+              <?php echo $form->repository
+                ->label(__('Repository'))
+                ->renderRow() ?>
+            </div>
+          </div>
+
+        </div>
+      <?php endif; ?>
+
+      <p><?php echo __('Filter results by:') ?></p>
+
+      <div class="criteria">
+
+        <div class="filter-row triple">
+
+          <div class="filter-left">
+            <?php echo $form->hasDigitalObject
+              ->label(__('%1% available', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))
+              ->renderRow() ?>
+          </div>
+
+          <div class="filter-center">
+            <?php echo $form->entityType
+              ->label(__('%1% available', array('%1%' => __('Entity type'))))
+              ->renderRow() ?>
+          </div>
+
+          <div class="filter-right">
+            <?php echo $form->emptyField
+              ->label(__('Empty field'))
+              ->renderRow() ?>
+          </div>
+
+        </div>
+      </div>
+
+      <section class="actions">
+        <input type="submit" class="c-btn c-btn-submit" value="<?php echo __('Search') ?>"/>
+        <input type="button" class="reset c-btn c-btn-delete" value="<?php echo __('Reset') ?>"/>
+      </section>
+
+    </form>
+
+  </div>
+</section>

--- a/apps/qubit/modules/actor/templates/browseSuccess.php
+++ b/apps/qubit/modules/actor/templates/browseSuccess.php
@@ -1,102 +1,157 @@
-<?php decorate_with('layout_2col') ?>
+<?php if (isset($pager) && $pager->getNbResults()): ?>
+  <?php decorate_with('layout_2col') ?>
+<?php else: ?>
+  <?php decorate_with('layout_1col') ?>
+<?php endif; ?>
+
 <?php use_helper('Date') ?>
 
 <?php slot('title') ?>
   <div class="multiline-header">
     <?php echo image_tag('/images/icons-large/icon-people.png', array('alt' => '')) ?>
-    <h1 aria-describedby="results-label"><?php echo __('Showing %1% results', array('%1%' => $pager->getNbResults())) ?></h1>
+    <h1 aria-describedby="results-label">
+      <?php if (isset($pager) && $pager->getNbResults()): ?>
+        <?php echo __('Showing %1% results', array('%1%' => $pager->getNbResults())) ?>
+      <?php else: ?>
+        <?php echo __('No results found') ?>
+      <?php endif; ?>
+    </h1>
     <span class="sub" id="results-label"><?php echo sfConfig::get('app_ui_label_actor') ?></span>
   </div>
 <?php end_slot() ?>
 
-<?php slot('sidebar') ?>
+<?php if (isset($pager) && $pager->getNbResults()): ?>
 
-  <section id="facets">
+  <?php slot('sidebar') ?>
 
-    <div class="visible-phone facets-header">
-      <a class="x-btn btn-wide">
-        <i class="fa fa-filter"></i>
-        <?php echo __('Filters') ?>
-      </a>
-    </div>
+    <section id="facets">
 
-    <div class="content">
+      <div class="visible-phone facets-header">
+        <a class="x-btn btn-wide">
+          <i class="fa fa-filter"></i>
+          <?php echo __('Filters') ?>
+        </a>
+      </div>
 
-      <h2><?php echo sfConfig::get('app_ui_label_facetstitle') ?></h2>
+      <div class="content">
 
-      <?php echo get_partial('search/aggregation', array(
-        'id' => '#facet-languages',
-        'label' => __('Language'),
-        'name' => 'languages',
-        'aggs' => $aggs,
-        'filters' => $search->filters)) ?>
+        <h2><?php echo sfConfig::get('app_ui_label_facetstitle') ?></h2>
 
-      <?php echo get_partial('search/aggregation', array(
-        'id' => '#facet-entitytype',
-        'label' => __('Entity type'),
-        'name' => 'types',
-        'aggs' => $aggs,
-        'filters' => $search->filters)) ?>
+        <?php echo get_partial('search/aggregation', array(
+          'id' => '#facet-languages',
+          'label' => __('Language'),
+          'name' => 'languages',
+          'aggs' => $aggs,
+          'filters' => $search->filters)) ?>
 
-      <?php echo get_partial('search/aggregation', array(
-        'id' => '#facet-maintainingrepository',
-        'label' => __('Maintained by'),
-        'name' => 'maintainingRepository',
-        'aggs' => $aggs,
-        'filters' => $search->filters)) ?>
+        <?php echo get_partial('search/aggregation', array(
+          'id' => '#facet-entitytype',
+          'label' => __('Entity type'),
+          'name' => 'entityType',
+          'aggs' => $aggs,
+          'filters' => $search->filters)) ?>
 
-      <?php echo get_partial('search/aggregation', array(
-        'id' => '#facet-occupation',
-        'label' => __('Occupation'),
-        'name' => 'occupation',
-        'aggs' => $aggs,
-        'filters' => $search->filters)) ?>
+        <?php echo get_partial('search/aggregation', array(
+          'id' => '#facet-maintainingrepository',
+          'label' => __('Maintained by'),
+          'name' => 'repository',
+          'aggs' => $aggs,
+          'filters' => $search->filters)) ?>
 
-      <?php echo get_partial('search/aggregation', array(
-        'id' => '#facet-places',
-        'label' => sfConfig::get('app_ui_label_place'),
-        'name' => 'places',
-        'aggs' => $aggs,
-        'filters' => $search->filters)) ?>
+        <?php echo get_partial('search/aggregation', array(
+          'id' => '#facet-occupation',
+          'label' => __('Occupation'),
+          'name' => 'occupation',
+          'aggs' => $aggs,
+          'filters' => $search->filters)) ?>
 
-      <?php echo get_partial('search/aggregation', array(
-        'id' => '#facet-subjects',
-        'label' => sfConfig::get('app_ui_label_subject'),
-        'name' => 'subjects',
-        'aggs' => $aggs,
-        'filters' => $search->filters)) ?>
+        <?php echo get_partial('search/aggregation', array(
+          'id' => '#facet-places',
+          'label' => sfConfig::get('app_ui_label_place'),
+          'name' => 'places',
+          'aggs' => $aggs,
+          'filters' => $search->filters)) ?>
 
-    </div>
+        <?php echo get_partial('search/aggregation', array(
+          'id' => '#facet-subjects',
+          'label' => sfConfig::get('app_ui_label_subject'),
+          'name' => 'subjects',
+          'aggs' => $aggs,
+          'filters' => $search->filters)) ?>
 
-  </section>
-<?php end_slot() ?>
+      </div>
+
+    </section>
+  <?php end_slot() ?>
+
+<?php endif; ?>
 
 <?php slot('before-content') ?>
 
   <section class="header-options">
+    <?php if (isset($sf_request->hasDigitalObject)): ?>
+      <span class="search-filter">
+        <?php if (filter_var($sf_request->hasDigitalObject, FILTER_VALIDATE_BOOLEAN)): ?>
+          <?php echo __('With digital objects') ?>
+        <?php else: ?>
+          <?php echo __('Without digital objects') ?>
+        <?php endif; ?>
+        <?php $params = $sf_data->getRaw('sf_request')->getGetParameters() ?>
+        <?php unset($params['hasDigitalObject']) ?>
+        <a href="<?php echo url_for(array('module' => 'actor', 'action' => 'browse') + $params) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
+      </span>
+    <?php endif; ?>
+
+    <?php echo get_component('search', 'filter', array('object' => @$repository, 'param' => 'repository')) ?>
+    <?php echo get_component('search', 'filter', array('object' => @$entityType, 'param' => 'entityType')) ?>
+    <?php echo get_component('search', 'filter', array('object' => @$occupation, 'param' => 'occupation')) ?>
+    <?php echo get_component('search', 'filter', array('object' => @$places, 'param' => 'places')) ?>
+    <?php echo get_component('search', 'filter', array('object' => @$subjects, 'param' => 'subjects')) ?>
+
     <div class="row">
       <div class="span5">
         <?php echo get_component('search', 'inlineSearch', array(
           'label' => __('Search %1%', array('%1%' => strtolower(sfConfig::get('app_ui_label_actor')))))) ?>
       </div>
+    </div>
+
+  </section>
+
+<?php end_slot() ?>
+
+<?php slot('content') ?>
+
+  <?php echo get_partial('actor/advancedSearch', array(
+    'criteria'     => $search->criteria,
+    'form'         => $form,
+    'fieldOptions' => $fieldOptions,
+    'hiddenFields' => $hiddenFields)) ?>
+
+  <?php if (isset($pager) && $pager->getNbResults()): ?>
+    <section class="browse-options">
 
       <div class="pickers">
         <?php echo get_partial('default/sortPickers',
           array(
             'options' => array(
               'lastUpdated' => __('Date modified'),
-              'alphabetic' => __('Name'),
-              'identifier' => __('Identifier')))) ?>
+              'alphabetic'  => __('Name'),
+              'identifier'  => __('Identifier')))) ?>
       </div>
+
+    </section>
+
+    <div id="content" class="browse-content">
+
+      <?php foreach ($pager->getResults() as $hit): ?>
+        <?php $doc = $hit->getData() ?>
+        <?php echo include_partial('actor/searchResult', array('doc' => $doc, 'pager' => $pager, 'culture' => $selectedCulture)) ?>
+      <?php endforeach; ?>
+
     </div>
-  </section>
+  <?php endif; ?>
 
 <?php end_slot() ?>
-
-<?php foreach ($pager->getResults() as $hit): ?>
-  <?php $doc = $hit->getData() ?>
-  <?php echo include_partial('actor/searchResult', array('doc' => $doc, 'pager' => $pager, 'culture' => $selectedCulture)) ?>
-<?php endforeach; ?>
 
 <?php slot('after-content') ?>
   <?php echo get_partial('default/pager', array('pager' => $pager)) ?>

--- a/apps/qubit/modules/default/actions/browseAction.class.php
+++ b/apps/qubit/modules/default/actions/browseAction.class.php
@@ -114,6 +114,25 @@ class DefaultBrowseAction extends sfAction
     return $buckets;
   }
 
+  protected function setHiddenFields($request, $allowed, $ignored)
+  {
+    // Store current params to add them as hidden inputs
+    // in the form, to keep GET and POST params in sync
+    $this->hiddenFields = array();
+
+    // Keep control of what is added to avoid
+    // Cross-Site Scripting vulnerability.
+    foreach ($request->getGetParameters() as $key => $value)
+    {
+      if (!in_array($key, $allowed) || in_array($key, $ignored))
+      {
+        continue;
+      }
+
+      $this->hiddenFields[$key] = $value;
+    }
+  }
+
   public function execute($request)
   {
     // Force subclassing

--- a/apps/qubit/modules/search/actions/filterComponent.class.php
+++ b/apps/qubit/modules/search/actions/filterComponent.class.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class SearchFilterComponent extends sfComponent
+{
+  public function execute($request)
+  {
+    // Display nothing unless any object have been provided
+    if (!isset($this->object))
+    {
+      return sfView::NONE;
+    }
+
+    // Remove selected parameter from the current GET parameters
+    $this->params = $request->getGetParameters();
+    unset($this->params[$this->param]);
+
+    // Default module and action to the current module/action
+    $this->module = isset($this->module) ? $this->module : $this->context->getModuleName();
+    $this->action = isset($this->action) ? $this->action : $this->context->getActionName();
+  }
+}

--- a/apps/qubit/modules/search/templates/_filter.php
+++ b/apps/qubit/modules/search/templates/_filter.php
@@ -1,0 +1,4 @@
+<span class="search-filter">
+  <?php echo render_title($object) ?>
+  <a href="<?php echo url_for(array('module' => $module, 'action' => $action) + $params) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
+</span>

--- a/js/dominion.js
+++ b/js/dominion.js
@@ -707,7 +707,7 @@
     checkReposFilter: function (event)
     {
       // Disable repository filter and facet if top-level description selected
-      if (this.$reposFilter.length && this.$collectionFilter.val() != '')
+      if (typeof($collectionFilter) !== 'undefined' && this.$reposFilter.length && this.$collectionFilter.val() != '')
       {
         this.$reposFilter.attr("disabled", "disabled");
         this.$reposFilter.val('');
@@ -844,7 +844,7 @@
   $(function ()
     {
       // Find search for if on an appropriate page
-      var $advancedSearch = $('body.informationobject.browse,body.search.descriptionUpdates');
+      var $advancedSearch = $('body.informationobject.browse,body.actor.browse,body.search.descriptionUpdates');
       if (0 < $advancedSearch.length)
       {
         new AdvancedSearch($advancedSearch.get(0));

--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -330,6 +330,7 @@ mapping:
       autocompleteFields: [authorizedFormOfName]
       rawFields:  [authorizedFormOfName]
     _foreign_types:
+      maintenance_notes: note
       other_names: other_name
       parallel_names: other_name
       standardized_names: other_name
@@ -354,6 +355,7 @@ mapping:
       maintaining_repository_id: { type: integer, include_in_all: false }
       direct_subjects: { type: integer, include_in_all: false }
       direct_places: { type: integer, include_in_all: false }
+      has_digital_object: { type: boolean, include_in_all: false }
 
   accession:
     _attributes:

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginQuery.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginQuery.class.php
@@ -166,7 +166,7 @@ class arElasticSearchPluginQuery
     }
 
     // Default to show only top level descriptions
-    if (!isset($params['topLod']) || filter_var($params['topLod'], FILTER_VALIDATE_BOOLEAN))
+    if ($archivalStandard != 'isaar' && (!isset($params['topLod']) || filter_var($params['topLod'], FILTER_VALIDATE_BOOLEAN)))
     {
       $this->queryBool->addMust(new \Elastica\Query\Term(array('parentId' => QubitInformationObject::ROOT_ID)));
     }
@@ -386,11 +386,110 @@ class arElasticSearchPluginQuery
 
         break;
 
+      case 'authorizedFormOfName':
+        $queryField = new \Elastica\Query\QueryString($query);
+        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.authorizedFormOfName'));
+        $queryField->setDefaultOperator('AND');
+
+        break;
+
+      case 'datesOfExistence':
+        $queryField = new \Elastica\Query\QueryString($query);
+        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.datesOfExistence'));
+        $queryField->setDefaultOperator('AND');
+
+        break;
+
+      case 'history':
+        $queryField = new \Elastica\Query\QueryString($query);
+        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.history'));
+        $queryField->setDefaultOperator('AND');
+
+        break;
+
+      case 'legalStatus':
+        $queryField = new \Elastica\Query\QueryString($query);
+        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.legalStatus'));
+        $queryField->setDefaultOperator('AND');
+
+        break;
+
+      case 'generalContext':
+        $queryField = new \Elastica\Query\QueryString($query);
+        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.generalContext'));
+        $queryField->setDefaultOperator('AND');
+
+        break;
+
+      case 'institutionResponsibleIdentifier':
+        $queryField = new \Elastica\Query\QueryString($query);
+        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.institutionResponsibleIdentifier'));
+        $queryField->setDefaultOperator('AND');
+
+        break;
+
+      case 'sources':
+        $queryField = new \Elastica\Query\QueryString($query);
+        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.sources'));
+        $queryField->setDefaultOperator('AND');
+
+        break;
+
+      case 'parallelNames':
+        $queryField = new \Elastica\Query\QueryString($query);
+        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('parallelNames.i18n.%s.name'));
+        $queryField->setDefaultOperator('AND');
+
+        break;
+
+      case 'otherNames':
+        $queryField = new \Elastica\Query\QueryString($query);
+        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('otherNames.i18n.%s.name'));
+        $queryField->setDefaultOperator('AND');
+
+        break;
+
+      case 'occupations':
+        $queryField = new \Elastica\Query\QueryString($query);
+        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('occupations.i18n.%s.name'));
+        $queryField->setDefaultOperator('AND');
+
+        break;
+
+      case 'occupationNotes':
+        $queryField = new \Elastica\Query\QueryString($query);
+        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('occupations.i18n.%s.content'));
+        $queryField->setDefaultOperator('AND');
+
+        break;
+
+      case 'maintenanceNotes':
+        $queryField = new \Elastica\Query\QueryString($query);
+        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('maintenanceNotes.i18n.%s.content'));
+        $queryField->setDefaultOperator('AND');
+
+        break;
+
+      case 'places':
+        $queryField = new \Elastica\Query\QueryString($query);
+        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.places'));
+        $queryField->setDefaultOperator('AND');
+
+        break;
+
+      case 'descriptionIdentifier':
+        $queryField = new \Elastica\Query\QueryString($query);
+        $queryField->setDefaultField('descriptionIdentifier');
+        $queryField->setDefaultOperator('AND');
+
+        break;
+
       case '_all':
       default:
         $queryField = new \Elastica\Query\QueryString($query);
         $queryField->setDefaultOperator('AND');
-        arElasticSearchPluginUtil::setFields($queryField, 'informationObject');
+        $documentType = ($archivalStandard == 'isaar') ? 'actor' : 'informationObject';
+        arElasticSearchPluginUtil::setFields($queryField, $documentType);
 
         break;
     }


### PR DESCRIPTION
Adds a form, etc., to perform advanced searches on authority records.

To support this, adds ElasticSearch indexing for maintenance notes and
whether or not an authority record has a digital object associated with
it.