### PR TITLE
Update keyboard handling events in JS, refs #12725

### DIFF
--- a/js/dominion.js
+++ b/js/dominion.js
@@ -248,13 +248,7 @@
         this.$element
           .on('focus', $.proxy(this.focus, this))
           .on('blur', $.proxy(this.blur, this))
-          .on('keypress', $.proxy(this.keypress, this))
-          .on('keyup', $.proxy(this.keyup, this));
-
-        if ($.browser.webkit || $.browser.msie)
-        {
-          this.$element.on('keydown', $.proxy(this.keypress, this));
-        }
+          .on('keydown', $.proxy(this.keydown, this));
 
         this.$menu.on('mouseenter', 'li', $.proxy(this.mouseenter, this));
         this.$menu.on('mouseleave', 'li', $.proxy(this.mouseleave, this));
@@ -463,24 +457,20 @@
         }
       },
 
-    keyup: function (e)
+    keydown: function (e)
       {
-        switch (e.keyCode)
+        switch (e.which)
         {
           case 40: // Down arrow
           case 38: // Up arrow
-            // Firefox 65 and higher handle arrows with keyup, not keypress
-            if (YAHOO.env.ua.gecko >= 65)
-            {
-              if (e.keyCode == 38)
-              {
-                this.move(-1);
-              }
-              else
-              {
-                this.move(1);
-              }
-            }
+              this.move((e.which == 38) ? -1 : 1);
+
+            break;
+
+          case 13: // Enter
+            e.preventDefault();
+            this.select();
+
             break;
 
           case 27: // Escape
@@ -500,44 +490,6 @@
                 self.lookup();
               }, this.timeout);
         }
-
-        e.stopPropagation();
-        e.preventDefault();
-      },
-
-    keypress: function (e)
-      {
-        switch (e.keyCode)
-        {
-          case 27: // Escape
-            e.preventDefault();
-            break;
-
-          case 13: // Enter
-            e.preventDefault();
-            this.select();
-            break;
-
-          case 38: // Up arrow
-            // If charCode is 38 then, in Chrome, it's an ampersand
-            if (e.charCode == 0)
-            {
-              e.preventDefault();
-              this.move(-1);
-            }
-            break;
-
-          case 40: // Down arrow
-            // If charCode is 40 then, in Chrome/IE, it's an open parenthesis
-            if (e.charCode == 0)
-            {
-              e.preventDefault();
-              this.move(1);
-            }
-            break;
-        }
-
-        e.stopPropagation();
       },
 
     blur: function (e)
@@ -886,7 +838,7 @@
             $inlineSearch.find('#subqueryField')
               .val($this.data('subquery-field-value'));
           })
-        .on('keypress', 'input', function(e)
+        .on('keydown', 'input', function(e)
           {
             if (e.which == 13)
             {

--- a/js/multiInput.js
+++ b/js/multiInput.js
@@ -31,8 +31,8 @@
                     // Don't fire on keydown other than tab (9) or enter (13)
                     if ($(this).val()
                         && ('keydown' !== event.type
-                          || 9 === event.keyCode
-                          || 13 === event.keyCode))
+                          || 9 === event.which
+                          || 13 === event.which))
                     {
                       // Cancel default action so as not to loose focus
                       if ('keydown' === event.type)

--- a/js/multiRow.js
+++ b/js/multiRow.js
@@ -115,9 +115,9 @@
               })
 
             // If user press enter, add new row
-            .find('input, select').live('keypress', function(event)
+            .find('input, select').live('keydown', function(event)
               {
-                if (event.keyCode == 13 || event.charCode == 13)
+                if (event.which == 13)
                 {
                   var table = $(this).parents('table:first');
 

--- a/js/rename.js
+++ b/js/rename.js
@@ -85,8 +85,8 @@
     enableFields();
 
     // Submit when users hits the enter key
-    $renameForm.on('keypress', function (e) {
-      if (e.keyCode == 13) {
+    $renameForm.on('keydown', function (e) {
+      if (e.which == 13) {
         e.preventDefault();
 
         // If user pressing enter from title field, update slug if enabled

--- a/js/select.js
+++ b/js/select.js
@@ -56,7 +56,7 @@
 
                 .bind('blur click keydown', function (event)
                   {
-                    if ($(this).val() && ('keydown' != event.type || 9 == event.keyCode))
+                    if ($(this).val() && ('keydown' != event.type || 9 == event.which))
                     {
                       // Cancel default action so as not to loose focus
                       if ('keydown' == event.type)

--- a/js/sidebarPaginatedList.js
+++ b/js/sidebarPaginatedList.js
@@ -44,20 +44,20 @@
 
       this.$pageInput.keydown(function (e) {
         // Allow: backspace, delete, tab, escape, enter and .
-        if ($.inArray(e.keyCode, [46, 8, 9, 27, 13, 110, 190]) !== -1 ||
+        if ($.inArray(e.which, [46, 8, 9, 27, 13, 110, 190]) !== -1 ||
            // Allow: Ctrl+A
-          (e.keyCode == 65 && e.ctrlKey === true) ||
+          (e.which == 65 && e.ctrlKey === true) ||
            // Allow: Ctrl+C
-          (e.keyCode == 67 && e.ctrlKey === true) ||
+          (e.which == 67 && e.ctrlKey === true) ||
            // Allow: Ctrl+X
-          (e.keyCode == 88 && e.ctrlKey === true) ||
+          (e.which == 88 && e.ctrlKey === true) ||
            // Allow: home, end, left, right
-          (e.keyCode >= 35 && e.keyCode <= 39)) {
+          (e.which >= 35 && e.which <= 39)) {
                // let it happen, don't do anything
                return;
         }
         // Ensure that it is a number and stop the keypress
-        if ((e.shiftKey || (e.keyCode < 48 || e.keyCode > 57)) && (e.keyCode < 96 || e.keyCode > 105)) {
+        if ((e.shiftKey || (e.which < 48 || e.which > 57)) && (e.which < 96 || e.which > 105)) {
           e.preventDefault();
         }
       });


### PR DESCRIPTION
Updates keyboard handling events to remove use of the deprecated
"keypress" event and "keyCode" event properties replacing these,
respectively, with "keydown" events and "which" event properties.
jQuery populates the "which" event property even in browsers that
don't support "which" natively.