### PR TITLE
Context-sensitive D.O. browse link, refs #12797

### DIFF
--- a/apps/qubit/modules/informationobject/templates/_actionIcons.php
+++ b/apps/qubit/modules/informationobject/templates/_actionIcons.php
@@ -46,18 +46,20 @@
       </a>
     </li>
 
-    <li>
-      <a href="<?php echo url_for(array(
-        'module' => 'informationobject',
-        'action' => 'browse',
-        'collection' => $resource->getCollectionRoot()->id,
-        'topLod' => false,
-        'view' => 'card',
-        'onlyMedia' => true)) ?>">
-        <i class="fa fa-picture-o"></i>
-        <?php echo __('Browse digital objects') ?>
-      </a>
-    </li>
+    <?php if (!empty($resource->getDigitalObject())): ?>
+      <li>
+        <a href="<?php echo url_for(array(
+          'module' => 'informationobject',
+          'action' => 'browse',
+          'collection' => $resource->getCollectionRoot()->id,
+          'topLod' => false,
+          'view' => 'card',
+          'onlyMedia' => true)) ?>">
+          <i class="fa fa-picture-o"></i>
+          <?php echo __('Browse digital objects') ?>
+        </a>
+      </li>
+    <?php endif; ?>
 
     <?php if ($sf_user->isAdministrator()): ?>
       <li class="separator"><h4><?php echo __('Import') ?></h4></li>


### PR DESCRIPTION
Added a check, in the context menu of information object detail pages,
to see if a digital object exists before displaying a "Browse digital
objects" link.