### PR TITLE
 Improve alphabetic sort, refs #5173

### DIFF
--- a/apps/qubit/modules/actor/actions/browseAction.class.php
+++ b/apps/qubit/modules/actor/actions/browseAction.class.php
@@ -253,7 +253,7 @@ class ActorBrowseAction extends DefaultBrowseAction
     {
       // I don't think that this is going to scale, but let's leave it for now
       case 'alphabetic':
-        $field = sprintf('i18n.%s.authorizedFormOfName.untouched', $this->selectedCulture);
+        $field = sprintf('i18n.%s.authorizedFormOfName.alphasort', $this->selectedCulture);
         $this->search->query->setSort(array($field => $request->sortDir));
 
         break;

--- a/apps/qubit/modules/actor/actions/relatedInformationObjectsAction.class.php
+++ b/apps/qubit/modules/actor/actions/relatedInformationObjectsAction.class.php
@@ -103,7 +103,7 @@ class ActorRelatedInformationObjectsAction extends sfAction
     }
 
     QubitAclSearch::filterDrafts($queryBool);
-    $title = sprintf('i18n.%s.title.untouched', sfContext::getInstance()->user->getCulture());
+    $title = sprintf('i18n.%s.title.alphasort', sfContext::getInstance()->user->getCulture());
 
     $query->setQuery($queryBool);
     $query->setSort(array($title => 'asc'));

--- a/apps/qubit/modules/informationobject/actions/autocompleteAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/autocompleteAction.class.php
@@ -41,7 +41,7 @@ class InformationObjectAutocompleteAction extends sfAction
     $this->query->setSort(array(
       'levelOfDescriptionId' => 'asc',
       'identifier.untouched' => 'asc',
-      'i18n.'.$culture.'.title.untouched' => 'asc'));
+      'i18n.'.$culture.'.title.alphasort' => 'asc'));
 
     $this->queryBool = new \Elastica\Query\BoolQuery;
 
@@ -63,7 +63,7 @@ class InformationObjectAutocompleteAction extends sfAction
         $this->query->setSort(array(
           'levelOfDescriptionId' => 'asc',
           'referenceCode.untouched' => 'asc',
-          'i18n.'.$culture.'.title.untouched' => 'asc'));
+          'i18n.'.$culture.'.title.alphasort' => 'asc'));
       }
       else
       {

--- a/apps/qubit/modules/informationobject/actions/browseAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/browseAction.class.php
@@ -542,7 +542,7 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
         break;
 
       case 'alphabetic':
-        $field = sprintf('i18n.%s.title.untouched', $this->selectedCulture);
+        $field = sprintf('i18n.%s.title.alphasort', $this->selectedCulture);
         $this->search->query->addSort(array($field => $request->sortDir));
 
         break;

--- a/apps/qubit/modules/informationobject/actions/inventoryAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/inventoryAction.class.php
@@ -120,12 +120,12 @@ class InformationObjectInventoryAction extends DefaultBrowseAction
         break;
 
       case 'titleUp':
-        $query->setSort(array($i18n.'title.untouched' => 'asc'));
+        $query->setSort(array($i18n.'title.alphasort' => 'asc'));
 
         break;
 
       case 'titleDown':
-        $query->setSort(array($i18n.'title.untouched' => 'desc'));
+        $query->setSort(array($i18n.'title.alphasort' => 'desc'));
 
         break;
 

--- a/apps/qubit/modules/repository/actions/browseAction.class.php
+++ b/apps/qubit/modules/repository/actions/browseAction.class.php
@@ -134,11 +134,11 @@ class RepositoryBrowseAction extends DefaultBrowseAction
     switch ($request->sort)
     {
       case 'nameUp':
-        $this->search->query->setSort(array($i18n.'authorizedFormOfName.untouched' => 'asc'));
+        $this->search->query->setSort(array($i18n.'authorizedFormOfName.alphasort' => 'asc'));
         break;
 
       case 'nameDown':
-        $this->search->query->setSort(array($i18n.'authorizedFormOfName.untouched' => 'desc'));
+        $this->search->query->setSort(array($i18n.'authorizedFormOfName.alphasort' => 'desc'));
         break;
 
       case 'regionUp':
@@ -159,9 +159,9 @@ class RepositoryBrowseAction extends DefaultBrowseAction
 
       case 'identifier':
         $this->search->query->addSort(array('identifier.untouched' => $request->sortDir));
-      case 'alphabetic':
-        $this->search->query->addSort(array($i18n.'authorizedFormOfName.untouched' => $request->sortDir));
 
+      case 'alphabetic':
+        $this->search->query->addSort(array($i18n.'authorizedFormOfName.alphasort' => $request->sortDir));
         break;
 
       case 'lastUpdated':

--- a/apps/qubit/modules/repository/actions/holdingsAction.class.php
+++ b/apps/qubit/modules/repository/actions/holdingsAction.class.php
@@ -38,7 +38,7 @@ class RepositoryHoldingsAction extends sfAction
       // Return nothing to not break the list
       return;
     }
-    
+
     $resultSet = self::getHoldings($request->id, $request->page, $limit);
 
     $pager = new QubitSearchPager($resultSet);
@@ -85,7 +85,7 @@ class RepositoryHoldingsAction extends sfAction
     $query->setSize($limit);
     $query->setFrom($limit * ($page - 1));
 
-    $title = sprintf('i18n.%s.title.untouched', sfContext::getInstance()->user->getCulture());
+    $title = sprintf('i18n.%s.title.alphasort', sfContext::getInstance()->user->getCulture());
     $query->setSort(array($title => 'asc'));
 
     $resultSet = QubitSearch::getInstance()->index->getType('QubitInformationObject')->search($query);

--- a/apps/qubit/modules/repository/actions/maintainedActorsAction.class.php
+++ b/apps/qubit/modules/repository/actions/maintainedActorsAction.class.php
@@ -78,7 +78,7 @@ class RepositoryMaintainedActorsAction extends sfAction
     $query->setSize($limit);
     $query->setFrom($limit * ($page - 1));
 
-    $field = sprintf('i18n.%s.authorizedFormOfName.untouched', sfContext::getInstance()->user->getCulture());
+    $field = sprintf('i18n.%s.authorizedFormOfName.alphasort', sfContext::getInstance()->user->getCulture());
     $query->setSort(array($field => 'asc'));
 
     $resultSet = QubitSearch::getInstance()->index->getType('QubitActor')->search($query);

--- a/apps/qubit/modules/taxonomy/actions/indexAction.class.php
+++ b/apps/qubit/modules/taxonomy/actions/indexAction.class.php
@@ -38,7 +38,7 @@ class TaxonomyIndexAction extends sfAction
       $this->resource = $this->getRoute()->resource;
     }
 
-    // Explicitly add resource to sf_route to make it available to components 
+    // Explicitly add resource to sf_route to make it available to components
     $request->getAttribute('sf_route')->resource = $this->resource;
 
     // Disallow access to locked taxonomies
@@ -203,7 +203,7 @@ class TaxonomyIndexAction extends sfAction
     {
       // I don't think that this is going to scale, but let's leave it for now
       case 'alphabetic':
-        $field = sprintf('i18n.%s.name.untouched', $culture);
+        $field = sprintf('i18n.%s.name.alphasort', $culture);
         $this->query->setSort(array($field => $request->sortDir));
 
         break;

--- a/apps/qubit/modules/term/actions/indexAction.class.php
+++ b/apps/qubit/modules/term/actions/indexAction.class.php
@@ -286,7 +286,7 @@ EOF;
             break;
 
           case 'alphabetic':
-            $field = sprintf('i18n.%s.title.untouched', $this->culture);
+            $field = sprintf('i18n.%s.title.alphasort', $this->culture);
             $this->search->query->setSort(array($field => $request->sortDir));
             break;
 
@@ -327,7 +327,7 @@ EOF;
 
     $listQuery = new \Elastica\Query();
     $listQuery->setSize($request->listLimit);
-    $listQuery->setSort(array(sprintf('i18n.%s.name.untouched', $this->culture) => 'asc'));
+    $listQuery->setSort(array(sprintf('i18n.%s.name.alphasort', $this->culture) => 'asc'));
 
     if (!empty($request->listPage))
     {

--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -315,6 +315,7 @@ mapping:
       timestamp: true
       autocompleteFields: [name]
       rawFields:  [name]
+      sortFields: [name]
     _foreign_types: { use_for: other_name, scope_notes: note }
     dynamic: strict
     properties:
@@ -329,6 +330,7 @@ mapping:
       timestamp: true
       autocompleteFields: [authorizedFormOfName]
       rawFields:  [authorizedFormOfName]
+      sortFields: [authorizedFormOfName]
     _foreign_types:
       maintenance_notes: note
       other_names: other_name
@@ -370,6 +372,7 @@ mapping:
       i18n: true
       timestamp: true
       rawFields:  [title]
+      sortFields: [title]
     _foreign_types: { donors: donor, creators: actor }
     dynamic: strict
     properties:
@@ -388,6 +391,7 @@ mapping:
       timestamp: true
       autocompleteFields: [authorizedFormOfName]
       rawFields:  [authorizedFormOfName, region, city]
+      sortFields: [authorizedFormOfName]
     _foreign_types:
       contact_informations: contact_information
       other_names: other_name
@@ -430,6 +434,7 @@ mapping:
       timestamp: true
       autocompleteFields: [title]
       rawFields:  [title]
+      sortFields: [title]
       # Select which foreign type i18n fields we'll include when searching _all
       i18nIncludeInAll:
         - repository.authorizedFormOfName

--- a/plugins/arElasticSearchPlugin/config/search.yml
+++ b/plugins/arElasticSearchPlugin/config/search.yml
@@ -126,6 +126,14 @@ all:
             tokenizer: standard
             filter: [lowercase, turkish_stop, preserved_asciifolding]
 
+        normalizer:
+          # Custom normalizer that lowercases text, removes punctation, and
+          # does ascii folding for more natural alphabetic sorting
+          alphasort:
+            type: custom
+            filter: [lowercase, preserved_asciifolding]
+            char_filter: [punctuation_filter]
+
         filter:
           engram:
             type: edgeNGram
@@ -222,7 +230,6 @@ all:
             type: stop
             stopwords: _turkish_
 
-
         char_filter:
 
           # This char_filter is added to all analyzers when the index
@@ -237,6 +244,12 @@ all:
             type: pattern_replace
             pattern: '[\*_#!\[\]\(\)\->`\+\\~:\|\^=]'
             replacement: ' '
+
+          # Strip punctation from a string
+          punctuation_filter:
+            type: pattern_replace
+            pattern: '["''_\-\?!\.\(\)\[\]#\*`:;]'
+            replacement: ''
 
       # Disable dynamic creation of mappings for unmapped types
       mapper:

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchMapping.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchMapping.class.php
@@ -279,6 +279,8 @@ class arElasticSearchMapping
             }
           }
 
+          $nestedI18nFields = $this->addSortFields($nestedI18nFields, $typeProperties);
+
           // i18n documents (one per culture)
           $nestedI18nObjects = $this->getNestedI18nObjects($languages, $nestedI18nFields);
 
@@ -481,5 +483,30 @@ class arElasticSearchMapping
     $mapping['languages'] = array('type' => 'keyword');
 
     return $mapping;
+  }
+
+  /**
+   * Add "alphasort" Elasticsearch fields
+   *
+   * Add i18n "alphasort" keyword field that is lowercase, has punctation
+   * stripped, and is ASCII folded to allow more natural alphabetic sorting
+   */
+  protected function addSortFields($nestedI18nFields, $typeProperties)
+  {
+    if (!isset($typeProperties['_attributes']['sortFields']))
+    {
+      return $nestedI18nFields;
+    }
+
+    foreach ($typeProperties['_attributes']['sortFields'] as $item)
+    {
+      $nestedI18nFields[$item]['fields']['alphasort'] = array(
+        'type' => 'keyword',
+        'normalizer' => 'alphasort',
+        'include_in_all' => false,
+      );
+    }
+
+    return $nestedI18nFields;
   }
 }

--- a/plugins/arRestApiPlugin/modules/api/actions/informationobjectsBrowseAction.class.php
+++ b/plugins/arRestApiPlugin/modules/api/actions/informationobjectsBrowseAction.class.php
@@ -71,7 +71,7 @@ class ApiInformationObjectsBrowseAction extends QubitApiAction
 
       // I don't think that this is going to scale, but let's leave it for now
       case 'alphabetic':
-        $field = sprintf('i18n.%s.title.untouched', sfContext::getInstance()->user->getCulture());
+        $field = sprintf('i18n.%s.title.alphasort', sfContext::getInstance()->user->getCulture());
         $order = 'asc';
         break;
 

--- a/plugins/qtAccessionPlugin/modules/accession/actions/browseAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/browseAction.class.php
@@ -142,7 +142,7 @@ class AccessionBrowseAction extends sfAction
 
       case 'title':
       case 'alphabetic': // For backward compatibility
-        $field = sprintf('i18n.%s.title.untouched', $this->context->user->getCulture());
+        $field = sprintf('i18n.%s.title.alphasort', $this->context->user->getCulture());
         $this->query->addSort(array($field => $request->sortDir));
 
         break;


### PR DESCRIPTION
- Add custom 'alphasort' normalizer that converts text to lowercase, removes punctation, and does ASCII folding
- Add "sortFields" parameter to ES mapping which creates special "alphasort" keyword field
- Add information_object_i18n.title and actor.authorizedFormOfName "alphasort" fields to ES index
- Use alphasort field for actor, information object, and repository sorting