### PR TITLE
Video player fixes, refs #12902

### DIFF
--- a/apps/qubit/modules/digitalobject/templates/_showVideo.php
+++ b/apps/qubit/modules/digitalobject/templates/_showVideo.php
@@ -11,7 +11,7 @@
 <?php elseif ($usageType == QubitTerm::REFERENCE_ID): ?>
 
   <?php if ($showFlashPlayer): ?>
-    <video class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>"></video>
+    <video preload="metadata" class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>"></video>
   <?php else: ?>
     <div style="text-align: center">
       <?php echo image_tag($representation->getFullPath(), array('style' => 'border: #999 1px solid', 'alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>

--- a/apps/qubit/modules/informationobject/actions/indexAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/indexAction.class.php
@@ -118,6 +118,9 @@ class InformationObjectIndexAction extends sfAction
       $this->getResponse()->addJavascript('treeViewPager', 'last');
       $this->getResponse()->addJavascript('fullWidthTreeView', 'last');
       $this->getResponse()->addJavascript('/vendor/jstree/jstree.min.js', 'last');
+      $this->getResponse()->addJavaScript('/vendor/mediaelement/mediaelement-and-player.min.js');
+      $this->getResponse()->addJavaScript('mediaelement');
+      $this->getResponse()->addStyleSheet('/vendor/mediaelement/mediaelementplayer.min.css');
     }
 
     $scopeAndContent = $this->resource->getScopeAndContent(array('cultureFallback' => true));

--- a/js/mediaelement.js
+++ b/js/mediaelement.js
@@ -1,12 +1,16 @@
 (function ($)
   {
-    $(document).ready(function() {
-      $('.mediaelement-player').mediaelementplayer({
-        pluginPath: Qubit.relativeUrlRoot + '/vendor/mediaelement/',
-        renderers: ['html5', 'flash_video'],
-        alwaysShowControls: true,
-        stretching: 'responsive'
-      });
-    });
-  }
-)(jQuery);
+    Drupal.behaviors.mediaelement = {
+      attach: function (context)
+        {
+          $('.mediaelement-player', context).each(function ()
+            {
+              $(this).mediaelementplayer({
+                pluginPath: Qubit.relativeUrlRoot + '/vendor/mediaelement/',
+                renderers: ['html5', 'flash_video'],
+                alwaysShowControls: true,
+                stretching: 'responsive'
+              });
+            });
+        }};
+  })(jQuery);


### PR DESCRIPTION
This PR:

- Sets metadata preloading of the new `video` tag to scale the MedialElement player better https://github.com/artefactual/atom/commit/1e1a6f1507f12d573f21d4b7e5c95873934d537c
- Fixes audio/video DO loading from the full-width treeview https://github.com/artefactual/atom/commit/b7aee74d45f972e204dde747bef543d668117fc3
- Fixes video thumbnail generation https://github.com/artefactual/atom/commit/a9199fb211fd4862ad361cb0dc1025b58a9c6f47