### PR TITLE
CSV actor import index option fix, refs #12845

### DIFF
--- a/lib/task/import/csvAuthorityRecordImportTask.class.php
+++ b/lib/task/import/csvAuthorityRecordImportTask.class.php
@@ -149,6 +149,10 @@ EOF;
           }
         ));
       }
+
+      // Allow search indexing to be enabled via a CLI option
+      $import->searchIndexingDisabled = ($options['index']) ? false : true;
+
       $import->csv($fh);
       $aliases = $import->getStatus('aliases');
     }
@@ -558,6 +562,9 @@ EOF;
             }
           }
         ));
+
+        // Allow search indexing to be enabled via a CLI option
+        $import->searchIndexingDisabled = ($options['index']) ? false : true;
 
         $import->csv($fh);
       }


### PR DESCRIPTION
The $import variable is reassigned multiple times in the CSV actor
import CLI task. Ensure that the QubitFlatfileImport
searchIndexingDisabled property is reassigned the --index option value
before each call to the QubitFlatfileImport::csv() method.