### PR TITLE
Escape entities, refs #13125

### DIFF
--- a/apps/qubit/modules/search/templates/_filterTag.php
+++ b/apps/qubit/modules/search/templates/_filterTag.php
@@ -1,6 +1,6 @@
 <span class="search-filter">
   <?php if (!empty($label)): ?>
-    <?php echo $label ?>
+    <?php echo esc_entities($label) ?>
   <?php else: ?>
     <?php echo render_title($object) ?>
   <?php endif; ?>

--- a/apps/qubit/modules/search/templates/_inlineSearch.php
+++ b/apps/qubit/modules/search/templates/_inlineSearch.php
@@ -33,7 +33,7 @@
       <?php endif; ?>
 
       <?php if (isset($sf_request->subquery)): ?>
-        <input type="text" name="subquery" value="<?php echo $sf_request->subquery ?>" />
+        <input type="text" name="subquery" value="<?php echo esc_entities($sf_request->subquery) ?>" />
         <a class="btn" href="<?php echo $cleanRoute ?>">
           <i class="fa fa-times"></i>
         </a>


### PR DESCRIPTION
- The start and end dates from the adv. search were used to form the
  filter tag label directly from user input.
- The inline-search query was not escaped, this will normally raise an
  ES error before the template is rendered, but it may be an issue if
  the "Escape special chars from searches" setting avoids that error.