### PR TITLE
Update storage perms, refs #13169

### DIFF
--- a/apps/qubit/modules/physicalobject/config/security.yml
+++ b/apps/qubit/modules/physicalobject/config/security.yml
@@ -1,13 +1,20 @@
-browse:
-  credentials: administrator
-
-delete:
-  credentials: [[ contributor, editor, administrator ]]
-  is_secure: true
-
-edit:
-  credentials: [[ contributor, editor, administrator, translator ]]
-  is_secure: true
-
 all:
   is_secure: true
+
+autocomplete:
+  credentials: [[ administrator, contributor, editor ]]
+
+boxList:
+  credentials: [[ administrator, editor ]]
+
+browse:
+  credentials: [[ administrator, editor, translator ]]
+
+delete:
+  credentials: [[ administrator, editor ]]
+
+edit:
+  credentials: [[ administrator, editor, translator ]]
+
+index:
+  credentials: [[ administrator, contributor, editor, translator ]]


### PR DESCRIPTION
In the 2.4 release, we discovered some inconsistencies in the default permissions, and that authenticated users who were not part of any group could access modules they should not be able to view. We corrected many of these in issue #[11075](https://projects.artefactual.com/issues/11075).

However, in that fix, we implemented too extreme a solution, allowing only administrators to view the physical storage module. There are many cases where Editors may need access, and local translators may also need to add translated container names.

It turns out that the default permissions are contained in a configurable YAML file, located here:

* https://github.com/artefactual/atom/blob/HEAD/apps/qubit/modules/physicalobject/config/security.yml

This fix will change the default permissions so that:

* Administrators, Contributors, Editors, and Translators can view and browse physical storage
* Administrators, Editors, and Translators, can edit physical storage containers
* Administrators and Editors can delete physical storage containers

For any users who wish to restrict these permissions further, they can make local edits to the YAML file listed above.