### PR TITLE
New digitalobject load task option, refs #13103

### DIFF
--- a/lib/task/digitalobject/digitalObjectLoadTask.class.php
+++ b/lib/task/digitalobject/digitalObjectLoadTask.class.php
@@ -50,6 +50,7 @@ class digitalObjectLoadTask extends sfBaseTask
       new sfCommandOption('path', 'p', sfCommandOption::PARAMETER_OPTIONAL, 'Path prefix for digital objects', null),
       new sfCommandOption('limit', 'l', sfCommandOption::PARAMETER_OPTIONAL, 'Limit number of digital objects imported to n', null),
       new sfCommandOption('index', 'i', sfCommandOption::PARAMETER_NONE, 'Update search index (defaults to false)', null),
+      new sfCommandOption('attach-only', 'a', sfCommandOption::PARAMETER_NONE, 'Always attach digital objects instead of linking', null),
     ));
 
     $this->namespace = 'digitalobject';
@@ -182,17 +183,19 @@ EOF;
       }
 
       // No information_object_id specified, try looking up id via identifier
-      if (!$ioQuery->execute(array($key)))
+      $ioQuery->execute(array($key));
+      $results = $ioQuery->fetch();
+      if (!$results)
       {
         $this->log("Couldn't find information object with $idType: $key");
 
         continue;
       }
 
-      // Fetch results
-      $results = $ioQuery->fetch();
-
-      if (!is_array($item))
+      // If attach-only is set, the task will attach the new DO via a new
+      // information obj regardless of whether there is one vs more in the
+      // import CSV.
+      if (!is_array($item) && !$options['attach-only'])
       {
         // Skip if this information object already has a digital object attached
         if ($results[1] !== null)
@@ -215,25 +218,33 @@ EOF;
       }
       else
       {
-        // If more than one digital object linked to this information object
-        for ($i=0; $i < count($item); $i++)
+        if (!is_array($item))
         {
-          if (!file_exists($path = self::getPath($item[$i])))
+          if (!file_exists($path = self::getPath($item)))
           {
-            $this->log(sprintf("Couldn't read file '$item[$i]'"));
+            $this->log(sprintf("Couldn't read file '$item'"));
             $this->skippedCount++;
 
             continue;
           }
 
-          // Create new information objects, to maintain one-to-one
-          // relationship with digital objects
-          $informationObject = new QubitInformationObject;
-          $informationObject->parent = QubitInformationObject::getById($results[0]);
-          $informationObject->title = basename($item[$i]);
-          $informationObject->save($options['conn']);
+          self::attachDigitalObject($item, $results[0]);
+        }
+        else
+        {
+          // If more than one digital object linked to this information object
+          for ($i=0; $i < count($item); $i++)
+          {
+            if (!file_exists($path = self::getPath($item[$i])))
+            {
+              $this->log(sprintf("Couldn't read file '$item[$i]'"));
+              $this->skippedCount++;
 
-          self::addDigitalObject($informationObject->id, $item[$i], $options);
+              continue;
+            }
+
+            self::attachDigitalObject($item[$i], $results[0]);
+          }
         }
       }
 
@@ -247,6 +258,18 @@ EOF;
     {
       $this->logSection('digital-object', 'Please update the search index manually to reflect any changes');
     }
+  }
+
+  protected function attachDigitalObject($item, $informationObjectId)
+  {
+    // Create new information objects, to maintain one-to-one
+    // relationship with digital objects
+    $informationObject = new QubitInformationObject;
+    $informationObject->parent = QubitInformationObject::getById($informationObjectId);
+    $informationObject->title = basename($item);
+    $informationObject->save($options['conn']);
+
+    self::addDigitalObject($informationObject->id, $item, $options);
   }
 
   protected function getPath($path)


### PR DESCRIPTION
Add new option to the CLI digitalobject:load CLI task: --attach-only

When set, this option will force all digital objects in the import CSV
file to be attached via their own information object record.