### PR TITLE
Fix advanced search form JS issue, refs #12815

### DIFF
--- a/js/dominion.js
+++ b/js/dominion.js
@@ -707,7 +707,7 @@
     checkReposFilter: function (event)
     {
       // Disable repository filter and facet if top-level description selected
-      if (typeof($collectionFilter) !== 'undefined' && this.$reposFilter.length && this.$collectionFilter.val() != '')
+      if (typeof(this.$collectionFilter) !== 'undefined' && this.$reposFilter.length && this.$collectionFilter.val() != '')
       {
         this.$reposFilter.attr("disabled", "disabled");
         this.$reposFilter.val('');


### PR DESCRIPTION
Fix advanced search form issue preventing repository selector from
being disabled when a top-level description is selected.