### PR TITLE
Related term ES index speed, refs #13175

### DIFF
--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
@@ -22,9 +22,11 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
   protected static
     $conn,
     $statement,
-    $counter = 0;
+    $counter = 0,
+    $termParentList = array();
 
-  protected $errors = array();
+  protected
+    $errors = array();
 
   public function load()
   {
@@ -36,9 +38,24 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
     $this->count = QubitPdo::fetchColumn($sql, array(QubitInformationObject::ROOT_ID));
   }
 
+  static function loadTermParentList($options = array())
+  {
+    $sql  = 'SELECT term.id, term.parent_id';
+    $sql .= ' FROM '.QubitTerm::TABLE_NAME;
+
+    if (isset($options['taxonomyIds']) && is_array($options['taxonomyIds']))
+    {
+      $sql .= ' WHERE '.QubitTerm::TABLE_NAME.'.taxonomy_id IN ('.implode(',',$options['taxonomyIds']).')';
+    }
+    $rows = QubitPdo::fetchAll($sql, array() ,array('fetchMode' => PDO::FETCH_KEY_PAIR));
+
+    return $rows;
+  }
+
   public function populate()
   {
     $this->load();
+    self::$termParentList = self::loadTermParentList(array('taxonomyIds' => array(QubitTaxonomy::SUBJECT_ID, QubitTaxonomy::PLACE_ID, QubitTaxonomy::GENRE_ID)));
 
     // Recursively descend down hierarchy
     $this->recursivelyAddInformationObjects(QubitInformationObject::ROOT_ID, $this->count);
@@ -53,7 +70,7 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
     {
       try
       {
-        $node = new arElasticSearchInformationObjectPdo($item->id, $options);
+        $node = new arElasticSearchInformationObjectPdo($item->id, array_merge($options, array('terms' => self::$termParentList)));
         $data = $node->serialize();
 
         QubitSearch::getInstance()->addDocument($data, 'QubitInformationObject');
@@ -81,8 +98,26 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
 
   public static function update($object, $options = array())
   {
+    if (!isset(self::$conn))
+    {
+      self::$conn = Propel::getConnection();
+    }
+
+    $sql  = 'SELECT DISTINCT otr.term_id as id';
+    $sql .= ' FROM '.QubitObjectTermRelation::TABLE_NAME.' otr';
+    $sql .= ' WHERE otr.object_id = :id';
+
+    $rows = QubitPdo::fetchAll($sql, array(':id' => $object->id), array('fetchMode' => PDO::FETCH_ASSOC));
+
+    if (count($rows) > 0 && empty(self::$termParentList))
+    {
+      self::$termParentList = self::loadTermParentList(array('taxonomyIds' => array(QubitTaxonomy::SUBJECT_ID, QubitTaxonomy::PLACE_ID, QubitTaxonomy::GENRE_ID)));
+    }
+
     // Update description
-    $node = new arElasticSearchInformationObjectPdo($object->id);
+    $node = new arElasticSearchInformationObjectPdo($object->id,
+      array('terms' => self::$termParentList));
+
     QubitSearch::getInstance()->addDocument($node->serialize(), 'QubitInformationObject');
 
     // Update descendants if requested and they exists

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
@@ -37,6 +37,7 @@ class arElasticSearchInformationObjectPdo
   protected
     $data = array(),
     $events,
+    $termParentList = array(),
     $languages = array(),
     $scripts = array();
 
@@ -63,6 +64,12 @@ class arElasticSearchInformationObjectPdo
     if (isset($options['ancestors']))
     {
       $this->ancestors = $options['ancestors'];
+    }
+
+    // Get system term id hierarchy
+    if (isset($options['terms']))
+    {
+      $this->termParentList = $options['terms'];
     }
 
     // Get inherited repository, unless a repository is set at current level
@@ -612,32 +619,77 @@ class arElasticSearchInformationObjectPdo
   }
 
   /*
-   * Get related terms and its ancestors
+   * Prepare term query.
+   */
+  protected function prepareRelatedTermsQuery()
+  {
+    if (!isset(self::$statements['relatedTerms']))
+    {
+      $sql  = 'SELECT
+                  DISTINCT current.id';
+      $sql .= ' FROM '.QubitObjectTermRelation::TABLE_NAME.' otr';
+      $sql .= ' JOIN '.QubitTerm::TABLE_NAME.' current
+                  ON otr.term_id = current.id';
+      $sql .= ' WHERE otr.object_id = :id
+                  AND current.taxonomy_id = :taxonomyId';
+
+      self::$statements['relatedTerms'] = self::$conn->prepare($sql);
+    }
+  }
+
+  /*
+   * Get related terms plus any ancestors
    */
   protected function getRelatedTerms($typeId)
   {
-    $sql  = 'SELECT
-                DISTINCT term.id,
-                term.taxonomy_id,
-                term.source_culture,
-                slug.slug,
-                i18n.name';
-    $sql .= ' FROM '.QubitObjectTermRelation::TABLE_NAME.' otr';
-    $sql .= ' JOIN '.QubitTerm::TABLE_NAME.' current
-                ON otr.term_id = current.id';
-    $sql .= ' JOIN '.QubitTerm::TABLE_NAME.' term
-                ON term.lft <= current.lft AND term.rgt >= current.rgt';
-    $sql .= ' JOIN '.QubitTermI18n::TABLE_NAME.' i18n
-                ON term.id = i18n.id';
-    $sql .= ' JOIN '.QubitSlug::TABLE_NAME.' slug
-                ON term.id = slug.object_id';
-    $sql .= ' WHERE otr.object_id = ?
-               AND term.taxonomy_id = ?';
+    $relatedTerms = array();
 
-    self::$statements['relatedTerms'] = self::$conn->prepare($sql);
-    self::$statements['relatedTerms']->execute(array($this->__get('id'), $typeId));
+    $this->prepareRelatedTermsQuery();
 
-    return self::$statements['relatedTerms']->fetchAll(PDO::FETCH_OBJ);
+    self::$statements['relatedTerms']->execute(array(':id' => $this->__get('id'), ':taxonomyId' => $typeId));
+
+    // Get directly related terms.
+    $rows = self::$statements['relatedTerms']->fetchAll(PDO::FETCH_ASSOC);
+
+    if (0 == count($rows))
+    {
+      return $relatedTerms;
+    }
+
+    // Iterate over each directly related term, adding all ancestors of each
+    foreach($rows as $row)
+    {
+      $relatedTerms = array_merge($relatedTerms, $this->recursivelyGetParentTerms($row['id']));
+    }
+
+    $relatedTerms = array_unique($relatedTerms);
+
+    return $relatedTerms;
+  }
+
+  /**
+   * Recursively find all parent terms for any given term. Subject, Place and
+   * Genre terms are preloaded in array $this->termParentList. The import array $ids is
+   * appended to for every parent that is added on each recursive call.
+   *
+   * @param array $id  The term id to find the parents for.
+   * @return array  Array with directly related term first, followed by
+   *                any parents found, in child to top parent order.
+   */
+  private function recursivelyGetParentTerms($id)
+  {
+    if (null === $parent = $this->termParentList[$id])
+    {
+      return array($id);
+    }
+
+    // Do not include root term id.
+    if (QubitTerm::ROOT_ID == $parent)
+    {
+      return array($id);
+    }
+
+    return array_merge(array($id), $this->recursivelyGetParentTerms($parent));
   }
 
   /*
@@ -645,18 +697,10 @@ class arElasticSearchInformationObjectPdo
    */
   protected function getDirectlyRelatedTerms($typeId)
   {
-    $sql  = 'SELECT
-                DISTINCT current.id';
-    $sql .= ' FROM '.QubitObjectTermRelation::TABLE_NAME.' otr';
-    $sql .= ' JOIN '.QubitTerm::TABLE_NAME.' current
-                ON otr.term_id = current.id';
-    $sql .= ' WHERE otr.object_id = ?
-                AND current.taxonomy_id = ?';
+    $this->prepareRelatedTermsQuery();
+    self::$statements['relatedTerms']->execute(array(':id' => $this->__get('id'), ':taxonomyId' => $typeId));
 
-    self::$statements['relatedTerms'] = self::$conn->prepare($sql);
-    self::$statements['relatedTerms']->execute(array($this->__get('id'), $typeId));
-
-    return self::$statements['relatedTerms']->fetchAll(PDO::FETCH_OBJ);
+    return self::$statements['relatedTerms']->fetchAll(PDO::FETCH_ASSOC);
   }
 
   protected function getLanguagesAndScripts()
@@ -802,20 +846,20 @@ class arElasticSearchInformationObjectPdo
   {
     if (!isset(self::$statements[$statementType]))
     {
-      $sql  = 'SELECT term.id';
+      $sql  = 'SELECT otr.term_id as id';
       $sql .= ' FROM '.QubitObjectTermRelation::TABLE_NAME.' otr';
-      $sql .= ' JOIN '.QubitTerm::TABLE_NAME.' term
-                  ON otr.term_id = term.id';
-      $sql .= ' WHERE object_id = ?';
-      $sql .= ' AND term.taxonomy_id = '.$taxonomyId;
+      $sql .= ' WHERE otr.object_id = :id';
+      $sql .= ' AND otr.term_id IN';
+      $sql .= ' (SELECT term.id';
+      $sql .= ' FROM '.QubitTerm::TABLE_NAME.' term';
+      $sql .= ' WHERE term.taxonomy_id = :taxonomyId)';
 
       self::$statements[$statementType] = self::$conn->prepare($sql);
     }
 
-    self::$statements[$statementType]->execute(array(
-      $this->__get('id')));
+    self::$statements[$statementType]->execute(array(':id' => $this->__get('id'), ':taxonomyId' => $taxonomyId));
 
-    return self::$statements[$statementType]->fetchAll(PDO::FETCH_OBJ);
+    return self::$statements[$statementType]->fetchAll(PDO::FETCH_ASSOC);
   }
 
   public function getStorageNames()
@@ -1192,7 +1236,7 @@ class arElasticSearchInformationObjectPdo
     // Material type
     foreach ($this->getMaterialTypeId() as $item)
     {
-      $serialized['materialTypeId'][] = $item->id;
+      $serialized['materialTypeId'][] = $item['id'];
     }
 
     // Make sure that media_type_id gets a value in case that one was not
@@ -1259,25 +1303,25 @@ class arElasticSearchInformationObjectPdo
     // Places
     foreach ($this->getRelatedTerms(QubitTaxonomy::PLACE_ID) as $item)
     {
-      $node = new arElasticSearchTermPdo($item->id);
+      $node = new arElasticSearchTermPdo($item);
       $serialized['places'][] = $node->serialize();
     }
 
     foreach ($this->getDirectlyRelatedTerms(QubitTaxonomy::PLACE_ID) as $item)
     {
-      $serialized['directPlaces'][] = $item->id;
+      $serialized['directPlaces'][] = $item['id'];
     }
 
     // Subjects
     foreach ($this->getRelatedTerms(QubitTaxonomy::SUBJECT_ID) as $item)
     {
-      $node = new arElasticSearchTermPdo($item->id);
+      $node = new arElasticSearchTermPdo($item);
       $serialized['subjects'][] = $node->serialize();
     }
 
     foreach ($this->getDirectlyRelatedTerms(QubitTaxonomy::SUBJECT_ID) as $item)
     {
-      $serialized['directSubjects'][] = $item->id;
+      $serialized['directSubjects'][] = $item['id'];
     }
 
     // Name access points
@@ -1303,13 +1347,13 @@ class arElasticSearchInformationObjectPdo
     // Genres
     foreach ($this->getRelatedTerms(QubitTaxonomy::GENRE_ID) as $item)
     {
-      $node = new arElasticSearchTermPdo($item->id);
+      $node = new arElasticSearchTermPdo($item);
       $serialized['genres'][] = $node->serialize();
     }
 
     foreach ($this->getDirectlyRelatedTerms(QubitTaxonomy::GENRE_ID) as $item)
     {
-      $serialized['directGenres'][] = $item->id;
+      $serialized['directGenres'][] = $item['id'];
     }
 
     // Creators


### PR DESCRIPTION
This commit contains an enhancement to speed up ES indexing of
information objects when there is a large number of terms in the terms
table.

Subject, place and genre term ids and parent_ids are preloaded into an
array so a term's parent can be found directly using the term id as the
array index.

For each directly related term, parents are found by searching the term
array recursively instead of using the nested set ancestors query using
the LFT and RGT columns.

This change results in a large performance increase when indexing
information objects when testing with ~350K place and subject terms.