### PR TITLE
Fix copyright pop-up HTML, refs #13070

### DIFF
--- a/apps/qubit/modules/digitalobject/templates/viewCopyrightStatementSuccess.php
+++ b/apps/qubit/modules/digitalobject/templates/viewCopyrightStatementSuccess.php
@@ -15,7 +15,7 @@
 <div class="page">
 
   <div>
-    <?php echo render_value($sf_data->getRaw('copyrightStatement')) ?>
+    <?php echo render_value_html($sf_data->getRaw('copyrightStatement')) ?>
   </div>
 
 </div>


### PR DESCRIPTION
This prevents the content of the popup to be escaped by using the
Parsedown text method in unsafe mode.