### PR TITLE
DIP upload fixes, refs #13067 and #13068

### DIFF
--- a/plugins/qtSwordPlugin/lib/qtPackageExtractorMETSArchivematicaDIP.class.php
+++ b/plugins/qtSwordPlugin/lib/qtPackageExtractorMETSArchivematicaDIP.class.php
@@ -254,11 +254,11 @@ class qtPackageExtractorMETSArchivematicaDIP extends qtPackageExtractorBase
 
   protected function recursivelyAddChildsFromLogicalStructMapDiv($structMapDiv, $parent)
   {
-    $structMapDiv->registerXPathNamespace('m', 'http://www.loc.gov/METS/');
+    $this->metsParser->registerNamespaces($structMapDiv, array('m' => 'mets'));
 
     foreach ($structMapDiv->xpath('m:div') as $item)
     {
-      $item->registerXPathNamespace('m', 'http://www.loc.gov/METS/');
+      $this->metsParser->registerNamespaces($item, array('m' => 'mets'));
 
       // Directory
       if (count($fptr = $item->xpath('m:fptr')) == 0)


### PR DESCRIPTION
**Get namespaces from METS file when possible:**

Use `getDocNamespaces` to get the namespaces declared in the METS file
dynamically from the document. To keep backwards compatibility, add the
old URI for main namespaces if they're not found in the document.

Use a key/name mapping to add those namespaces in XPath queries without
modifying the existing ones.

**Allow different namespaces in DC metadata:**

Allow no namespace and `dc` or `dcterms` namespaces.

**Fix main DMD section finding:**

Use always the physical (default) structMap.

**Fix all DMD section finding:**

The DMDID attribute can contain one or more DMD section ids
(e.g.: DMDID="dmdSec_2 dmdSec_3"). When multiple DMD sections
are associated with the same file/dir we'll try to return the
latest one created.