### PR TITLE
Remove identifier etc. Markdown, refs #13173

### DIFF
--- a/apps/qubit/modules/default/actions/fullTreeViewAction.class.php
+++ b/apps/qubit/modules/default/actions/fullTreeViewAction.class.php
@@ -124,7 +124,7 @@ class DefaultFullTreeViewAction extends sfAction
       // Add identifier based on setting
       if ($this->showIdentifier === 'identifier' && !empty($result['identifier']))
       {
-        $result['text'] = render_value_inline($result['identifier']).' - '.$result['text'];
+        $result['text'] = $result['identifier'] .' - '. $result['text'];
       }
 
       // Add reference code based on setting

--- a/apps/qubit/modules/informationobject/templates/autocompleteSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/autocompleteSuccess.php
@@ -4,7 +4,7 @@
       <?php $doc = $hit->getData() ?>
       <tr>
         <td>
-          <?php echo link_to(render_value_inline(get_search_autocomplete_string($doc)), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?><?php if (isset($doc['publicationStatusId']) && QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $doc['publicationStatusId']): ?> <span class="publicationStatus"><?php echo render_value_inline(QubitTerm::getById($doc['publicationStatusId'])) ?></span><?php endif; ?>
+          <?php echo link_to(render_autocomplete_string($doc), array('module' => 'informationobject', 'slug' => $doc['slug'])) ?><?php if (isset($doc['publicationStatusId']) && QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $doc['publicationStatusId']): ?> <span class="publicationStatus"><?php echo render_value_inline(QubitTerm::getById($doc['publicationStatusId'])) ?></span><?php endif; ?>
         </td>
       </tr>
     <?php endforeach; ?>

--- a/apps/qubit/modules/search/templates/_searchResult.php
+++ b/apps/qubit/modules/search/templates/_searchResult.php
@@ -35,9 +35,9 @@
 
       <?php if ('1' == sfConfig::get('app_inherit_code_informationobject', 1)
         && isset($doc['referenceCode']) && !empty($doc['referenceCode'])) : ?>
-          <li class="reference-code"><?php echo render_value_inline($doc['referenceCode']) ?></li>
+          <li class="reference-code"><?php echo $doc['referenceCode'] ?></li>
       <?php elseif (isset($doc['identifier']) && !empty($doc['identifier'])) : ?>
-          <li class="reference-code"><?php echo render_value_inline($doc['identifier']) ?></li>
+          <li class="reference-code"><?php echo $doc['identifier'] ?></li>
       <?php endif; ?>
 
       <?php if (isset($doc['levelOfDescriptionId']) && !empty($doc['levelOfDescriptionId'])): ?>

--- a/lib/helper/QubitHelper.php
+++ b/lib/helper/QubitHelper.php
@@ -123,9 +123,9 @@ function render_show_repository($label, $resource)
   }
 }
 
-function render_title($value)
+function render_title($value, $renderMarkdown = true)
 {
-  $value = render_value_inline($value);
+  $value = ($renderMarkdown) ? render_value_inline($value) : $value;
 
   if (0 < strlen($value))
   {
@@ -289,7 +289,7 @@ function render_treeview_node($item, array $classes = array(), array $options = 
       $title = '';
       if ($item->identifier)
       {
-        $title = render_value_inline($item->identifier) . "&nbsp;-&nbsp;";
+        $title = $item->identifier . "&nbsp;-&nbsp;";
       }
       $title .= render_title($item);
 
@@ -449,7 +449,7 @@ function get_search_creation_details($hit, $culture = null)
   return implode(', ', $details);
 }
 
-function get_search_autocomplete_string($hit)
+function render_autocomplete_string($hit)
 {
   if ($hit instanceof sfOutputEscaperObjectDecorator && 'Elastica\Result' == $hit->getClass())
   {
@@ -484,7 +484,7 @@ function get_search_autocomplete_string($hit)
 
   if (null !== $title = get_search_i18n($hit, 'title'))
   {
-    $titleAndPublicationStatus[] = $title;
+    $titleAndPublicationStatus[] = render_value_inline($title);
   }
 
   if (isset($hit['publicationStatusId']) && QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $hit['publicationStatusId'])

--- a/plugins/qtAccessionPlugin/modules/accession/templates/browseSuccess.php
+++ b/plugins/qtAccessionPlugin/modules/accession/templates/browseSuccess.php
@@ -47,7 +47,7 @@
         <?php $doc = $hit->getData() ?>
         <tr>
           <td width="20%">
-            <?php echo link_to(render_value_inline($doc['identifier']), array('module' => 'accession', 'slug' => $doc['slug'])) ?>
+            <?php echo link_to($doc['identifier'], array('module' => 'accession', 'slug' => $doc['slug'])) ?>
           </td>
           <td>
             <?php echo link_to(render_title(get_search_i18n($doc, 'title')), array('module' => 'accession', 'slug' => $doc['slug'])) ?>

--- a/plugins/qtAccessionPlugin/modules/accession/templates/indexSuccess.php
+++ b/plugins/qtAccessionPlugin/modules/accession/templates/indexSuccess.php
@@ -23,7 +23,7 @@
 
 <?php end_slot() ?>
 
-<?php echo render_show(__('Accession number'), render_value($resource->identifier)) ?>
+<?php echo render_show(__('Accession number'), $resource->identifier) ?>
 
 <?php echo render_show(__('Acquisition date'), render_value(Qubit::renderDate($resource->date))) ?>
 
@@ -160,7 +160,7 @@
     <div class="field">
       <h3><?php echo __('Deaccession') ?></h3>
       <div>
-        <?php echo link_to(render_title($item), array($item, 'module' => 'deaccession')) ?>
+        <?php echo link_to(render_title($item, false), array($item, 'module' => 'deaccession')) ?>
       </div>
     </div>
 

--- a/plugins/qtAccessionPlugin/modules/deaccession/templates/indexSuccess.php
+++ b/plugins/qtAccessionPlugin/modules/deaccession/templates/indexSuccess.php
@@ -26,11 +26,11 @@
 <div class="field">
   <h3>Accession record</h3>
   <div class="value">
-    <?php echo link_to(render_title($resource->accession), array($resource->accession, 'module' => 'accession')) ?>
+    <?php echo link_to(render_title($resource->accession, false), array($resource->accession, 'module' => 'accession')) ?>
   </div>
 </div>
 
-<?php echo render_show(__('Deaccession number'), render_value($resource->identifier)) ?>
+<?php echo render_show(__('Deaccession number'), $resource->identifier) ?>
 
 <?php echo render_show(__('Scope'), render_value($resource->scope)) ?>
 

--- a/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/templates/indexSuccess.php
@@ -54,7 +54,7 @@
     </div>
   </div>
 
-  <?php echo render_show(__('Classification'), render_value($resource->getClassification(array('cultureFallback' => true)))) ?>
+  <?php echo render_show(__('Classification'), $resource->getClassification(array('cultureFallback' => true))) ?>
 
 </div> <!-- /.section#identityArea -->
 

--- a/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
@@ -84,7 +84,7 @@
 
   <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'repository'), '<h2>'.__('Identity area').'</h2>', array($resource, 'module' => 'repository', 'action' => 'edit'), array('anchor' => 'identityArea', 'title' => __('Edit identity area'))) ?>
 
-  <?php echo render_show(__('Identifier'), render_value($resource->identifier)) ?>
+  <?php echo render_show(__('Identifier'), $resource->identifier) ?>
 
   <?php echo render_show(__('Authorized form of name'), render_value($resource)) ?>
 


### PR DESCRIPTION
Got rid of more Markdown parsing of identifiers, accession numbers,
and deaccession numbers.