### PR TITLE
Add warning to security settings, refs #13105

### DIFF
--- a/apps/qubit/modules/settings/templates/securitySuccess.php
+++ b/apps/qubit/modules/settings/templates/securitySuccess.php
@@ -14,6 +14,10 @@
 
 <?php slot('content') ?>
 
+  <div class="alert alert-info">
+    <?php echo __('Note: Incorrect security settings can result in the AtoM web UI becoming inaccessible.') ?>
+  </div>
+
   <form action="<?php echo url_for('settings/security') ?>" method="post">
 
     <div id="content">


### PR DESCRIPTION
Added a warning to the security settings page to let users know that
incorrect security settings can result in the web UI becoming
inaccessible.