### PR TITLE
Fix DO metadata component, refs #13145

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/metadataComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/metadataComponent.class.php
@@ -53,5 +53,8 @@ class DigitalObjectMetadataComponent extends sfComponent
     // Provide longitude to template
     $longitudeProperty = $this->object->digitalObjectsRelatedByobjectId[0]->getPropertyByName('longitude');
     $this->longitude = $longitudeProperty->value;
+
+    // Check related object type to display IO properties in the template
+    $this->relatedToIo = $this->resource->object instanceOf QubitInformationObject;
   }
 }

--- a/apps/qubit/modules/digitalobject/templates/_metadata.php
+++ b/apps/qubit/modules/digitalobject/templates/_metadata.php
@@ -47,7 +47,7 @@
     <?php echo render_show(__('Uploaded'), format_date($resource->createdAt, 'f'), array('fieldLabel' => 'uploaded')) ?>
   <?php endif; ?>
 
-  <?php if ($sf_user->isAuthenticated() && $resource->object instanceOf QubitInformationObject): ?>
+  <?php if ($sf_user->isAuthenticated() && $relatedToIo): ?>
     <?php echo render_show(__('Object UUID'), render_value($resource->object->objectUUID), array('fieldLabel' => 'objectUUID')) ?>
     <?php echo render_show(__('AIP UUID'), render_value($resource->object->aipUUID), array('fieldLabel' => 'aipUUID')) ?>
     <?php echo render_show(__('Format name'), render_value($resource->object->formatName), array('fieldLabel' => 'formatName')) ?>


### PR DESCRIPTION
When Markdown is disabled the escaping strategy converts
`$resource->object` to an instance of `sfOutputEscaperObjectDecorator`,
which fails to match `QubitInformationObject` when it's compared in the
template. Check the related resource type in the component action
before the transformation happens.