### PR TITLE
Get raw parameters in filter tags, refs #13131

### DIFF
--- a/apps/qubit/modules/search/templates/_filterTag.php
+++ b/apps/qubit/modules/search/templates/_filterTag.php
@@ -4,5 +4,5 @@
   <?php else: ?>
     <?php echo render_title($object) ?>
   <?php endif; ?>
-  <a href="<?php echo url_for(array('module' => $module, 'action' => $action) + $getParams) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
+  <a href="<?php echo url_for(array('module' => $module, 'action' => $action) + $sf_data->getRaw('getParams')) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
 </span>


### PR DESCRIPTION
When the escaping strategy is enabled and Markdown support is disabled,
`getParams` is converted to a `sfOutputEscaperArrayDecorator` instance.
This needs to be converted back using `$sf_data->getRaw()` to be able
to merge it with another array in the template.