### PR TITLE
Store only necessary repository fields, refs #9773

### DIFF
--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -459,8 +459,14 @@ mapping:
         properties:
           id: { type: integer }
           slug: { type: keyword }
+      repository:
+        _i18nFields: [authorizedFormOfName]
+        dynamic: strict
+        properties:
+          id: { type: integer }
+          slug: { type: keyword }
+          identifier: { type: keyword }
     _foreign_types:
-      repository: repository
       names: actor
       creators: actor
       inherited_creators: actor

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
@@ -1245,7 +1245,15 @@ class arElasticSearchInformationObjectPdo
     // Repository
     if (null !== $repository = $this->getRepository())
     {
-      $serialized['repository'] = arElasticSearchRepository::serialize($repository);
+      $serialized['repository']['id'] = $this->repository->id;
+      $serialized['repository']['slug'] = $this->repository->slug;
+      $serialized['repository']['identifier'] = $this->repository->identifier;
+
+      $serialized['repository']['i18n'] = arElasticSearchModelBase::serializeI18ns(
+        $repository->id,
+        array('QubitActor'),
+        array('fields' => array('authorized_form_of_name'))
+      );
     }
 
     // Places

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchRepository.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchRepository.class.php
@@ -61,7 +61,6 @@ class arElasticSearchRepository extends arElasticSearchModelBase
 
     $serialized['id'] = $object->id;
     $serialized['slug'] = $object->slug;
-
     $serialized['identifier'] = $object->identifier;
 
     foreach ($object->getTermRelations(QubitTaxonomy::REPOSITORY_TYPE_ID) as $relation)


### PR DESCRIPTION
Reduce the repository data stored in the information object ES document to the fields required for search functionality.