### PR TITLE
Non-create event actor display/facet, refs #12718

### DIFF
--- a/apps/qubit/modules/informationobject/templates/_nameAccessPoints.php
+++ b/apps/qubit/modules/informationobject/templates/_nameAccessPoints.php
@@ -10,12 +10,14 @@
 
   <div>
     <ul>
-      <?php if (isset($sidebar)): ?>
+      <?php if (isset($showActorEvents) || isset($sidebar)): ?>
         <?php $actorsShown = array(); ?>
         <?php foreach ($resource->getActorEvents() as $item): ?>
-          <?php if (isset($item->actor) && !isset($actorsShown[$item->actor->id])): ?>
-            <li><?php echo link_to(render_title($item->actor), array($item->actor)) ?> <span class="note2">(<?php echo render_value_inline($item->type->getRole()) ?>)</span></li>
-            <?php $actorsShown[$item->actor->id] = true; ?>
+          <?php if (isset($sidebar) || $item->type->id != QubitTerm::CREATION_ID): ?>
+            <?php if (isset($item->actor) && !isset($actorsShown[$item->actor->id])): ?>
+              <li><?php echo link_to(render_title($item->actor), array($item->actor)) ?> <span class="note2">(<?php echo render_value_inline($item->type->getRole()) ?>)</span></li>
+              <?php $actorsShown[$item->actor->id] = true; ?>
+            <?php endif; ?>
           <?php endif; ?>
         <?php endforeach; ?>
       <?php endif; ?>

--- a/plugins/arDacsPlugin/modules/arDacsPlugin/templates/indexSuccess.php
+++ b/plugins/arDacsPlugin/modules/arDacsPlugin/templates/indexSuccess.php
@@ -260,7 +260,7 @@
 
   <?php echo get_partial('object/placeAccessPoints', array('resource' => $resource)) ?>
 
-  <?php echo get_partial('informationobject/nameAccessPoints', array('resource' => $resource)) ?>
+  <?php echo get_partial('informationobject/nameAccessPoints', array('resource' => $resource, 'showActorEvents' => true)) ?>
 
   <?php echo get_partial('informationobject/genreAccessPoints', array('resource' => $resource)) ?>
 

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
@@ -615,6 +615,17 @@ class arElasticSearchInformationObjectPdo
       $names[$item->id] = $item;
     }
 
+    // Add actors in related, non-creation events
+    foreach ($this->events as $event)
+    {
+      if ($event->type_id != QubitTerm::CREATION_ID)
+      {
+        $actor = new stdClass;
+        $actor->id = $event->actor_id;
+        $names[$actor->id] = $actor;
+      }
+    }
+
     return $names;
   }
 

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/indexSuccess.php
@@ -234,7 +234,7 @@
   </div>
 
   <div class="nameAccessPoints">
-    <?php echo get_partial('informationobject/nameAccessPoints', array('resource' => $resource)) ?>
+    <?php echo get_partial('informationobject/nameAccessPoints', array('resource' => $resource, 'showActorEvents' => true)) ?>
   </div>
 
   <div class="genreAccessPoints">

--- a/plugins/sfModsPlugin/modules/sfModsPlugin/templates/indexSuccess.php
+++ b/plugins/sfModsPlugin/modules/sfModsPlugin/templates/indexSuccess.php
@@ -79,7 +79,7 @@
 
   <?php echo get_partial('object/placeAccessPoints', array('resource' => $resource, 'mods' => true)) ?>
 
-  <?php echo get_partial('informationobject/nameAccessPoints', array('resource' => $resource, 'mods' => true)) ?>
+  <?php echo get_partial('informationobject/nameAccessPoints', array('resource' => $resource, 'mods' => true, 'showActorEvents' => true)) ?>
 
   <?php echo render_show(__('Access condition'), render_value($resource->getAccessConditions(array('cultureFallback' => true)))) ?>
 


### PR DESCRIPTION
Show non-create event actors in name access points section of
descriptions.

Include non-create event actions in name access point facet display
and search.