### PR TITLE
Digital object master discarding, refs #12840

### DIFF
--- a/data/fixtures/taxonomyTerms.yml
+++ b/data/fixtures/taxonomyTerms.yml
@@ -2511,6 +2511,13 @@ QubitTerm:
       th: ประกอบ
       vi: 'điều đình'
       zh: 混合物
+  QubitTerm_local_file_id:
+    taxonomy_id: QubitTaxonomy_17
+    parent_id: QubitTerm_110
+    id: 191
+    source_culture: en
+    name:
+      en: External file
   QubitTerm_140:
     taxonomy_id: QubitTaxonomy_18
     parent_id: QubitTerm_110

--- a/lib/model/QubitActor.php
+++ b/lib/model/QubitActor.php
@@ -778,7 +778,7 @@ class QubitActor extends BaseActor
     }
 
     $digitalObject = $this->digitalObjectsRelatedByobjectId[0];
-    if (QubitTerm::OFFLINE_ID == $digitalObject->usageId)
+    if (!$digitalObject->masterAccessibleViaUrl())
     {
       return;
     }

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -1461,6 +1461,23 @@ class QubitDigitalObject extends BaseDigitalObject
     throw new sfException(sprintf('Error downloading "%s" (attempts: %s).', $uri, $i));
   }
 
+  private function file_get_contents_if_not_empty($filepath)
+  {
+    // Only return file contents if file is indeed a file and isn't empty
+    if (is_file($filepath))
+    {
+      $contents = file_get_contents($filepath);
+
+      if (!empty($contents))
+      {
+        return $contents;
+      }
+    }
+
+    // Throw exception on failure
+    throw new sfException(sprintf('Error reading file or file is empty.', $filepath));
+  }
+
   /**
    * Get filename from URI path
    *
@@ -1503,12 +1520,51 @@ class QubitDigitalObject extends BaseDigitalObject
     // If not creating derivatives right now, don't download the resource
     if (!$this->createDerivatives)
     {
-      return $self;
+      return;
     }
 
     // Download the remote resource bitstream
     $contents = $this->downloadExternalObject($uri, $options);
+    $this->saveAndAttachFileContent($filename, $contents);
+  }
 
+  /**
+   * Populate a digital object from a file, but don't store the master
+   *
+   * @param string $filepath path to digital object
+   * @param array $options Optional arguments
+   *
+   * @return QubitDigitalObject this object
+   */
+  public function importFromFile($filepath, $options = array())
+  {
+    $filename = basename($filepath);
+
+    // Set general properties that don't require downloading the asset
+    $this->usageId = QubitTerm::EXTERNAL_FILE_ID;
+    $this->name = $filename;
+    $this->path = $filepath;
+    $this->setMimeAndMediaType();
+
+    // If not creating derivatives right now, don't download the resource
+    if (!$this->createDerivatives)
+    {
+      return;
+    }
+
+    // Download the remote resource bitstream
+    $contents = $this->file_get_contents_if_not_empty($filepath);
+    $this->saveAndAttachFileContent($filename, $contents);
+  }
+
+  /**
+   * Save data as file and attach as an asset
+   *
+   * @param string $filename name of file
+   * @param string $contents data to save
+   */
+  protected function saveAndAttachFileContent($filename, $contents)
+  {
     // Save downloaded bitstream to a temp file
     if (false === $this->localPath = Qubit::saveTemporaryFile($filename, $contents))
     {
@@ -1523,8 +1579,6 @@ class QubitDigitalObject extends BaseDigitalObject
     $this->checksum = $asset->getChecksum();
     $this->checksumType = $asset->getChecksumAlgorithm();
     $this->byteSize = strlen($contents);
-
-    return $self;
   }
 
   /**
@@ -1578,13 +1632,29 @@ class QubitDigitalObject extends BaseDigitalObject
   }
 
   /**
+   * Check whether the digital object usage involves an externally stored
+   * master that's used to generate derivatives
+   *
+   * @return boolean  whether or not usage relies on an external master
+   */
+  public function derivativesGeneratedFromExternalMaster($usageId)
+  {
+    return QubitTerm::EXTERNAL_URI_ID == $usageId || QubitTerm::EXTERNAL_FILE_ID == $usageId;
+  }
+
+  public function masterAccessibleViaUrl()
+  {
+    return QubitTerm::OFFLINE_ID != $this->usageId && QubitTerm::EXTERNAL_FILE_ID != $this->usageId;
+  }
+
+  /**
    * Get path to asset, relative to sf_web_dir
    *
    * @return string  path to asset
    */
   public function getFullPath()
   {
-    if (QubitTerm::EXTERNAL_URI_ID != $this->usageId)
+    if (!$this->derivativesGeneratedFromExternalMaster($this->usageId))
     {
       return $this->getPath().$this->getName();
     }
@@ -1604,7 +1674,7 @@ class QubitDigitalObject extends BaseDigitalObject
    */
   public function getPublicPath()
   {
-    if ($this->usageId == QubitTerm::EXTERNAL_URI_ID)
+    if ($this->derivativesGeneratedFromExternalMaster($this->usageId))
     {
       return $this->getPath();
     }
@@ -1832,7 +1902,7 @@ class QubitDigitalObject extends BaseDigitalObject
       throw new sfException('Couldn\'t find related object for digital object');
     }
 
-    if ($this->usageId == QubitTerm::MASTER_ID || $this->parent->usageId == QubitTerm::EXTERNAL_URI_ID)
+    if ($this->usageId == QubitTerm::MASTER_ID || $this->derivativesGeneratedFromExternalMaster($this->parent->usageId))
     {
       $id = (string) $object->id;
 
@@ -2013,7 +2083,7 @@ class QubitDigitalObject extends BaseDigitalObject
         // Scale images and create derivatives
         if ($this->canThumbnail())
         {
-          if ($usageId == QubitTerm::EXTERNAL_URI_ID || $usageId == QubitTerm::MASTER_ID)
+          if ($this->derivativesGeneratedFromExternalMaster($usageId) || $usageId == QubitTerm::MASTER_ID)
           {
             $this->createReferenceImage($connection);
             $this->createThumbnail($connection);
@@ -2033,7 +2103,7 @@ class QubitDigitalObject extends BaseDigitalObject
       case QubitTerm::TEXT_ID:
         if ($this->canThumbnail())
         {
-          if ($usageId == QubitTerm::EXTERNAL_URI_ID || $usageId == QubitTerm::MASTER_ID)
+          if ($this->derivativesGeneratedFromExternalMaster($usageId) || $usageId == QubitTerm::MASTER_ID)
           {
             // Thumbnail PDFs (may add other formats in future)
             $this->createReferenceImage($connection);
@@ -2055,7 +2125,7 @@ class QubitDigitalObject extends BaseDigitalObject
         break;
 
       case QubitTerm::VIDEO_ID:
-        if ($usageId == QubitTerm::EXTERNAL_URI_ID || $usageId == QubitTerm::MASTER_ID)
+        if ($this->derivativesGeneratedFromExternalMaster($usageId) || $usageId == QubitTerm::MASTER_ID)
         {
           $this->createVideoDerivative(QubitTerm::REFERENCE_ID, $connection);
           $this->createVideoDerivative(QubitTerm::THUMBNAIL_ID, $connection);
@@ -2070,6 +2140,7 @@ class QubitDigitalObject extends BaseDigitalObject
       case QubitTerm::AUDIO_ID:
         if (in_array($usageId, array(
           QubitTerm::EXTERNAL_URI_ID,
+          QubitTerm::EXTERNAL_FILE_ID,
           QubitTerm::MASTER_ID,
           QubitTerm::REFERENCE_ID
         )))
@@ -2100,7 +2171,7 @@ class QubitDigitalObject extends BaseDigitalObject
   {
     if ($this->canThumbnail() && self::hasImageMagick())
     {
-      $filename = (QubitTerm::EXTERNAL_URI_ID == $this->usageId) ? $this->getLocalPath() : $this->getAbsolutePath();
+      $filename = ($this->derivativesGeneratedFromExternalMaster($this->usageId)) ? $this->getLocalPath() : $this->getAbsolutePath();
 
       $extension = pathinfo($filename, PATHINFO_EXTENSION);
 
@@ -2172,7 +2243,7 @@ class QubitDigitalObject extends BaseDigitalObject
 
     if ($pageCount > 1 && $this->canThumbnail())
     {
-      if (QubitTerm::EXTERNAL_URI_ID == $this->usageId)
+      if ($this->derivativesGeneratedFromExternalMaster($this->usageId))
       {
         $path = $this->localPath;
       }
@@ -2372,12 +2443,19 @@ class QubitDigitalObject extends BaseDigitalObject
     return $derivative;
   }
 
-  private function getLocalPath()
+  public function getLocalPath()
   {
     if (null === $this->localPath && QubitTerm::EXTERNAL_URI_ID == $this->usageId)
     {
       $filename = $this->getFilenameFromUri($this->path);
       $contents = $this->downloadExternalObject($this->path);
+      $this->localPath = Qubit::saveTemporaryFile($filename, $contents);
+    }
+
+    if (null === $this->localPath && QubitTerm::EXTERNAL_FILE_ID == $this->usageId)
+    {
+      $filename = basename($this->path);
+      $contents = $this->file_get_contents_if_not_empty($this->path);
       $this->localPath = Qubit::saveTemporaryFile($filename, $contents);
     }
 
@@ -2396,7 +2474,7 @@ class QubitDigitalObject extends BaseDigitalObject
     $maxDimensions = self::getImageMaxDimensions($usageId);
 
     // Build new filename and path
-    if (QubitTerm::EXTERNAL_URI_ID == $this->usageId)
+    if ($this->derivativesGeneratedFromExternalMaster($this->usageId))
     {
       $originalFullPath = $this->getLocalPath();
     }
@@ -2699,7 +2777,7 @@ class QubitDigitalObject extends BaseDigitalObject
       return false;
     }
 
-    if (QubitTerm::EXTERNAL_URI_ID == $this->usageId)
+    if ($this->derivativesGeneratedFromExternalMaster($this->usageId))
     {
       $originalFullPath = $this->getLocalPath();
 
@@ -3044,7 +3122,7 @@ class QubitDigitalObject extends BaseDigitalObject
       return;
     }
 
-    if (QubitTerm::EXTERNAL_URI_ID == $this->usageId)
+    if ($this->derivativesGeneratedFromExternalMaster($this->usageId))
     {
       $path = $this->localPath;
 

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -1448,7 +1448,7 @@ class QubitInformationObject extends BaseInformationObject
       return;
     }
 
-    if (QubitTerm::OFFLINE_ID == $do->usageId)
+    if (!$do->masterAccessibleViaUrl())
     {
       return;
     }
@@ -3196,7 +3196,7 @@ class QubitInformationObject extends BaseInformationObject
     }
 
     $digitalObject = $this->digitalObjectsRelatedByobjectId[0];
-    if (QubitTerm::OFFLINE_ID == $digitalObject->usageId)
+    if (!$digitalObject->masterAccessibleViaUrl())
     {
       return;
     }

--- a/lib/model/QubitTerm.php
+++ b/lib/model/QubitTerm.php
@@ -172,7 +172,10 @@ class QubitTerm extends BaseTerm
 
     // User action taxonomy
     USER_ACTION_CREATION_ID = 189,
-    USER_ACTION_MODIFICATION_ID = 190;
+    USER_ACTION_MODIFICATION_ID = 190,
+
+    // Digital object usage taxonomy (addition)
+    EXTERNAL_FILE_ID = 191;
 
   public static function isProtected($id)
   {

--- a/lib/task/digitalobject/digitalObjectDeleteTask.class.php
+++ b/lib/task/digitalobject/digitalObjectDeleteTask.class.php
@@ -107,7 +107,7 @@ EOF;
 
   private function deleteDigitalObject($digitalObject)
   {
-    if ($digitalObject->usageId == QubitTerm::EXTERNAL_URI_ID || $digitalObject->usageId == QubitTerm::OFFLINE_ID)
+    if ($digitalObject->derivativesGeneratedFromExternalMaster() || $digitalObject->usageId == QubitTerm::OFFLINE_ID)
     {
       return;
     }

--- a/lib/task/digitalobject/digitalObjectLoadTask.class.php
+++ b/lib/task/digitalobject/digitalObjectLoadTask.class.php
@@ -46,6 +46,7 @@ class digitalObjectLoadTask extends sfBaseTask
       new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
       new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
       new sfCommandOption('connection', null, sfCommandOption::PARAMETER_REQUIRED, 'The connection name', 'propel'),
+      new sfCommandOption('link-source', 's', sfCommandOption::PARAMETER_NONE, 'Link source', null),
       new sfCommandOption('path', 'p', sfCommandOption::PARAMETER_OPTIONAL, 'Path prefix for digital objects', null),
       new sfCommandOption('limit', 'l', sfCommandOption::PARAMETER_OPTIONAL, 'Limit number of digital objects imported to n', null),
       new sfCommandOption('index', 'i', sfCommandOption::PARAMETER_NONE, 'Update search index (defaults to false)', null),
@@ -196,7 +197,7 @@ EOF;
         // Skip if this information object already has a digital object attached
         if ($results[1] !== null)
         {
-          $this->log(sprintf('Information object $idType: %s already has a digital object. Skipping.', $key));
+          $this->log(sprintf("Information object $idType: %s already has a digital object. Skipping.", $key));
           $this->skippedCount++;
 
           continue;
@@ -241,14 +242,6 @@ EOF;
       $path = $options['path'].$path;
     }
 
-    // read file contents
-    if (false === $content = file_get_contents($path))
-    {
-      $this->log("Couldn't read file '$path'");
-
-      return;
-    }
-
     $filename = basename($path);
 
     $remainingImportCount = $this->totalObjCount - $this->skippedCount - $importedCount;
@@ -265,8 +258,25 @@ EOF;
     // Create digital object
     $do = new QubitDigitalObject;
     $do->objectId = $objectId;
-    $do->usageId = QubitTerm::MASTER_ID;
-    $do->assets[] = new QubitAsset($filename, $content);
+
+    if ($options['link-source'])
+    {
+      $do->importFromFile($path);
+    }
+    else
+    {
+      // Read file contents
+      if (false === $content = file_get_contents($path))
+      {
+        $this->log("Couldn't read file '$path'");
+
+        return;
+      }
+
+      $do->usageId = QubitTerm::MASTER_ID;
+      $do->assets[] = new QubitAsset($filename, $content);
+    }
+
     $do->save($options['conn']);
 
     self::$count++;

--- a/lib/task/digitalobject/digitalObjectRegenDerivativesTask.class.php
+++ b/lib/task/digitalobject/digitalObjectRegenDerivativesTask.class.php
@@ -213,7 +213,14 @@ EOF;
         break;
 
       default:
-        $usageId = $digitalObject->usageId; // MASTER_ID or EXTERNAL_URI_ID
+        $usageId = $digitalObject->usageId; // MASTER_ID or EXTERNAL_URI_ID or EXTERNAL_FILE_ID
+    }
+
+    // If master isn't stored in AtoM, attempt to cache external resource before deleting
+    // existing derivatives (an unavailable resource will result in an exception)
+    if ($digitalObject->derivativesGeneratedFromExternalMaster($digitalObject->usageId))
+    {
+      $digitalObject->getLocalPath();
     }
 
     // Delete existing derivatives

--- a/lib/task/migrate/migrations/arMigration0171.class.php
+++ b/lib/task/migrate/migrations/arMigration0171.class.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add new term for external file digital object usage
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0171
+{
+  const
+    VERSION = 171, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  public function up($configuration)
+  {
+    // Create new term for external file digital object usage
+    QubitMigrate::bumpTerm(QubitTerm::EXTERNAL_FILE_ID, $configuration);
+    $term = new QubitTerm;
+    $term->id = QubitTerm::EXTERNAL_FILE_ID;
+    $term->parentId = QubitTerm::ROOT_ID;
+    $term->taxonomyId = QubitTaxonomy::DIGITAL_OBJECT_USAGE_ID;
+    $term->name = 'Local file';
+    $term->culture = 'en';
+    $term->save();
+
+    return true;
+  }
+}


### PR DESCRIPTION
Added functionality to the digital object load task, and model, to
support a new digital object usage type: local files.

Local files exist outside of AtoM and, when associated with an
information object using the digital:object task, their representations
will be displayed on the information object's detail page but the
master file won't be accessible.