### PR TITLE
Dockerfile change PHP version, refs #12821

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-fpm-alpine
+FROM php:7.2-fpm-alpine
 
 ARG GIT_BRANCH=qa/2.5.x
 
@@ -8,6 +8,7 @@ RUN set -xe \
 		&& apk add --no-cache --virtual .phpext-builddeps \
 			gettext-dev \
 			libxslt-dev \
+			libzip-dev \
 			zlib-dev \
 			libmemcached-dev \
 			autoconf \
@@ -22,7 +23,11 @@ RUN set -xe \
 			sockets \
 			xsl \
 			zip \
+		# libzip required for PHP > 7.2
+		&& docker-php-ext-configure zip --with-libzip \
+		&& docker-php-ext-install zip \
 		# https://bugs.php.net/bug.php?id=70751
+		# Memcache config below will not work with PHP > 7.2
 		&& curl -Ls https://github.com/websupport-sk/pecl-memcache/archive/NON_BLOCKING_IO_php7.tar.gz | tar xz -C / \
 		&& cd /pecl-memcache-NON_BLOCKING_IO_php7 \
 		&& phpize && ./configure && make && make install \


### PR DESCRIPTION
Memcache will not install correctly from pecl as specified in our
Dockerfile under PHP 7.3. This issue appears that it could be limited
to affecting Windows and Mac hosts and not Linux.

Update the Dockerfile to install Alpine with PHP 7.2.x. Add code to also
load libzip library which is necessary under PHP 7.3 but also works for
PHP 7.0 and up.