### PR TITLE
Fix OAI base URL in identify XML, refs #13163

### DIFF
--- a/lib/oai/QubitOai.class.php
+++ b/lib/oai/QubitOai.class.php
@@ -170,29 +170,6 @@ class QubitOai
   }
 
   /**
-   * Extracts the port and script name, and derives the scheme, from the _SERVER global.
-   * Then, combines those with the user-defined siteBaseUrl setting to form the base URL.
-   *
-   * @return string base URL
-   */
-  public static function getBaseUrl()
-  {
-    $scheme = $_SERVER['HTTPS'] == 'on' ? 'https://' : 'http://';
-    
-    $siteBaseUrl = QubitSetting::getByName('siteBaseUrl')->getValue(array('cultureFallback' => true));
-    $host = QubitOai::parseUrlHost($siteBaseUrl);
-    
-    $baseURL = $scheme.$host;
-    if ($_SERVER['SERVER_PORT'] != '80')
-    {
-      $baseURL .= ':'.$_SERVER['SERVER_PORT'];
-    }
-    $baseURL .= $_SERVER['SCRIPT_NAME'];
-    
-    return $baseURL;
-  }
-
-  /**
    * Returns formated date
    *
    * @param string  $date optional date value

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/actions/identifyComponent.class.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/actions/identifyComponent.class.php
@@ -35,6 +35,7 @@ class arOaiPluginIdentifyComponent extends arOaiPluginComponent
     list ($this->earliestDatestamp) = Propel::getConnection()->query('SELECT MIN('.QubitObject::UPDATED_AT.') FROM '.QubitObject::TABLE_NAME)->fetch();
     $this->earliestDatestamp = date_format(date_create($this->earliestDatestamp), 'Y-m-d\TH:i:s\Z');
 
+    $this->baseUrl = QubitSetting::getByName('siteBaseUrl')->getValue(array('sourceCulture' => true));
     $this->granularity = 'YYYY-MM-DDThh:mm:ssZ';
     $this->deletedRecord = 'no';
     $this->compression = 'gzip';

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_identify.xml.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_identify.xml.php
@@ -1,6 +1,6 @@
   <Identify>
     <repositoryName><?php echo esc_specialchars($title) ?></repositoryName>
-    <baseURL><?php echo QubitOai::getBaseUrl() ?></baseURL>
+    <baseURL><?php echo $baseUrl ?></baseURL>
     <protocolVersion><?php echo $protocolVersion ?></protocolVersion>
     <?php foreach ($adminEmails as $email): ?>
       <adminEmail><?php echo trim($email) ?></adminEmail>


### PR DESCRIPTION
When AtoM's base URL was set to an "https" URL the identify response
was changing this to an "http" URL. Fixed and simplified.