### PR TITLE
Escape entities in hidden inputs, refs #13125

### DIFF
--- a/apps/qubit/modules/actor/templates/_advancedSearch.php
+++ b/apps/qubit/modules/actor/templates/_advancedSearch.php
@@ -7,7 +7,7 @@
     <?php echo $form->renderFormTag(url_for(array('module' => 'actor', 'action' => 'browse')), array('name' => 'advanced-search-form', 'method' => 'get')) ?>
 
       <?php foreach ($hiddenFields as $name => $value): ?>
-        <input type="hidden" name="<?php echo $name ?>" value="<?php echo $value ?>"/>
+        <input type="hidden" name="<?php echo $name ?>" value="<?php echo esc_entities($value) ?>"/>
       <?php endforeach; ?>
 
       <p><?php echo __('Find results with:') ?></p>

--- a/apps/qubit/modules/repository/templates/_advancedFilters.php
+++ b/apps/qubit/modules/repository/templates/_advancedFilters.php
@@ -1,7 +1,7 @@
 <form method="get">
 
   <?php foreach ($hiddenFields as $name => $value): ?>
-    <input type="hidden" name="<?php echo $name ?>" value="<?php echo $value ?>"/>
+    <input type="hidden" name="<?php echo $name ?>" value="<?php echo esc_entities($value) ?>"/>
   <?php endforeach; ?>
 
   <div class="advanced-repository-filters-content">

--- a/apps/qubit/modules/search/templates/_advancedSearch.php
+++ b/apps/qubit/modules/search/templates/_advancedSearch.php
@@ -7,7 +7,7 @@
     <?php echo $form->renderFormTag(url_for(array('module' => 'informationobject', 'action' => 'browse')), array('name' => 'advanced-search-form', 'method' => 'get')) ?>
 
       <?php foreach ($hiddenFields as $name => $value): ?>
-        <input type="hidden" name="<?php echo $name ?>" value="<?php echo $value ?>"/>
+        <input type="hidden" name="<?php echo $name ?>" value="<?php echo esc_entities($value) ?>"/>
       <?php endforeach; ?>
 
       <p><?php echo __('Find results with:') ?></p>

--- a/apps/qubit/modules/search/templates/_inlineSearch.php
+++ b/apps/qubit/modules/search/templates/_inlineSearch.php
@@ -3,13 +3,13 @@
   <form method="get" action="<?php echo $route ?>">
 
     <?php if (isset($sf_request->subqueryField) && 0 < strlen($sf_request->subqueryField)): ?>
-      <input type="hidden" name="subqueryField" id="subqueryField" value="<?php echo $sf_request->subqueryField ?>" />
+      <input type="hidden" name="subqueryField" id="subqueryField" value="<?php echo esc_entities($sf_request->subqueryField) ?>" />
     <?php elseif (isset($fields)): ?>
       <input type="hidden" name="subqueryField" id="subqueryField" value="<?php echo array_keys($sf_data->getRaw('fields'))[0] ?>" />
     <?php endif; ?>
 
     <?php if (isset($sf_request->view)): ?>
-      <input type="hidden" name="view" value="<?php echo $sf_request->view ?>"/>
+      <input type="hidden" name="view" value="<?php echo esc_entities($sf_request->view) ?>"/>
     <?php endif; ?>
 
     <div class="input-prepend input-append">


### PR DESCRIPTION
When Markdown support is enabled, the escaping strategy gets disabled.
This may cause issues in some hidden fields where the user input is
added without validation. The keys added to those inputs are already
validated in the controllers, but the values need to be escaped.