### PR TITLE
Make upload/download dirs on install, refs #12985

### DIFF
--- a/apps/qubit/modules/informationobject/actions/uploadFindingAidAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/uploadFindingAidAction.class.php
@@ -71,7 +71,7 @@ class InformationObjectUploadFindingAidAction extends sfAction
       $i18n = $this->context->i18n;
 
       // Move temporary file before it's deleted at the end of the request
-      arFindingAidJob::checkDownloadsExistsAndCreate();
+      Qubit::createDownloadsDirIfNeeded();
       $path = sfConfig::get('sf_web_dir') . DIRECTORY_SEPARATOR . arFindingAidJob::getFindingAidPath($this->resource->id);
 
       if (!move_uploaded_file($file->getTempName(), $path))

--- a/lib/Qubit.class.php
+++ b/lib/Qubit.class.php
@@ -414,6 +414,18 @@ class Qubit
   }
 
   /**
+   * Create "downloads/" directory if it doesn't exist
+   */
+  public static function createDownloadsDirIfNeeded()
+  {
+    $downloadsPath = sfConfig::get('sf_web_dir') . DIRECTORY_SEPARATOR . 'downloads';
+    if (!is_dir($downloadsPath))
+    {
+      mkdir($downloadsPath, 0755);
+    }
+  }
+
+  /**
    * Generate an identifier using a counter value and a mask
    *
    * @param int $counter  current counter value

--- a/lib/job/arFindingAidJob.class.php
+++ b/lib/job/arFindingAidJob.class.php
@@ -46,7 +46,7 @@ class arFindingAidJob extends arBaseJob
       return false;
     }
 
-    self::checkDownloadsExistsAndCreate();
+    Qubit::createDownloadsDirIfNeeded();
 
     if (isset($parameters['delete']) && $parameters['delete'])
     {
@@ -366,15 +366,6 @@ class arFindingAidJob extends arBaseJob
     $meta_data = stream_get_meta_data($handle);
 
     return $meta_data['uri'];
-  }
-
-  public static function checkDownloadsExistsAndCreate()
-  {
-    $dlPath = sfConfig::get('sf_web_dir') . DIRECTORY_SEPARATOR . 'downloads';
-    if (!is_dir($dlPath))
-    {
-      mkdir($dlPath, 0755);
-    }
   }
 
   public static function getStatus($id)

--- a/plugins/sfInstallPlugin/lib/sfInstall.class.php
+++ b/plugins/sfInstallPlugin/lib/sfInstall.class.php
@@ -71,11 +71,22 @@ class sfInstall
       mkdir(sfConfig::get('sf_log_dir'), 0777, true);
     }
 
+    Qubit::createUploadDirsIfNeeded();
+    Qubit::createDownloadsDirIfNeeded();
+
     $writablePaths = array();
 
     $finder = sfFinder::type('any');
 
-    foreach (array(sfConfig::get('sf_cache_dir'), sfConfig::get('sf_data_dir'), sfConfig::get('sf_log_dir')) as $path)
+    $pathsToCheck = array(
+      sfConfig::get('sf_cache_dir'),
+      sfConfig::get('sf_data_dir'),
+      sfConfig::get('sf_log_dir'),
+      sfConfig::get('sf_upload_dir'),
+      sfConfig::get('sf_web_dir') . DIRECTORY_SEPARATOR . 'downloads'
+    );
+
+    foreach ($pathsToCheck as $path)
     {
       // TODO sfFinder::in() does not include the argument path
       if (!is_writable($path))


### PR DESCRIPTION
Move downloads directory creation code to general class. Add creation
of uploads and downloads directories to installation logic. Add
downloads and uploads directories to list of directories to check (to
make sure they’re writeable).