### PR TITLE
Fix task plugin loading issue, refs #13109

### DIFF
--- a/lib/task/migrate/arUpgradeSqlTask.class.php
+++ b/lib/task/migrate/arUpgradeSqlTask.class.php
@@ -57,7 +57,15 @@ EOF;
     ));
 
     // Disable plugin loading from plugins/ before this task.
-    sfPluginAdminPluginConfiguration::$loadPlugins = false;
+    // Using command.pre_command to ensure that it happens early enough.
+    $this->dispatcher->connect('command.pre_command', function($e) {
+      if (!$e->getSubject() instanceof self)
+      {
+        return;
+      }
+
+      sfPluginAdminPluginConfiguration::$loadPlugins = false;
+    });
   }
 
   /**


### PR DESCRIPTION
This commit ensures that the action of disabling plugin loading in
tools:upgrade-sql is performed in a way that does not affect other
tasks.

tools:upgrade-sql disables application plugin loading by setting the
$loadPlugins global to false. However, that change was affecting all
tasks because it's performed in the configure method which is always
executed during the CLI bootstrap process, for every task, regardless
the task that the user is running.

A side effect was that jobs:worker was not able to access application
plugins like qtSwordPlugin unless the autoloading config had already
been cached by hitting the website first.

For QA:
1. Clear the cache
2. Do not visit the web application site
3. Start the atom worker
4. Confirm that the qtSwordPlugin ability is loaded