### PR TITLE
Add new SECURITY.md, refs #13139

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,98 @@
 # Contributing
 
-Thank you for your interest in contributing to the Access to Memory
-(AtoM) project! Third-party patches and community development help keep the
-AtoM project vibrant and responsive to our users' needs. We hope to simplify
-the contribution process as much as possible. We have posted some simple
+Thank you for your interest in contributing to the Access to Memory (AtoM)
+project! Third-party patches and community development help keep the AtoM
+project vibrant and responsive to our users' needs. We hope to simplify the
+contribution process as much as possible. We have posted some simple
 guidelines to help you get started. Please review these guidelines before
-making pull requests or patch contributions to the AtoM project.
-
-To get help with bugs or to submit bug reports, visit our [community page](https://www.accesstomemory.org/community).
-
-If you're considering contributing code to the project, please read our [contribution page](https://wiki.accesstomemory.org/Development/Contribute_code) and familiarize yourself with our coding style and code review guidelines.
+reporting issues or making pull requests to the AtoM project.
 
 Thanks!
+
+**Contents**
+
+* [Reporting general bugs](#reporting-general-bugs)
+* [Contributing code](#contributing-code)
+* [Contributing documentation and translations](#contributing-documentation-and-translations)
+
+## Reporting general bugs
+
+**If you are reporting a security vulnerability**, please consult the
+instructions in our SECURITY.md file before proceeding. If you have discovered
+an issue in AtoM that is **not** related to a security vulnerability, we
+welcome your reports.
+
+You can report general bugs in two ways: 
+
+* By creating a new post in the [AtoM user forum](https://groups.google.com/forum/#!forum/ica-atom-users)
+* By [opening an issue](https://github.com/artefactual/atom/issues) in our
+  GitHub repository
+
+Please be sure to include all the information we will need to reproduce the
+issue locally. This includes:
+
+* The version of AtoM you are using
+* Basic information about your installation environment, including PHP, MySQL,
+  Elasticsearch, and operating system versions
+* Steps to reproduce the issue
+* The resulting error or vulnerability and the expected outcome
+* If there are any error logs related to the issue, please include the
+  relevant parts as well
+
+You can find more useful information on how to find this information in the
+Troubleshooting page in our documentation:
+
+* https://www.accesstomemory.org/docs/latest/admin-manual/maintenance/troubleshooting/
+
+Note as well that, as a community-driven open source project, we depend on our
+community to be able to maintain and develop AtoM. We are committed to
+including as many bug fixes as we can in each new release, but a confirmed
+report is not enough alone to guarantee that a fix will be included in the
+next release. If your institution is interested in sponsoring a fix, feel free
+to contact Artefactual Systems for an estimate - all sponsored development
+will be included in the next public release. For more information on how we
+develop and maintain AtoM, please see:
+
+* https://wiki.accesstomemory.org/Development/Philosophy
+
+We also welcome pull requests to fix issues!
+
+## Contributing code
+
+If you're considering contributing code to the project, please read our
+contribution page and familiarize yourself with our coding style and code
+review guidelines.
+
+* Find out more about our Code Review process here: [Code review](https://wiki.accesstomemory.org/Development/Code_review)
+* Learn about our Coding standards here: [Coding standard](https://wiki.accesstomemory.org/Development/Coding_standard)
+* Find information about our Code repository here: [Code repository](https://wiki.accesstomemory.org/Resources/Code_repository)
+
+We ask that all code contributors complete and return a signed Contributor’s
+Agreement before we will review and merge your contribution. This is to
+protect both you and the AtoM project - for more details and a link to the
+Contributor’s Agreement, see the 
+[Copyright and license](https://wiki.accesstomemory.org/Development/Contribute_code#Copyright_and_license) 
+section of our contributing page on the wiki. Signed agreements can be sent 
+to:
+
+* [agreement@artefactual.com](mailto:agreement@artefactual.com) 
+
+**If you are working on a larger pull request and/or new feature**, please be
+sure to read this page:
+
+* https://wiki.accesstomemory.org/Development/Recommendations
+
+## Contributing documentation and translations
+
+If you would like to help us improve the AtoM documentation, please see our
+wiki for more information:
+
+* https://wiki.accesstomemory.org/Resources/Documentation
+
+Additionally, with each new AtoM release we include user interface
+translations generously provided by our volunteer translator community. To
+learn more, including how you can help contribute translations, please see:
+
+* https://wiki.accesstomemory.org/Resources/Translation
+
+Thanks! 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,117 @@
+# Security Policy
+
+This document outlines security procedures and general policies for the Access
+to Memory (AtoM) project. For more general information on AtoM, see:
+
+* https://www.accesstomemory.org.
+
+**Contents**
+
+* [Reporting a security vulnerability](#reporting-a-security-vulnerability)
+* [Disclosure policy](#disclosure-policy)
+* [Supported versions](#supported-versions)
+* [AtoM and security overview](#atom-and-security-overview)
+* [Reporting general bugs](#reporting-general-bugs)
+
+## Reporting a security vulnerability
+
+The AtoM development team takes security seriously and will investigate all
+reported vulnerabilities. Thank you for your interest in helping!
+
+If you would like to report a vulnerability or have a security concern
+regarding AtoM, **please do not file a public issue in our GitHub
+repository.** Instead, please email a report to:
+
+* [security@accesstomemory.org](mailto:security@accesstomemory.org)
+
+We will be better able to evaluate and respond to your report if it includes
+all the details needed for us to reproduce the issue locally. Please include
+the following information in your email:
+
+* The version of AtoM you are using
+* Basic information about your installation environment, including PHP, MySQL,
+  Elasticsearch, and operating system versions
+* Steps to reproduce the issue The resulting error or vulnerability
+* If there are any error logs related to the issue, please include the
+  relevant parts as well
+
+Your report will be acknowledged within 2 business days, and we’ll follow up
+with a more detailed response indicating the next steps we intend to take
+within 1 week.
+
+If you haven’t received a reply to your submission after 5 business days of
+the original report, there are a couple steps you can take:
+
+* Email the AtoM Program Manager directly: dan@artefactual.com 
+* Join the [AtoM user forum](https://groups.google.com/forum/#!forum/ica-atom-users)
+
+Please note that the AtoM user forum is a public forum not suitable for
+discussing security vulnerabilities without potentially impacting other users.
+**When escalating in the User forum, please do not discuss your issue**.
+Simply say that you are trying to get a hold of someone from the AtoM
+development team, and we will follow up with you off-list.
+
+Any information you share with the AtoM development team as a part of this
+process will be kept confidential within the team. If we determine that the
+vulnerability is located upstream in one of the libraries or dependencies that
+AtoM uses, we may need to share some information about the report with the
+dependency’s core team - in this case, we will notify you before proceeding.
+
+If the vulnerability is first reported by you, we will credit you with the
+discovery in the public disclosure, unless you tell us you would prefer to
+remain anonymous. 
+
+## Disclosure policy 
+
+When the AtoM development team receives a security bug report, we will assign
+it to a primary handler. This person will coordinate the fix and release
+process, involving the following steps:
+
+* Confirm the problem and determine the affected versions;
+* Audit code to find any similar potential problems;
+* Prepare fixes for all releases still under maintenance. These fixes will be
+  released as fast as possible.
+
+Once new releases and/or security patches have been prepared, tested, and made
+publicly available, we will also make a post in the AtoM user forum advising
+users of the issue, and encouraging them to upgrade (or apply the supplied
+patch) as soon as possible. Any internal tickets created in our issue tracker
+related to the issue will be made public after disclosure, and referenced in
+the release notes for the new version(s). 
+
+## Supported versions
+
+In the case of a confirmed security issue, we will add the fix to the most
+recent stable branch, and the development branch (prefaced by `qa/` in our
+branch naming conventions. For more information on this, see 
+[this section](https://wiki.accesstomemory.org/Resources/Code_repository#Branch_organization)
+of our wiki). If the severity of the issue is high, we may in some cases also
+backport the fix to the previous stable branch as well (e.g. `stable.2.5.x`,
+etc), so that community users running a legacy version have the option of
+adding the fix as a patch to their local installations. We will attempt to
+ensure that fixes, and/or a confirmed workaround that resolves the security
+issue, are available prior to disclosing any security issues publicly.
+
+## AtoM and security overview
+
+AtoM’s security guidelines are available here: 
+
+* https://www.accesstomemory.org/docs/latest/#security
+
+AtoM also provides additional security measures via the administrative
+settings in the user interface - see:
+
+* https://www.accesstomemory.org/docs/latest/user-manual/administer/settings/#security-panel
+
+To provide greater redundancy in the case of something going wrong, users may
+be interested in learning more about AtoM’s 2-site deployment model and
+replication script. For more information, see:
+
+* https://www.slideshare.net/accesstomemory/2-sitereplication-with-atom
+* https://github.com/artefactual-labs/atom-replication
+
+## Reporting general bugs
+
+If you have discovered an issue in AtoM that is **not related to a security
+vulnerability**, we welcome your reports. Please see our CONTRIBUTING.md file
+for more information.


### PR DESCRIPTION
This PR introduces a new SECURITY.md files to the AtoM repository, which includes information on AtoM's security reporting and disclosure policies. 

Additionally, some enhancements have been added to the CONTRIBUTING.md file. 