### PR TITLE
Gracefully handle missing user menus, refs #13113

### DIFF
--- a/apps/qubit/modules/menu/actions/userMenuComponent.class.php
+++ b/apps/qubit/modules/menu/actions/userMenuComponent.class.php
@@ -41,16 +41,43 @@ class MenuUserMenuComponent extends sfComponent
       'required' => $this->context->i18n->__('You must enter your password'))));
     $this->form->setWidget('password', new sfWidgetFormInputPassword);
 
+    $this->showLogin = false;
     if ($this->context->user->isAuthenticated())
     {
       $this->gravatar = sprintf('https://www.gravatar.com/avatar/%s?s=%s',
         md5(strtolower(trim($this->context->user->user->email))),
         25,
         urlencode(public_path('/images/gravatar-anonymous.png', false)));
+
+      $this->menuLabels = array(
+        'logout' => $this->getMenuLabel('logout'),
+        'myProfile' => $this->getMenuLabel('myProfile')
+      );
+    }
+    elseif (check_field_visibility('app_element_visibility_global_login_button'))
+    {
+      $this->showLogin = true;
+      $this->menuLabels = array('login' => $this->getMenuLabel('login'));
+    }
+  }
+
+  protected function getMenuLabel($name)
+  {
+    if (null !== $menu = QubitMenu::getByName($name))
+    {
+      return $menu->getLabel(array('cultureFallback' => true));
     }
 
-    $this->logInMenu = QubitMenu::getByName('login');
-    $this->logOutMenu = QubitMenu::getByName('logout');
-    $this->profileMenu = QubitMenu::getByName('myProfile');
+    switch($name)
+    {
+      case 'login':
+        return  $this->context->getI18n()->__('Log in');
+
+      case 'logout':
+        return  $this->context->getI18n()->__('Log out');
+
+      case 'myProfile':
+        return  $this->context->getI18n()->__('Profile');
+    }
   }
 }

--- a/apps/qubit/modules/menu/templates/_userMenu.php
+++ b/apps/qubit/modules/menu/templates/_userMenu.php
@@ -1,10 +1,10 @@
-<?php if (!$sf_user->isAuthenticated()): ?>
+<?php if ($showLogin): ?>
 
   <div id="user-menu">
-
-    <?php if ($sf_user->isAuthenticated() || check_field_visibility('app_element_visibility_global_login_button')): ?>
-    <button class="top-item top-dropdown" data-toggle="dropdown" data-target="#" aria-expanded="false"><?php echo $logInMenu->getLabel(array('cultureFallback' => true)) ?></button>
-    <?php endif; ?>
+    <button class="top-item top-dropdown" data-toggle="dropdown" data-target="#"
+      aria-expanded="false">
+        <?php echo $menuLabels['login'] ?>
+    </button>
 
     <div class="top-dropdown-container">
 
@@ -26,7 +26,7 @@
 
           <?php echo $form->password->renderRow(array('autocomplete' => 'off')) ?>
 
-          <button type="submit"><?php echo $logInMenu->getLabel(array('cultureFallback' => true)) ?></button>
+          <button type="submit"><?php echo $menuLabels['login'] ?></button>
 
         </form>
 
@@ -35,10 +35,10 @@
       <div class="top-dropdown-bottom"></div>
 
     </div>
-
   </div>
+<?php endif; ?>
 
-<?php else: ?>
+<?php if($sf_user->isAuthenticated()): ?>
 
   <div id="user-menu">
 
@@ -60,8 +60,10 @@
       <div class="top-dropdown-body">
 
         <ul>
-          <li><?php echo link_to($profileMenu->getLabel(array('cultureFallback' => true)), array($sf_user->user, 'module' => 'user')) ?></li>
-          <li><?php echo link_to($logOutMenu->getLabel(array('cultureFallback' => true)), array('module' => 'user', 'action' => 'logout')) ?></li>
+          <li><?php echo link_to($menuLabels['myProfile'], array(
+            $sf_user->user, 'module' => 'user')) ?></li>
+          <li><?php echo link_to($menuLabels['logout'], array(
+            'module' => 'user', 'action' => 'logout')) ?></li>
         </ul>
 
       </div>

--- a/apps/qubit/modules/menu/templates/_userMenu.php
+++ b/apps/qubit/modules/menu/templates/_userMenu.php
@@ -36,9 +36,8 @@
 
     </div>
   </div>
-<?php endif; ?>
 
-<?php if($sf_user->isAuthenticated()): ?>
+<?php elseif($sf_user->isAuthenticated()): ?>
 
   <div id="user-menu">
 


### PR DESCRIPTION
- Fall back to old i18n labels if login, logout, or myProfile menus have
been deleted or renamed.
- Simplify display logic in template