### PR TITLE
Fixed issue with REST API routing, refs #12829

### DIFF
--- a/apps/qubit/config/routing.yml
+++ b/apps/qubit/config/routing.yml
@@ -83,10 +83,6 @@ slug;default_index:
   param:
     action: index
 
-slug/default:
-  url: /:slug/:module/:action
-  class: QubitResourceRoute
-
 id/default:
   url: /:module/:action/id/:id
   class: QubitRoute

--- a/plugins/arRestApiPlugin/config/arRestApiPluginConfiguration.class.php
+++ b/plugins/arRestApiPlugin/config/arRestApiPluginConfiguration.class.php
@@ -139,7 +139,7 @@ class arRestApiPluginConfiguration extends sfPluginConfiguration
     }
 
     // Add route before slug;default_index
-    $this->routing->insertRouteBefore('slug;default_index', $name,
+    $this->routing->insertRouteBefore('slug/default', $name,
       new sfRequestRoute($pattern, $defaults, $requirements));
   }
 


### PR DESCRIPTION
Moved REST API routes before a "catch all" route to prevent API
endpoints from 404ing.

Removed redundant route (was in routing.yml twice).