### PR TITLE
Fix CSV notes import, refs #13209

### DIFF
--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -1455,7 +1455,7 @@ class QubitFlatfileImport
   public function createOrUpdateNotes($typeId, $textArray, $transformationLogic = false)
   {
     // If importing a translation row we currently don't handle notes
-    if (!property_exists(get_class($this->object), 'sourceCulture'))
+    if (!defined(get_class($this->object).'::SOURCE_CULTURE'))
     {
       return;
     }


### PR DESCRIPTION
Check `SOURCE_CULTURE` constant instead of `sourceCulture` property
as the latter is accessed through magic methods and `property_exits`
can't find it.