### PR TITLE
Fix D.O. metadata header display, refs #13190

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/metadataComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/metadataComponent.class.php
@@ -56,5 +56,6 @@ class DigitalObjectMetadataComponent extends sfComponent
 
     // Check related object type to display IO properties in the template
     $this->relatedToIo = $this->resource->object instanceOf QubitInformationObject;
+    $this->relatedToActor = $this->resource->object instanceOf QubitActor;
   }
 }

--- a/apps/qubit/modules/digitalobject/templates/_metadata.php
+++ b/apps/qubit/modules/digitalobject/templates/_metadata.php
@@ -2,9 +2,9 @@
 
 <section>
 
-  <?php if ($resource->object instanceOf QubitInformationObject): ?>
+  <?php if ($relatedToIo): ?>
     <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationobject'), '<h2>'.__('%1% metadata', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))).'</h2>', array($resource, 'module' => 'digitalobject', 'action' => 'edit'), array('title' => __('Edit %1%', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))))) ?>
-  <?php elseif ($resource->object instanceOf QubitActor): ?>
+  <?php elseif ($relatedToActor): ?>
     <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'actor'), '<h2>'.__('%1% metadata', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))).'</h2>', array($resource, 'module' => 'digitalobject', 'action' => 'edit'), array('title' => __('Edit %1%', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))))) ?>
   <?php endif; ?>
 


### PR DESCRIPTION
Fixed issued where, if Markdown is disabled, digital object metadata section
header doesn't display.