### PR TITLE
Prevent use of reserved slug names, refs #12947

### DIFF
--- a/lib/model/QubitObject.php
+++ b/lib/model/QubitObject.php
@@ -196,12 +196,23 @@ class QubitObject extends BaseObject implements Zend_Acl_Resource_Interface
       {
         try
         {
+          if (in_array($this->slug, array('api', 'sword')))
+          {
+            throw new RuntimeException('Reserved slug');
+          }
+
           $statement->execute(array($this->id, $this->slug));
           unset($suffix);
         }
         // Collision? Try next suffix
-        catch (PDOException $e)
+        catch (Exception $e)
         {
+          // If exception is unexpected re-throw it
+          if (!($e instanceof RuntimeException || $e instanceof PdoException))
+          {
+            throw $e;
+          }
+
           if (!$triedQuery)
           {
             $triedQuery = true;


### PR DESCRIPTION
Added logic to throw error if slug is reserved for use by an optional
plugin (currently only "api" and "sword").