### PR TITLE
CSV Import terms performance, refs #12826

### DIFF
--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -682,6 +682,9 @@ EOF;
         {
           if (isset($self->rowStatusVars[$columnName]))
           {
+            // Create/relate terms from array of term names.
+            $self->createOrFetchTermAndAddRelation($taxonomyId, $self->rowStatusVars[$columnName]);
+
             $index = 0;
             foreach ($self->rowStatusVars[$columnName] as $subject)
             {
@@ -692,8 +695,6 @@ EOF;
                 {
                   $scope = $self->rowStatusVars['subjectAccessPointScopes'][$index];
                 }
-
-                $self->createOrFetchTermAndAddRelation($taxonomyId, $subject);
 
                 if ($scope)
                 {


### PR DESCRIPTION
Change logic so that csv:import retrieves existing terms for a
taxonomy once only, while still ensuring that terms that do not yet
exist in the database are still created.