### PR TITLE
Improve hierarchy management queries, refs #13224

### DIFF
--- a/lib/model/om/BaseInformationObject.php
+++ b/lib/model/om/BaseInformationObject.php
@@ -586,7 +586,26 @@ abstract class BaseInformationObject extends QubitObject implements ArrayAccess
 
   public function addAncestorsCriteria(Criteria $criteria)
   {
-    return $criteria->add(QubitInformationObject::LFT, $this->lft, Criteria::LESS_THAN)->add(QubitInformationObject::RGT, $this->rgt, Criteria::GREATER_THAN);
+    if (isset($this->parentId))
+    {
+      $condition = '= '.$this->parentId;
+    }
+    else
+    {
+      $condition = 'IS NULL';
+    }
+
+    $subquery = "information_object.id IN (
+    	WITH RECURSIVE cte AS
+    	(
+    	  SELECT tb1.id, tb1.parent_id FROM information_object tb1 WHERE tb1.id $condition
+    	  UNION ALL
+    	  SELECT tb2.id, tb2.parent_id FROM information_object tb2 JOIN cte ON cte.parent_id=tb2.id
+    	)
+    	SELECT id FROM cte
+    )";
+
+    return $criteria->add('', $subquery, Criteria::CUSTOM);
   }
 
   public function addDescendantsCriteria(Criteria $criteria)

--- a/lib/model/om/BaseMenu.php
+++ b/lib/model/om/BaseMenu.php
@@ -831,7 +831,26 @@ abstract class BaseMenu implements ArrayAccess
 
   public function addAncestorsCriteria(Criteria $criteria)
   {
-    return $criteria->add(QubitMenu::LFT, $this->lft, Criteria::LESS_THAN)->add(QubitMenu::RGT, $this->rgt, Criteria::GREATER_THAN);
+    if (isset($this->parentId))
+    {
+      $condition = '= '.$this->parentId;
+    }
+    else
+    {
+      $condition = 'IS NULL';
+    }
+
+    $subquery = "menu.id IN (
+    	WITH RECURSIVE cte AS
+    	(
+    	  SELECT tb1.id, tb1.parent_id FROM menu tb1 WHERE tb1.id $condition
+    	  UNION ALL
+    	  SELECT tb2.id, tb2.parent_id FROM menu tb2 JOIN cte ON cte.parent_id=tb2.id
+    	)
+    	SELECT id FROM cte
+    )";
+
+    return $criteria->add('', $subquery, Criteria::CUSTOM);
   }
 
   public function addDescendantsCriteria(Criteria $criteria)

--- a/lib/model/om/BasePhysicalObject.php
+++ b/lib/model/om/BasePhysicalObject.php
@@ -491,7 +491,26 @@ abstract class BasePhysicalObject extends QubitObject implements ArrayAccess
 
   public function addAncestorsCriteria(Criteria $criteria)
   {
-    return $criteria->add(QubitPhysicalObject::LFT, $this->lft, Criteria::LESS_THAN)->add(QubitPhysicalObject::RGT, $this->rgt, Criteria::GREATER_THAN);
+    if (isset($this->parentId))
+    {
+      $condition = '= '.$this->parentId;
+    }
+    else
+    {
+      $condition = 'IS NULL';
+    }
+
+    $subquery = "physical_object.id IN (
+    	WITH RECURSIVE cte AS
+    	(
+    	  SELECT tb1.id, tb1.parent_id FROM physical_object tb1 WHERE tb1.id $condition
+    	  UNION ALL
+    	  SELECT tb2.id, tb2.parent_id FROM physical_object tb2 JOIN cte ON cte.parent_id=tb2.id
+    	)
+    	SELECT id FROM cte
+    )";
+
+    return $criteria->add('', $subquery, Criteria::CUSTOM);
   }
 
   public function addDescendantsCriteria(Criteria $criteria)

--- a/lib/model/om/BaseTaxonomy.php
+++ b/lib/model/om/BaseTaxonomy.php
@@ -526,7 +526,26 @@ abstract class BaseTaxonomy extends QubitObject implements ArrayAccess
 
   public function addAncestorsCriteria(Criteria $criteria)
   {
-    return $criteria->add(QubitTaxonomy::LFT, $this->lft, Criteria::LESS_THAN)->add(QubitTaxonomy::RGT, $this->rgt, Criteria::GREATER_THAN);
+    if (isset($this->parentId))
+    {
+      $condition = '= '.$this->parentId;
+    }
+    else
+    {
+      $condition = 'IS NULL';
+    }
+
+    $subquery = "taxonomy.id IN (
+    	WITH RECURSIVE cte AS
+    	(
+    	  SELECT tb1.id, tb1.parent_id FROM taxonomy tb1 WHERE tb1.id $condition
+    	  UNION ALL
+    	  SELECT tb2.id, tb2.parent_id FROM taxonomy tb2 JOIN cte ON cte.parent_id=tb2.id
+    	)
+    	SELECT id FROM cte
+    )";
+
+    return $criteria->add('', $subquery, Criteria::CUSTOM);
   }
 
   public function addDescendantsCriteria(Criteria $criteria)

--- a/lib/model/om/BaseTerm.php
+++ b/lib/model/om/BaseTerm.php
@@ -1963,7 +1963,26 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
 
   public function addAncestorsCriteria(Criteria $criteria)
   {
-    return $criteria->add(QubitTerm::LFT, $this->lft, Criteria::LESS_THAN)->add(QubitTerm::RGT, $this->rgt, Criteria::GREATER_THAN);
+    if (isset($this->parentId))
+    {
+      $condition = '= '.$this->parentId;
+    }
+    else
+    {
+      $condition = 'IS NULL';
+    }
+
+    $subquery = "term.id IN (
+    	WITH RECURSIVE cte AS
+    	(
+    	  SELECT tb1.id, tb1.parent_id FROM term tb1 WHERE tb1.id $condition
+    	  UNION ALL
+    	  SELECT tb2.id, tb2.parent_id FROM term tb2 JOIN cte ON cte.parent_id=tb2.id
+    	)
+    	SELECT id FROM cte
+    )";
+
+    return $criteria->add('', $subquery, Criteria::CUSTOM);
   }
 
   public function addDescendantsCriteria(Criteria $criteria)

--- a/plugins/qbAclPlugin/lib/model/om/BaseAclGroup.php
+++ b/plugins/qbAclPlugin/lib/model/om/BaseAclGroup.php
@@ -911,7 +911,26 @@ abstract class BaseAclGroup implements ArrayAccess
 
   public function addAncestorsCriteria(Criteria $criteria)
   {
-    return $criteria->add(QubitAclGroup::LFT, $this->lft, Criteria::LESS_THAN)->add(QubitAclGroup::RGT, $this->rgt, Criteria::GREATER_THAN);
+    if (isset($this->parentId))
+    {
+      $condition = '= '.$this->parentId;
+    }
+    else
+    {
+      $condition = 'IS NULL';
+    }
+
+    $subquery = "acl_group.id IN (
+    	WITH RECURSIVE cte AS
+    	(
+    	  SELECT tb1.id, tb1.parent_id FROM acl_group tb1 WHERE tb1.id $condition
+    	  UNION ALL
+    	  SELECT tb2.id, tb2.parent_id FROM acl_group tb2 JOIN cte ON cte.parent_id=tb2.id
+    	)
+    	SELECT id FROM cte
+    )";
+
+    return $criteria->add('', $subquery, Criteria::CUSTOM);
   }
 
   public function addDescendantsCriteria(Criteria $criteria)


### PR DESCRIPTION
**WORK IN PROGRESS**
Based on https://github.com/artefactual/atom/pull/997 until it's merged.

---

**Use CTE to fetch ancestors:**

Modify the criteria from `addAncestorsCriteria` to use a recursive
CTE in order the fetch the resource's ancestors without using the
nested set columns.

Modify the `QubitObjectBuilder` and build models.