### PR TITLE
Accession extent multiline edit, refs #13198

### DIFF
--- a/plugins/qtAccessionPlugin/modules/accession/actions/editAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/editAction.class.php
@@ -202,7 +202,6 @@ class AccessionEditAction extends DefaultEditAction
 
         break;
 
-      case 'receivedExtentUnits':
       case 'title':
         $this->form->setDefault($name, $this->resource[$name]);
         $this->form->setValidator($name, new sfValidatorString);
@@ -215,6 +214,7 @@ class AccessionEditAction extends DefaultEditAction
       case 'locationInformation':
       case 'physicalCharacteristics':
       case 'processingNotes':
+      case 'receivedExtentUnits':
       case 'scopeAndContent':
       case 'sourceOfAcquisition':
         $this->form->setDefault($name, $this->resource[$name]);

--- a/plugins/qtAccessionPlugin/modules/accession/templates/editSuccess.php
+++ b/plugins/qtAccessionPlugin/modules/accession/templates/editSuccess.php
@@ -110,7 +110,8 @@
           ->label(__('Physical condition')), $resource, array('class' => 'resizable')) ?>
 
         <?php echo render_field($form->receivedExtentUnits
-          ->help(__('The number of units as a whole number and the measurement of the received volume of records in the accession.')), $resource) ?>
+          ->help(__('The number of units as a whole number and the measurement of the received volume of records in the accession.'))
+          ->label(__('Received extent units')), $resource, array('class' => 'resizable')) ?>
 
         <?php echo $form->processingStatus
           ->help(__('An indicator of the accessioning process.'))


### PR DESCRIPTION
Change the accession edit page to accept multiline input for the
"Received extent units" field.