### PR TITLE
Authority digtial obj migration fix, refs #12650

### DIFF
--- a/lib/task/migrate/migrations/arMigration0169.class.php
+++ b/lib/task/migrate/migrations/arMigration0169.class.php
@@ -45,7 +45,7 @@ CHANGE COLUMN `information_object_id` `object_id` INT(11) NULL DEFAULT NULL ;
 ALTER TABLE `atom`.`digital_object`
 ADD CONSTRAINT `digital_object_FK_2`
   FOREIGN KEY (`object_id`)
-  REFERENCES `atom`.`information_object` (`id`);
+  REFERENCES `atom`.`object` (`id`);
 
 sql;
 


### PR DESCRIPTION
Correct the foreign key assignment in migration 169 so FK2 relates to
the object table and not information_object.