### PR TITLE
Optional full treeview collapse, refs #13135

### DIFF
--- a/apps/qubit/modules/informationobject/actions/treeViewComponent.class.php
+++ b/apps/qubit/modules/informationobject/actions/treeViewComponent.class.php
@@ -26,6 +26,8 @@ class InformationObjectTreeViewComponent extends sfComponent
     $this->treeviewType = sfConfig::get('app_treeview_type__source', 'sidebar');
     if ($this->treeviewType != 'sidebar')
     {
+      $this->collapsible = sfConfig::get('app_treeview_allow_full_width_collapse');
+
       return sfView::SUCCESS;
     }
 

--- a/apps/qubit/modules/informationobject/templates/_treeView.php
+++ b/apps/qubit/modules/informationobject/templates/_treeView.php
@@ -107,7 +107,11 @@
 
     <input type="button" id="fullwidth-treeview-reset-button" class="c-btn c-btn-submit" value="<?php echo __('Reset') ?>" />
     <input type="button" id="fullwidth-treeview-more-button" class="c-btn c-btn-submit" data-label="<?php echo __('%1% more') ?>" value="" />
-    <span id="fullwidth-treeview-collection-url" data-collection-url="<?php echo url_for(array($resource->getCollectionRoot(), 'module' => 'informationobject')) ?>"></span>
+    <span id="fullwidth-treeview-configuration"
+      data-collection-url="<?php echo url_for(array($resource->getCollectionRoot(), 'module' => 'informationobject')) ?>"
+      data-collapse-enabled="<?php echo $collapsible ?>"
+      data-opened-text="<?php echo sfConfig::get('app_ui_label_fullTreeviewCollapseOpenedButtonText') ?>"
+      data-closed-text="<?php echo sfConfig::get('app_ui_label_fullTreeviewCollapseClosedButtonText') ?>"></span>
 
   <?php endif; ?>
 

--- a/apps/qubit/modules/settings/actions/treeviewAction.class.php
+++ b/apps/qubit/modules/settings/actions/treeviewAction.class.php
@@ -24,6 +24,7 @@ class SettingsTreeviewAction extends DefaultEditAction
     $NAMES = array(
       'type',
       'showBrowseHierarchyPage',
+      'allowFullWidthTreeviewCollapse',
       'ioSort',
       'showIdentifier',
       'showLevelOfDescription',
@@ -57,6 +58,17 @@ class SettingsTreeviewAction extends DefaultEditAction
           'yes' => $this->i18n->__('Yes'));
 
         $this->addSettingRadioButtonsField($this->showBrowseHierarchyPageSetting, $name, $default, $options);
+
+        break;
+
+      case 'allowFullWidthTreeviewCollapse':
+        $this->allowFullWidthTreeviewCollapse = QubitSetting::getByName('treeview_allow_full_width_collapse');
+        $default = 'no';
+        $options = array(
+          'no' => $this->i18n->__('No'),
+          'yes' => $this->i18n->__('Yes'));
+
+        $this->addSettingRadioButtonsField($this->allowFullWidthTreeviewCollapse, $name, $default, $options);
 
         break;
 
@@ -132,6 +144,11 @@ class SettingsTreeviewAction extends DefaultEditAction
 
       case 'showBrowseHierarchyPage':
         $this->createOrUpdateSetting($this->showBrowseHierarchyPageSetting, 'treeview_show_browse_hierarchy_page', $field->getValue());
+
+        break;
+
+      case 'allowFullWidthTreeviewCollapse':
+        $this->createOrUpdateSetting($this->allowFullWidthTreeviewCollapse, 'treeview_allow_full_width_collapse', $field->getValue());
 
         break;
 

--- a/apps/qubit/modules/settings/templates/treeviewSuccess.php
+++ b/apps/qubit/modules/settings/templates/treeviewSuccess.php
@@ -39,6 +39,12 @@
 
         </div>
 
+        <p>
+          <?php echo $form->allowFullWidthTreeviewCollapse
+            ->label(__('Make full width treeview collapsible on description pages'))
+            ->renderRow() ?>
+        </p>
+
       </fieldset>
 
       <fieldset class="collapsible">

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 173
+    value: 174
   milestone:
     name: milestone
     editable: 0
@@ -762,6 +762,22 @@ QubitSetting:
       pt-BR: 'Busque nossa coleção'
       sr: 'Претражи наше збирке'
       sv: 'Sök i vår samling'
+  QubitSetting_fullTreeviewCollapseOpenedButtonText:
+    name: fullTreeviewCollapseOpenedButtonText
+    scope: ui_label
+    editable: 1
+    deleteable: 0
+    source_culture: en
+    value:
+      en: Hide hierarchy
+  QubitSetting_fullTreeviewCollapseClosedButtonText:
+    name: fullTreeviewCollapseClosedButtonText
+    scope: ui_label
+    editable: 1
+    deleteable: 0
+    source_culture: en
+    value:
+      en: Show hierarchy
   QubitSetting_26:
     name: en
     scope: i18n_languages

--- a/js/fullWidthTreeView.js
+++ b/js/fullWidthTreeView.js
@@ -4,9 +4,46 @@
 
   $(loadTreeView);
 
+  function makeFullTreeviewCollapsible ($treeViewConfig, $mainHeader, $fwTreeViewRow)
+  {
+    var $wrapper = $('<section class="full-treeview-section"></section>');
+    var $toggleButton = $('<a href="#" class="fullview-treeview-toggle"></a>');
+
+    // Adjust bottom margins
+    var bottomMargin = $fwTreeViewRow.css('margin-bottom');
+    $fwTreeViewRow.css('margin-bottom', '0px');
+    $wrapper.css('margin-bottom', bottomMargin);
+
+    // Set toggle button text and add to wrapper
+    $toggleButton.text($treeViewConfig.data('closed-text'));
+    $toggleButton.appendTo($wrapper);
+
+    // Add wrapper to the DOM then hide the treeview and add it to the wrapper
+    $mainHeader.after($wrapper);
+    $fwTreeViewRow.hide();
+    $fwTreeViewRow.appendTo($wrapper);
+
+    // Activate toggle button
+    $toggleButton.click(function() {
+      // Determine appropriate toggle button text
+      var toggleText = $treeViewConfig.data('opened-text');
+
+      if ($fwTreeViewRow.css('display') != 'none')
+      {
+        toggleText = $treeViewConfig.data('closed-text');
+      }
+
+      // Toggle treeview and set toggle button text
+      $fwTreeViewRow.toggle(400);
+      $toggleButton.text(toggleText);
+    });
+  }
+
   function loadTreeView ()
   {
-    var collectionUrl = $('#fullwidth-treeview-collection-url').data('collection-url');
+    var $treeViewConfig = $('#fullwidth-treeview-configuration');
+    var treeViewCollapseEnabled = $treeViewConfig.data('collapse-enabled') == 'yes';
+    var collectionUrl = $treeViewConfig.data('collection-url');
     var pathToApi  = '/informationobject/fullWidthTreeView';
     var $fwTreeView = $('<div id="fullwidth-treeview"></div>');
     var $fwTreeViewRow = $('<div id="fullwidth-treeview-row"></div>');
@@ -25,6 +62,12 @@
 
     $mainHeader.before($resetButton);
     $mainHeader.before($moreButton);
+
+    // Optionally wrap treeview in a collapsible container
+    if (treeViewCollapseEnabled)
+    {
+      makeFullTreeviewCollapsible($treeViewConfig, $mainHeader, $fwTreeViewRow);
+    }
 
     // Declare jsTree options
     var options = {
@@ -129,7 +172,11 @@
         // Add empty breadcrumb section if current page has none, but response does
         if (!$('#main-column .breadcrumb').length && $(response.find('#main-column .breadcrumb').length))
         {
-          $('#fullwidth-treeview-row').after($('<section>', {class: 'breadcrumb'}));
+          var breadcrumbDestinationSelector = (treeViewCollapseEnabled)
+            ? '.full-treeview-section'
+            : '#fullwidth-treeview-row';
+
+          $(breadcrumbDestinationSelector).after($('<section>', {class: 'breadcrumb'}));
         }
 
         $('#main-column .breadcrumb').replaceWith($(response.find('#main-column .breadcrumb')));

--- a/lib/task/migrate/migrations/arMigration0174.class.php
+++ b/lib/task/migrate/migrations/arMigration0174.class.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add new user interface labels for optional collapse/expand of full width treeview.
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0174
+{
+  const
+    VERSION = 174, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  /**
+   * Upgrade
+   *
+   * @return bool True if the upgrade succeeded, False otherwise
+   */
+  public function up($configuration)
+  {
+    $settings = array(
+      'fullTreeviewCollapseOpenedButtonText' => 'Hide hierarchy',
+      'fullTreeviewCollapseClosedButtonText' => 'Show hierarchy'
+    );
+
+    foreach ($settings as $settingName => $settingValue)
+    {
+      if (null === QubitSetting::getByName($settingName))
+      {
+        $setting = new QubitSetting;
+        $setting->name  = $settingName;
+        $setting->scope = 'ui_label';
+        $setting->editable = 1;
+        $setting->deleteable = 0;
+        $setting->source_culture = 'en';
+        $setting->setValue($settingValue, array('culture' => 'en'));
+        $setting->save();
+      }
+    }
+
+    return true;
+  }
+}

--- a/plugins/arDominionPlugin/css/less/search.less
+++ b/plugins/arDominionPlugin/css/less/search.less
@@ -63,7 +63,7 @@ h1 {
 
 // Advanced search
 
-.advanced-search-toggle {
+.advanced-search-toggle, .fullview-treeview-toggle {
   text-align: center;
   display: inline-block;
   width: 100%;
@@ -584,7 +584,7 @@ h1 {
 }
 
 // Similar to #content
-.advanced-search-section {
+.advanced-search-section, .full-treeview-section {
   background-color: @white;
   border: 1px solid @borderOutlineColor;
   .border-radius(4px);


### PR DESCRIPTION
Add, optionally, a collapsible area around the full width treeview on
description pages.