### PR TITLE
Remove identifier Markdown parsing, refs #13173

### DIFF
--- a/apps/qubit/modules/informationobject/actions/headerComponent.class.php
+++ b/apps/qubit/modules/informationobject/actions/headerComponent.class.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class InformationObjectHeaderComponent extends sfComponent
+{
+  public function execute($request)
+  {
+    $this->levelOfDescriptionAndIdentifier = $this->assemblelevelOfDescriptionAndIdentifierText();
+  }
+
+  public function assemblelevelOfDescriptionAndIdentifierText($resource)
+  {
+    $string = '';
+
+    // Add level of description, if set and not hidden
+    if (!$this->hideLevelOfDescription)
+    {
+      if (isset($this->resource->levelOfDescription))
+      {
+        $string .= $this->resource->levelOfDescription->__toString();
+      }
+    }
+
+    // Add identifier, if set
+    if (isset($this->resource->identifier))
+    {
+      $string .= (!empty($string)) ? ' ' : '';
+      $string .= $this->resource->identifier;
+    }
+
+    return $string;
+  }
+}

--- a/apps/qubit/modules/informationobject/templates/_alternativeIdentifiersIndex.php
+++ b/apps/qubit/modules/informationobject/templates/_alternativeIdentifiersIndex.php
@@ -4,7 +4,7 @@
 
   <div>
     <?php foreach ($resource->getProperties(null, 'alternativeIdentifiers') as $item): ?>
-      <?php echo render_show(render_value_inline($item->name), render_value_inline($item->getValue(array('cultureFallback' => true)))) ?>
+      <?php echo render_show(render_value_inline($item->name), $item->getValue(array('cultureFallback' => true))) ?>
     <?php endforeach; ?>
   </div>
 

--- a/apps/qubit/modules/informationobject/templates/_header.php
+++ b/apps/qubit/modules/informationobject/templates/_header.php
@@ -1,0 +1,1 @@
+<h1><?php echo $levelOfDescriptionAndIdentifier ?><?php if (!empty($levelOfDescriptionAndIdentifier)): ?> - <?php endif; ?><?php echo render_title($title) ?></h1>

--- a/plugins/arDacsPlugin/modules/arDacsPlugin/templates/indexSuccess.php
+++ b/plugins/arDacsPlugin/modules/arDacsPlugin/templates/indexSuccess.php
@@ -61,7 +61,7 @@
     <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Identity elements').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'identityArea', 'title' => __('Edit identity elements'))) ?>
   <?php endif; ?>
 
-  <?php echo render_show(__('Reference code'), render_value($dacs->referenceCode)) ?>
+  <?php echo render_show(__('Reference code'), $dacs->referenceCode) ?>
 
   <?php echo render_show_repository(__('Name and location of repository'), $resource) ?>
 

--- a/plugins/sfDcPlugin/lib/sfDcPlugin.class.php
+++ b/plugins/sfDcPlugin/lib/sfDcPlugin.class.php
@@ -37,32 +37,23 @@ class sfDcPlugin implements ArrayAccess
 
   public function __toString()
   {
-    $string = array();
+    $string = '';
 
-    if (isset($this->resource->identifier))
-    {
-      $string[] = $this->resource->identifier;
-    }
-
-    $resourceAndPublicationStatus = array();
-
+    // Add title if set
     if (0 < strlen($title = $this->resource->__toString()))
     {
-      $resourceAndPublicationStatus[] = $title;
+      $string .= $title;
     }
 
+    // Add publication status
     $publicationStatus = $this->resource->getPublicationStatus();
     if (isset($publicationStatus) && QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $publicationStatus->statusId)
     {
-      $resourceAndPublicationStatus[] = "({$publicationStatus->status->__toString()})";
+      $string .= (!empty($string)) ? ' ' : '';
+      $string .= "({$publicationStatus->status->__toString()})";
     }
 
-    if (0 < count($resourceAndPublicationStatus))
-    {
-      $string[] = implode($resourceAndPublicationStatus, ' ');
-    }
-
-    return implode(' - ', $string);
+    return $string;
   }
 
   public function offsetExists($offset)

--- a/plugins/sfDcPlugin/modules/sfDcPlugin/templates/editSuccess.php
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/templates/editSuccess.php
@@ -9,7 +9,7 @@
 
 <?php slot('title') ?>
 
-  <h1><?php echo render_title($dc) ?></h1>
+  <?php echo get_component('informationobject', 'header', array('resource' => $resource, 'title' => (string)$dc, 'hideLevelOfDescription' => true)) ?>
 
   <?php if (isset($sf_request->source)): ?>
     <div class="messages status">

--- a/plugins/sfDcPlugin/modules/sfDcPlugin/templates/indexSuccess.php
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/templates/indexSuccess.php
@@ -6,7 +6,7 @@
 
 <?php slot('title') ?>
 
-  <h1><?php echo render_title($dc) ?></h1>
+  <?php echo get_component('informationobject', 'header', array('resource' => $resource, 'title' => (string)$dc, 'hideLevelOfDescription' => true)) ?>
 
   <?php if (isset($errorSchema)): ?>
     <div class="messages error">
@@ -57,7 +57,7 @@
 
   <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Elements area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'mainArea', 'title' => __('Edit elements area'))) ?>
 
-  <?php echo render_show(__('Identifier'), render_value($resource->identifier)) ?>
+  <?php echo render_show(__('Identifier'), $resource->identifier) ?>
 
   <?php echo render_show(__('Title'), render_value($resource->getTitle(array('cultureFallback' => true)))) ?>
 

--- a/plugins/sfIsadPlugin/lib/sfIsadPlugin.class.php
+++ b/plugins/sfIsadPlugin/lib/sfIsadPlugin.class.php
@@ -38,44 +38,23 @@ class sfIsadPlugin implements ArrayAccess
 
   public function __toString()
   {
-    $string = array();
+    $string = '';
 
-    $levelOfDescriptionAndIdentifier = array();
-
-    if (isset($this->resource->levelOfDescription))
-    {
-      $levelOfDescriptionAndIdentifier[] = $this->resource->levelOfDescription->__toString();
-    }
-
-    if (isset($this->resource->identifier))
-    {
-      $levelOfDescriptionAndIdentifier[] = $this->resource->identifier;
-    }
-
-    if (0 < count($levelOfDescriptionAndIdentifier))
-    {
-      $string[] = implode($levelOfDescriptionAndIdentifier, ' ');
-    }
-
-    $titleAndPublicationStatus = array();
-
+    // Add title if set
     if (0 < strlen($title = $this->resource->__toString()))
     {
-      $titleAndPublicationStatus[] = $title;
+      $string .= $title;
     }
 
+    // Add publication status
     $publicationStatus = $this->resource->getPublicationStatus();
     if (isset($publicationStatus) && QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $publicationStatus->statusId)
     {
-      $titleAndPublicationStatus[] = "({$publicationStatus->status->__toString()})";
+      $string .= (!empty($string)) ? ' ' : '';
+      $string .= "({$publicationStatus->status->__toString()})";
     }
 
-    if (0 < count($titleAndPublicationStatus))
-    {
-      $string[] = implode($titleAndPublicationStatus, ' ');
-    }
-
-    return implode(' - ', $string);
+    return $string;
   }
 
   public function __get($name)

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/editSuccess.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/editSuccess.php
@@ -8,7 +8,7 @@
 <?php end_slot() ?>
 
 <?php slot('title') ?>
-  <h1><?php echo render_title($isad) ?></h1>
+  <?php echo get_component('informationobject', 'header', array('resource' => $resource, 'title' => (string)$isad)) ?>
 
   <?php if (isset($sf_request->source)): ?>
     <div class="messages status">

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/indexSuccess.php
@@ -6,7 +6,7 @@
 
 <?php slot('title') ?>
 
-  <h1><?php echo render_title($isad) ?></h1>
+  <?php echo get_component('informationobject', 'header', array('resource' => $resource, 'title' => (string)$isad)) ?>
 
   <?php if (isset($errorSchema)): ?>
     <div class="messages error">
@@ -61,7 +61,7 @@
     <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Identity area').'</h2>', array($resource, 'module' => 'informationobject', 'action' => 'edit'), array('anchor' => 'identityArea', 'title' => __('Edit identity area'))) ?>
   <?php endif; ?>
 
-  <?php echo render_show(__('Reference code'), render_value($isad->referenceCode), array('fieldLabel' => 'referenceCode')) ?>
+  <?php echo render_show(__('Reference code'), $isad->referenceCode, array('fieldLabel' => 'referenceCode')) ?>
 
   <?php echo render_show(__('Title'), render_title($resource), array('fieldLabel' => 'title')) ?>
 
@@ -249,11 +249,11 @@
   <?php endif; ?>
 
   <?php if (check_field_visibility('app_element_visibility_isad_control_description_identifier')): ?>
-    <?php echo render_show(__('Description identifier'), render_value($resource->getDescriptionIdentifier(array('cultureFallback' => true))), array('fieldLabel' => 'descriptionIdentifier')) ?>
+    <?php echo render_show(__('Description identifier'), $resource->getDescriptionIdentifier(array('cultureFallback' => true)), array('fieldLabel' => 'descriptionIdentifier')) ?>
   <?php endif; ?>
 
   <?php if (check_field_visibility('app_element_visibility_isad_control_institution_identifier')): ?>
-    <?php echo render_show(__('Institution identifier'), render_value($resource->getInstitutionResponsibleIdentifier(array('cultureFallback' => true))), array('fieldLabel' => 'institutionIdentifier')) ?>
+    <?php echo render_show(__('Institution identifier'), $resource->getInstitutionResponsibleIdentifier(array('cultureFallback' => true)), array('fieldLabel' => 'institutionIdentifier')) ?>
   <?php endif; ?>
 
   <?php if (check_field_visibility('app_element_visibility_isad_control_rules_conventions')): ?>

--- a/plugins/sfModsPlugin/lib/sfModsPlugin.class.php
+++ b/plugins/sfModsPlugin/lib/sfModsPlugin.class.php
@@ -37,44 +37,41 @@ class sfModsPlugin implements ArrayAccess
 
   public function __toString()
   {
-    $string = array();
+    $string = '';
 
-    $levelOfDescriptionAndIdentifier = array();
+    // Add title if set
+    if (0 < strlen($title = $this->resource->__toString()))
+    {
+      $string .= $title;
+    }
+
+    // Add publication status
+    $publicationStatus = $this->resource->getPublicationStatus();
+    if (isset($publicationStatus) && QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $publicationStatus->statusId)
+    {
+      $string .= (!empty($string)) ? ' ' : '';
+      $string .= "({$publicationStatus->status->__toString()})";
+    }
+
+    return $string;
+  }
+
+  public function levelOfDescriptionAndIdentifier()
+  {
+    $string = '';
 
     if (isset($this->resource->levelOfDescription))
     {
-      $levelOfDescriptionAndIdentifier[] = $this->resource->levelOfDescription->__toString();
+      $string .= $this->resource->levelOfDescription->__toString();
     }
 
     if (isset($this->resource->identifier))
     {
-      $levelOfDescriptionAndIdentifier[] = $this->resource->identifier;
+      $string .= (!empty($string)) ? ' ' : '';
+      $string .= $this->resource->identifier;
     }
 
-    if (0 < count($levelOfDescriptionAndIdentifier))
-    {
-      $string[] = implode($levelOfDescriptionAndIdentifier, ' ');
-    }
-
-    $resourceAndPublicationStatus = array();
-
-    if (0 < strlen($title = $this->resource->__toString()))
-    {
-      $resourceAndPublicationStatus[] = $title;
-    }
-
-    $publicationStatus = $this->resource->getPublicationStatus();
-    if (isset($publicationStatus) && QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $publicationStatus->statusId)
-    {
-      $resourceAndPublicationStatus[] = "({$publicationStatus->status->__toString()})";
-    }
-
-    if (0 < count($resourceAndPublicationStatus))
-    {
-      $string[] = implode($resourceAndPublicationStatus, ' ');
-    }
-
-    return implode(' - ', $string);
+    return $string;
   }
 
   public function offsetExists($offset)

--- a/plugins/sfModsPlugin/modules/sfModsPlugin/templates/editSuccess.php
+++ b/plugins/sfModsPlugin/modules/sfModsPlugin/templates/editSuccess.php
@@ -9,7 +9,7 @@
 
 <?php slot('title') ?>
 
-  <h1><?php echo render_title($mods) ?></h1>
+  <?php echo get_component('informationobject', 'header', array('resource' => $resource, 'title' => (string)$mods)) ?>
 
   <?php if (isset($sf_request->source)): ?>
     <div class="messages status">

--- a/plugins/sfModsPlugin/modules/sfModsPlugin/templates/indexSuccess.php
+++ b/plugins/sfModsPlugin/modules/sfModsPlugin/templates/indexSuccess.php
@@ -6,7 +6,7 @@
 
 <?php slot('title') ?>
 
-  <h1><?php echo render_title($mods) ?></h1>
+  <?php echo get_component('informationobject', 'header', array('resource' => $resource, 'title' => (string)$mods)) ?>
 
   <?php if (isset($errorSchema)): ?>
     <div class="messages error">
@@ -57,7 +57,7 @@
     <?php echo get_component('digitalobject', 'show', array('link' => $digitalObjectLink, 'resource' => $resource->digitalObjectsRelatedByobjectId[0], 'usageType' => QubitTerm::REFERENCE_ID)) ?>
   <?php endif; ?>
 
-  <?php echo render_show(__('Identifier'), render_value($resource->identifier)) ?>
+  <?php echo render_show(__('Identifier'), $resource->identifier) ?>
 
   <?php echo render_show(__('Title'), render_value($resource->getTitle(array('cultureFallback' => true)))) ?>
 

--- a/plugins/sfRadPlugin/lib/sfRadPlugin.class.php
+++ b/plugins/sfRadPlugin/lib/sfRadPlugin.class.php
@@ -38,44 +38,21 @@ class sfRadPlugin implements ArrayAccess
 
   public function __toString()
   {
-    $string = array();
-
-    $levelOfDescriptionAndIdentifier = array();
-
-    if (isset($this->resource->levelOfDescription))
-    {
-      $levelOfDescriptionAndIdentifier[] = $this->resource->levelOfDescription->__toString();
-    }
-
-    if (isset($this->resource->identifier))
-    {
-      $levelOfDescriptionAndIdentifier[] = $this->resource->identifier;
-    }
-
-    if (0 < count($levelOfDescriptionAndIdentifier))
-    {
-      $string[] = implode($levelOfDescriptionAndIdentifier, ' ');
-    }
-
-    $titleAndPublicationStatus = array();
+    $string = '';
 
     if (0 < strlen($title = $this->resource->__toString()))
     {
-      $titleAndPublicationStatus[] = $title;
+      $string .= $title;
     }
 
     $publicationStatus = $this->resource->getPublicationStatus();
     if (isset($publicationStatus) && QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $publicationStatus->statusId)
     {
-      $titleAndPublicationStatus[] = "({$publicationStatus->status->__toString()})";
+      $string .= (!empty($string)) ? ' ' : '';
+      $string .= "({$publicationStatus->status->__toString()})";
     }
 
-    if (0 < count($titleAndPublicationStatus))
-    {
-      $string[] = implode($titleAndPublicationStatus, ' ');
-    }
-
-    return implode(' - ', $string);
+    return $string;
   }
 
   public function __get($name)

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/templates/editSuccess.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/templates/editSuccess.php
@@ -9,7 +9,7 @@
 
 <?php slot('title') ?>
 
-  <h1><?php echo render_title($rad) ?></h1>
+  <?php echo get_component('informationobject', 'header', array('resource' => $resource, 'title' => (string)$rad)) ?>
 
   <?php if (isset($sf_request->source)): ?>
     <div class="messages status">
@@ -84,7 +84,7 @@
         <?php echo get_partial('informationobject/identifierOptions', array('mask' => $mask)) ?>
         <?php echo get_partial('informationobject/alternativeIdentifiers', $sf_data->getRaw('alternativeIdentifiersComponent')->getVarHolder()->getAll()) ?>
 
-        <?php echo render_show(__('Reference code'), render_value($rad->referenceCode)) ?>
+        <?php echo render_show(__('Reference code'), $rad->referenceCode) ?>
 
       </fieldset> <!-- #titleAndStatementOfResponsibilityArea -->
 

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
@@ -6,7 +6,7 @@
 
 <?php slot('title') ?>
 
-  <h1><?php echo render_title($rad) ?></h1>
+  <?php echo get_component('informationobject', 'header', array('resource' => $resource, 'title' => (string)$rad)) ?>
 
   <?php if (isset($errorSchema)): ?>
     <div class="messages error">
@@ -98,7 +98,7 @@
     <?php echo render_show_repository(__('Repository'), $resource) ?>
   </div>
 
-  <?php echo render_show(__('Reference code'), render_value($rad->__get('referenceCode', array('cultureFallback' => true))), array('fieldLabel' => 'referenceCode')) ?>
+  <?php echo render_show(__('Reference code'), $rad->__get('referenceCode', array('cultureFallback' => true)), array('fieldLabel' => 'referenceCode')) ?>
 
 </section> <!-- /section#titleAndStatementOfResponsibilityArea -->
 
@@ -328,11 +328,11 @@
   <?php endif; ?>
 
   <?php if (check_field_visibility('app_element_visibility_rad_control_description_identifier')): ?>
-    <?php echo render_show(__('Description record identifier'), render_value($resource->descriptionIdentifier), array('fieldLabel' => 'descriptionRecordIdentifier')) ?>
+    <?php echo render_show(__('Description record identifier'), $resource->descriptionIdentifier, array('fieldLabel' => 'descriptionRecordIdentifier')) ?>
   <?php endif; ?>
 
   <?php if (check_field_visibility('app_element_visibility_rad_control_institution_identifier')): ?>
-    <?php echo render_show(__('Institution identifier'), render_value($resource->getInstitutionResponsibleIdentifier(array('cultureFallback' => true))), array('fieldLabel' => 'institutionIdentifier')) ?>
+    <?php echo render_show(__('Institution identifier'), $resource->getInstitutionResponsibleIdentifier(array('cultureFallback' => true)), array('fieldLabel' => 'institutionIdentifier')) ?>
   <?php endif; ?>
 
   <?php if (check_field_visibility('app_element_visibility_rad_control_rules_conventions')): ?>


### PR DESCRIPTION
Refactored display of title, etc., in a number of description standard plugins
and got rid of Markdown parsing of identifiers.

* Created a component to display level of description, reference code, title,
  and publication status
* In the component the reference code doesn't get parsed as Markdown, but the
  title does
* Refactored description standard plugins to use component
* Removed Markdown parsing for misc. identifiers in index/edit page templates