### PR TITLE
Add warning to CSV I.O. I18n import, refs #8572

### DIFF
--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -1188,10 +1188,14 @@ class QubitFlatfileImport
         && $value
       )
       {
-        $self->object->addProperty(
-          $self->propertyMap[$columnName],
-          $self->content($value)
-        );
+        // Ignore property coluns if importing a translation
+        if (!substr_count(get_class($self->object), 'I18n'))
+        {
+          $self->object->addProperty(
+            $self->propertyMap[$columnName],
+            $self->content($value)
+          );
+        }
       }
       else if (
         isset($self->columnNames[$index])


### PR DESCRIPTION
Prevent attempts to add related data during CSV import of information
object translations.

Add a warning to CSV import of information object translations when
columns that aren't supported are populated.