### PR TITLE
Authority record digital object linking, refs #12650

### DIFF
--- a/apps/qubit/config/routing.yml
+++ b/apps/qubit/config/routing.yml
@@ -46,12 +46,16 @@ add:
 
 # -------------------------------------------------------- </QubitMetadataRoute>
 
+slug/default:
+  url: /:slug/:module/:action
+  class: QubitResourceRoute
+
 informationobject/action:
   url: /:slug/:action
   class: QubitResourceRoute
   param:
     module: informationobject
-    action: { pattern: 'addDigitalObject|fileList|multiFileUpload|rename|reports|slugPreview|modifications|calculateDates' }
+    action: { pattern: 'fileList|multiFileUpload|rename|reports|slugPreview|modifications|calculateDates' }
 
 oai:
   url: /;oai

--- a/apps/qubit/modules/actor/actions/indexAction.class.php
+++ b/apps/qubit/modules/actor/actions/indexAction.class.php
@@ -42,5 +42,7 @@ class ActorIndexAction extends sfAction
     $criteria->addJoin(QubitRelation::SUBJECT_ID, QubitFunction::ID);
 
     $this->functions = QubitFunction::get($criteria);
+
+    $this->digitalObjectLink = $this->resource->getDigitalObjectLink();
   }
 }

--- a/apps/qubit/modules/actor/templates/_searchResult.php
+++ b/apps/qubit/modules/actor/templates/_searchResult.php
@@ -45,6 +45,9 @@
 
     </ul>
 
+    <?php if (null !== $history = get_search_i18n($doc, 'history', array('culture' => $culture))): ?>
+      <div class="history"><?php echo render_value($history) ?></div>
+    <?php endif; ?>
   </div>
 
 </article>

--- a/apps/qubit/modules/actor/templates/_searchResult.php
+++ b/apps/qubit/modules/actor/templates/_searchResult.php
@@ -1,6 +1,27 @@
 <?php use_helper('Text') ?>
 
-<article class="search-result">
+<?php if (isset($doc['hasDigitalObject']) && true === $doc['hasDigitalObject']): ?>
+  <article class="search-result has-preview">
+<?php else: ?>
+  <article class="search-result">
+<?php endif; ?>
+
+  <?php if (isset($doc['hasDigitalObject']) && true === $doc['hasDigitalObject']): ?>
+    <div class="search-result-preview">
+      <a href="<?php echo url_for(array('module' => 'actor', 'slug' => $doc['slug'])) ?>">
+        <div class="preview-container">
+          <?php if (isset($doc['digitalObject']['thumbnailPath'])): ?>
+            <?php echo image_tag($doc['digitalObject']['thumbnailPath'],
+              array('alt' => truncate_text(strip_markdown(get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture))), 100))) ?>
+          <?php else: ?>
+            <?php echo image_tag(QubitDigitalObject::getGenericIconPathByMediaTypeId($doc['digitalObject']['mediaTypeId']),
+              array('alt' => truncate_text(strip_markdown(get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture))), 100))) ?>
+          <?php endif; ?>
+        </div>
+      </a>
+    </div>
+  <?php endif; ?>
+
 
   <div class="search-result-description">
 

--- a/apps/qubit/modules/actor/templates/_searchResult.php
+++ b/apps/qubit/modules/actor/templates/_searchResult.php
@@ -12,10 +12,10 @@
         <div class="preview-container">
           <?php if (isset($doc['digitalObject']['thumbnailPath'])): ?>
             <?php echo image_tag($doc['digitalObject']['thumbnailPath'],
-              array('alt' => truncate_text(strip_markdown(get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture))), 100))) ?>
+              array('alt' => isset($doc['digitalObject']['digitalObjectAltText']) ? $doc['digitalObject']['digitalObjectAltText'] : truncate_text(strip_markdown(get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false, 'culture' => $culture))), 100))) ?>
           <?php else: ?>
             <?php echo image_tag(QubitDigitalObject::getGenericIconPathByMediaTypeId($doc['digitalObject']['mediaTypeId']),
-              array('alt' => truncate_text(strip_markdown(get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture))), 100))) ?>
+              array('alt' => isset($doc['digitalObject']['digitalObjectAltText']) ? $doc['digitalObject']['digitalObjectAltText'] : truncate_text(strip_markdown(get_search_i18n($doc, 'authorizedFormOfName', array('allowEmpty' => false, 'culture' => $culture))), 100))) ?>
           <?php endif; ?>
         </div>
       </a>

--- a/apps/qubit/modules/actor/templates/_searchResult.php
+++ b/apps/qubit/modules/actor/templates/_searchResult.php
@@ -1,12 +1,12 @@
 <?php use_helper('Text') ?>
 
-<?php if (isset($doc['hasDigitalObject']) && true === $doc['hasDigitalObject']): ?>
+<?php if (!empty($doc['hasDigitalObject'])): ?>
   <article class="search-result has-preview">
 <?php else: ?>
   <article class="search-result">
 <?php endif; ?>
 
-  <?php if (isset($doc['hasDigitalObject']) && true === $doc['hasDigitalObject']): ?>
+  <?php if (!empty($doc['hasDigitalObject'])): ?>
     <div class="search-result-preview">
       <a href="<?php echo url_for(array('module' => 'actor', 'slug' => $doc['slug'])) ?>">
         <div class="preview-container">
@@ -21,7 +21,6 @@
       </a>
     </div>
   <?php endif; ?>
-
 
   <div class="search-result-description">
 

--- a/apps/qubit/modules/digitalobject/actions/deleteAction.class.php
+++ b/apps/qubit/modules/digitalobject/actions/deleteAction.class.php
@@ -32,8 +32,7 @@ class DigitalObjectDeleteAction extends sfAction
 
     $this->resource = $this->getRoute()->resource;
 
-    // Get related information object by first grabbing top-level digital
-    // object
+    // Get related object by first grabbing top-level digital object
     $parent = $this->resource->parent;
     if (isset($parent))
     {
@@ -59,16 +58,27 @@ class DigitalObjectDeleteAction extends sfAction
       // Delete the digital object record from the database
       $this->resource->delete();
       QubitSearch::getInstance()->update($this->object);
-      $this->object->updateXmlExports();
 
-      // Redirect to edit page for parent Info Object
+      if ($this->object instanceOf QubitInformationObject)
+      {
+        $this->object->updateXmlExports();
+      }
+
+      // Redirect to edit page for parent Object
       if (isset($parent))
       {
         $this->redirect(array($parent, 'module' => 'digitalobject', 'action' => 'edit'));
       }
       else
       {
-        $this->redirect(array($this->object, 'module' => 'informationobject'));
+        if ($this->object instanceOf QubitInformationObject)
+        {
+          $this->redirect(array($this->object, 'module' => 'informationobject'));
+        }
+        else if ($this->object instanceOf QubitActor)
+        {
+          $this->redirect(array($this->object, 'module' => 'actor'));
+        }
       }
     }
   }

--- a/apps/qubit/modules/digitalobject/actions/editAction.class.php
+++ b/apps/qubit/modules/digitalobject/actions/editAction.class.php
@@ -46,13 +46,16 @@ class DigitalObjectEditAction extends sfAction
     // Only display "compound digital object" toggle if we have a child with a
     // digital object
     $this->showCompoundObjectToggle = false;
-    foreach ($this->object->getChildren() as $item)
+    if ($this->object instanceof QubitInformationObject)
     {
-      if (null !== $item->getDigitalObjectRelatedByobjectId())
+      foreach ($this->object->getChildren() as $item)
       {
-        $this->showCompoundObjectToggle = true;
+        if (null !== $item->getDigitalObjectRelatedByobjectId())
+        {
+          $this->showCompoundObjectToggle = true;
 
-        break;
+          break;
+        }
       }
     }
 
@@ -134,8 +137,18 @@ class DigitalObjectEditAction extends sfAction
 
     $this->object = $this->resource->object;
 
+
+/*
+if (($this->object instanceOf QubitInformationObject) &&
+  !QubitAcl::check($this->object, 'update') &&
+  !$this->getUser()->hasGroup(QubitAclGroup::EDITOR_ID) ||
+  ($this->object instanceOf QubitActor &&
+  //!$this->context->user->isAdministrator()))
+  !QubitAcl::check($this->object, 'update')))
+*/
     // Check user authorization
-    if (!QubitAcl::check($this->object, 'update') && !$this->getUser()->hasGroup(QubitAclGroup::EDITOR_ID))
+    if (!QubitAcl::check($this->object, 'update') &&
+      !$this->getUser()->hasGroup(QubitAclGroup::EDITOR_ID))
     {
       QubitAcl::forwardUnauthorized();
     }
@@ -162,7 +175,11 @@ class DigitalObjectEditAction extends sfAction
         $this->processForm();
 
         $this->resource->save();
-        $this->object->updateXmlExports();
+
+        if ($this->object instanceOf QubitInformationObject)
+        {
+          $this->object->updateXmlExports();
+        }
 
         $this->redirect(array($this->object, 'module' => 'informationobject'));
       }

--- a/apps/qubit/modules/digitalobject/actions/editAction.class.php
+++ b/apps/qubit/modules/digitalobject/actions/editAction.class.php
@@ -78,6 +78,13 @@ class DigitalObjectEditAction extends sfAction
       }
     }
 
+    $this->form->setValidator('digitalObjectAltText', new sfValidatorString);
+    $this->form->setWidget('digitalObjectAltText', new sfWidgetFormTextarea);
+    if (null !== $this->digitalObjectAltText = $this->resource->getDigitalObjectAltText())
+    {
+      $this->form->setDefault('digitalObjectAltText', $this->digitalObjectAltText);
+    }
+
     $maxUploadSize = QubitDigitalObject::getMaxUploadSize();
 
     ProjectConfiguration::getActive()->loadHelpers('Qubit');
@@ -137,15 +144,6 @@ class DigitalObjectEditAction extends sfAction
 
     $this->object = $this->resource->object;
 
-
-/*
-if (($this->object instanceOf QubitInformationObject) &&
-  !QubitAcl::check($this->object, 'update') &&
-  !$this->getUser()->hasGroup(QubitAclGroup::EDITOR_ID) ||
-  ($this->object instanceOf QubitActor &&
-  //!$this->context->user->isAdministrator()))
-  !QubitAcl::check($this->object, 'update')))
-*/
     // Check user authorization
     if (!QubitAcl::check($this->object, 'update') &&
       !$this->getUser()->hasGroup(QubitAclGroup::EDITOR_ID))
@@ -195,6 +193,8 @@ if (($this->object instanceOf QubitInformationObject) &&
   {
     // Set property 'displayAsCompound'
     $this->resource->setDisplayAsCompoundObject($this->form->getValue('displayAsCompound'));
+
+    $this->resource->setDigitalObjectAltText($this->form->getValue('digitalObjectAltText'));
 
     // Update media type
     $this->resource->mediaTypeId = $this->form->getValue('mediaType');

--- a/apps/qubit/modules/digitalobject/actions/metadataComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/metadataComponent.class.php
@@ -28,15 +28,17 @@ class DigitalObjectMetadataComponent extends sfComponent
 {
   public function execute($request)
   {
-    $id = $this->infoObj->id;
+    $id = $this->object->id;
     $this->denyFileNameByPremis = false;
 
     // Special case: If all digital object representations are
     // denied by premis, we will hide the filename when displaying
-    // the digital object metadata for security reasons.
+    // the digital object metadata for security reasons. Only check
+    // rights for info obj linked digital objects.
     if (!QubitGrantedRight::checkPremis($id, 'readThumb') &&
         !QubitGrantedRight::checkPremis($id, 'readReference') &&
-        !QubitGrantedRight::checkPremis($id, 'readMaster'))
+        !QubitGrantedRight::checkPremis($id, 'readMaster') &&
+        $this->object instanceOf QubitInformationObject)
     {
       $this->denyFileNameByPremis = true;
     }
@@ -45,11 +47,11 @@ class DigitalObjectMetadataComponent extends sfComponent
     $this->googleMapsApiKey = sfConfig::get('app_google_maps_api_key');
 
     // Provide latitude to template
-    $latitudeProperty = $this->infoObj->digitalObjectsRelatedByobjectId[0]->getPropertyByName('latitude');
+    $latitudeProperty = $this->object->digitalObjectsRelatedByobjectId[0]->getPropertyByName('latitude');
     $this->latitude = $latitudeProperty->value;
 
     // Provide longitude to template
-    $longitudeProperty = $this->infoObj->digitalObjectsRelatedByobjectId[0]->getPropertyByName('longitude');
+    $longitudeProperty = $this->object->digitalObjectsRelatedByobjectId[0]->getPropertyByName('longitude');
     $this->longitude = $longitudeProperty->value;
   }
 }

--- a/apps/qubit/modules/digitalobject/actions/showGenericIconComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/showGenericIconComponent.class.php
@@ -35,6 +35,15 @@ class DigitalObjectShowGenericIconComponent extends sfComponent
   public function execute($request)
   {
     $this->representation = QubitDigitalObject::getGenericRepresentation($this->resource->mimeType, $this->resource->usageId);
-    $this->canReadMaster = QubitAcl::check($this->resource->object, 'readMaster');
+
+    if ($this->resource->object instanceOf QubitInformationObject)
+    {
+      $this->canReadMaster = QubitAcl::check($this->resource->object, 'readMaster');
+    }
+    else if ($this->resource->object instanceOf QubitActor &&
+      $this->context->user->isAuthenticated())
+    {
+      $this->canReadMaster = QubitAcl::check($this->resource->object, 'read');;
+    }
   }
 }

--- a/apps/qubit/modules/digitalobject/actions/uploadAction.class.php
+++ b/apps/qubit/modules/digitalobject/actions/uploadAction.class.php
@@ -28,7 +28,7 @@ class DigitalObjectUploadAction extends sfAction
     $uploadFiles = array();
     $warning = null;
 
-    $this->object = QubitInformationObject::getById($request->objectId);
+    $this->object = QubitObject::getById($request->objectId);
 
     if (!isset($this->object))
     {

--- a/apps/qubit/modules/digitalobject/actions/viewAction.class.php
+++ b/apps/qubit/modules/digitalobject/actions/viewAction.class.php
@@ -45,8 +45,10 @@ class DigitalObjectViewAction extends sfAction
     list($obj, $action) = $this->getObjAndAction();
 
     // Do appropriate ACL check(s). Master copy of text objects are always allowed for reading
+    // QubitActor does not have a ACL check for readmaster.
     if ((!QubitAcl::check($obj, $action) || !QubitGrantedRight::checkPremis($obj->id, $action))
-      && !($action == 'readMaster' && $this->resource->mediaTypeId == QubitTerm::TEXT_ID))
+      && !($action == 'readMaster' && $this->resource->mediaTypeId == QubitTerm::TEXT_ID)
+      && $obj instanceOf QubitInformationObject)
     {
       $this->forward404();
     }

--- a/apps/qubit/modules/digitalobject/templates/_metadata.php
+++ b/apps/qubit/modules/digitalobject/templates/_metadata.php
@@ -2,7 +2,11 @@
 
 <section>
 
-  <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('%1% metadata', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))).'</h2>', array($resource, 'module' => 'digitalobject', 'action' => 'edit'), array('title' => __('Edit %1%', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))))) ?>
+  <?php if ($resource->object instanceOf QubitInformationObject): ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationobject'), '<h2>'.__('%1% metadata', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))).'</h2>', array($resource, 'module' => 'digitalobject', 'action' => 'edit'), array('title' => __('Edit %1%', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))))) ?>
+  <?php elseif ($resource->object instanceOf QubitActor): ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'actor'), '<h2>'.__('%1% metadata', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))).'</h2>', array($resource, 'module' => 'digitalobject', 'action' => 'edit'), array('title' => __('Edit %1%', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))))) ?>
+  <?php endif; ?>
 
   <?php if (sfConfig::get('app_toggleDigitalObjectMap') && is_numeric($latitude) && is_numeric($longitude) && $googleMapsApiKey): ?>
     <div id="front-map" class="simple-map" data-key="<?php echo $googleMapsApiKey ?>" data-latitude="<?php echo $latitude ?>" data-longitude="<?php echo $longitude ?>"></div>

--- a/apps/qubit/modules/digitalobject/templates/_metadata.php
+++ b/apps/qubit/modules/digitalobject/templates/_metadata.php
@@ -43,7 +43,7 @@
     <?php echo render_show(__('Uploaded'), format_date($resource->createdAt, 'f'), array('fieldLabel' => 'uploaded')) ?>
   <?php endif; ?>
 
-  <?php if ($sf_user->isAuthenticated()): ?>
+  <?php if ($sf_user->isAuthenticated() && $resource->object instanceOf QubitInformationObject): ?>
     <?php echo render_show(__('Object UUID'), render_value($resource->object->objectUUID), array('fieldLabel' => 'objectUUID')) ?>
     <?php echo render_show(__('AIP UUID'), render_value($resource->object->aipUUID), array('fieldLabel' => 'aipUUID')) ?>
     <?php echo render_show(__('Format name'), render_value($resource->object->formatName), array('fieldLabel' => 'formatName')) ?>

--- a/apps/qubit/modules/digitalobject/templates/_showAudio.php
+++ b/apps/qubit/modules/digitalobject/templates/_showAudio.php
@@ -18,14 +18,14 @@
 
   <?php if ($iconOnly): ?>
 
-    <?php echo link_to(image_tag('play', array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
+    <?php echo link_to(image_tag('play', array('alt' => __($resource->getDigitalObjectAltText() ?: 'Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
 
   <?php else: ?>
 
     <div class="resource">
 
       <div class="resourceRep">
-        <?php echo link_to(image_tag('play', array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
+        <?php echo link_to(image_tag('play', array('alt' => __($resource->getDigitalObjectAltText() ?: 'Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
       </div>
 
       <div class="resourceDesc">
@@ -40,7 +40,7 @@
 
   <div class="resource">
 
-    <?php echo image_tag('play', array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
+    <?php echo image_tag('play', array('alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
 
   </div>
 

--- a/apps/qubit/modules/digitalobject/templates/_showCompound.php
+++ b/apps/qubit/modules/digitalobject/templates/_showCompound.php
@@ -4,16 +4,24 @@
     <tr>
       <td>
         <?php if (null !== $representation = $leftObject->getCompoundRepresentation()): ?>
-          <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject') || QubitTerm::TEXT_ID == $resource->mediaType->id, image_tag($representation->getFullPath(), array('alt' => '')), public_path($leftObject->getFullPath(), array('title' => __('View full size')))) ?>
+          <?php if ($resource->object instanceOf QubitInformationObject): ?>
+            <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject') || QubitTerm::TEXT_ID == $resource->mediaType->id, image_tag($representation->getFullPath(), array('alt' => '')), public_path($leftObject->getFullPath(), array('title' => __('View full size')))) ?>
+          <?php elseif ($resource->object instanceOf QubitActor): ?>
+            <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'actor') || QubitTerm::TEXT_ID == $resource->mediaType->id, image_tag($representation->getFullPath(), array('alt' => '')), public_path($leftObject->getFullPath(), array('title' => __('View full size')))) ?>
+          <?php endif; ?>
         <?php endif; ?>
       </td><td>
         <?php if (null !== $rightObject && null !== $representation = $rightObject->getCompoundRepresentation()): ?>
-          <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject') || QubitTerm::TEXT_ID == $resource->mediaType->id, image_tag($representation->getFullPath(), array('alt' => '')), public_path($rightObject->getFullPath(), array('title' => __('View full size')))) ?>
+          <?php if ($resource->object instanceOf QubitInformationObject): ?>
+            <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject') || QubitTerm::TEXT_ID == $resource->mediaType->id, image_tag($representation->getFullPath(), array('alt' => '')), public_path($rightObject->getFullPath(), array('title' => __('View full size')))) ?>
+          <?php elseif ($resource->object instanceOf QubitActor): ?>
+            <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'actor') || QubitTerm::TEXT_ID == $resource->mediaType->id, image_tag($representation->getFullPath(), array('alt' => '')), public_path($rightObject->getFullPath(), array('title' => __('View full size')))) ?>
+          <?php endif; ?>
         <?php endif; ?>
       </td>
     </tr>
 
-    <?php if (SecurityPrivileges::editCredentials($sf_user, 'informationObject')): ?>
+    <?php if (($resource->object instanceOf QubitInformationObject && SecurityPrivileges::editCredentials($sf_user, 'informationObject')) || ($resource->object instanceOf QubitActor && SecurityPrivileges::editCredentials($sf_user, 'actor'))): ?>
       <tr>
         <td colspan="2" class="download_link">
           <?php echo link_to(__('Download %1%', array('%1%' => $resource)), public_path($resource->getFullPath()), array('class' => 'download')) ?>

--- a/apps/qubit/modules/digitalobject/templates/_showDownload.php
+++ b/apps/qubit/modules/digitalobject/templates/_showDownload.php
@@ -3,25 +3,25 @@
 <?php if (QubitTerm::REFERENCE_ID == $usageType): ?>
 
   <?php if (isset($link)): ?>
-    <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
+    <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __($representation->getDigitalObjectAltText() ?: 'Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
   <?php else: ?>
-    <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
+    <?php echo image_tag($representation->getFullPath(), array('alt' => __($representation->getDigitalObjectAltText() ?: 'Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
   <?php endif; ?>
 
 <?php else: ?>
 
   <?php if ($iconOnly && isset($link)): ?>
 
-    <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
+    <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __($representation->getDigitalObjectAltText() ?: 'Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
 
   <?php else: ?>
 
     <div style="width: 100px; text-align: center"/>
 
       <?php if (isset($link)): ?>
-        <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
+        <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __($representation->getDigitalObjectAltText() ?: 'Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
       <?php else: ?>
-        <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% is not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
+        <?php echo image_tag($representation->getFullPath(), array('alt' => __($representation->getDigitalObjectAltText() ?: 'Original %1% is not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
       <?php endif; ?>
 
       <?php echo wrap_text($digitalObject->name, 15) ?>

--- a/apps/qubit/modules/digitalobject/templates/_showGenericIcon.php
+++ b/apps/qubit/modules/digitalobject/templates/_showGenericIcon.php
@@ -4,9 +4,9 @@
 
   <div class="digitalObjectRep">
     <?php if (isset($link) && $canReadMaster): ?>
-      <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link, array('target' => '_blank')) ?>
+      <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __($resource->getDigitalObjectAltText() ?: 'Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link, array('target' => '_blank')) ?>
     <?php else: ?>
-      <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
+      <?php echo image_tag($representation->getFullPath(), array('alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
     <?php endif; ?>
   </div>
 

--- a/apps/qubit/modules/digitalobject/templates/_showImage.php
+++ b/apps/qubit/modules/digitalobject/templates/_showImage.php
@@ -3,19 +3,18 @@
 <?php if (QubitTerm::MASTER_ID == $usageType || QubitTerm::REFERENCE_ID == $usageType): ?>
 
   <?php if (isset($link)): ?>
-    <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link, array('target' => '_blank')) ?>
+    <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __($resource->getDigitalObjectAltText() ?: 'Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link, array('target' => '_blank')) ?>
   <?php else: ?>
-    <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
+    <?php echo image_tag($representation->getFullPath(), array('alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
   <?php endif; ?>
 
 <?php elseif (QubitTerm::THUMBNAIL_ID == $usageType): ?>
 
   <?php if ($iconOnly): ?>
-
     <?php if (isset($link)): ?>
-      <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
+      <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __($resource->getDigitalObjectAltText() ?: 'Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
     <?php else: ?>
-      <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
+      <?php echo image_tag($representation->getFullPath(), array('alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
     <?php endif; ?>
 
   <?php else: ?>
@@ -24,9 +23,9 @@
 
       <div class="digitalObjectRep">
         <?php if (isset($link)): ?>
-          <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
+          <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __($resource->getDigitalObjectAltText() ?: 'Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
         <?php else: ?>
-          <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
+          <?php echo image_tag($representation->getFullPath(), array('alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
         <?php endif; ?>
       </div>
 

--- a/apps/qubit/modules/digitalobject/templates/_showText.php
+++ b/apps/qubit/modules/digitalobject/templates/_showText.php
@@ -1,5 +1,5 @@
 <?php if (isset($link)): ?>
-  <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link, array('target' => '_blank')) ?>
+  <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __($resource->getDigitalObjectAltText() ?: 'Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link, array('target' => '_blank')) ?>
 <?php else: ?>
-  <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
+  <?php echo image_tag($representation->getFullPath(), array('alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
 <?php endif; ?>

--- a/apps/qubit/modules/digitalobject/templates/_showVideo.php
+++ b/apps/qubit/modules/digitalobject/templates/_showVideo.php
@@ -3,9 +3,9 @@
 <?php if ($usageType == QubitTerm::MASTER_ID): ?>
 
   <?php if (isset($link)): ?>
-    <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
+    <?php echo image_tag($representation->getFullPath(), array('alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
   <?php else: ?>
-    <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
+    <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __($resource->getDigitalObjectAltText() ?: 'Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
   <?php endif; ?>
 
 <?php elseif ($usageType == QubitTerm::REFERENCE_ID): ?>
@@ -14,7 +14,7 @@
     <a class="flowplayer" href="<?php echo public_path($representation->getFullPath()) ?>"></a>
   <?php else: ?>
     <div style="text-align: center">
-      <?php echo image_tag($representation->getFullPath(), array('style' => 'border: #999 1px solid', 'alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
+      <?php echo image_tag($representation->getFullPath(), array('style' => 'border: #999 1px solid', 'alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
     </div>
   <?php endif;?>
 
@@ -28,9 +28,9 @@
   <?php if ($iconOnly): ?>
 
     <?php if (isset($link)): ?>
-      <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
+      <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __($resource->getDigitalObjectAltText() ?: 'Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
     <?php else: ?>
-      <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
+      <?php echo image_tag($representation->getFullPath(), array('alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
     <?php endif; ?>
 
   <?php else: ?>
@@ -38,9 +38,9 @@
     <div class="digitalObject">
       <div class="digitalObjectRep">
         <?php if (isset($link)): ?>
-          <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __('Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
+          <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __($resource->getDigitalObjectAltText() ?: 'Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
         <?php else: ?>
-          <?php echo image_tag($representation->getFullPath(), array('alt' => __('Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
+          <?php echo image_tag($representation->getFullPath(), array('alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>
         <?php endif; ?>
       </div>
       <div class="digitalObjectDesc">

--- a/apps/qubit/modules/digitalobject/templates/editSuccess.php
+++ b/apps/qubit/modules/digitalobject/templates/editSuccess.php
@@ -3,7 +3,12 @@
 <?php slot('title') ?>
   <h1 class="multiline">
     <?php echo __('Edit %1%', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))) ?>
-    <span class="sub"><?php echo render_title(QubitInformationObject::getStandardsBasedInstance($informationObject)) ?></span>
+
+    <?php if ($resource->object instanceOf QubitInformationObject): ?>
+      <span class="sub"><?php echo render_title(QubitInformationObject::getStandardsBasedInstance($informationObject)) ?></span>
+    <?php elseif ($resource->object instanceOf QubitActor): ?>
+      <span class="sub"><?php echo render_title($object) ?></span>
+    <?php endif; ?>
   </h1>
 <?php end_slot() ?>
 
@@ -80,7 +85,7 @@
         <?php if (isset($sf_request->getAttribute('sf_route')->resource)): ?>
           <li><?php echo link_to(__('Delete'), array($resource, 'module' => 'digitalobject', 'action' => 'delete'), array('class' => 'c-btn c-btn-delete')) ?></li>
         <?php endif; ?>
-        <li><?php echo link_to(__('Cancel'), array($informationObject, 'module' => 'informationobject'), array('class' => 'c-btn')) ?></li>
+        <li><?php echo link_to(__('Cancel'), array($object, 'module' => $sf_request->module), array('class' => 'c-btn')) ?></li>
         <li><input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Save') ?>"/></li>
       </ul>
     </section>

--- a/apps/qubit/modules/digitalobject/templates/editSuccess.php
+++ b/apps/qubit/modules/digitalobject/templates/editSuccess.php
@@ -5,7 +5,7 @@
     <?php echo __('Edit %1%', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))) ?>
 
     <?php if ($resource->object instanceOf QubitInformationObject): ?>
-      <span class="sub"><?php echo render_title(QubitInformationObject::getStandardsBasedInstance($informationObject)) ?></span>
+      <span class="sub"><?php echo render_title(QubitInformationObject::getStandardsBasedInstance($object)) ?></span>
     <?php elseif ($resource->object instanceOf QubitActor): ?>
       <span class="sub"><?php echo render_title($object) ?></span>
     <?php endif; ?>
@@ -37,6 +37,8 @@
         <?php echo render_show(__('Filesize'), hr_filesize($resource->byteSize)) ?>
 
         <?php echo $form->mediaType->renderRow() ?>
+
+        <?php echo $form->digitalObjectAltText->label(__('Alt text'))->renderRow() ?>
 
         <?php if ($showCompoundObjectToggle): ?>
           <?php echo $form->displayAsCompound

--- a/apps/qubit/modules/informationobject/templates/_actions.php
+++ b/apps/qubit/modules/informationobject/templates/_actions.php
@@ -43,7 +43,7 @@
               <?php if (0 < count($resource->digitalObjectsRelatedByobjectId) && QubitDigitalObject::isUploadAllowed()): ?>
                 <li><?php echo link_to(__('Edit %1%', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))), array($resource->digitalObjectsRelatedByobjectId[0], 'module' => 'digitalobject', 'action' => 'edit')) ?></li>
               <?php elseif (QubitDigitalObject::isUploadAllowed()): ?>
-                <li><?php echo link_to(__('Link %1%', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))), array($resource, 'module' => 'informationobject', 'action' => 'addDigitalObject')) ?></li>
+                <li><?php echo link_to(__('Link %1%', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))), array($resource, 'module' => 'object', 'action' => 'addDigitalObject')) ?></li>
               <?php endif; // has digital object ?>
 
               <?php if ((null === $resource->repository || 0 != $resource->repository->uploadLimit) && QubitDigitalObject::isUploadAllowed()): ?>

--- a/apps/qubit/modules/informationobject/templates/_cardViewResults.php
+++ b/apps/qubit/modules/informationobject/templates/_cardViewResults.php
@@ -18,13 +18,13 @@
           && QubitGrantedRight::checkPremis($hit->getId(), 'readThumb')): ?>
 
           <?php echo link_to(image_tag($doc['digitalObject']['thumbnailPath'],
-            array('alt' => truncate_text(strip_markdown($title), 100))),
+            array('alt' => isset($doc['digitalObject']['digitalObjectAltText']) ? $doc['digitalObject']['digitalObjectAltText'] : truncate_text(strip_markdown($title), 100))),
             array('module' => 'informationobject', 'slug' => $doc['slug'])) ?>
 
         <?php elseif (isset($doc['digitalObject']) && !empty($doc['digitalObject']['mediaTypeId'])): // Show generic icon since no thumbnail present ?>
 
           <?php echo link_to(image_tag(QubitDigitalObject::getGenericIconPathByMediaTypeId($doc['digitalObject']['mediaTypeId']),
-            array('alt' => truncate_text(strip_markdown($title), 100))),
+            array('alt' => isset($doc['digitalObject']['digitalObjectAltText']) ? $doc['digitalObject']['digitalObjectAltText'] : truncate_text(strip_markdown($title), 100))),
             array('module' => 'informationobject', 'slug' => $doc['slug'])) ?>
 
         <?php else: // No digital object, just display description title ?>

--- a/apps/qubit/modules/object/actions/addDigitalObjectAction.class.php
+++ b/apps/qubit/modules/object/actions/addDigitalObjectAction.class.php
@@ -58,6 +58,11 @@ class ObjectAddDigitalObjectAction extends sfAction
     {
       $this->repository = $this->resource->getRepository(array('inherit' => true));
     }
+    else if ($this->resource instanceof QubitActor)
+    {
+      $this->repository = $this->resource->getMaintainingRepository();
+    }
+
     // Check that object exists and that it is not the root
     if (!isset($this->resource) || !isset($this->resource->parent))
     {

--- a/apps/qubit/modules/object/actions/addDigitalObjectAction.class.php
+++ b/apps/qubit/modules/object/actions/addDigitalObjectAction.class.php
@@ -24,7 +24,7 @@
  * @subpackage digital object
  * @author     david juhasz <david@artefactual.com>
  */
-class InformationObjectAddDigitalObjectAction extends sfAction
+class ObjectAddDigitalObjectAction extends sfAction
 {
   protected function addFields($request)
   {
@@ -54,8 +54,10 @@ class InformationObjectAddDigitalObjectAction extends sfAction
     $this->resource = $this->getRoute()->resource;
 
     // Get repository to test upload limits
-    $this->repository = $this->resource->getRepository(array('inherit' => true));
-
+    if ($this->resource instanceOf QubitInformationObject)
+    {
+      $this->repository = $this->resource->getRepository(array('inherit' => true));
+    }
     // Check that object exists and that it is not the root
     if (!isset($this->resource) || !isset($this->resource->parent))
     {
@@ -92,9 +94,12 @@ class InformationObjectAddDigitalObjectAction extends sfAction
         $this->processForm();
 
         $this->resource->save();
-        $this->resource->updateXmlExports();
 
-        $this->redirect(array($this->resource, 'module' => 'informationobject'));
+        if ($this->resource instanceOf QubitInformationObject)
+        {
+          $this->resource->updateXmlExports();
+        }
+        $this->redirect(array($this->resource, 'module' => 'object'));
       }
     }
   }
@@ -113,7 +118,6 @@ class InformationObjectAddDigitalObjectAction extends sfAction
     {
       $name = $this->form->getValue('file')->getOriginalName();
       $content = file_get_contents($this->form->getValue('file')->getTempName());
-
       $digitalObject->assets[] = new QubitAsset($name, $content);
       $digitalObject->usageId = QubitTerm::MASTER_ID;
     }

--- a/apps/qubit/modules/object/config/view.yml
+++ b/apps/qubit/modules/object/config/view.yml
@@ -21,3 +21,13 @@ exportSuccess:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/collapse:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/form:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/textarea:
+
+addDigitalObjectSuccess:
+  javascripts:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/jquery.once.js:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/collapse:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/form:
+    /vendor/yui/connection/connection-min:
+    /vendor/yui/datasource/datasource-min:
+    /vendor/yui/container/container-min:
+    blank:

--- a/apps/qubit/modules/object/templates/addDigitalObjectSuccess.php
+++ b/apps/qubit/modules/object/templates/addDigitalObjectSuccess.php
@@ -3,7 +3,12 @@
 <?php slot('title') ?>
   <h1 class="multiline">
     <?php echo __('Link %1%', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))) ?>
-    <span class="sub"><?php echo render_title(new sfIsadPlugin($resource)) ?></span>
+
+    <?php if ($resource instanceof QubitActor): ?>
+      <span class="sub"><?php echo render_title(new sfIsaarPlugin($resource)) ?></span>
+    <?php elseif ($resource instanceof QubitInformationObject): ?>
+      <span class="sub"><?php echo render_title(new sfIsadPlugin($resource)) ?></span>
+    <?php endif; ?>
   </h1>
 <?php end_slot() ?>
 
@@ -20,7 +25,7 @@
 
     <section class="actions">
       <ul>
-        <li><?php echo link_to(__('Cancel'), array($resource, 'module' => 'informationobject'), array('class' => 'c-btn')) ?></li>
+        <li><?php echo link_to(__('Cancel'), array($resource, 'module' => $sf_request->module), array('class' => 'c-btn')) ?></li>
       </ul>
     </section>
 
@@ -32,7 +37,7 @@
 
     <?php echo $form->renderGlobalErrors() ?>
 
-    <?php echo $form->renderFormTag(url_for(array($resource, 'module' => 'informationobject', 'action' => 'addDigitalObject')), array('id' => 'uploadForm')) ?>
+    <?php echo $form->renderFormTag(url_for(array($resource, 'module' => 'object', 'action' => 'addDigitalObject')), array('id' => 'uploadForm')) ?>
 
       <?php echo $form->renderHiddenFields() ?>
 
@@ -79,7 +84,7 @@
 
       <section class="actions">
         <ul>
-          <li><?php echo link_to(__('Cancel'), array($resource, 'module' => 'informationobject'), array('class' => 'c-btn')) ?></li>
+          <li><?php echo link_to(__('Cancel'), array($resource, 'module' => $sf_request->module), array('class' => 'c-btn')) ?></li>
           <li><input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Create') ?>"/></li>
         </ul>
       </section>

--- a/apps/qubit/modules/search/templates/_searchResult.php
+++ b/apps/qubit/modules/search/templates/_searchResult.php
@@ -15,10 +15,10 @@
                     QubitAcl::check(QubitInformationObject::getById($hit->getId()), 'readThumbnail') &&
                     QubitGrantedRight::checkPremis($hit->getId(), 'readThumb')): ?>
             <?php echo image_tag($doc['digitalObject']['thumbnailPath'],
-              array('alt' => truncate_text(strip_markdown(get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture))), 100))) ?>
+              array('alt' => isset($doc['digitalObject']['digitalObjectAltText']) ? $doc['digitalObject']['digitalObjectAltText'] : truncate_text(strip_markdown(get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture))), 100))) ?>
           <?php else: ?>
             <?php echo image_tag(QubitDigitalObject::getGenericIconPathByMediaTypeId($doc['digitalObject']['mediaTypeId']),
-              array('alt' => truncate_text(strip_markdown(get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture))), 100))) ?>
+              array('alt' => isset($doc['digitalObject']['digitalObjectAltText']) ? $doc['digitalObject']['digitalObjectAltText'] : truncate_text(strip_markdown(get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture))), 100))) ?>
           <?php endif; ?>
         </div>
       </a>

--- a/apps/qubit/modules/search/templates/_searchResult.php
+++ b/apps/qubit/modules/search/templates/_searchResult.php
@@ -1,13 +1,13 @@
 <?php use_helper('Text') ?>
 
 <?php $doc = $hit->getData() ?>
-<?php if (isset($doc['hasDigitalObject']) && true === $doc['hasDigitalObject']): ?>
+<?php if (!empty($doc['hasDigitalObject'])): ?>
   <article class="search-result has-preview">
 <?php else: ?>
   <article class="search-result">
 <?php endif; ?>
 
-  <?php if (isset($doc['hasDigitalObject']) && true === $doc['hasDigitalObject']): ?>
+  <?php if (!empty($doc['hasDigitalObject'])): ?>
     <div class="search-result-preview">
       <a href="<?php echo url_for(array('module' => 'informationobject', 'slug' => $doc['slug'])) ?>">
         <div class="preview-container">

--- a/js/qubit.js
+++ b/js/qubit.js
@@ -17,7 +17,7 @@ window.log = function()
 Drupal.behaviors.expander = {
   attach: function (context)
     {
-      jQuery('div.field:not(:has(div.field)) > div, article.search-result .scope-and-content').each(function (index, element) {
+      jQuery('div.field:not(:has(div.field)) > div, article.search-result .scope-and-content, article.search-result .history').each(function (index, element) {
         var $element = jQuery(element);
         // Don't apply expander to fields with only one child, if that child is a list
         if ($element.children().length !== 1 || !$element.children().first().is('ul')) {

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -3156,7 +3156,7 @@ class QubitDigitalObject extends BaseDigitalObject
    * Setter for "displayAsCompound" property
    *
    * @param string $value new value for property
-   * @return QubitInformationObject this object
+   * @return QubitDigitalObject this object
    */
   public function setDisplayAsCompoundObject($value)
   {
@@ -3189,6 +3189,52 @@ class QubitDigitalObject extends BaseDigitalObject
     if (null !== $displayAsCompoundProp)
     {
       return $displayAsCompoundProp->getValue(array('sourceCulture' => true));
+    }
+  }
+
+  /**
+   * Setter for "digitalObjectAltText" property
+   *
+   * @param string $value new value for property
+   * @return QubitDigitalObject this object
+   */
+  public function setDigitalObjectAltText($value)
+  {
+    $criteria = new Criteria;
+    $criteria->add(QubitProperty::OBJECT_ID, $this->id);
+    $criteria->add(QubitProperty::NAME, 'digitalObjectAltText');
+
+    $digitalObjectAltText = QubitProperty::getOne($criteria);
+    if (is_null($digitalObjectAltText))
+    {
+      $digitalObjectAltText = new QubitProperty;
+      $digitalObjectAltText->setObjectId($this->id);
+      $digitalObjectAltText->setName('digitalObjectAltText');
+    }
+
+    $digitalObjectAltText->setValue($value, array('sourceCulture' => true));
+    $digitalObjectAltText->save();
+
+    return $this;
+  }
+
+  /**
+   * Getter for related "digitalObjectAltText" property. Called during ES indexing
+   * and from DO module templates. Search results thumbs get alt text from ES.
+   *
+   * @return string property value
+   */
+  public function getDigitalObjectAltText()
+  {
+    // This is most likely going to be a derivative so check by parentId first.
+    if (null !== $digitalObjectAltText = QubitProperty::getOneByObjectIdAndName($this->parentId, 'digitalObjectAltText'))
+    {
+      return $digitalObjectAltText->getValue(array('sourceCulture' => true));
+    }
+
+    if (null !== $digitalObjectAltText = QubitProperty::getOneByObjectIdAndName($this->id, 'digitalObjectAltText'))
+    {
+      return $digitalObjectAltText->getValue(array('sourceCulture' => true));
     }
   }
 

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -1837,7 +1837,11 @@ class QubitDigitalObject extends BaseDigitalObject
 
       // determine path for current repository
       $repoDir = '';
-      if (null !== ($repo = $object->getRepository(array('inherit' => true))))
+      if ($object instanceof QubitInformationObject && null !== ($repo = $object->getRepository(array('inherit' => true))))
+      {
+        $repoDir = $repo->slug;
+      }
+      else if ($object instanceof QubitActor && null !== ($repo = $object->getMaintainingRepository()))
       {
         $repoDir = $repo->slug;
       }

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -1167,10 +1167,11 @@ class QubitDigitalObject extends BaseDigitalObject
     // Create child objects (derivatives)
     if (0 < count($this->assets) && $this->createDerivatives)
     {
-      if (sfConfig::get('app_explode_multipage_files') && $this->getPageCount() > 1)
+      if (sfConfig::get('app_explode_multipage_files') && $this->getPageCount() > 1 &&
+        $this->getObject() instanceOf QubitInformationObject)
       {
-        // If DO is a compound object, then create child objects and set to
-        // display as compound object (with pager)
+        // If DO is a compound object and attached to informationObject, then
+        // create child objects and set to display as compound object (with pager)
         $this->createCompoundChildren($connection);
 
         // Set parent digital object to be displayed as compound
@@ -3216,8 +3217,7 @@ class QubitDigitalObject extends BaseDigitalObject
     // Return false if this object has no children with digital objects
     $criteria = new Criteria;
     $criteria->addJoin(QubitInformationObject::ID, QubitDigitalObject::OBJECT_ID);
-    $criteria->add(QubitInformationObject::PARENT_ID, $this->ObjectId);
-
+    $criteria->add(QubitInformationObject::PARENT_ID, $this->objectId);
     if (0 === count(QubitDigitalObject::get($criteria)))
     {
       return false;

--- a/plugins/arDacsPlugin/modules/arDacsPlugin/templates/indexSuccess.php
+++ b/plugins/arDacsPlugin/modules/arDacsPlugin/templates/indexSuccess.php
@@ -266,7 +266,7 @@
 
 <?php if (0 < count($resource->digitalObjectsRelatedByobjectId)): ?>
 
-  <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjectsRelatedByobjectId[0], 'infoObj' => $resource)) ?>
+  <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjectsRelatedByobjectId[0], 'object' => $resource)) ?>
 
   <?php echo get_partial('digitalobject/rights', array('resource' => $resource->digitalObjectsRelatedByobjectId[0])) ?>
 

--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -356,6 +356,13 @@ mapping:
       direct_subjects: { type: integer, include_in_all: false }
       direct_places: { type: integer, include_in_all: false }
       has_digital_object: { type: boolean, include_in_all: false }
+      digital_object:
+        type: object
+        properties:
+          media_type_id: { type: integer, include_in_all: false }
+          usage_id: { type: integer, include_in_all: false }
+          thumbnail_path: { type: keyword }
+          filename: { type: text }
 
   accession:
     _attributes:

--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -363,6 +363,7 @@ mapping:
           usage_id: { type: integer, include_in_all: false }
           thumbnail_path: { type: keyword }
           filename: { type: text }
+          digital_object_alt_text: { type: text }
 
   accession:
     _attributes:
@@ -513,6 +514,7 @@ mapping:
           usage_id: { type: integer, include_in_all: false }
           thumbnail_path: { type: keyword }
           filename: { type: text }
+          digital_object_alt_text: { type: text }
       alternative_identifiers:
         type: object
         properties:

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchActorPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchActorPdo.class.php
@@ -54,19 +54,6 @@ class arElasticSearchActorPdo
     }
 
     $this->loadData($id, $options);
-/*
-    // Get inherited ancestors
-    if (isset($options['ancestors']))
-    {
-      $this->ancestors = $options['ancestors'];
-    }
-
-    // Get inherited repository, unless a repository is set at current level
-    if (isset($options['repository']) && !$this->__isset('repository_id'))
-    {
-      $this->repository = $options['repository'];
-    }
-*/
   }
 
   public function __isset($name)
@@ -308,13 +295,13 @@ class arElasticSearchActorPdo
       $serialized['directSubjects'][] = $item->id;
     }
 
-<<<<<<< HEAD
     // Maintenance notes
     $sql = 'SELECT id, source_culture FROM '.QubitNote::TABLE_NAME.' WHERE object_id = ? AND type_id = ?';
     foreach (QubitPdo::fetchAll($sql, array($this->id, QubitTerm::MAINTENANCE_NOTE_ID)) as $item)
     {
       $serialized['maintenanceNotes'][] = arElasticSearchNote::serialize($item);
-=======
+    }
+
     // Media
     if ($this->media_type_id)
     {
@@ -329,7 +316,6 @@ class arElasticSearchActorPdo
     else
     {
       $serialized['hasDigitalObject'] = false;
->>>>>>> Auth DO update ES Actor indexing, refs #12650
     }
 
     $serialized['createdAt'] = arElasticSearchPluginUtil::convertDate($this->created_at);

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchActorPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchActorPdo.class.php
@@ -163,6 +163,22 @@ class arElasticSearchActorPdo
     }
   }
 
+  public function getDigitalObjectAltText()
+  {
+    if (!$this->__isset('digital_object_id'))
+    {
+      return;
+    }
+
+    $criteria = new Criteria;
+    $criteria->add(QubitDigitalObject::PARENT_ID, $this->__get('digital_object_id'));
+
+    if (null !== $do = QubitDigitalObject::getOne($criteria))
+    {
+      return $do->getDigitalObjectAltText();
+    }
+  }
+
   protected function getMaintainingRepositoryId()
   {
     if (!isset(self::$statements['maintainingRepository']))
@@ -306,6 +322,7 @@ class arElasticSearchActorPdo
       $serialized['digitalObject']['usageId'] = $this->usage_id;
       $serialized['digitalObject']['filename'] = $this->filename;
       $serialized['digitalObject']['thumbnailPath'] = $this->getThumbnailPath();
+      $serialized['digitalObject']['digitalObjectAltText'] = $this->getDigitalObjectAltText();
 
       $serialized['hasDigitalObject'] = true;
     }
@@ -370,5 +387,19 @@ class arElasticSearchActorPdo
     self::$statements['relatedTerms']->execute(array($this->__get('id'), $typeId));
 
     return self::$statements['relatedTerms']->fetchAll(PDO::FETCH_OBJ);
+  }
+
+  protected function getProperty($name)
+  {
+    $sql  = 'SELECT
+                prop.id, prop.source_culture';
+    $sql .= ' FROM '.QubitProperty::TABLE_NAME.' prop';
+    $sql .= ' WHERE prop.object_id = ?
+                AND prop.name = ?';
+
+    self::$statements['property'] = self::$conn->prepare($sql);
+    self::$statements['property']->execute(array($this->__get('id'), $name));
+
+    return self::$statements['property']->fetch(PDO::FETCH_OBJ);
   }
 }

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
@@ -777,6 +777,22 @@ class arElasticSearchInformationObjectPdo
     }
   }
 
+  public function getDigitalObjectAltText()
+  {
+    if (!$this->__isset('digital_object_id'))
+    {
+      return;
+    }
+
+    $criteria = new Criteria;
+    $criteria->add(QubitDigitalObject::PARENT_ID, $this->__get('digital_object_id'));
+
+    if (null !== $do = QubitDigitalObject::getOne($criteria))
+    {
+      return $do->getDigitalObjectAltText();
+    }
+  }
+
   public function getMaterialTypeId()
   {
     return $this->getObjectTermRelations('materialType', QubitTaxonomy::MATERIAL_TYPE_ID);
@@ -1193,6 +1209,7 @@ class arElasticSearchInformationObjectPdo
       $serialized['digitalObject']['usageId'] = $this->usage_id;
       $serialized['digitalObject']['filename'] = $this->filename;
       $serialized['digitalObject']['thumbnailPath'] = $this->getThumbnailPath();
+      $serialized['digitalObject']['digitalObjectAltText'] = $this->getDigitalObjectAltText();
 
       $serialized['hasDigitalObject'] = true;
     }

--- a/plugins/sfDcPlugin/modules/sfDcPlugin/templates/indexSuccess.php
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/templates/indexSuccess.php
@@ -140,7 +140,7 @@
 
 <?php if (0 < count($resource->digitalObjectsRelatedByobjectId)): ?>
 
-  <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjectsRelatedByobjectId[0], 'infoObj' => $resource)) ?>
+  <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjectsRelatedByobjectId[0], 'object' => $resource)) ?>
 
   <?php echo get_partial('digitalobject/rights', array('resource' => $resource->digitalObjectsRelatedByobjectId[0])) ?>
 

--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/indexSuccess.php
@@ -248,6 +248,14 @@
 
 </section> <!-- /section#controlArea -->
 
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)): ?>
+
+  <div class="digitalObjectMetadata">
+    <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjectsRelatedByobjectId[0], 'object' => $resource)) ?>
+  </div>
+
+<?php endif; ?>
+
 <?php slot('after-content') ?>
 
   <section class="actions">

--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/indexSuccess.php
@@ -60,6 +60,10 @@
 
 <?php end_slot() ?>
 
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)): ?>
+  <?php echo get_component('digitalobject', 'show', array('link' => $digitalObjectLink, 'resource' => $resource->digitalObjectsRelatedByobjectId[0], 'usageType' => QubitTerm::REFERENCE_ID)) ?>
+<?php endif; ?>
+
 <section id="identityArea">
 
   <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Identity area').'</h2>', array($resource, 'module' => 'actor', 'action' => 'edit'), array('anchor' => 'identityArea', 'title' => __('Edit identity area'))) ?>
@@ -262,6 +266,26 @@
           <li><?php echo link_to(__('Add new'), array('module' => 'actor', 'action' => 'add'), array('class' => 'c-btn', 'title' => __('Add new'))) ?></li>
         <?php endif; ?>
 
+        <?php if (QubitAcl::check($resource, 'update') || sfContext::getInstance()->getUser()->hasGroup(QubitAclGroup::EDITOR_ID)): ?>
+        <li class="divider"></li>
+
+        <li>
+          <div class="btn-group dropup">
+            <a class="c-btn dropdown-toggle" data-toggle="dropdown" href="#">
+              <?php echo __('More') ?>
+              <span class="caret"></span>
+            </a>
+
+            <ul class="dropdown-menu">
+              <?php if (0 < count($resource->digitalObjectsRelatedByobjectId) && QubitDigitalObject::isUploadAllowed()): ?>
+                <li><?php echo link_to(__('Edit %1%', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))), array($resource->digitalObjectsRelatedByobjectId[0], 'module' => 'digitalobject', 'action' => 'edit')) ?></li>
+              <?php elseif (QubitDigitalObject::isUploadAllowed()): ?>
+                <li><?php echo link_to(__('Link %1%', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))), array($resource, 'module' => 'object', 'action' => 'addDigitalObject')) ?></li>
+              <?php endif; // has digital object ?>
+            </ul>
+          </div>
+        </li>
+        <?php endif; // user has update permission ?>
     </ul>
 
   </section>

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/indexSuccess.php
@@ -327,7 +327,7 @@
 <?php if (0 < count($resource->digitalObjectsRelatedByobjectId)): ?>
 
   <div class="digitalObjectMetadata">
-    <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjectsRelatedByobjectId[0], 'infoObj' => $resource)) ?>
+    <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjectsRelatedByobjectId[0], 'object' => $resource)) ?>
   </div>
 
   <div class="digitalObjectRights">

--- a/plugins/sfModsPlugin/modules/sfModsPlugin/templates/indexSuccess.php
+++ b/plugins/sfModsPlugin/modules/sfModsPlugin/templates/indexSuccess.php
@@ -138,7 +138,7 @@
 
 <?php if (0 < count($resource->digitalObjectsRelatedByobjectId)): ?>
 
-  <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjectsRelatedByobjectId[0], 'infoObj' => $resource)) ?>
+  <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjectsRelatedByobjectId[0], 'object' => $resource)) ?>
 
   <?php echo get_partial('digitalobject/rights', array('resource' => $resource->digitalObjectsRelatedByobjectId[0])) ?>
 

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
@@ -395,7 +395,7 @@
 
 <?php if (0 < count($resource->digitalObjectsRelatedByobjectId)): ?>
   <div class="digitalObjectMetadata">
-    <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjectsRelatedByobjectId[0], 'infoObj' => $resource)) ?>
+    <?php echo get_component('digitalobject', 'metadata', array('resource' => $resource->digitalObjectsRelatedByobjectId[0], 'object' => $resource)) ?>
   </div>
   <div class="digitalObjectRights">
     <?php echo get_partial('digitalobject/rights', array('resource' => $resource->digitalObjectsRelatedByobjectId[0])) ?>


### PR DESCRIPTION
Allow authority records to link a single digital object. This functionality matches the current "Link Digital Object" functionality currently available for descriptions.  This feature includes the ability to set the alt text for the digital object - the alt text field can be set on the digital object edit page.

Access control behaves differently from information objects. There are no PREMIS rules for authorities.  Access to these digital objects is controlled via the existing authority record ACL controls. Editing the digital object requires authority update permissions etc.

- Must have read privileges to view
- PDF master is always accessible to view as with Descriptions
- Create permission is needed to create an actor
- Update privileges are needed to add or update an actor linked digital object as this is technically updating the actor
- Delete privileges are needed to delete