### PR TITLE
Add rights field visible elements, refs #12845

### DIFF
--- a/apps/qubit/modules/settings/templates/visibleElementsSuccess.php
+++ b/apps/qubit/modules/settings/templates/visibleElementsSuccess.php
@@ -125,6 +125,7 @@
           'rad_immediate_source' => __('Immediate source of acquisition'),
           'rad_general_notes' => __('General note(s)'),
           'rad_conservation_notes' => __('Conservation note(s)'),
+          'rad_rights_notes' => __('Rights note(s)'),
           'rad_control_description_identifier' => __('Description identifier'),
           'rad_control_institution_identifier' => __('Institution identifier'),
           'rad_control_rules_conventions' => __('Rules or conventions'),

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 169
+    value: 170
   milestone:
     name: milestone
     editable: 0
@@ -966,6 +966,10 @@ QubitSetting:
     value: 1
   Qubit_Settings_visibleElements_RadConservationNotes:
     name: rad_conservation_notes
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_RadRightsNotes:
+    name: rad_rights_notes
     scope: element_visibility
     value: 1
   Qubit_Settings_visibleElements_RadPhysicalCondition:

--- a/lib/task/migrate/migrations/arMigration0170.class.php
+++ b/lib/task/migrate/migrations/arMigration0170.class.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add ability to set whether rad_rights_notes field shown on rad template.
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0170
+{
+  const
+    VERSION = 170, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  /**
+   * Upgrade
+   *
+   * @return bool True if the upgrade succeeded, False otherwise
+   */
+  public function up($configuration)
+  {
+    if (null === QubitSetting::getByName('rad_rights_notes'))
+    {
+      $setting = new QubitSetting;
+      $setting->setName('rad_rights_notes');
+      $setting->setScope('element_visibility');
+      $setting->setValue('1');
+      $setting->save();
+    }
+
+    return true;
+  }
+}

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
@@ -268,6 +268,10 @@
       <?php continue; ?>
     <?php endif; ?>
 
+    <?php if ('Rights' == $type && !check_field_visibility('app_element_visibility_rad_rights_notes')): ?>
+      <?php continue; ?>
+    <?php endif; ?>
+
     <div class="field">
       <h3><?php echo __(render_value_inline($item->type)) ?></h3>
       <div class="radNote">


### PR DESCRIPTION
Add the RAD Rights notes field to visible elements to control
the visibility of this field when viewing a descriptions using the
RAD template.