### PR TITLE
Init path as array instead of string, refs #13066

### DIFF
--- a/lib/task/import/importBulkTask.class.php
+++ b/lib/task/import/importBulkTask.class.php
@@ -202,7 +202,7 @@ EOF;
 
   protected function dir_tree($dir)
   {
-    $path = '';
+    $path = array();
     $stack[] = $dir;
 
     while ($stack)


### PR DESCRIPTION
This commit corrects the initialization of path in importBulkTask to an array
to counter breaking changes introduced in PHP 7.1 that prevented its previous
initialization to be silently converted to an array.

Connected to #902 