### PR TITLE
Fix DC XML creator inheritance, refs #13130

### DIFF
--- a/plugins/sfDcPlugin/lib/sfDcPlugin.class.php
+++ b/plugins/sfDcPlugin/lib/sfDcPlugin.class.php
@@ -68,7 +68,22 @@ class sfDcPlugin implements ArrayAccess
     switch ($name)
     {
       case 'creators':
-        return $this->resource->getActors(array('eventTypeId' => QubitTerm::CREATION_ID, 'inherit' => true));
+        $creators = null;
+
+        foreach ($this->resource->ancestors->andSelf()->orderBy('rgt') as $ancestor)
+        {
+          if ($ancestor->id == QubitInformationObject::ROOT_ID)
+          {
+            break;
+          }
+
+          if (0 < count($creators = $ancestor->getCreators()))
+          {
+            break;
+          }
+        }
+
+        return $creators;
 
       case '_event':
 


### PR DESCRIPTION
Changed the DC XML component so creators can be inherited from non-top
level information objects.