### PR TITLE
Render repo description as Parsedown, refs #13106

### DIFF
--- a/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
@@ -38,7 +38,7 @@
   <?php if ($sf_data->getRaw('htmlSnippet')): ?>
     <div class="row" id="repository-html-snippet">
       <div class="span7">
-        <?php echo $sf_data->getRaw('htmlSnippet') // Using htmlpurifier ?>
+        <?php echo render_value_html($sf_data->getRaw('htmlSnippet')) ?>
       </div>
     </div>
   <?php endif; ?>


### PR DESCRIPTION
Render the repo description HTML field as Parsedown rather than just
HTML.