### PR TITLE
Sitemap file flush fix, refs #12886

### DIFF
--- a/lib/sitemap/SitemapWriter.class.php
+++ b/lib/sitemap/SitemapWriter.class.php
@@ -18,7 +18,7 @@
  */
 
 /**
- * SitemapWriter 
+ * SitemapWriter
  */
 class SitemapWriter
 {
@@ -89,9 +89,6 @@ class SitemapWriter
 
     $this->loadConfiguration();
 
-    // __destructor() doesn't get called on fatal errors
-    register_shutdown_function(array($this, 'end'));
-
     $this->writer = new XMLWriter;
     $this->writer->openUri($this->file);
     $this->writer->setIndent($this->indent);
@@ -121,6 +118,7 @@ class SitemapWriter
     {
       $this->getSitemap()->add($item);
     }
+    $this->sitemap->flush();
   }
 
   /**
@@ -145,8 +143,7 @@ class SitemapWriter
   private function addSitemap()
   {
     $this->sitemapIndex++;
-    $this->sitemap = new SitemapWriterSection($this->file, $this->sitemapIndex, $this->baseUrl, $this->indent, $this->compress);    
-
+    $this->sitemap = new SitemapWriterSection($this->file, $this->sitemapIndex, $this->baseUrl, $this->indent, $this->compress);
     $this->writer->startElement('sitemap');
     $this->writer->writeElement('loc', $this->sitemap->getLocation());
     $this->writer->writeElement('lastmod', date('c'));

--- a/lib/sitemap/SitemapWriterSection.class.php
+++ b/lib/sitemap/SitemapWriterSection.class.php
@@ -133,7 +133,7 @@ class SitemapWriterSection
     return $this->baseUrl.'/'.basename($this->file).$ext;
   }
 
-  private function flush()
+  public function flush()
   {
     if ($this->bufferSize === 0)
     {

--- a/lib/task/tools/sitemapTask.class.php
+++ b/lib/task/tools/sitemapTask.class.php
@@ -123,6 +123,7 @@ EOF;
     $writer->addSet(new SitemapActorSet);
     $this->log('Indexing static pages');
     $writer->addSet(new SitemapStaticPageSet);
+    $writer->end();
 
     // Sitemap submission
     if ($options['ping'])


### PR DESCRIPTION
There was an issue with the sitemap CLI task where the last chunks of
data were never written to the output files because the end() method
registered with register_shutdown_function() was being called after
both the sitemap index file and the last sitemap file were closed for
writing - end() for the last files was being called after the "DONE"
message was written.

I have removed the call to register_shutdown_function() in favour of
calling end() directly from the sitemap task to complete writing the
last sitemap.#.xml file, and added a call to flush() in the
SitemapWriter class to flush the sitemap index file.

As per AtoM's documentation, a sitemap index file will always be created
and the sitemap file will be broken into 50K line chunks. The sitemap
index file can be ignored if there is only one sitemap chunk created.

A side effect of this fix is that static pages are now included in the
sitemap file as intended, where before they were always in the last
chunk and omitted due to the flush issue on the last file.