### PR TITLE
Nested set CLI task fix, refs #12754

### DIFF
--- a/lib/task/propel/propelBuildNestedSetTask.class.php
+++ b/lib/task/propel/propelBuildNestedSetTask.class.php
@@ -114,7 +114,7 @@ EOF;
         // There seems to be some limit on how many rows we can update with one
         // exec() statement, so chunk the update rows
         $incr = 4000;
-        for ($i=0; $i <= count($this->rows); $i+=$incr)
+        for ($i=0; $i < count($this->rows); $i+=$incr)
         {
           $sql = implode("\n", array_slice($this->rows, $i, $incr));
           $conn->exec($sql);


### PR DESCRIPTION
The build-nested-set CLI task iterates over database rows in chunks of
4000. The current logic had an off-by-one error where if there were a
multiple of 4000 rows in the DB to iterate over, it would run one too
many times resulting in a fatal error.

I have changed the comparison operator so that it will not perform the
logic when the iterator is equal to the number of rows in the database.