### PR TITLE
Add clipboard sending functionality, refs #12792

### DIFF
--- a/apps/qubit/modules/settings/actions/clipboardAction.class.php
+++ b/apps/qubit/modules/settings/actions/clipboardAction.class.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class SettingsClipboardAction extends SettingsEditAction
+{
+  // Arrays not allowed in class constants
+  public static
+    $NAMES = array(
+      'clipboard_save_max_age',
+      'clipboard_send_enabled',
+      'clipboard_send_url',
+      'clipboard_send_button_text',
+      'clipboard_send_message_html',
+      'clipboard_send_http_method');
+
+  public function earlyExecute()
+  {
+    parent::earlyExecute($request);
+
+    $this->updateMessage = $this->i18n->__('Clipboard settings saved.');
+
+    $this->settingDefaults = array(
+      'clipboard_save_max_age' => '0',
+      'clipboard_send_enabled' => '0',
+      'clipboard_send_button_text' => $this->i18n->__('Send'),
+      'clipboard_send_message_html' => $this->i18n->__('%1%Sending...%2%', array('%1%' => '<h1>', '%2%' => '</h1>')),
+      'clipboard_send_http_method' => 'POST'
+    );
+  }
+
+  protected function addField($name)
+  {
+    $this->setFormFieldDefault($name);
+
+    // Set form field format
+    switch ($name)
+    {
+      case 'clipboard_save_max_age':
+      case 'clipboard_send_url':
+      case 'clipboard_send_button_text':
+      case 'clipboard_send_message_html':
+        $this->form->setValidator($name, new sfValidatorString());
+        $this->form->setWidget($name, new sfWidgetFormInput);
+
+        break;
+
+      case 'clipboard_send_enabled':
+      case 'clipboard_send_http_method':
+        if ($name == 'clipboard_send_enabled')
+        {
+          $options = array($this->i18n->__('No'), $this->i18n->__('Yes'));
+        }
+        else
+        {
+          $options = array('POST' => 'POST', 'GET' => 'GET');
+        }
+
+        $this->form->setValidator($name, new sfValidatorString(array('required' => false)));
+        $this->form->setWidget($name, new sfWidgetFormSelectRadio(array('choices' => $options), array('class' => 'radio')));
+
+        break;
+    }
+  }
+}

--- a/apps/qubit/modules/settings/actions/editAction.class.php
+++ b/apps/qubit/modules/settings/actions/editAction.class.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class SettingsEditAction extends DefaultEditAction
+{
+  protected $settings = array();
+
+  protected function earlyExecute()
+  {
+    $this->i18n = sfContext::getInstance()->i18n;
+
+    // Load setting for each field name
+    foreach ($this::$NAMES as $name)
+    {
+      $this->settings[$name] = QubitSetting::getByName($name);
+    }
+  }
+
+  protected function setFormFieldDefault($name)
+  {
+    // If there's no settings default set, use blank string as default
+    $settingDefault = (isset($this->settingDefaults[$name]))
+      ? $this->settingDefaults[$name] : '';
+
+    // Default setting value in form will be current setting value or, if none exists, settings default
+    $settingValue = (null !== $this->settings[$name])
+      ? $this->settings[$name]->getValue(array('sourceCulture' => true)) : $settingDefault;
+
+    $this->form->setDefault($name, $settingValue);
+  }
+
+  protected function processField($field)
+  {
+    $name = $field->getName();
+
+    if (in_array($name, $this::$NAMES))
+    {
+      if (null === $this->settings[$name])
+      {
+        $this->settings[$name] = new QubitSetting;
+        $this->settings[$name]->name = $name;
+      }
+      $this->settings[$name]->setValue($field->getValue(), array('sourceCulture' => true));
+      $this->settings[$name]->save();
+    }
+  }
+
+  public function execute($request)
+  {
+    parent::execute($request);
+
+    if ($request->isMethod('post'))
+    {
+      $this->form->bind($request->getPostParameters());
+
+      if ($this->form->isValid())
+      {
+        $this->processForm();
+
+        QubitCache::getInstance()->removePattern('settings:i18n:*');
+
+        if (!empty($this->updateMessage))
+        {
+          $this->getUser()->setFlash('notice', $this->updateMessage);
+        }
+
+        $this->redirect(array('module' => 'settings', 'action' => $this->getContext()->getActionName()));
+      }
+    }
+  }
+}

--- a/apps/qubit/modules/settings/actions/globalAction.class.php
+++ b/apps/qubit/modules/settings/actions/globalAction.class.php
@@ -96,7 +96,6 @@ class SettingsGlobalAction extends sfAction
     $generateReportsAsPubUser = QubitSetting::getByName('generate_reports_as_pub_user');
     $enableInstitutionalScoping = QubitSetting::getByName('enable_institutional_scoping');
     $cacheXmlOnSave = QubitSetting::getByName('cache_xml_on_save');
-    $clipboardSaveMaxAge = QubitSetting::getByName('clipboard_save_max_age');
 
     // Set defaults for global form
     $this->globalForm->setDefaults(array(
@@ -122,7 +121,6 @@ class SettingsGlobalAction extends sfAction
       'generate_reports_as_pub_user' => (isset($generateReportsAsPubUser)) ? $generateReportsAsPubUser->getValue(array('sourceCulture'=>true)) : 1,
       'enable_institutional_scoping' => (isset($enableInstitutionalScoping)) ? intval($enableInstitutionalScoping->getValue(array('sourceCulture'=>true))) : 0,
       'cache_xml_on_save' => (isset($cacheXmlOnSave)) ? intval($cacheXmlOnSave->getValue(array('sourceCulture'=>true))) : 0,
-      'clipboard_save_max_age' => (isset($clipboardSaveMaxAge)) ? intval($clipboardSaveMaxAge->getValue(array('sourceCulture'=>true))) : 0,
     ));
   }
 
@@ -366,18 +364,6 @@ class SettingsGlobalAction extends sfAction
     }
 
     $setting->setValue($cacheXmlOnSave, array('sourceCulture' => true));
-    $setting->save();
-
-    // Saved clipboard maximum age
-    $clipboardSaveMaxAge = $thisForm->getValue('clipboard_save_max_age');
-
-    if (null === $setting = QubitSetting::getByName('clipboard_save_max_age'))
-    {
-      $setting = new QubitSetting;
-      $setting->name = 'clipboard_save_max_age';
-    }
-
-    $setting->setValue($clipboardSaveMaxAge, array('sourceCulture' => true));
     $setting->save();
 
     return $this;

--- a/apps/qubit/modules/settings/actions/menuComponent.class.php
+++ b/apps/qubit/modules/settings/actions/menuComponent.class.php
@@ -91,6 +91,10 @@ class SettingsMenuComponent extends sfComponent
       array(
         'label' => $i18n->__('Privacy Notification'),
         'action' => 'privacyNotification'
+      ),
+      array(
+        'label' => $i18n->__('Clipboard'),
+        'action' => 'clipboard'
       )
     );
 

--- a/apps/qubit/modules/settings/templates/clipboardSuccess.php
+++ b/apps/qubit/modules/settings/templates/clipboardSuccess.php
@@ -1,0 +1,68 @@
+<?php decorate_with('layout_2col.php') ?>
+
+<?php slot('sidebar') ?>
+
+  <?php echo get_component('settings', 'menu') ?>
+
+<?php end_slot() ?>
+
+<?php slot('title') ?>
+
+  <h1><?php echo __('Clipboard settings') ?></h1>
+
+<?php end_slot() ?>
+
+<?php slot('content') ?>
+
+  <?php echo $form->renderFormTag(url_for(array('module' => 'settings', 'action' => 'clipboard'))) ?>
+
+    <div id="content">
+
+      <fieldset class="collapsible">
+
+        <legend><?php echo __('Clipboard saving') ?></legend>
+
+        <?php echo $form->clipboard_save_max_age
+          ->label(__('Saved clipboard maximum age (in days)'))
+          ->help(__('The number of days a saved clipboard should be retained before it is eligible for deletion'))
+          ->renderRow() ?>
+
+      </fieldset>
+
+      <fieldset class="collapsible">
+
+        <legend><?php echo __('Clipboard sending') ?></legend>
+
+        <?php echo $form->clipboard_send_enabled
+          ->label(__('Enable clipboard send functionality'))
+          ->renderRow() ?>
+
+        <?php echo $form->clipboard_send_url
+          ->label(__('External URL to send clipboard contents to'))
+          ->renderRow() ?>
+
+        <?php echo $form->clipboard_send_button_text
+          ->label(__('Send button text'))
+          ->renderRow() ?>
+
+        <?php echo $form->clipboard_send_message_html
+          ->label(__('Text or HTML to display when sending clipboard contents'))
+          ->renderRow() ?>
+
+        <?php echo $form->clipboard_send_http_method
+          ->label(__('HTTP method to use when sending clipboard contents'))
+          ->renderRow() ?>
+
+      </fieldset>
+
+    </div>
+
+    <section class="actions">
+      <ul>
+        <li><input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Save') ?>"/></li>
+      </ul>
+    </section>
+
+  </form>
+
+<?php end_slot() ?>

--- a/apps/qubit/modules/user/actions/clipboardSendAction.class.php
+++ b/apps/qubit/modules/user/actions/clipboardSendAction.class.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class UserClipboardSendAction extends sfAction
+{
+  public function execute($request)
+  {
+    if (!sfConfig::get('app_clipboard_send_enabled', false))
+    {
+      // 403 - Forbidden
+      $this->getResponse()->setStatusCode(403);
+
+      return sfView::HEADER_ONLY;
+    }
+
+    $this->allSlugs = $this->context->user->getClipboard()->getAllByClassName();
+
+    if (!count($this->allSlugs))
+    {
+      // Inform user that there's nothing to send and return to clipboard page
+      $message = $this->context->i18n->__('No items in clipboard to send.');
+      $this->context->user->setFlash('error', $message);
+
+      $this->redirect(array('module' => 'user', 'action' => 'clipboard'));
+    }
+    else
+    {
+      // Set message shown to user while message is sent
+      $sendMessageHtml = $this->context->i18n->__('%1%Sending...%2%', array('%1%' => '<h1>', '%2%' => '</h1>'));
+      $this->sendMessageHtml = sfConfig::get('app_clipboard_send_message_html', $sendMessageHtml);
+
+      // Set where and how data is to be sentl
+      $this->sendUrl = sfConfig::get('app_clipboard_send_url', '');
+      $this->sendHttpMethod = sfConfig::get('app_clipboard_send_http_method', 'POST');
+
+      // Set payload data (site base URL and slugs in clipboard)
+      $this->siteBaseUrl = sfConfig::get('app_siteBaseUrl');
+      $this->classSlugFieldNames = array();
+
+      // Create human-friendly form input names based on clipboard item's class name
+      foreach ($this->allSlugs as $className => $slugs)
+      {
+        $this->classSlugFieldNames[$className] = sfInflector::underscore(str_replace('Qubit', '', $className)) .'_slugs';
+      }
+    }
+  }
+}

--- a/apps/qubit/modules/user/config/view.yml
+++ b/apps/qubit/modules/user/config/view.yml
@@ -1,3 +1,7 @@
+clipboardSendSuccess:
+  javascripts:
+    clipboardSend:
+
 editSuccess:
   javascripts:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/jquery.once.js:

--- a/apps/qubit/modules/user/templates/clipboardSendSuccess.php
+++ b/apps/qubit/modules/user/templates/clipboardSendSuccess.php
@@ -1,0 +1,26 @@
+<?php decorate_with('layout_1col') ?>
+
+<?php slot('title') ?>
+
+  <?php if (!empty($sendMessageHtml)): ?>
+    <?php echo __($sendMessageHtml) ?>
+  <?php endif; ?>
+
+<?php end_slot() ?>
+
+<?php slot('content') ?>
+
+  <form id="sendForm" action="<?php echo $sendUrl ?>" method="<?php echo $sendHttpMethod ?>">
+
+    <input name="base_url" type="hidden" value="<?php echo $siteBaseUrl ?>" />
+
+    <?php foreach ($allSlugs as $className => $slugs): ?>
+      <?php foreach($slugs as $slug): ?>
+        <input name="<?php echo $classSlugFieldNames[$className] ?>[]" type="hidden" value="<?php echo $slug ?>" />
+      <?php endforeach; ?>
+    <?php endforeach; ?>
+
+    <input id="sendFormSubmit" type="submit" value="<?php echo __('Send') ?>">
+  </form>
+
+<?php end_slot() ?>

--- a/apps/qubit/modules/user/templates/clipboardSuccess.php
+++ b/apps/qubit/modules/user/templates/clipboardSuccess.php
@@ -52,6 +52,9 @@
         <li><?php echo link_to(__('Clear %1 clipboard', array('%1' => lcfirst($uiLabels[$type]))), array('module' => 'user', 'action' => 'clipboardClear', 'type' => $entityType), array('class' => 'c-btn c-btn-delete')) ?></li>
         <li><?php echo link_to(__('Save'), array('module' => 'user', 'action' => 'clipboardSave'), array('class' => 'c-btn')) ?></li>
         <li><?php echo link_to(__('Export'), array('module' => 'object', 'action' => 'export', 'objectType' => $type), array('class' => 'c-btn')) ?></li>
+        <?php if (sfConfig::get('app_clipboard_send_enabled', false) && !empty(sfConfig::get('app_clipboard_send_url', ''))): ?>
+          <li><?php echo link_to(__(sfConfig::get('app_clipboard_send_button_text', __('Send'))), array('module' => 'user', 'action' => 'clipboardSend'), array('class' => 'c-btn')) ?></li>
+        <?php endif; ?>
       </ul>
     </section>
   <?php endif; ?>

--- a/js/clipboardSend.js
+++ b/js/clipboardSend.js
@@ -1,0 +1,12 @@
+"use strict";
+
+(function ($) {
+  $(document).ready(function()
+    {
+      // Hide submit form button (JavaScript's working so it's not needed)
+      $('#sendFormSubmit').hide();
+
+      // Automatically submit form
+      $('#sendForm').submit();
+    });
+})(jQuery);

--- a/lib/form/SettingsGlobalForm.class.php
+++ b/lib/form/SettingsGlobalForm.class.php
@@ -59,7 +59,6 @@ class SettingsGlobalForm extends sfForm
       'google_maps_api_key' => new sfWidgetFormInput,
       'generate_reports_as_pub_user' => new sfWidgetFormSelectRadio(array('choices' => array(1 => 'yes', 0 => 'no')), array('class' => 'radio')),
       'cache_xml_on_save' => new sfWidgetFormSelectRadio(array('choices' => array(1 => 'yes', 0 => 'no')), array('class' => 'radio')),
-      'clipboard_save_max_age' => new sfWidgetFormInput,
     ));
 
     // Add labels
@@ -89,7 +88,6 @@ class SettingsGlobalForm extends sfForm
       'google_maps_api_key' => $this->i18n->__('Google Maps Javascript API key (for displaying dynamic maps)'),
       'generate_reports_as_pub_user' => $this->i18n->__('Generate archival description reports as public user'),
       'cache_xml_on_save' => $this->i18n->__('Cache description XML exports upon creation/modification'),
-      'clipboard_save_max_age' => $this->i18n->__('Saved clipboard maximum age (in days)'),
     ));
 
     // Add helper text
@@ -112,7 +110,6 @@ class SettingsGlobalForm extends sfForm
       // 'explode_multipage_files' => $this->i18n->__('')
       // 'show_tooltips' => $this->i18n->__('')
       // 'sword_deposit_dir' => $this->i18n->__('')
-      'clipboard_save_max_age' => $this->i18n->__('The number of days a saved clipboard should be retained before it is eligible for deletion'),
     ));
 
     // Hits per page validator
@@ -152,7 +149,6 @@ class SettingsGlobalForm extends sfForm
     $this->validatorSchema['google_maps_api_key'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['generate_reports_as_pub_user'] = new sfValidatorInteger(array('required' => false));
     $this->validatorSchema['cache_xml_on_save'] = new sfValidatorInteger(array('required' => false));
-    $this->validatorSchema['clipboard_save_max_age'] = new sfValidatorInteger(array('required' => false));
 
     // Set decorator
     $decorator = new QubitWidgetFormSchemaFormatterList($this->widgetSchema);


### PR DESCRIPTION
Add the ability to, if the feature's enabled and configured, send the
contents of the clipboard to an external script for processing.

A new clipboard settings page has been added and new settings related
to clipboard sending.

A parent class for settings pages has been added.