### PR TITLE
Digital object master discarding, refs #12840

### DIFF
--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 169
+    value: 170
   milestone:
     name: milestone
     editable: 0

--- a/data/fixtures/taxonomyTerms.yml
+++ b/data/fixtures/taxonomyTerms.yml
@@ -2511,6 +2511,13 @@ QubitTerm:
       th: ประกอบ
       vi: 'điều đình'
       zh: 混合物
+  QubitTerm_local_file_id:
+    taxonomy_id: QubitTaxonomy_17
+    parent_id: QubitTerm_110
+    id: 191
+    source_culture: en
+    name:
+      en: External file
   QubitTerm_140:
     taxonomy_id: QubitTaxonomy_18
     parent_id: QubitTerm_110

--- a/lib/model/QubitActor.php
+++ b/lib/model/QubitActor.php
@@ -778,7 +778,7 @@ class QubitActor extends BaseActor
     }
 
     $digitalObject = $this->digitalObjectsRelatedByobjectId[0];
-    if (QubitTerm::OFFLINE_ID == $digitalObject->usageId)
+    if (QubitTerm::OFFLINE_ID == $digitalObject->usageId || QubitTerm::EXTERNAL_FILE_ID == $digitalObject->usageId)
     {
       return;
     }

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -1448,7 +1448,7 @@ class QubitInformationObject extends BaseInformationObject
       return;
     }
 
-    if (QubitTerm::OFFLINE_ID == $do->usageId)
+    if (QubitTerm::OFFLINE_ID == $do->usageId || QubitTerm::EXTERNAL_FILE_ID == $digitalObject->usageId)
     {
       return;
     }
@@ -3196,7 +3196,7 @@ class QubitInformationObject extends BaseInformationObject
     }
 
     $digitalObject = $this->digitalObjectsRelatedByobjectId[0];
-    if (QubitTerm::OFFLINE_ID == $digitalObject->usageId)
+    if (QubitTerm::OFFLINE_ID == $digitalObject->usageId || QubitTerm::EXTERNAL_FILE_ID == $digitalObject->usageId)
     {
       return;
     }

--- a/lib/model/QubitTerm.php
+++ b/lib/model/QubitTerm.php
@@ -172,7 +172,10 @@ class QubitTerm extends BaseTerm
 
     // User action taxonomy
     USER_ACTION_CREATION_ID = 189,
-    USER_ACTION_MODIFICATION_ID = 190;
+    USER_ACTION_MODIFICATION_ID = 190,
+
+    // Digital object usage taxonomy (addition)
+    EXTERNAL_FILE_ID = 191;
 
   public static function isProtected($id)
   {

--- a/lib/task/migrate/migrations/arMigration0170.class.php
+++ b/lib/task/migrate/migrations/arMigration0170.class.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add new term to the levels of description taxonomy
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0170
+{
+  const
+    VERSION = 170, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  public function up($configuration)
+  {
+    // Check if term actually exists before adding
+    $criteria = new Criteria;
+    $criteria->add(QubitTerm::TAXONOMY_ID, QubitTaxonomy::DIGITAL_OBJECT_USAGE_ID);
+    $criteria->addJoin(QubitTerm::ID, QubitTermI18n::ID);
+    $criteria->add(QubitTermI18n::NAME, 'External file');
+    $criteria->add(QubitTermI18n::CULTURE, 'en');
+
+    if (null === QubitTerm::get($criteria))
+    {
+      // Create new term for external file digital object usage
+      QubitMigrate::bumpTerm(QubitTerm::EXTERNAL_FILE_ID, $configuration);
+      $term = new QubitTerm;
+      $term->id = QubitTerm::EXTERNAL_FILE_ID;
+      $term->parentId = QubitTerm::ROOT_ID;
+      $term->taxonomyId = QubitTaxonomy::DIGITAL_OBJECT_USAGE_ID;
+      $term->name = 'Local file';
+      $term->culture = 'en';
+      $term->save();
+
+      return true;
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
Added functionality to the digital object load task, and model, to
support a new digital object usage type: local files.

Local files exist outside of AtoM and, when associated with an
information object using the digital:object task, their representations
will be displayed on the information object's detail page but the
master file won't be accessible.