### PR TITLE
Full treeview fix and paging setting, refs #13186

### DIFF
--- a/apps/qubit/modules/informationobject/actions/treeViewComponent.class.php
+++ b/apps/qubit/modules/informationobject/actions/treeViewComponent.class.php
@@ -27,6 +27,7 @@ class InformationObjectTreeViewComponent extends sfComponent
     if ($this->treeviewType != 'sidebar')
     {
       $this->collapsible = sfConfig::get('app_treeview_allow_full_width_collapse');
+      $this->itemsPerPage = sfConfig::get('app_treeview_full_items_per_page', 50);
 
       return sfView::SUCCESS;
     }

--- a/apps/qubit/modules/informationobject/templates/_treeView.php
+++ b/apps/qubit/modules/informationobject/templates/_treeView.php
@@ -111,7 +111,8 @@
       data-collection-url="<?php echo url_for(array($resource->getCollectionRoot(), 'module' => 'informationobject')) ?>"
       data-collapse-enabled="<?php echo $collapsible ?>"
       data-opened-text="<?php echo sfConfig::get('app_ui_label_fullTreeviewCollapseOpenedButtonText') ?>"
-      data-closed-text="<?php echo sfConfig::get('app_ui_label_fullTreeviewCollapseClosedButtonText') ?>"></span>
+      data-closed-text="<?php echo sfConfig::get('app_ui_label_fullTreeviewCollapseClosedButtonText') ?>"
+      data-items-per-page="<?php echo $itemsPerPage ?>"></span>
 
   <?php endif; ?>
 

--- a/apps/qubit/modules/settings/actions/treeviewAction.class.php
+++ b/apps/qubit/modules/settings/actions/treeviewAction.class.php
@@ -28,7 +28,8 @@ class SettingsTreeviewAction extends DefaultEditAction
       'ioSort',
       'showIdentifier',
       'showLevelOfDescription',
-      'showDates');
+      'showDates',
+      'fullItemsPerPage');
 
   protected function earlyExecute()
   {
@@ -117,6 +118,21 @@ class SettingsTreeviewAction extends DefaultEditAction
         $this->addSettingRadioButtonsField($this->showDatesSetting, $name, $default, $options);
 
         break;
+
+      case 'fullItemsPerPage':
+        $this->fullItemsPerPageSetting = QubitSetting::getByName('treeview_full_items_per_page');
+
+        $default = 50;
+        if (isset($this->fullItemsPerPageSetting))
+        {
+          $default = $this->fullItemsPerPageSetting->getValue(array('sourceCulture' => true));
+        }
+        $this->form->setDefault($name, $default);
+
+        $this->form->setValidator($name, new sfValidatorInteger(array('min' => 10, 'max' => 1000)));
+        $this->form->setWidget($name, new sfWidgetFormInput);
+
+        break;
     }
   }
 
@@ -169,6 +185,11 @@ class SettingsTreeviewAction extends DefaultEditAction
 
       case 'showDates':
         $this->createOrUpdateSetting($this->showDatesSetting, 'treeview_show_dates', $field->getValue());
+
+        break;
+
+      case 'fullItemsPerPage':
+        $this->createOrUpdateSetting($this->fullItemsPerPageSetting, 'treeview_full_items_per_page', $field->getValue());
 
         break;
     }

--- a/apps/qubit/modules/settings/templates/treeviewSuccess.php
+++ b/apps/qubit/modules/settings/templates/treeviewSuccess.php
@@ -84,6 +84,13 @@
 
         </div>
 
+        <p>
+            <?php echo $form->fullItemsPerPage
+              ->label(__('Items per page'))
+              ->help(__('Items per page can be a minimum of 10 and a maximum of 1000'))
+              ->renderRow() ?>
+        </p>
+
       </fieldset>
 
     </div>

--- a/js/fullWidthTreeView.js
+++ b/js/fullWidthTreeView.js
@@ -44,13 +44,14 @@
     var $treeViewConfig = $('#fullwidth-treeview-configuration');
     var treeViewCollapseEnabled = $treeViewConfig.data('collapse-enabled') == 'yes';
     var collectionUrl = $treeViewConfig.data('collection-url');
+    var itemsPerPage = $treeViewConfig.data('items-per-page');
     var pathToApi  = '/informationobject/fullWidthTreeView';
     var $fwTreeView = $('<div id="fullwidth-treeview"></div>');
     var $fwTreeViewRow = $('<div id="fullwidth-treeview-row"></div>');
     var $mainHeader = $('#main-column h1').first();
     var $moreButton = $('#fullwidth-treeview-more-button');
     var $resetButton = $('#fullwidth-treeview-reset-button');
-    var pager = new Qubit.TreeviewPager(50, $fwTreeView, collectionUrl + pathToApi);
+    var pager = new Qubit.TreeviewPager(itemsPerPage, $fwTreeView, collectionUrl + pathToApi);
 
     // Add tree-view divs after main header, animate and allow resize
     $mainHeader.after(
@@ -144,13 +145,15 @@
     var readyListener = function ()
     {
       var $activeNode = $('li[selected_on_load="true"]')[0];
+
+      pager.updateMoreLink($moreButton, $resetButton);
+
+      // Override default scrolling
       if ($activeNode !== undefined)
       {
         $activeNode.scrollIntoView(true);
         $('body')[0].scrollIntoView(true);
       }
-
-      pager.updateMoreLink($moreButton, $resetButton);
     };
 
     // On node selection: load the informationobject's page and insert the current page


### PR DESCRIPTION
Fixed issue with full treeview not scrolling to the active treeview
node. Made the number of nodes shown, per treeview page, configurable
via a setting.