### PR TITLE
Convert UTC time to localtime in OAI requests, refs #13025

### DIFF
--- a/plugins/arOaiPlugin/lib/arOaiPluginComponent.class.php
+++ b/plugins/arOaiPlugin/lib/arOaiPluginComponent.class.php
@@ -55,7 +55,7 @@ abstract class arOaiPluginComponent extends sfComponent
     }
     else
     {
-      $this->from = $request->from;
+      $this->from = strtotime($request->from);
     }
 
     if (!isset($request->until))
@@ -64,7 +64,7 @@ abstract class arOaiPluginComponent extends sfComponent
     }
     else
     {
-      $this->until = $request->until;
+      $this->until = strtotime($request->until);
     }
 
     if (!isset($request->set))


### PR DESCRIPTION
Convert "from" and "until" dates in OAI requests from UTC to localtime for use when looking up informationObjects in database. This will make arOaiPluginComponent conform with [OAI protocol standard 4.5](https://www.openarchives.org/OAI/openarchivesprotocol.html#ListRecords). 

This PR will resolve https://github.com/artefactual/atom/issues/893
