### PR TITLE
Fix to EAD repository name import, refs #6317

### DIFF
--- a/apps/qubit/modules/object/config/import/ead.yml
+++ b/apps/qubit/modules/object/config/import/ead.yml
@@ -62,8 +62,17 @@ information_object:
       Method: SetLevelOfDescriptionByName
 
     repository:
-      XPath:   "(did/repository[not(*)] | did/repository/corpname | did/repository/name)[1]"
+      XPath:   "(did/repository/corpname | did/repository/name)[1]"
       Method:  setRepositoryByName
+      Filters:
+        -
+          emph:
+            QubitMarkdown: eadTagToMarkdown
+
+    repository_alternate:
+      XPath:   "did/repository[not(corpname) and not(name)]"
+      Method:  setRepositoryByName
+      IgnoreChildElementText: yes
       Filters:
         -
           emph:

--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -610,7 +610,7 @@ class QubitXmlImport
               }
 
               // normalize the node text; NB: this will strip any child elements, eg. HTML tags
-              $nodeValue = self::normalizeNodeValue($domNode2);
+              $nodeValue = self::normalizeNodeValue($domNode2, $methodMap);
 
               // if you want the full XML from the node, use this
               $nodeXML = $domNode2->ownerDocument->saveXML($domNode2);
@@ -878,7 +878,7 @@ class QubitXmlImport
    *
    * @return node value without linebreaks tags
    */
-  public static function replaceLineBreaks($node)
+  public static function replaceLineBreaks($node, $methodMap = array())
   {
     $nodeValue = '';
     $fieldsArray = array('extent', 'physfacet', 'dimensions');
@@ -905,7 +905,10 @@ class QubitXmlImport
       }
       else
       {
-        $nodeValue .= preg_replace('/[\n\r\s]+/', ' ', $child->nodeValue);
+        if (empty($methodMap['IgnoreChildElementText']) || !($child instanceOf DOMElement))
+        {
+          $nodeValue .= preg_replace('/[\n\r\s]+/', ' ', $child->nodeValue);
+        }
       }
     }
 
@@ -989,7 +992,7 @@ class QubitXmlImport
    *
    * @return node value normalized
    */
-  public static function normalizeNodeValue($node)
+  public static function normalizeNodeValue($node, $methodMap = array())
   {
     $nodeValue = '';
 
@@ -1004,17 +1007,17 @@ class QubitXmlImport
         {
           if ($i++ == 0)
           {
-            $nodeValue .= self::replaceLineBreaks($pNode);
+            $nodeValue .= self::replaceLineBreaks($pNode, $methodMap);
           }
           else
           {
-            $nodeValue .= "\n\n" . self::replaceLineBreaks($pNode);
+            $nodeValue .= "\n\n" . self::replaceLineBreaks($pNode, $methodMap);
           }
         }
       }
       else
       {
-        $nodeValue .= self::replaceLineBreaks($node);
+        $nodeValue .= self::replaceLineBreaks($node, $methodMap);
       }
     }
     else


### PR DESCRIPTION
Support, as per the EAD standard, the ability to specify a repository
name using text directly inside a "repository" element (rather than in
a "corpname" or "name" element nested in a "repository" element).

Added, in order to support this, an XML import configuration property:
"IgnoreChildElementText".

Normally if an xpath in a format's XML import configuration selects
an element that contains child elements then the text from the child
elements will get added to the selected element's text. This, for
example, enables the EAD configuration's "did/repository/address"
selector to incorporate the text of all child "addressline" elements.
The "IgnoreChildElementText" configuration property prevents this.