### PR TITLE
Fix DIP upload routing issue, refs #12932

### DIFF
--- a/apps/qubit/config/routing.yml
+++ b/apps/qubit/config/routing.yml
@@ -46,6 +46,18 @@ add:
 
 # -------------------------------------------------------- </QubitMetadataRoute>
 
+sword/action/slug:
+  url: /sword/:action/:slug
+  class: QubitResourceRoute
+  param:
+    module: qtSwordPlugin
+    throw404: false
+
+sword:
+  url: /sword/:action
+  param:
+    module: qtSwordPlugin
+
 slug/default:
   url: /:slug/:module/:action
   class: QubitResourceRoute
@@ -62,18 +74,6 @@ oai:
   param:
     module: arOaiPlugin
     action: index
-
-sword/action/slug:
-  url: /sword/:action/:slug
-  class: QubitResourceRoute
-  param:
-    module: qtSwordPlugin
-    throw404: false
-
-sword:
-  url: /sword/:action
-  param:
-    module: qtSwordPlugin
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
The sword/deposit/<slug> route was getting caught by the slug/default
route. Move the sword routes ahead of any :slug routes so they are
caught first and not interpreted as slugs. The api/ routes are also
inserted before the :slug routes.