### PR TITLE
Fix finding aid generation job issue, refs #12969

### DIFF
--- a/lib/job/arFindingAidJob.class.php
+++ b/lib/job/arFindingAidJob.class.php
@@ -103,7 +103,7 @@ class arFindingAidJob extends arBaseJob
     // Call generate EAD task
     $slug = $this->resource->slug;
     $output = array();
-    exec("php $appRoot/symfony export:bulk --single-slug=\"$slug\" $public $eadFilePath 2>&1", $output, $exitCode);
+    exec(PHP_BINARY ." $appRoot/symfony export:bulk --single-slug=\"$slug\" $public $eadFilePath 2>&1", $output, $exitCode);
 
     if ($exitCode > 0)
     {


### PR DESCRIPTION
Fixed issue, in Centos 7, with finding aid generation job. Made
location of PHP executable explicit when executing task.