### PR TITLE
403 response for permission error, refs #12782

### DIFF
--- a/apps/qubit/modules/admin/actions/secureAction.class.php
+++ b/apps/qubit/modules/admin/actions/secureAction.class.php
@@ -21,5 +21,6 @@ class AdminSecureAction extends sfAction
 {
   public function execute($request)
   {
+    $this->getResponse()->setStatusCode(403);
   }
 }


### PR DESCRIPTION
Changed the permission error page so it responds using a 403 HTTP code
rather than a 200 code.