### PR TITLE
Move composer autoload to importer, refs #13183

### DIFF
--- a/config/ProjectConfiguration.class.php
+++ b/config/ProjectConfiguration.class.php
@@ -22,7 +22,6 @@ sfCoreAutoload::register();
 
 require_once __DIR__.'/../vendor/symfony2/src/Symfony/Component/ClassLoader/UniversalClassLoader.php';
 require_once __DIR__.'/../lib/QubitApcUniversalClassLoader.php';
-require_once __DIR__.'/../vendor/composer/autoload.php';
 
 use Symfony\Component\ClassLoader\UniversalClassLoader;
 

--- a/lib/PhysicalobjectCsvImporter.class.php
+++ b/lib/PhysicalobjectCsvImporter.class.php
@@ -17,6 +17,8 @@
  * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
  */
 
+require_once __DIR__.'/../vendor/composer/autoload.php';
+
 /**
  * Importer for Physical Object CSV data
  *


### PR DESCRIPTION
Requiring `vendor/composer/autoload.php` in ProjectConfiguration was causing an
application-wide critical error if the autoloader wasn't installed via
composer.