### PR TITLE
Custom link to markdown fix, refs 12880

### DIFF
--- a/lib/task/i18n/i18nCustomLinkToMarkdownTask.class.php
+++ b/lib/task/i18n/i18nCustomLinkToMarkdownTask.class.php
@@ -80,17 +80,17 @@ EOF;
         {
           return "[$matches[2]".trim($matches[3])."](".($matches[2] == "www." ? "http://www." : $matches[2]).trim($matches[3]).")";
         }
-      }, $row->$column);
+      }, $row[$column]);
 
       // Save changed values
-      if ($row->$column != $transformedValue)
+      if ($row[$column] != $transformedValue)
       {
         $columnValues[$column] = $transformedValue;
       }
     }
 
     // Update row
-    $this->updateRow($tableName, $row->id, $row->culture, $columnValues);
+    $this->updateRow($tableName, $row['id'], $row['culture'], $columnValues);
 
     return count($columnValues);
   }

--- a/lib/task/i18n/i18nTransformBaseTask.class.php
+++ b/lib/task/i18n/i18nTransformBaseTask.class.php
@@ -132,7 +132,7 @@ abstract class i18nTransformBaseTask extends arBaseTask
       $query = 'SELECT * FROM '.$tableName.' WHERE id NOT IN ('.$rootIds.')';
       $statement = QubitPdo::prepareAndExecute($query);
 
-      while ($row = $statement->fetch(PDO::FETCH_OBJ))
+      while ($row = $statement->fetch(PDO::FETCH_ASSOC))
       {
         // Process row in subclasses
         $columnsChanged = $this->processRow($row, $tableName, $columns);
@@ -145,7 +145,7 @@ abstract class i18nTransformBaseTask extends arBaseTask
         }
 
         // Report progress
-        $message = 'Processed '.$tableName.' row '.$row->id.' ('.$row->culture.')';
+        $message = 'Processed '.$tableName.' row '.$row['id'].' ('.$row['culture'].')';
 
         if ($columnsChanged)
         {


### PR DESCRIPTION
In the i18n custom link to markdown task, fetch row data as associative
array instead of objects to save memory.

This fix along with the change to remove create_function() will help reduce
the memory usage of migration 163 so that large databases can be upgraded
successfully.