### PR TITLE
Fix creation of DOs without path, refs #13144

### DIFF
--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -1162,6 +1162,13 @@ class QubitDigitalObject extends BaseDigitalObject
       }
     }
 
+    // The path is a not null column but it's not being set in some cases,
+    // like offline digital objects created in the metadata only DIP upload.
+    if (!isset($this->path))
+    {
+      $this->path = '';
+    }
+
     parent::save($connection);
 
     // Create child objects (derivatives)


### PR DESCRIPTION
This issue came out now probably because of the upgrade to MySQL 5.7
and/or the re-addition of `STRICT_TRANS_TABLES` to the `sql_mode`.