### PR TITLE
Escape apostrophe in XML parser, refs #13204

### DIFF
--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -658,7 +658,7 @@ class QubitXmlImport
                         if (null !== ($node = eval('return '.$str.';')))
                         {
                           // Substitute node value for search string
-                          $parameter = str_replace($match, '\''.$node->nodeValue.'\'', $parameter);
+                          $parameter = str_replace($match, '\''.addcslashes($node->nodeValue, "'").'\'', $parameter);
                         }
                         else
                         {


### PR DESCRIPTION
Apostrophes were causing a syntax error during eval in XML parsing
code.