### PR TITLE
Allow 'add' menu access, Refs #13202

### DIFF
--- a/apps/qubit/modules/menu/actions/mainMenuComponent.class.php
+++ b/apps/qubit/modules/menu/actions/mainMenuComponent.class.php
@@ -35,6 +35,7 @@ class MenuMainMenuComponent extends sfComponent
     }
 
     // Only include menu for adding content if user is in an appropriate group
+    // or has create permission for a relevant content type
     $this->addMenu = false;
 
     // Specify what groups can add content
@@ -45,7 +46,7 @@ class MenuMainMenuComponent extends sfComponent
     );
 
     // Add, if applicable, menu for adding content
-    if ($this->context->user->hasGroup($groupsAllowedToAddContent))
+    if ($this->context->user->hasGroup($groupsAllowedToAddContent) || $this->userCanCreate())
     {
       $this->addMenu = QubitMenu::getById(QubitMenu::ADD_EDIT_ID);
     }
@@ -53,5 +54,13 @@ class MenuMainMenuComponent extends sfComponent
     $this->manageMenu = QubitMenu::getById(QubitMenu::MANAGE_ID);
     $this->importMenu = QubitMenu::getById(QubitMenu::IMPORT_ID);
     $this->adminMenu = QubitMenu::getById(QubitMenu::ADMIN_ID);
+  }
+
+  private function userCanCreate()
+  {
+    return QubitAcl::check(QubitInformationObject::getById(QubitInformationObject::ROOT_ID), 'create')
+           || QubitAcl::check(QubitActor::getById(QubitActor::ROOT_ID), 'create')
+           || QubitAcl::check(QubitRepository::getById(QubitRepository::ROOT_ID), 'create')
+           || QubitAcl::check(QubitTerm::getById(QubitTerm::ROOT_ID), 'create');
   }
 }

--- a/apps/qubit/modules/term/config/security.yml
+++ b/apps/qubit/modules/term/config/security.yml
@@ -1,3 +1,0 @@
-edit:
-  credentials: [[ translator, editor, administrator ]]
-  is_secure: true

--- a/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/config/security.yml
+++ b/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/config/security.yml
@@ -1,3 +1,0 @@
-edit:
-  credentials: [[ translator, editor, administrator ]]
-  is_secure: true

--- a/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/config/security.yml
+++ b/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/config/security.yml
@@ -1,3 +1,0 @@
-edit:
-  credentials: [[ translator, editor, administrator ]]
-  is_secure: true


### PR DESCRIPTION
In addition to restricting AtoM's 'add' menu to specific hard coded
groups, check ACL groups to see if the 'add' menu should appear for
users in custom ACL groups. Previously, custom groups were not being
checked to determine if AtoM's 'add' menu should be displayed for
these users.

Removed term, Isdf and Isdiah security.yml files to allow access to
these modules to authenticated users in custom groups.

Co-Authored-By: Mike Cantelon <mcantelon@gmail.com>