### PR TITLE
Create downloads folder, refs #12985

### DIFF
--- a/apps/qubit/modules/informationobject/actions/uploadFindingAidAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/uploadFindingAidAction.class.php
@@ -71,6 +71,7 @@ class InformationObjectUploadFindingAidAction extends sfAction
       $i18n = $this->context->i18n;
 
       // Move temporary file before it's deleted at the end of the request
+      arFindingAidJob::checkDownloadsExistsAndCreate();
       $path = sfConfig::get('sf_web_dir') . DIRECTORY_SEPARATOR . arFindingAidJob::getFindingAidPath($this->resource->id);
 
       if (!move_uploaded_file($file->getTempName(), $path))

--- a/lib/job/arFindingAidJob.class.php
+++ b/lib/job/arFindingAidJob.class.php
@@ -46,7 +46,7 @@ class arFindingAidJob extends arBaseJob
       return false;
     }
 
-    $this->checkDownloadsExistsAndCreate();
+    self::checkDownloadsExistsAndCreate();
 
     if (isset($parameters['delete']) && $parameters['delete'])
     {
@@ -368,7 +368,7 @@ class arFindingAidJob extends arBaseJob
     return $meta_data['uri'];
   }
 
-  private function checkDownloadsExistsAndCreate()
+  public static function checkDownloadsExistsAndCreate()
   {
     $dlPath = sfConfig::get('sf_web_dir') . DIRECTORY_SEPARATOR . 'downloads';
     if (!is_dir($dlPath))


### PR DESCRIPTION
If the downloads folder does not yet exist, allow the 'Upload Finding
Aid' functionality to automatically create it so that the upload will
be successful.