### PR TITLE
Replace deprecated create_function, refs #12568

### DIFF
--- a/lib/task/i18n/i18nCustomLinkToMarkdownTask.class.php
+++ b/lib/task/i18n/i18nCustomLinkToMarkdownTask.class.php
@@ -51,16 +51,6 @@ EOF;
 
     foreach ($columns as $column)
     {
-      $callback = '
-        if (!empty($matches[1]))
-        {
-          return "[$matches[1]](".($matches[2] == "www." ? "http://www." : $matches[2]).trim($matches[3]).")";
-        }
-        else
-        {
-          return "[$matches[2]".trim($matches[3])."](".($matches[2] == "www." ? "http://www." : $matches[2]).trim($matches[3]).")";
-        }';
-
       $regex = '~
         (?:
           (?:&quot;|\")(.*?)(?:\&quot;|\")\:            # Double quote and colon
@@ -80,7 +70,17 @@ EOF;
         )
         ~x';
 
-      $transformedValue = preg_replace_callback($regex, create_function('$matches', $callback), $row->$column);
+      $transformedValue = preg_replace_callback($regex, function ($matches)
+      {
+        if (!empty($matches[1]))
+        {
+          return "[$matches[1]](".($matches[2] == "www." ? "http://www." : $matches[2]).trim($matches[3]).")";
+        }
+        else
+        {
+          return "[$matches[2]".trim($matches[3])."](".($matches[2] == "www." ? "http://www." : $matches[2]).trim($matches[3]).")";
+        }
+      }, $row->$column);
 
       // Save changed values
       if ($row->$column != $transformedValue)

--- a/lib/task/migrate/QubitMigrate103.class.php
+++ b/lib/task/migrate/QubitMigrate103.class.php
@@ -188,7 +188,10 @@ class QubitMigrate103 extends QubitMigrate
     {
       if ($page['permalink'] == 'homepage' || $page['permalink'] == 'about')
       {
-        array_walk($this->data['QubitStaticPage'][$key]['content'], create_function('&$x', '$x=str_replace(\'1.0.3\', \'1.0.4\', $x);'));
+        array_walk($this->data['QubitStaticPage'][$key]['content'], function(&$x)
+        {
+          $x = str_replace('1.0.3', '1.0.4', $x);
+        });
       }
     }
 

--- a/lib/task/migrate/QubitMigrate104.class.php
+++ b/lib/task/migrate/QubitMigrate104.class.php
@@ -176,7 +176,10 @@ class QubitMigrate104 extends QubitMigrate
     {
       if ($page['permalink'] == 'homepage' || $page['permalink'] == 'about')
       {
-        array_walk($this->data['QubitStaticPage'][$key]['content'], create_function('&$x', '$x=str_replace(\'1.0.4\', \'1.0.5\', $x);'));
+        array_walk($this->data['QubitStaticPage'][$key]['content'], function(&$x)
+        {
+          $x = str_replace('1.0.4', '1.0.5', $x);
+        });
       }
     }
 

--- a/lib/task/migrate/QubitMigrate105.class.php
+++ b/lib/task/migrate/QubitMigrate105.class.php
@@ -192,7 +192,10 @@ class QubitMigrate105 extends QubitMigrate
     {
       if ($page['permalink'] == 'homepage' || $page['permalink'] == 'about')
       {
-        array_walk($this->data['QubitStaticPage'][$key]['content'], create_function('&$x', '$x=str_replace(\'1.0.5\', \'1.0.6\', $x);'));
+        array_walk($this->data['QubitStaticPage'][$key]['content'], function(&$x)
+        {
+          $x = str_replace('1.0.5', '1.0.6', $x);
+        });
       }
     }
 

--- a/lib/task/migrate/QubitMigrate106.class.php
+++ b/lib/task/migrate/QubitMigrate106.class.php
@@ -402,7 +402,10 @@ class QubitMigrate106 extends QubitMigrate
     {
       if ($page['permalink'] == 'homepage' || $page['permalink'] == 'about')
       {
-        array_walk($this->data['QubitStaticPage'][$key]['content'], create_function('&$x', '$x=str_replace(\'1.0.6\', \'1.0.7\', $x);'));
+        array_walk($this->data['QubitStaticPage'][$key]['content'], function(&$x)
+        {
+          $x = str_replace('1.0.6', '1.0.7', $x);
+        });
       }
     }
 

--- a/lib/task/migrate/QubitMigrate107.class.php
+++ b/lib/task/migrate/QubitMigrate107.class.php
@@ -904,7 +904,10 @@ class QubitMigrate107 extends QubitMigrate
     {
       if ($page['permalink'] == 'homepage' || $page['permalink'] == 'about')
       {
-        array_walk($this->data['QubitStaticPage'][$key]['content'], create_function('&$x', '$x=str_replace(\'1.0.7\', \'1.0.8\', $x);'));
+        array_walk($this->data['QubitStaticPage'][$key]['content'], function(&$x)
+        {
+          $x = str_replace('1.0.7', '1.0.8', $x);
+        });
       }
     }
 

--- a/lib/task/migrate/QubitMigrate108.class.php
+++ b/lib/task/migrate/QubitMigrate108.class.php
@@ -958,7 +958,7 @@ class QubitMigrate108 extends QubitMigrate
     {
       $group_id = $row['group_id'];
 
-      // If group_id points to a QubitAclGroup row, then use `id` column from 
+      // If group_id points to a QubitAclGroup row, then use `id` column from
       // that row
       if (isset($this->data['QubitAclGroup'][$row['group_id']]))
       {
@@ -1482,7 +1482,10 @@ class QubitMigrate108 extends QubitMigrate
     {
       if ($page['permalink'] == 'homepage' || $page['permalink'] == 'about')
       {
-        array_walk($this->data['QubitStaticPage'][$key]['content'], create_function('&$x', '$x=preg_replace(\'/1\\.0\\.8(\\.1)?/\', \'1.0.9\', $x);'));
+        array_walk($this->data['QubitStaticPage'][$key]['content'], function(&$x)
+        {
+          $x = preg_replace('/1\.0\.8(\.1)?/', '1.0.9', $x);
+        });
       }
     }
 

--- a/lib/task/migrate/QubitMigrate109.class.php
+++ b/lib/task/migrate/QubitMigrate109.class.php
@@ -305,7 +305,10 @@ class QubitMigrate109 extends QubitMigrate
     {
       if ($page['permalink'] == 'homepage' || $page['permalink'] == 'about')
       {
-        array_walk($this->data['QubitStaticPage'][$key]['content'], create_function('&$x', '$x=preg_replace(\'/1\\.0\\.9/\', \'1.1\', $x);'));
+        array_walk($this->data['QubitStaticPage'][$key]['content'], function(&$x)
+        {
+          $x = preg_replace('/1\.0\.9/', '1.1', $x);
+        });
       }
     }
 

--- a/vendor/symfony/lib/cache/sfMemcacheCache.class.php
+++ b/vendor/symfony/lib/cache/sfMemcacheCache.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -204,9 +204,12 @@ class sfMemcacheCache extends sfCache
   public function getMany($keys)
   {
     $values = array();
-    foreach ($this->memcache->get(array_map(create_function('$k', 'return "'.$this->getOption('prefix').'".$k;'), $keys)) as $key => $value)
+    $prefix = $this->getOption('prefix');
+    $prefixed_keys = array_map(function($k) use ($prefix) { return $prefix . $k; }, $keys);
+
+    foreach ($this->memcache->get($prefixed_keys) as $key => $value)
     {
-      $values[str_replace($this->getOption('prefix'), '', $key)] = $value;
+      $values[str_replace($prefix, '', $key)] = $value;
     }
 
     return $values;

--- a/vendor/symfony/lib/command/sfCommandApplication.class.php
+++ b/vendor/symfony/lib/command/sfCommandApplication.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -564,7 +564,12 @@ abstract class sfCommandApplication
     }
 
     // close the streams on script termination
-    register_shutdown_function(create_function('', 'fclose(STDIN); fclose(STDOUT); fclose(STDERR); return true;'));
+    register_shutdown_function(function() {
+        fclose(STDIN);
+        fclose(STDOUT);
+        fclose(STDERR);
+        return true;
+    });
   }
 
   /**

--- a/vendor/symfony/lib/config/sfConfigHandler.class.php
+++ b/vendor/symfony/lib/config/sfConfigHandler.class.php
@@ -75,7 +75,7 @@ abstract class sfConfigHandler
   {
     if (is_array($value))
     {
-      array_walk_recursive($value, create_function('&$value', '$value = sfToolkit::replaceConstants($value);'));
+      array_walk_recursive($value, function(& $value) { $value = sfToolkit::replaceConstants($value); });
     }
     else
     {
@@ -96,7 +96,7 @@ abstract class sfConfigHandler
   {
     if (is_array($path))
     {
-      array_walk_recursive($path, create_function('&$path', '$path = sfConfigHandler::replacePath($path);'));
+      array_walk_recursive($path, function(&$path) { $path = sfConfigHandler::replacePath($path); });
     }
     else
     {

--- a/vendor/symfony/lib/helper/TextHelper.php
+++ b/vendor/symfony/lib/helper/TextHelper.php
@@ -247,33 +247,25 @@ function _auto_link_urls($text, $href_options = array(), $truncate = false, $tru
 {
   $href_options = _tag_options($href_options);
 
-  $callback_function = '
+  $callback_function = function($matches) use ($href_options, $truncate, $truncate_len, $pad) {
     if (preg_match("/<a\s/i", $matches[1]))
     {
-      return $matches[0];
+        return $matches[0];
     }
-    ';
 
-  if ($truncate)
-  {
-    $callback_function .= '
-      else if (strlen($matches[2].$matches[3]) > '.$truncate_len.')
-      {
-        return $matches[1].\'<a href="\'.($matches[2] == "www." ? "http://www." : $matches[2]).$matches[3].\'"'.$href_options.'>\'.substr($matches[2].$matches[3], 0, '.$truncate_len.').\''.$pad.'</a>\'.$matches[4];
-      }
-      ';
-  }
+    $text = $matches[2] . $matches[3];
+    $href = ($matches[2] == "www." ? "http://www." : $matches[2]) . $matches[3];
 
-  $callback_function .= '
-    else
+    if ($truncate && strlen($text) > $truncate_len)
     {
-      return $matches[1].\'<a href="\'.($matches[2] == "www." ? "http://www." : $matches[2]).$matches[3].\'"'.$href_options.'>\'.$matches[2].$matches[3].\'</a>\'.$matches[4];
+        $text = substr($text, 0, $truncate_len).$pad;
     }
-    ';
+    return sprintf('%s<a href="%s"%s>%s</a>%s', $matches[1], $href, $href_options, $text, $matches[4]);
+  };
 
   return preg_replace_callback(
     SF_AUTO_LINK_RE,
-    create_function('$matches', $callback_function),
+    $callback_function,
     $text
     );
 }
@@ -286,7 +278,7 @@ function _auto_link_email_addresses($text)
   // Taken from http://snippets.dzone.com/posts/show/6156
   return preg_replace("#(^|[\n ])([a-z0-9&\-_\.]+?)@([\w\-]+\.([\w\-\.]+\.)*[\w]+)#i", "\\1<a href=\"mailto:\\2@\\3\">\\2@\\3</a>", $text);
 
-  // Removed since it destroys already linked emails 
+  // Removed since it destroys already linked emails
   // Example:   <a href="mailto:me@example.com">bar</a> gets <a href="mailto:me@example.com">bar</a> gets <a href="mailto:<a href="mailto:me@example.com">bar</a>
   //return preg_replace('/([\w\.!#\$%\-+.]+@[A-Za-z0-9\-]+(\.[A-Za-z0-9\-]+)+)/', '<a href="mailto:\\1">\\1</a>', $text);
 }

--- a/vendor/symfony/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineDeleteModelFilesTask.class.php
+++ b/vendor/symfony/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineDeleteModelFilesTask.class.php
@@ -76,7 +76,7 @@ EOF;
       {
         if (!$options['no-confirmation'] && !$this->askConfirmation(array_merge(
           array('The following '.$modelName.' files will be deleted:', ''),
-          array_map(create_function('$v', 'return \' - \'.sfDebug::shortenFilePath($v);'), $files),
+          array_map(function($v) { return ' - '.sfDebug::shortenFilePath($v); }, $files),
           array('', 'Continue? (y/N)')
         ), 'QUESTION_LARGE', false))
         {
@@ -100,10 +100,10 @@ EOF;
 
   /**
    * Converts an array of values to a regular expression pattern fragment.
-   * 
+   *
    * @param array  $values    An array of values for the pattern
    * @param string $delimiter The regular expression delimiter
-   * 
+   *
    * @return string A regular expression fragment
    */
   protected function valuesToRegex($values, $delimiter = '/')

--- a/vendor/symfony/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineDropDbTask.class.php
+++ b/vendor/symfony/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineDropDbTask.class.php
@@ -73,7 +73,7 @@ EOF;
       &&
       !$this->askConfirmation(array_merge(
         array(sprintf('This command will remove all data in the following "%s" connection(s):', $environment), ''),
-        array_map(create_function('$v', 'return \' - \'.$v;'), array_keys($databases)),
+        array_map(function($v) { return ' - '.$v; }, array_keys($databases)),
         array('', 'Are you sure you want to proceed? (y/N)')
       ), 'QUESTION_LARGE', false)
     )

--- a/vendor/symfony/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineMigrateTask.class.php
+++ b/vendor/symfony/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineMigrateTask.class.php
@@ -137,7 +137,7 @@ EOF;
       {
         $this->logBlock(array_merge(
           array('The following errors occurred:', ''),
-          array_map(create_function('$e', 'return \' - \'.$e->getMessage();'), $migration->getErrors())
+          array_map(function($e) { return ' - '.$e->getMessage(); }, $migration->getErrors())
         ), 'ERROR_LARGE');
       }
 

--- a/vendor/symfony/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Parser/sfYaml/sfYamlInline.php
+++ b/vendor/symfony/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Parser/sfYaml/sfYamlInline.php
@@ -135,7 +135,7 @@ class sfYamlInline
     if (
       (1 == count($keys) && '0' == $keys[0])
       ||
-      (count($keys) > 1 && array_reduce($keys, create_function('$v,$w', 'return (integer) $v + $w;'), 0) == count($keys) * (count($keys) - 1) / 2))
+      (count($keys) > 1 && array_sum(array_map('intval', $keys)) == count($keys) * (count($keys) - 1) / 2))
     {
       $output = array();
       foreach ($value as $val)

--- a/vendor/symfony/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Query.php
+++ b/vendor/symfony/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Query.php
@@ -1421,8 +1421,12 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
                 foreach ($e as $f) {
                     if ($f == 0 || $f % 2 == 0) {
                         $partOriginal = str_replace(',', '', trim($f));
-                        $callback = create_function('$e', 'return trim($e, \'[]`"\');');
-                        $part = trim(implode('.', array_map($callback, explode('.', $partOriginal))));
+
+                        $e = explode('.', $partOriginal);
+                        foreach ($e as &$v) {
+                            $v = trim($v, '[]`"');
+                        }
+                        $part = trim(implode('.', $e));
 
                         if (strpos($part, '.') === false) {
                             continue;

--- a/vendor/symfony/lib/routing/sfRoute.class.php
+++ b/vendor/symfony/lib/routing/sfRoute.class.php
@@ -687,7 +687,7 @@ class sfRoute implements Serializable
       'extra_parameters_as_query_string' => true,
     ), $this->getDefaultOptions(), $this->options);
 
-    $preg_quote_hash = create_function('$a', 'return preg_quote($a, \'#\');');
+    $preg_quote_hash = function($a) { return preg_quote($a, '#'); };
 
     // compute some regexes
     $this->options['variable_prefix_regex'] = '(?:'.implode('|', array_map($preg_quote_hash, $this->options['variable_prefixes'])).')';
@@ -697,7 +697,7 @@ class sfRoute implements Serializable
       $this->options['segment_separators_regex'] = '(?:'.implode('|', array_map($preg_quote_hash, $this->options['segment_separators'])).')';
 
       // as of PHP 5.3.0, preg_quote automatically quotes dashes "-" (see http://bugs.php.net/bug.php?id=47229)
-      $preg_quote_hash_53 = create_function('$a', 'return str_replace(\'-\', \'\-\', preg_quote($a, \'#\'));');
+      $preg_quote_hash_53 = function($a) { return str_replace('-', '\-', preg_quote($a, '#')); };
       $this->options['variable_content_regex'] = '[^'.implode('',
           array_map(version_compare(PHP_VERSION, '5.3.0RC4', '>=') ? $preg_quote_hash : $preg_quote_hash_53, $this->options['segment_separators'])
         ).']+';

--- a/vendor/symfony/lib/task/project/sfProjectPermissionsTask.class.php
+++ b/vendor/symfony/lib/task/project/sfProjectPermissionsTask.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -72,18 +72,18 @@ EOF;
     {
       $this->logBlock(array_merge(
         array('Permissions on the following file(s) could not be fixed:', ''),
-        array_map(create_function('$f', 'return \' - \'.sfDebug::shortenFilePath($f);'), $this->failed)
+        array_map(function($f) { return ' - '.sfDebug::shortenFilePath($f); }, $this->failed)
       ), 'ERROR_LARGE');
     }
   }
 
   /**
    * Chmod and capture any failures.
-   * 
+   *
    * @param string  $file
    * @param integer $mode
    * @param integer $umask
-   * 
+   *
    * @see sfFilesystem
    */
   protected function chmod($file, $mode, $umask = 0000)
@@ -109,7 +109,7 @@ EOF;
 
   /**
    * Captures those chmod commands that fail.
-   * 
+   *
    * @see http://www.php.net/set_error_handler
    */
   public function handleError($no, $string, $file, $line, $context)

--- a/vendor/symfony/lib/util/sfBrowserBase.class.php
+++ b/vendor/symfony/lib/util/sfBrowserBase.class.php
@@ -925,7 +925,7 @@ abstract class sfBrowserBase
     if (false !== $pos = strpos($name, '['))
     {
       $var = &$vars;
-      $tmps = array_filter(preg_split('/(\[ | \[\] | \])/x', $name), create_function('$s', 'return $s !== "";'));
+      $tmps = array_filter(preg_split('/(\[ | \[\] | \])/x', $name), function($s) { return $s !== ''; });
       foreach ($tmps as $tmp)
       {
         $var = &$var[$tmp];

--- a/vendor/symfony/lib/validator/sfValidatorErrorSchema.class.php
+++ b/vendor/symfony/lib/validator/sfValidatorErrorSchema.class.php
@@ -301,8 +301,8 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
   protected function updateCode()
   {
     $this->code = implode(' ', array_merge(
-      array_map(create_function('$e', 'return $e->getCode();'), $this->globalErrors),
-      array_map(create_function('$n,$e', 'return $n.\' [\'.$e->getCode().\']\';'), array_keys($this->namedErrors), array_values($this->namedErrors))
+      array_map(function($e) { /** @var $e sfValidatorError */ return $e->getCode(); }, $this->globalErrors),
+      array_map(function($n, $e) { /** @var $e sfValidatorError */ return $n.' ['.$e->getCode().']'; }, array_keys($this->namedErrors), array_values($this->namedErrors))
     ));
   }
 
@@ -312,8 +312,8 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
   protected function updateMessage()
   {
     $this->message = implode(' ', array_merge(
-      array_map(create_function('$e', 'return $e->getMessage();'), $this->globalErrors),
-      array_map(create_function('$n,$e', 'return $n.\' [\'.$e->getMessage().\']\';'), array_keys($this->namedErrors), array_values($this->namedErrors))
+      array_map(function($e) { /** @var $e sfValidatorError */ return $e->getMessage(); }, $this->globalErrors),
+      array_map(function($n, $e) { /** @var $e sfValidatorError */ return $n.' ['.$e->getMessage().']'; }, array_keys($this->namedErrors), array_values($this->namedErrors))
     ));
   }
 

--- a/vendor/symfony/lib/validator/sfValidatorFromDescription.class.php
+++ b/vendor/symfony/lib/validator/sfValidatorFromDescription.class.php
@@ -294,7 +294,7 @@ class sfValidatorFDToken
 
   public function asPhp()
   {
-    return sprintf('new %s(%s)', $this->class, implode(', ', array_map(create_function('$a', 'return var_export($a, true);'), $this->arguments)));
+    return sprintf('new %s(%s)', $this->class, implode(', ', array_map(function($a) { return var_export($a, true); }, $this->arguments)));
   }
 
   public function getValidator()
@@ -353,7 +353,7 @@ class sfValidatorFDTokenOperator
       $this->class,
       is_object($tokenLeft) && in_array(get_class($tokenLeft), array('sfValidatorFDToken', 'sfValidatorFDTokenFilter')) ? $tokenLeft->asPhp() : $tokenLeft,
       is_object($tokenRight) && in_array(get_class($tokenRight), array('sfValidatorFDToken', 'sfValidatorFDTokenFilter')) ? $tokenRight->asPhp() : $tokenRight,
-      implode(', ', array_map(create_function('$a', 'return var_export($a, true);'), $this->arguments))
+      implode(', ', array_map(function($a) { return var_export($a, true); }, $this->arguments))
     );
   }
 

--- a/vendor/symfony/lib/yaml/sfYamlInline.php
+++ b/vendor/symfony/lib/yaml/sfYamlInline.php
@@ -135,7 +135,7 @@ class sfYamlInline
     if (
       (1 == count($keys) && '0' == $keys[0])
       ||
-      (count($keys) > 1 && array_reduce($keys, create_function('$v,$w', 'return (integer) $v + $w;'), 0) == count($keys) * (count($keys) - 1) / 2))
+      (count($keys) > 1 && array_sum(array_map('intval', $keys)) == count($keys) * (count($keys) - 1) / 2))
     {
       $output = array();
       foreach ($value as $val)


### PR DESCRIPTION
These commits apply fixes from the community maintained Symfony version 
to remove and replace calls to 'create_function' since this function
is deprecated in PHP 7.2.

These changes affect:
- vendor/symfony code
- older migrations where this function was used
- the i18n custom link to markdown CLI task

References to the Symfony community changes applied here:
https://github.com/FriendsOfSymfony1/symfony1/pull/146
https://github.com/FriendsOfSymfony1/symfony1/pull/163
https://github.com/FriendsOfSymfony1/doctrine1/commit/7085ccf20b054eecde066f8a23a7e9c805f417c7#diff-fc589948371098da9ffc0958ab7057f0

Functionality should not be modified in any of these cases where create_function
has been removed.