### PR TITLE
Video player fixes after testing, refs #12902

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/showAudioComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/showAudioComponent.class.php
@@ -48,8 +48,8 @@ class DigitalObjectShowAudioComponent extends sfComponent
     {
       $this->showFlashPlayer = true;
 
-      $this->response->addJavaScript('/vendor/mediaelement/mediaelement-and-player.min.js');
-      $this->response->addJavaScript('mediaelement');
+      $this->response->addJavaScript('/vendor/mediaelement/mediaelement-and-player.min.js', 'last');
+      $this->response->addJavaScript('mediaelement', 'last');
       $this->response->addStyleSheet('/vendor/mediaelement/mediaelementplayer.min.css');
     }
     else

--- a/apps/qubit/modules/digitalobject/actions/showVideoComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/showVideoComponent.class.php
@@ -46,8 +46,8 @@ class DigitalObjectShowVideoComponent extends sfComponent
     // Set up display of video in mediaelement
     if ($this->representation)
     {
-      $this->response->addJavaScript('/vendor/mediaelement/mediaelement-and-player.min.js');
-      $this->response->addJavaScript('mediaelement');
+      $this->response->addJavaScript('/vendor/mediaelement/mediaelement-and-player.min.js', 'last');
+      $this->response->addJavaScript('mediaelement', 'last');
       $this->response->addStyleSheet('/vendor/mediaelement/mediaelementplayer.min.css');
 
       // If this is a reference movie, get the thumbnail representation for the

--- a/apps/qubit/modules/digitalobject/templates/_showVideo.php
+++ b/apps/qubit/modules/digitalobject/templates/_showVideo.php
@@ -11,7 +11,7 @@
 <?php elseif ($usageType == QubitTerm::REFERENCE_ID): ?>
 
   <?php if ($showFlashPlayer): ?>
-    <video preload="metadata" class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>"></video>
+    <video width="320" height="240" preload="metadata" class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>"></video>
   <?php else: ?>
     <div style="text-align: center">
       <?php echo image_tag($representation->getFullPath(), array('style' => 'border: #999 1px solid', 'alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>

--- a/apps/qubit/modules/informationobject/actions/indexAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/indexAction.class.php
@@ -118,8 +118,8 @@ class InformationObjectIndexAction extends sfAction
       $this->getResponse()->addJavascript('treeViewPager', 'last');
       $this->getResponse()->addJavascript('fullWidthTreeView', 'last');
       $this->getResponse()->addJavascript('/vendor/jstree/jstree.min.js', 'last');
-      $this->getResponse()->addJavaScript('/vendor/mediaelement/mediaelement-and-player.min.js');
-      $this->getResponse()->addJavaScript('mediaelement');
+      $this->getResponse()->addJavaScript('/vendor/mediaelement/mediaelement-and-player.min.js', 'last');
+      $this->getResponse()->addJavaScript('mediaelement', 'last');
       $this->getResponse()->addStyleSheet('/vendor/mediaelement/mediaelementplayer.min.css');
     }
 

--- a/js/mediaelement.js
+++ b/js/mediaelement.js
@@ -8,8 +8,7 @@
               $(this).mediaelementplayer({
                 pluginPath: Qubit.relativeUrlRoot + '/vendor/mediaelement/',
                 renderers: ['html5', 'flash_video'],
-                alwaysShowControls: true,
-                stretching: 'responsive'
+                alwaysShowControls: true
               });
             });
         }};

--- a/plugins/arDominionPlugin/css/less/scaffolding.less
+++ b/plugins/arDominionPlugin/css/less/scaffolding.less
@@ -1232,6 +1232,9 @@ section .vcard:last-child > .field:last-child > div {
     text-align: left;
   }
 
+  .mediaelement-player {
+    margin: 0 auto;
+  }
 }
 
 // Horizontal space that takes the sort dropdown or a search bar in a browser


### PR DESCRIPTION
This PR:

* Loads the mediaelement JS assets *last* to avoid a problem when the user is authenticated and jQuery is loaded first https://github.com/artefactual/atom/commit/de3395513c5c4bcae178505f9f0f09a239d9b88a
* Sets a fixed and centered 320x240 size for the mediaelement player used previously by the flowplayer https://github.com/artefactual/atom/commit/76df3fd89b990634f49b51b5049deec095796721