### PR TITLE
Do not disable escaping strategy, refs #13192

### DIFF
--- a/apps/qubit/modules/actor/templates/_advancedSearch.php
+++ b/apps/qubit/modules/actor/templates/_advancedSearch.php
@@ -7,7 +7,7 @@
     <?php echo $form->renderFormTag(url_for(array('module' => 'actor', 'action' => 'browse')), array('name' => 'advanced-search-form', 'method' => 'get')) ?>
 
       <?php foreach ($hiddenFields as $name => $value): ?>
-        <input type="hidden" name="<?php echo $name ?>" value="<?php echo esc_entities($value) ?>"/>
+        <input type="hidden" name="<?php echo $name ?>" value="<?php echo $value ?>"/>
       <?php endforeach; ?>
 
       <p><?php echo __('Find results with:') ?></p>

--- a/apps/qubit/modules/actor/templates/autocompleteSuccess.php
+++ b/apps/qubit/modules/actor/templates/autocompleteSuccess.php
@@ -38,7 +38,7 @@
 
 <div class="search">
   <form action="<?php echo url_for(array('module' => 'actor', 'action' => 'list')) ?>">
-    <input name="subquery" value="<?php echo esc_entities($sf_request->subquery) ?>"/>
+    <input name="subquery" value="<?php echo $sf_request->subquery ?>"/>
     <input class="form-submit" type="submit" value="<?php echo __('Search %1%', array('%1%' => sfConfig::get('app_ui_label_actor'))) ?>"/>
   </form>
 </div>

--- a/apps/qubit/modules/default/templates/moveSuccess.php
+++ b/apps/qubit/modules/default/templates/moveSuccess.php
@@ -11,7 +11,7 @@
       <form action="<?php echo url_for(array($resource, 'module' => 'default', 'action' => 'move')) ?>">
         <div class="input-append">
           <?php if (isset($sf_request->query)): ?>
-            <input type="text" name="query" value="<?php echo esc_entities($sf_request->query) ?>" />
+            <input type="text" name="query" value="<?php echo $sf_request->query ?>" />
             <a class="btn" href="<?php echo url_for(array($resource, 'module' => 'default', 'action' => 'move')) ?>">
               <i class="fa fa-times"></i>
             </a>

--- a/apps/qubit/modules/repository/templates/_advancedFilters.php
+++ b/apps/qubit/modules/repository/templates/_advancedFilters.php
@@ -1,7 +1,7 @@
 <form method="get">
 
   <?php foreach ($hiddenFields as $name => $value): ?>
-    <input type="hidden" name="<?php echo $name ?>" value="<?php echo esc_entities($value) ?>"/>
+    <input type="hidden" name="<?php echo $name ?>" value="<?php echo $value ?>"/>
   <?php endforeach; ?>
 
   <div class="advanced-repository-filters-content">

--- a/apps/qubit/modules/repository/templates/_holdingsInstitution.php
+++ b/apps/qubit/modules/repository/templates/_holdingsInstitution.php
@@ -27,7 +27,7 @@
       <form class="sidebar-search" action="<?php echo url_for(array('module' => 'informationobject', 'action' => 'browse')) ?>">
         <input type="hidden" name="repos" value="<?php echo $resource->id ?>">
         <div class="input-prepend input-append">
-          <input type="text" name="query" value="<?php echo esc_entities($sf_request->query) ?>" placeholder="<?php echo __('Search') ?>">
+          <input type="text" name="query" value="<?php echo $sf_request->query ?>" placeholder="<?php echo __('Search') ?>">
           <button class="btn" type="submit">
             <i class="fa fa-search"></i>
           </button>

--- a/apps/qubit/modules/rightsholder/templates/listSuccess.php
+++ b/apps/qubit/modules/rightsholder/templates/listSuccess.php
@@ -8,7 +8,7 @@
   <div class="nav">
     <div class="search">
       <form action="<?php echo url_for(array('module' => 'rightsholder', 'action' => 'list')) ?>">
-        <input name="subquery" value="<?php echo esc_entities($sf_request->subquery) ?>"/>
+        <input name="subquery" value="<?php echo $sf_request->subquery ?>"/>
         <input class="form-submit" type="submit" value="<?php echo __('Search rights holder') ?>"/>
       </form>
     </div>

--- a/apps/qubit/modules/search/templates/_advancedSearch.php
+++ b/apps/qubit/modules/search/templates/_advancedSearch.php
@@ -7,7 +7,7 @@
     <?php echo $form->renderFormTag(url_for(array('module' => 'informationobject', 'action' => 'browse')), array('name' => 'advanced-search-form', 'method' => 'get')) ?>
 
       <?php foreach ($hiddenFields as $name => $value): ?>
-        <input type="hidden" name="<?php echo $name ?>" value="<?php echo esc_entities($value) ?>"/>
+        <input type="hidden" name="<?php echo $name ?>" value="<?php echo $value ?>"/>
       <?php endforeach; ?>
 
       <p><?php echo __('Find results with:') ?></p>

--- a/apps/qubit/modules/search/templates/_box.php
+++ b/apps/qubit/modules/search/templates/_box.php
@@ -8,9 +8,9 @@
     <input type="hidden" name="sort" value="relevance"/>
 
     <?php if (isset($repository) && !sfConfig::get('app_enable_institutional_scoping')): ?>
-      <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php echo esc_entities($sf_request->query) ?>" placeholder="<?php echo __('Search %1%', array('%1%' => strip_markdown($repository))) ?>"/>
+      <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php echo $sf_request->query ?>" placeholder="<?php echo __('Search %1%', array('%1%' => strip_markdown($repository))) ?>"/>
     <?php else: ?>
-      <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php if (!$sf_user->getAttribute('search-realm') || !sfConfig::get('app_enable_institutional_scoping')) echo esc_entities($sf_request->query) ?>" placeholder="<?php echo __('%1%', array('%1%' => sfConfig::get('app_ui_label_globalSearch'))) ?>"/>
+      <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php if (!$sf_user->getAttribute('search-realm') || !sfConfig::get('app_enable_institutional_scoping')) echo $sf_request->query ?>" placeholder="<?php echo __('%1%', array('%1%' => sfConfig::get('app_ui_label_globalSearch'))) ?>"/>
     <?php endif; ?>
 
     <button><span><?php echo __('Search') ?></span></button>

--- a/apps/qubit/modules/search/templates/_filterTag.php
+++ b/apps/qubit/modules/search/templates/_filterTag.php
@@ -1,6 +1,6 @@
 <span class="search-filter">
   <?php if (!empty($label)): ?>
-    <?php echo esc_entities($label) ?>
+    <?php echo $label ?>
   <?php else: ?>
     <?php echo render_title($object) ?>
   <?php endif; ?>

--- a/apps/qubit/modules/search/templates/_inlineSearch.php
+++ b/apps/qubit/modules/search/templates/_inlineSearch.php
@@ -3,13 +3,13 @@
   <form method="get" action="<?php echo $route ?>">
 
     <?php if (isset($sf_request->subqueryField) && 0 < strlen($sf_request->subqueryField)): ?>
-      <input type="hidden" name="subqueryField" id="subqueryField" value="<?php echo esc_entities($sf_request->subqueryField) ?>" />
+      <input type="hidden" name="subqueryField" id="subqueryField" value="<?php echo $sf_request->subqueryField ?>" />
     <?php elseif (isset($fields)): ?>
       <input type="hidden" name="subqueryField" id="subqueryField" value="<?php echo array_keys($sf_data->getRaw('fields'))[0] ?>" />
     <?php endif; ?>
 
     <?php if (isset($sf_request->view)): ?>
-      <input type="hidden" name="view" value="<?php echo esc_entities($sf_request->view) ?>"/>
+      <input type="hidden" name="view" value="<?php echo $sf_request->view ?>"/>
     <?php endif; ?>
 
     <div class="input-prepend input-append">
@@ -33,7 +33,7 @@
       <?php endif; ?>
 
       <?php if (isset($sf_request->subquery)): ?>
-        <input type="text" name="subquery" value="<?php echo esc_entities($sf_request->subquery) ?>" />
+        <input type="text" name="subquery" value="<?php echo $sf_request->subquery ?>" />
         <a class="btn" href="<?php echo $cleanRoute ?>">
           <i class="fa fa-times"></i>
         </a>

--- a/lib/QubitMarkdown.class.php
+++ b/lib/QubitMarkdown.class.php
@@ -75,7 +75,7 @@ class QubitMarkdown
    */
   public function parse($content, $options = array())
   {
-    $content = $this->getString($content);
+    $content = $this->getUnescapedString($content);
 
     if (!$this->enabled || strlen($content) == 0)
     {
@@ -115,7 +115,7 @@ class QubitMarkdown
    */
   public function strip($content)
   {
-    $content = $this->getString($content);
+    $content = $this->getUnescapedString($content);
 
     if (!$this->enabled || strlen($content) == 0)
     {
@@ -148,11 +148,16 @@ class QubitMarkdown
    * returns an empty string, like it does with everything else that
    * is not an object or a string.
    *
+   * We normally reach this function from the templates and, with the
+   * escaping strategy enabled by default, the content will be escaped.
+   *
    * @param mixed $content  Object/String to normalize.
    * @return string  String value of content or empty string.
    */
-  protected function getString($content)
+  protected function getUnescapedString($content)
   {
+    $content = sfOutputEscaper::unescape($content);
+
     if (is_string($content))
     {
       return $content;

--- a/lib/model/QubitSetting.php
+++ b/lib/model/QubitSetting.php
@@ -103,15 +103,6 @@ class QubitSetting extends BaseSetting
       $settings[$key.'__source'] = $qubitSetting->value_source;
     }
 
-    // Disable Symfony escaping strategy if Markdown is enabled to allow
-    // parsing tags like blockquote ('>'). Parsedown is used in safe mode
-    // to escape the content while parsing when necesary in QubitMarkdown.
-    // Markdown is enabled by default if the setting doesn't exists.
-    if (!isset($settings['app_markdown_enabled']) || $settings['app_markdown_enabled'])
-    {
-      $settings['sf_escaping_strategy'] = false;
-    }
-
     return $settings;
   }
 

--- a/plugins/arArchivesCanadaPlugin/modules/search/templates/_box.php
+++ b/plugins/arArchivesCanadaPlugin/modules/search/templates/_box.php
@@ -7,9 +7,9 @@
     <div class="input-append">
 
       <?php if (isset($repository)): ?>
-        <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php echo esc_entities($sf_request->query) ?>" placeholder="<?php echo __('Search %1%', array('%1%' => strip_markdown($repository))) ?>"/>
+        <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php echo $sf_request->query ?>" placeholder="<?php echo __('Search %1%', array('%1%' => strip_markdown($repository))) ?>"/>
       <?php else: ?>
-        <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php echo esc_entities($sf_request->query) ?>" placeholder="<?php echo __('Search') ?>"/>
+        <input type="text" name="query"<?php if (isset($sf_request->query)) echo ' class="focused"' ?> value="<?php echo $sf_request->query ?>" placeholder="<?php echo __('Search') ?>"/>
       <?php endif; ?>
 
       <div class="btn-group">

--- a/plugins/qtAccessionPlugin/modules/donor/templates/listSuccess.php
+++ b/plugins/qtAccessionPlugin/modules/donor/templates/listSuccess.php
@@ -8,7 +8,7 @@
   <div class="nav">
     <div class="search">
       <form action="<?php echo url_for(array('module' => 'donor', 'action' => 'list')) ?>">
-        <input name="subquery" value="<?php echo esc_entities($sf_request->subquery) ?>"/>
+        <input name="subquery" value="<?php echo $sf_request->subquery ?>"/>
         <input class="form-submit" type="submit" value="<?php echo __('Search donor') ?>"/>
       </form>
     </div>


### PR DESCRIPTION
To avoid issues rendering Markdown, unescape the content only in the
Markdown parsing process, which is normally used in safe mode. This
reduces performance (escaping and unescaping the content) but increases
security (having all user inputs escaped by default).

Additionally, escape boolean queries inputs. Just in case, as the
escaping strategy could be manually disabled in the configuration.
