### PR TITLE
RemoveHtml task fix, refs #12880

### DIFF
--- a/lib/task/i18n/i18nRemoveHtmlTagsTask.class.php
+++ b/lib/task/i18n/i18nRemoveHtmlTagsTask.class.php
@@ -55,14 +55,14 @@ EOF;
     foreach ($columns as $column)
     {
       // Store column name/value for processing if it contains tags
-      if ($row->$column && (($row->$column != strip_tags($row->$column)) || ($row->$column != html_entity_decode($row->$column))))
+      if ($row[$column] && (($row[$column] != strip_tags($row[$column])) || ($row[$column] != html_entity_decode($row[$column]))))
       {
-        $columnValues[$column] = $this->transformHtmlToText($row->$column);
+        $columnValues[$column] = $this->transformHtmlToText($row[$column]);
       }
     }
 
     // Update database with transformed column values
-    $this->updateRow($tableName, $row->id, $row->culture, $columnValues);
+    $this->updateRow($tableName, $row['id'], $row['culture'], $columnValues);
 
     return count($columnValues);
   }


### PR DESCRIPTION
Change this task to match changes made to the i18nTransformBaseTask.

Row data is now passed as an associative array.