### PR TITLE
Add PMM to Docker environment, refs #13224

### DIFF
--- a/docker/docker-compose.pmm.yml
+++ b/docker/docker-compose.pmm.yml
@@ -1,0 +1,39 @@
+---
+version: "2"
+
+volumes:
+  pmm_prometheus_data:
+  pmm_consul_data:
+  pmm_mysql_lib:
+  pmm_grafana_lib:
+
+services:
+
+  percona:
+    volumes:
+      - ./etc/mysql/pmm.cnf:/etc/my.cnf.d/pmm.cnf:ro
+
+  pmm_server:
+    image: percona/pmm-server
+    volumes:
+      - pmm_prometheus_data:/opt/prometheus/data
+      - pmm_consul_data:/opt/consul-data
+      - pmm_mysql_lib:/var/lib/mysql
+      - pmm_grafana_lib:/var/lib/grafana
+    ports:
+      - "127.0.0.1:63006:80"
+    environment:
+      - SERVER_USER=pmm
+      - SERVER_PASSWORD=pmm
+
+  pmm_client:
+    image: perconalab/pmm-client
+    environment:
+      - PMM_SERVER=pmm_server
+      - PMM_USER=pmm
+      - PMM_PASSWORD=pmm
+      - DB_TYPE=mysql
+      - DB_HOST=percona
+      - DB_PORT=3306
+      - DB_USER=root
+      - DB_PASSWORD=my-secret-pw

--- a/docker/etc/mysql/pmm.cnf
+++ b/docker/etc/mysql/pmm.cnf
@@ -1,0 +1,4 @@
+[mysqld]
+performance_schema_instrument='%=on'
+innodb_monitor_enable=all
+userstat=1


### PR DESCRIPTION
Add Percona Monitoring and Management server and client services to the
Docker Compose environment (optional, extending the development setup).

Documentation PR: https://github.com/artefactual/atom-docs/pull/132