### PR TITLE
Update password hashing to Argon2, refs #12136

### DIFF
--- a/config/app.yml
+++ b/config/app.yml
@@ -45,3 +45,11 @@ all:
   # to a different string value to make sure the proper workers take the job for
   # their related instance.
   workers_key:
+
+  # Specify password_hash algorithm constant
+  # See: https://www.php.net/manual/en/password.constants.php
+  password_hash_algorithm: PASSWORD_ARGON2I
+
+  # Specify password_hash algorithm options (as JSON)
+  # See: https://www.php.net/manual/en/function.password-hash.php
+  password_hash_algorithm_options: {"memory_cost": "2048", "time_cost": "4", "threads": "3"}

--- a/config/schema.yml
+++ b/config/schema.yml
@@ -417,6 +417,6 @@ propel:
     id: { type: integer, required: true, primaryKey: true, foreignTable: actor, foreignReference: id, onDelete: cascade, inheritanceKey: true }
     username: varchar(255)
     email: varchar(255)
-    sha1_password: varchar(255)
+    password_hash: varchar(255)
     salt: varchar(255)
     active: { type: boolean, default: true }

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 174
+    value: 175
   milestone:
     name: milestone
     editable: 0

--- a/data/sql/lib.model.schema.sql
+++ b/data/sql/lib.model.schema.sql
@@ -1454,7 +1454,7 @@ CREATE TABLE `user`
 	`id` INTEGER  NOT NULL,
 	`username` VARCHAR(255),
 	`email` VARCHAR(255),
-	`sha1_password` VARCHAR(255),
+	`password_hash` VARCHAR(255),
 	`salt` VARCHAR(255),
 	`active` TINYINT default 1,
 	PRIMARY KEY (`id`),

--- a/lib/ldapUser.class.php
+++ b/lib/ldapUser.class.php
@@ -173,7 +173,7 @@ class ldapUser extends myUser implements Zend_Acl_Role_Interface
     }
 
     // Cache entry
-    $hash = password_hash($password, PASSWORD_BCRYPT, array('cost' => 10));
+    $hash = QubitUser::generatePasswordHash($password);
     $cache->set($cacheKey, $hash, 120);
 
     return true;

--- a/lib/model/map/UserTableMap.php
+++ b/lib/model/map/UserTableMap.php
@@ -39,7 +39,7 @@ class UserTableMap extends TableMap {
 		$this->addForeignPrimaryKey('ID', 'id', 'INTEGER' , 'actor', 'ID', true, null, null);
 		$this->addColumn('USERNAME', 'username', 'VARCHAR', false, 255, null);
 		$this->addColumn('EMAIL', 'email', 'VARCHAR', false, 255, null);
-		$this->addColumn('SHA1_PASSWORD', 'sha1Password', 'VARCHAR', false, 255, null);
+		$this->addColumn('PASSWORD_HASH', 'passwordHash', 'VARCHAR', false, 255, null);
 		$this->addColumn('SALT', 'salt', 'VARCHAR', false, 255, null);
 		$this->addColumn('ACTIVE', 'active', 'BOOLEAN', false, null, true);
 		// validators

--- a/lib/model/om/BaseUser.php
+++ b/lib/model/om/BaseUser.php
@@ -10,7 +10,7 @@ abstract class BaseUser extends QubitActor implements ArrayAccess
     ID = 'user.ID',
     USERNAME = 'user.USERNAME',
     EMAIL = 'user.EMAIL',
-    SHA1_PASSWORD = 'user.SHA1_PASSWORD',
+    PASSWORD_HASH = 'user.PASSWORD_HASH',
     SALT = 'user.SALT',
     ACTIVE = 'user.ACTIVE';
 
@@ -23,7 +23,7 @@ abstract class BaseUser extends QubitActor implements ArrayAccess
     $criteria->addSelectColumn(QubitUser::ID);
     $criteria->addSelectColumn(QubitUser::USERNAME);
     $criteria->addSelectColumn(QubitUser::EMAIL);
-    $criteria->addSelectColumn(QubitUser::SHA1_PASSWORD);
+    $criteria->addSelectColumn(QubitUser::PASSWORD_HASH);
     $criteria->addSelectColumn(QubitUser::SALT);
     $criteria->addSelectColumn(QubitUser::ACTIVE);
 

--- a/lib/task/migrate/migrations/arMigration0175.class.php
+++ b/lib/task/migrate/migrations/arMigration0175.class.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Re-hash stored SHA-1 hash (and salt) using Argon2 to improve password security.
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0175
+{
+  const
+    VERSION = 175, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  /**
+   * Upgrade
+   *
+   * @return bool True if the upgrade succeeded, False otherwise
+   */
+  public function up($configuration)
+  {
+    // Rename password hash column
+    $sql = "ALTER TABLE `user` CHANGE COLUMN `sha1_password` `password_hash` VARCHAR(255) DEFAULT NULL";
+    QubitPdo::modify($sql);
+
+    // Cycle through each user and re-hash stored SHA-1 hash (and salt)  
+    foreach(QubitUser::getAll() as $user)
+    {
+      $user->passwordHash = QubitUser::generatePasswordHash($user->passwordHash);
+      $user->save();
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
Updates the hashing logic from using SHA1 to using Argon2. To avoid
users having to re-enter their passwords we use Argon2 to hash the
original SHA1 hash of the user's password (plus salt). As Argon2
automatically generates the salt no additional salt-related logic is
needed.

The hashing algorithm and the options used with it can be changed by
editing the config/app.yml file and changing the
password_hash_algorithm and/or password_hash_algorithm_options options.

The hash algorithm and options are stored as part of the hash string
data so changing hash algorithm and options won't stop previously
stored password hashes from working.