### PR TITLE
Don't set a hardcoded database name in migrations

### DIFF
--- a/lib/task/migrate/migrations/arMigration0169.class.php
+++ b/lib/task/migrate/migrations/arMigration0169.class.php
@@ -38,14 +38,13 @@ class arMigration0169
     // Add object_id to digital_object with fk relationship
     $sql = <<<sql
 
-ALTER TABLE `atom`.`digital_object`
-DROP FOREIGN KEY `digital_object_FK_2`;
-ALTER TABLE `atom`.`digital_object`
-CHANGE COLUMN `information_object_id` `object_id` INT(11) NULL DEFAULT NULL ;
-ALTER TABLE `atom`.`digital_object`
+ALTER TABLE `digital_object` DROP FOREIGN KEY `digital_object_FK_2`;
+ALTER TABLE `digital_object`
+  CHANGE COLUMN `information_object_id` `object_id` INT(11) NULL DEFAULT NULL ;
+ALTER TABLE `digital_object`
 ADD CONSTRAINT `digital_object_FK_2`
   FOREIGN KEY (`object_id`)
-  REFERENCES `atom`.`object` (`id`);
+  REFERENCES `object` (`id`);
 
 sql;
 

--- a/lib/task/migrate/migrations/arMigration0172.class.php
+++ b/lib/task/migrate/migrations/arMigration0172.class.php
@@ -61,12 +61,12 @@ class arMigration0172
     foreach($i18nTables as $table)
     {
       // Increase size of i18n table's culture column
-      $sql = "ALTER TABLE `atom`.`%s` CHANGE `culture` `culture` VARCHAR(16)";
+      $sql = "ALTER TABLE `%s` CHANGE `culture` `culture` VARCHAR(16)";
       QubitPdo::modify(sprintf($sql, $table));
 
       // Increase size of base table's source_culture column
       $baseTable = str_replace('_i18n', '', $table);
-      $sql = "ALTER TABLE `atom`.`%s` CHANGE `source_culture` `source_culture` VARCHAR(16)";
+      $sql = "ALTER TABLE `%s` CHANGE `source_culture` `source_culture` VARCHAR(16)";
       QubitPdo::modify(sprintf($sql, $baseTable));
     }
 


### PR DESCRIPTION
This is breaking upgrades when the database has a name other than "atom"