### PR TITLE
Use config to generate jobs prefix, refs #13108

### DIFF
--- a/config/app.yml
+++ b/config/app.yml
@@ -36,3 +36,12 @@ all:
   # Specify a CSV Transform script that can be automatically applied from
   # the CSV Import Page in AtoM
   # csv_transform_script_name: /full/path/to/transformscript
+
+  # The workers_key is concatenated alongside the project folder absolute path
+  # to generate an unique hash that is used to associate the worker(s) abilities
+  # with the corresponding AtoM instance. The workers_key will normally be empty,
+  # unless multiple AtoM instances running on the same path are connected to the
+  # same Gearman server, in which case, each instance's workers_key must be set
+  # to a different string value to make sure the proper workers take the job for
+  # their related instance.
+  workers_key:

--- a/lib/job/arBaseJob.class.php
+++ b/lib/job/arBaseJob.class.php
@@ -255,9 +255,8 @@ class arBaseJob extends Net_Gearman_Job_Common
   protected function createJobTempDir()
   {
     $name = md5(
-      sfConfig::get('app_siteTitle') .
-      sfConfig::get('app_siteBaseUrl') .
       sfConfig::get('sf_root_dir') .
+      sfConfig::get('app_workers_key', '') .
       $this->job->id .
       date_timestamp_get()
     );

--- a/lib/model/QubitJob.php
+++ b/lib/model/QubitJob.php
@@ -315,13 +315,12 @@ class QubitJob extends BaseJob
 
   /**
    * Get a unique identifier to associate a job with a particular AtoM install.
-   * This is used to prevent workers from other AtoM installs on the same system
-   * from taking the jobs from AtoM instances they don't belong to.
+   * See workers_key in config/app.yml for more information.
    */
   public static function getJobPrefix()
   {
     // Deliberately avoiding spaces, tabs, etc by using md5 hashing, see #9648.
-    $key = sfConfig::get('app_siteTitle').sfConfig::get('app_siteBaseUrl').sfConfig::get('sf_root_dir');
+    $key = sfConfig::get('sf_root_dir').sfConfig::get('app_workers_key', '');
     return md5($key).'-';
   }
 


### PR DESCRIPTION
Add `workers_key` setting to `config/app.yml` and use it alongside the
`sf_root_dir` to generate the job prefix instead of the site title and
base URL.

The site title and base URL were used to generate the job prefix, which
leads to different prefixes when those values are changed in the
database or when using a different language. If the prefix changes
between the AtoM worker start and when a job is triggered, no worker
will be found to handle that job.

This prefix was introduced to avoid collisions between workers from
different instances connected to the same Gearman server. However, if
those instances are running on the same machine, the `sf_root_dir` will
be different on each of them. Therefore, using the title and URL only
prevents the collision when multiple instances are running on different
machines, on the same path and they're connected to the same Gearman
server.

This is not an usual scenario and requires to modify configuration files
manually, at least `config/gearman.yml` in some of those instances to
point to a different server. Therefore, setting a different value for
the `workers_key` on each instance seems like a good solution to avoid
the collisions.

In the majority of the deploys, even in those where multiple AtoM
instances are running on the same machine, this new setting can be left
empty.