### PR TITLE
Fix arDominionPlugin theme header, refs #13137

### DIFF
--- a/plugins/arDominionPlugin/css/less/header.less
+++ b/plugins/arDominionPlugin/css/less/header.less
@@ -19,8 +19,15 @@
 @topBarButtonHoverColor: @orange;
 
 #top-bar {
-  height: 50px;
   background-color: @topBarBackgroundColor;
+
+  // Hack to always wrap the header content
+  // without disrupting themes extending this one.
+  &:after {
+    content: '';
+    display: block;
+    clear: both;
+  }
 }
 
 header #logo {
@@ -363,6 +370,7 @@ nav > div {
 }
 
 #search-bar #search-form-wrapper {
+  padding-bottom: 10px;
 
   h2 {
     .hide();
@@ -436,11 +444,6 @@ nav > div {
 
 @media (max-width: 979px) {
 
-  // Increase height of the bar
-  #top-bar {
-    height: 150px;
-  }
-
   // Hide buttons
   nav {
     clear: both;
@@ -492,7 +495,6 @@ nav > div {
   #top-bar {
     margin: 0 -20px;
     height: auto;
-    padding-bottom: 10px;
   }
 
   #site-name {


### PR DESCRIPTION
Make sure the content of the site header is always wrapped within it.
Use a pseudo element and clearance to avoid disrupting themes extending
this one. This also makes the header play nicer with logos higher than
50px and long titles, fixing #3895 and #6293 too.