### PR TITLE
Add PMM to Docker environment, refs #13224

### DIFF
--- a/docker/docker-compose.pmm.yml
+++ b/docker/docker-compose.pmm.yml
@@ -1,0 +1,28 @@
+---
+version: "2"
+
+services:
+
+  percona:
+    volumes:
+      - ./etc/mysql/pmm.cnf:/etc/my.cnf.d/pmm.cnf:ro
+
+  pmm_server:
+    image: percona/pmm-server
+    ports:
+      - "127.0.0.1:63006:80"
+    environment:
+      - SERVER_USER=pmm
+      - SERVER_PASSWORD=pmm
+
+  pmm_client:
+    image: perconalab/pmm-client
+    environment:
+      - PMM_SERVER=pmm_server
+      - PMM_USER=pmm
+      - PMM_PASSWORD=pmm
+      - DB_TYPE=mysql
+      - DB_HOST=percona
+      - DB_PORT=3306
+      - DB_USER=root
+      - DB_PASSWORD=my-secret-pw

--- a/docker/etc/mysql/pmm.cnf
+++ b/docker/etc/mysql/pmm.cnf
@@ -1,0 +1,4 @@
+[mysqld]
+performance_schema_instrument='%=on'
+innodb_monitor_enable=all
+userstat=1


### PR DESCRIPTION
**WORK IN PROGRESS**

Add an optional way to deploy Percona Monitoring and Management on the
Docker Compose environment.

TODO:
- Add README with notes about running PMM.
- Update PR after #997 is merged.