### PR TITLE
Fix deaccession deletion issue, refs #12460

### DIFF
--- a/plugins/qtAccessionPlugin/lib/model/QubitDeaccession.php
+++ b/plugins/qtAccessionPlugin/lib/model/QubitDeaccession.php
@@ -38,15 +38,11 @@ class QubitDeaccession extends BaseDeaccession
   {
     parent::save($connection);
 
-    QubitSearch::getInstance()->update($this->accession);
-
     return $this;
   }
 
   public function delete($connection = null)
   {
-    QubitSearch::getInstance()->delete($this->accession);
-
     return parent::delete($connection);
   }
 }


### PR DESCRIPTION
Fixed issue where deleting a deaccession would remove the
accession/accural related to it from the search index.