### PR TITLE
Fix digital object bulk upload, refs #12760

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/uploadAction.class.php
+++ b/apps/qubit/modules/digitalobject/actions/uploadAction.class.php
@@ -92,7 +92,7 @@ class DigitalObjectUploadAction extends sfAction
       $tmpFileMimeType = QubitDigitalObject::deriveMimeType($tmpFileName);
 
       // Thumbnail name and path
-      $thumbName = pathinfo($tmpFileName, PATHINFO_FILENAME) .".jpg";
+      $thumbName = pathinfo('THUMB'. $tmpFileName, PATHINFO_FILENAME) .".jpg";
       $thumbPath = dirname($tmpFilePath) ."/". $thumbName;
 
       if ($canThumbnail = QubitDigitalObject::canThumbnailMimeType($tmpFileMimeType) || QubitDigitalObject::isVideoFile($tmpFilePath))


### PR DESCRIPTION
Fixed issue where thumbnails would overwrite original files when
uploading digital objects using the Flash-based multiple file
uploader.