### PR TITLE
Refactor advanced search filter tags, refs #12815

### DIFF
--- a/apps/qubit/modules/actor/templates/browseSuccess.php
+++ b/apps/qubit/modules/actor/templates/browseSuccess.php
@@ -68,14 +68,14 @@
         <?php echo get_partial('search/aggregation', array(
           'id' => '#facet-places',
           'label' => sfConfig::get('app_ui_label_place'),
-          'name' => 'places',
+          'name' => 'place',
           'aggs' => $aggs,
           'filters' => $search->filters)) ?>
 
         <?php echo get_partial('search/aggregation', array(
           'id' => '#facet-subjects',
           'label' => sfConfig::get('app_ui_label_subject'),
-          'name' => 'subjects',
+          'name' => 'subject',
           'aggs' => $aggs,
           'filters' => $search->filters)) ?>
 
@@ -96,34 +96,8 @@
 <?php slot('before-content') ?>
 
   <section class="header-options">
-    <?php if (isset($sf_request->hasDigitalObject)): ?>
-      <span class="search-filter">
-        <?php if (filter_var($sf_request->hasDigitalObject, FILTER_VALIDATE_BOOLEAN)): ?>
-          <?php echo __('With digital objects') ?>
-        <?php else: ?>
-          <?php echo __('Without digital objects') ?>
-        <?php endif; ?>
-        <?php $params = $sf_data->getRaw('sf_request')->getGetParameters() ?>
-        <?php unset($params['hasDigitalObject']) ?>
-        <a href="<?php echo url_for(array('module' => 'actor', 'action' => 'browse') + $params) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
-      </span>
-    <?php endif; ?>
 
-    <?php echo get_component('search', 'filter', array('object' => @$repository, 'param' => 'repository')) ?>
-    <?php echo get_component('search', 'filter', array('object' => @$entityType, 'param' => 'entityType')) ?>
-    <?php echo get_component('search', 'filter', array('object' => @$occupation, 'param' => 'occupation')) ?>
-    <?php echo get_component('search', 'filter', array('object' => @$places, 'param' => 'places')) ?>
-    <?php echo get_component('search', 'filter', array('object' => @$subjects, 'param' => 'subjects')) ?>
-    <?php echo get_component('search', 'filter', array('object' => @$mediatypes, 'param' => 'mediatypes')) ?>
-
-    <?php if (isset($sf_request->emptyField)): ?>
-      <span class="search-filter">
-        <?php echo __('Empty: %1%', array('%1%' => $fieldOptions[$sf_request->emptyField])) ?>
-        <?php $params = $sf_data->getRaw('sf_request')->getGetParameters() ?>
-        <?php unset($params['emptyField']) ?>
-        <a href="<?php echo url_for(array('module' => 'actor', 'action' => 'browse') + $params) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
-      </span>
-    <?php endif; ?>
+    <?php echo get_partial('search/filterTags', array('filterTags' => $filterTags)) ?>
 
     <div class="row">
       <div class="span5">

--- a/apps/qubit/modules/default/actions/browseAction.class.php
+++ b/apps/qubit/modules/default/actions/browseAction.class.php
@@ -114,6 +114,30 @@ class DefaultBrowseAction extends sfAction
     return $buckets;
   }
 
+  protected function populateFilterTags($request)
+  {
+    $this->filterTags = $this::$FILTERTAGS;
+
+    // Get model objects needed by filter tags
+    foreach($this->filterTags as $name => $config)
+    {
+      if (isset($config['model']))
+      {
+        $this->filterTags[$name]['object'] = $config['model']::getById($request->$name);
+      }
+    }
+  }
+
+  protected function getFilterTagObject($filterTag)
+  {
+    return $this->filterTags[$filterTag]['object'];
+  }
+
+  protected function setFilterTagLabel($filterTag, $label)
+  {
+    $this->filterTags[$filterTag]['label'] = $label;
+  }
+
   protected function setHiddenFields($request, $allowed, $ignored)
   {
     // Store current params to add them as hidden inputs

--- a/apps/qubit/modules/search/actions/filterTagComponent.class.php
+++ b/apps/qubit/modules/search/actions/filterTagComponent.class.php
@@ -17,18 +17,20 @@
  * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
  */
 
-class SearchFilterComponent extends sfComponent
+class SearchFilterTagComponent extends sfComponent
 {
   public function execute($request)
   {
-    // Display nothing unless any object have been provided
-    if (!isset($this->object))
+    $this->params = $request->getGetParameters();
+
+    // If filter param isn't set in the request, or filter is model-based yet no object
+    // has been stored, display nothing
+    if (!isset($this->params[$this->param]) || (isset($this->model) && !isset($this->object)))
     {
       return sfView::NONE;
     }
 
     // Remove selected parameter from the current GET parameters
-    $this->params = $request->getGetParameters();
     unset($this->params[$this->param]);
 
     // Default module and action to the current module/action

--- a/apps/qubit/modules/search/templates/_filterTag.php
+++ b/apps/qubit/modules/search/templates/_filterTag.php
@@ -1,4 +1,8 @@
 <span class="search-filter">
-  <?php echo render_title($object) ?>
+  <?php if (isset($label)): ?>
+    <?php echo $label ?>
+  <?php else: ?>
+    <?php echo render_title($object) ?>
+  <?php endif; ?>
   <a href="<?php echo url_for(array('module' => $module, 'action' => $action) + $params) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
 </span>

--- a/apps/qubit/modules/search/templates/_filterTags.php
+++ b/apps/qubit/modules/search/templates/_filterTags.php
@@ -1,0 +1,3 @@
+<?php foreach ($filterTags as $param => $config): ?>
+  <?php echo get_component('search', 'filterTag', array('model' => $config['model'],'object' => $config['object'], 'label' => $config['label'], 'param' => $param)) ?>
+<?php endforeach; ?>


### PR DESCRIPTION
Refactored filter tags so all of them can be rendered by a component.

Filter tag configuration can be added to an advanced search action
class and, with a call to a method of the parent DefaultBrowseAction
class, a single partial uses to display all filter tags.