### PR TITLE
Improve hierarchy management queries, refs #13224

### DIFF
--- a/apps/qubit/modules/informationobject/actions/calculateDatesAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/calculateDatesAction.class.php
@@ -147,7 +147,7 @@ class InformationObjectCalculateDatesAction extends DefaultEditAction
         INNER JOIN event e ON i.id=e.object_id
       WHERE
         i.lft > :lft
-        AND i.rgt < :rgt";
+        AND i.lft < :rgt";
 
     $params = array(
       ':lft' => $resource->lft,

--- a/apps/qubit/modules/informationobject/actions/calculateDatesAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/calculateDatesAction.class.php
@@ -87,7 +87,7 @@ class InformationObjectCalculateDatesAction extends DefaultEditAction
 
     // Set response to 403 forbidden if attempting to calculate dates using
     // non-existant descendants
-    if (!count($this->resource->descendants))
+    if ($this->resource->rgt - $this->resource->lft == 1)
     {
       $this->getResponse()->setStatusCode(403);
       return sfView::NONE;

--- a/apps/qubit/modules/informationobject/actions/deleteAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/deleteAction.class.php
@@ -52,7 +52,7 @@ class InformationObjectDeleteAction extends sfAction
 
     // Apparently we can't slice a QubitQuery. `previewSize` is shared with
     // the template so we can break the loop when desired.
-    $this->count = count($this->resource->descendants);
+    $this->count = ($this->resource->rgt - $this->resource->lft - 1) / 2;
     $this->previewSize = (int)sfConfig::get('app_hits_per_page', 10);
     $this->previewIsLimited = $this->count > $this->previewSize;
   }

--- a/apps/qubit/modules/term/actions/deleteAction.class.php
+++ b/apps/qubit/modules/term/actions/deleteAction.class.php
@@ -60,5 +60,7 @@ class TermDeleteAction extends sfAction
 
       $this->redirect(array('module' => 'taxonomy', 'action' => 'list'));
     }
+
+    $this->descendantsCount = ($this->resource->rgt - $this->resource->lft - 1) / 2;
   }
 }

--- a/apps/qubit/modules/term/templates/deleteSuccess.php
+++ b/apps/qubit/modules/term/templates/deleteSuccess.php
@@ -30,8 +30,8 @@
         </div>
       <?php endif; ?>
 
-      <?php if (0 < count($resource->descendants)): ?>
-        <h2><?php echo __('It has %1% descendants that will also be deleted', array('%1%' => count($resource->descendants))) ?><h2>
+      <?php if (0 < $descendantsCount): ?>
+        <h2><?php echo __('It has %1% descendants that will also be deleted', array('%1%' => $descendantsCount)) ?><h2>
         <div class="delete-list">
           <ul>
             <?php foreach ($resource->descendants as $item): ?>

--- a/lib/job/arCalculateDescendantDatesJob.class.php
+++ b/lib/job/arCalculateDescendantDatesJob.class.php
@@ -86,7 +86,7 @@ class arCalculateDescendantDatesJob extends arBaseJob
         INNER JOIN event e ON i.id=e.object_id
       WHERE
         i.lft > :lft
-        AND i.rgt < :rgt
+        AND i.lft < :rgt
         AND e.type_id=:eventType
         AND (e.start_date IS NOT NULL OR e.end_date IS NOT NULL)";
 

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -868,7 +868,7 @@ class QubitInformationObject extends BaseInformationObject
     $sql = "
       SELECT 1 FROM information_object
       INNER JOIN term_i18n on term_i18n.id = information_object.level_of_description_id
-      WHERE information_object.lft > ? and information_object.rgt < ?
+      WHERE information_object.lft > ? and information_object.lft < ?
       AND term_i18n.culture = ? AND term_i18n.name = ?
       LIMIT 1
     ";
@@ -1426,7 +1426,7 @@ class QubitInformationObject extends BaseInformationObject
     $sql = '
       SELECT COUNT(d.id) FROM information_object i
       INNER JOIN digital_object d ON i.id=d.object_id
-      WHERE i.lft > ? and i.rgt < ?
+      WHERE i.lft > ? and i.lft < ?
     ';
 
     $params = array($this->lft, $this->rgt);

--- a/lib/model/QubitPhysicalObject.php
+++ b/lib/model/QubitPhysicalObject.php
@@ -207,7 +207,7 @@ class QubitPhysicalObject extends BasePhysicalObject
       $sql = 'SELECT rel.id FROM relation rel
         INNER JOIN information_object io ON rel.object_id = io.id
         WHERE rel.subject_id = :id AND rel.type_id = :typeId
-        AND io.lft >= :lft AND io.rgt <= :rgt;';
+        AND io.lft >= :lft AND io.lft <= :rgt;';
 
       $params = array(
         ':id' => $physObj->id,

--- a/lib/model/om/BaseActor.php
+++ b/lib/model/om/BaseActor.php
@@ -665,7 +665,18 @@ abstract class BaseActor extends QubitObject implements ArrayAccess
 
   public function addDescendantsCriteria(Criteria $criteria)
   {
-    return $criteria->add(QubitActor::LFT, $this->lft, Criteria::GREATER_THAN)->add(QubitActor::RGT, $this->rgt, Criteria::LESS_THAN);
+    $criterion = $criteria->getNewCriterion(
+      QubitActor::LFT,
+      $this->lft,
+      Criteria::GREATER_THAN
+    );
+    $criterion->addAnd($criteria->getNewCriterion(
+      QubitActor::LFT,
+      $this->rgt,
+      Criteria::LESS_THAN
+    ));
+
+    return $criteria->add($criterion);
   }
 
   protected function updateNestedSet($connection = null)

--- a/lib/model/om/BaseInformationObject.php
+++ b/lib/model/om/BaseInformationObject.php
@@ -610,7 +610,18 @@ abstract class BaseInformationObject extends QubitObject implements ArrayAccess
 
   public function addDescendantsCriteria(Criteria $criteria)
   {
-    return $criteria->add(QubitInformationObject::LFT, $this->lft, Criteria::GREATER_THAN)->add(QubitInformationObject::RGT, $this->rgt, Criteria::LESS_THAN);
+    $criterion = $criteria->getNewCriterion(
+      QubitInformationObject::LFT,
+      $this->lft,
+      Criteria::GREATER_THAN
+    );
+    $criterion->addAnd($criteria->getNewCriterion(
+      QubitInformationObject::LFT,
+      $this->rgt,
+      Criteria::LESS_THAN
+    ));
+
+    return $criteria->add($criterion);
   }
 
   protected function updateNestedSet($connection = null)

--- a/lib/model/om/BaseInformationObject.php
+++ b/lib/model/om/BaseInformationObject.php
@@ -586,7 +586,26 @@ abstract class BaseInformationObject extends QubitObject implements ArrayAccess
 
   public function addAncestorsCriteria(Criteria $criteria)
   {
-    return $criteria->add(QubitInformationObject::LFT, $this->lft, Criteria::LESS_THAN)->add(QubitInformationObject::RGT, $this->rgt, Criteria::GREATER_THAN);
+    if (isset($this->parentId))
+    {
+      $condition = '= '.$this->parentId;
+    }
+    else
+    {
+      $condition = 'IS NULL';
+    }
+
+    $subquery = "information_object.id IN (
+    	WITH RECURSIVE cte AS
+    	(
+    	  SELECT tb1.id, tb1.parent_id FROM information_object tb1 WHERE tb1.id $condition
+    	  UNION ALL
+    	  SELECT tb2.id, tb2.parent_id FROM information_object tb2 JOIN cte ON cte.parent_id=tb2.id
+    	)
+    	SELECT id FROM cte
+    )";
+
+    return $criteria->add('', $subquery, Criteria::CUSTOM);
   }
 
   public function addDescendantsCriteria(Criteria $criteria)

--- a/lib/model/om/BaseMenu.php
+++ b/lib/model/om/BaseMenu.php
@@ -855,7 +855,18 @@ abstract class BaseMenu implements ArrayAccess
 
   public function addDescendantsCriteria(Criteria $criteria)
   {
-    return $criteria->add(QubitMenu::LFT, $this->lft, Criteria::GREATER_THAN)->add(QubitMenu::RGT, $this->rgt, Criteria::LESS_THAN);
+    $criterion = $criteria->getNewCriterion(
+      QubitMenu::LFT,
+      $this->lft,
+      Criteria::GREATER_THAN
+    );
+    $criterion->addAnd($criteria->getNewCriterion(
+      QubitMenu::LFT,
+      $this->rgt,
+      Criteria::LESS_THAN
+    ));
+
+    return $criteria->add($criterion);
   }
 
   protected function updateNestedSet($connection = null)

--- a/lib/model/om/BaseMenu.php
+++ b/lib/model/om/BaseMenu.php
@@ -831,7 +831,26 @@ abstract class BaseMenu implements ArrayAccess
 
   public function addAncestorsCriteria(Criteria $criteria)
   {
-    return $criteria->add(QubitMenu::LFT, $this->lft, Criteria::LESS_THAN)->add(QubitMenu::RGT, $this->rgt, Criteria::GREATER_THAN);
+    if (isset($this->parentId))
+    {
+      $condition = '= '.$this->parentId;
+    }
+    else
+    {
+      $condition = 'IS NULL';
+    }
+
+    $subquery = "menu.id IN (
+    	WITH RECURSIVE cte AS
+    	(
+    	  SELECT tb1.id, tb1.parent_id FROM menu tb1 WHERE tb1.id $condition
+    	  UNION ALL
+    	  SELECT tb2.id, tb2.parent_id FROM menu tb2 JOIN cte ON cte.parent_id=tb2.id
+    	)
+    	SELECT id FROM cte
+    )";
+
+    return $criteria->add('', $subquery, Criteria::CUSTOM);
   }
 
   public function addDescendantsCriteria(Criteria $criteria)

--- a/lib/model/om/BasePhysicalObject.php
+++ b/lib/model/om/BasePhysicalObject.php
@@ -515,7 +515,18 @@ abstract class BasePhysicalObject extends QubitObject implements ArrayAccess
 
   public function addDescendantsCriteria(Criteria $criteria)
   {
-    return $criteria->add(QubitPhysicalObject::LFT, $this->lft, Criteria::GREATER_THAN)->add(QubitPhysicalObject::RGT, $this->rgt, Criteria::LESS_THAN);
+    $criterion = $criteria->getNewCriterion(
+      QubitPhysicalObject::LFT,
+      $this->lft,
+      Criteria::GREATER_THAN
+    );
+    $criterion->addAnd($criteria->getNewCriterion(
+      QubitPhysicalObject::LFT,
+      $this->rgt,
+      Criteria::LESS_THAN
+    ));
+
+    return $criteria->add($criterion);
   }
 
   protected function updateNestedSet($connection = null)

--- a/lib/model/om/BasePhysicalObject.php
+++ b/lib/model/om/BasePhysicalObject.php
@@ -491,7 +491,26 @@ abstract class BasePhysicalObject extends QubitObject implements ArrayAccess
 
   public function addAncestorsCriteria(Criteria $criteria)
   {
-    return $criteria->add(QubitPhysicalObject::LFT, $this->lft, Criteria::LESS_THAN)->add(QubitPhysicalObject::RGT, $this->rgt, Criteria::GREATER_THAN);
+    if (isset($this->parentId))
+    {
+      $condition = '= '.$this->parentId;
+    }
+    else
+    {
+      $condition = 'IS NULL';
+    }
+
+    $subquery = "physical_object.id IN (
+    	WITH RECURSIVE cte AS
+    	(
+    	  SELECT tb1.id, tb1.parent_id FROM physical_object tb1 WHERE tb1.id $condition
+    	  UNION ALL
+    	  SELECT tb2.id, tb2.parent_id FROM physical_object tb2 JOIN cte ON cte.parent_id=tb2.id
+    	)
+    	SELECT id FROM cte
+    )";
+
+    return $criteria->add('', $subquery, Criteria::CUSTOM);
   }
 
   public function addDescendantsCriteria(Criteria $criteria)

--- a/lib/model/om/BaseTaxonomy.php
+++ b/lib/model/om/BaseTaxonomy.php
@@ -526,7 +526,26 @@ abstract class BaseTaxonomy extends QubitObject implements ArrayAccess
 
   public function addAncestorsCriteria(Criteria $criteria)
   {
-    return $criteria->add(QubitTaxonomy::LFT, $this->lft, Criteria::LESS_THAN)->add(QubitTaxonomy::RGT, $this->rgt, Criteria::GREATER_THAN);
+    if (isset($this->parentId))
+    {
+      $condition = '= '.$this->parentId;
+    }
+    else
+    {
+      $condition = 'IS NULL';
+    }
+
+    $subquery = "taxonomy.id IN (
+    	WITH RECURSIVE cte AS
+    	(
+    	  SELECT tb1.id, tb1.parent_id FROM taxonomy tb1 WHERE tb1.id $condition
+    	  UNION ALL
+    	  SELECT tb2.id, tb2.parent_id FROM taxonomy tb2 JOIN cte ON cte.parent_id=tb2.id
+    	)
+    	SELECT id FROM cte
+    )";
+
+    return $criteria->add('', $subquery, Criteria::CUSTOM);
   }
 
   public function addDescendantsCriteria(Criteria $criteria)

--- a/lib/model/om/BaseTaxonomy.php
+++ b/lib/model/om/BaseTaxonomy.php
@@ -550,7 +550,18 @@ abstract class BaseTaxonomy extends QubitObject implements ArrayAccess
 
   public function addDescendantsCriteria(Criteria $criteria)
   {
-    return $criteria->add(QubitTaxonomy::LFT, $this->lft, Criteria::GREATER_THAN)->add(QubitTaxonomy::RGT, $this->rgt, Criteria::LESS_THAN);
+    $criterion = $criteria->getNewCriterion(
+      QubitTaxonomy::LFT,
+      $this->lft,
+      Criteria::GREATER_THAN
+    );
+    $criterion->addAnd($criteria->getNewCriterion(
+      QubitTaxonomy::LFT,
+      $this->rgt,
+      Criteria::LESS_THAN
+    ));
+
+    return $criteria->add($criterion);
   }
 
   protected function updateNestedSet($connection = null)

--- a/lib/model/om/BaseTerm.php
+++ b/lib/model/om/BaseTerm.php
@@ -1963,7 +1963,26 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
 
   public function addAncestorsCriteria(Criteria $criteria)
   {
-    return $criteria->add(QubitTerm::LFT, $this->lft, Criteria::LESS_THAN)->add(QubitTerm::RGT, $this->rgt, Criteria::GREATER_THAN);
+    if (isset($this->parentId))
+    {
+      $condition = '= '.$this->parentId;
+    }
+    else
+    {
+      $condition = 'IS NULL';
+    }
+
+    $subquery = "term.id IN (
+    	WITH RECURSIVE cte AS
+    	(
+    	  SELECT tb1.id, tb1.parent_id FROM term tb1 WHERE tb1.id $condition
+    	  UNION ALL
+    	  SELECT tb2.id, tb2.parent_id FROM term tb2 JOIN cte ON cte.parent_id=tb2.id
+    	)
+    	SELECT id FROM cte
+    )";
+
+    return $criteria->add('', $subquery, Criteria::CUSTOM);
   }
 
   public function addDescendantsCriteria(Criteria $criteria)

--- a/lib/model/om/BaseTerm.php
+++ b/lib/model/om/BaseTerm.php
@@ -1987,7 +1987,18 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
 
   public function addDescendantsCriteria(Criteria $criteria)
   {
-    return $criteria->add(QubitTerm::LFT, $this->lft, Criteria::GREATER_THAN)->add(QubitTerm::RGT, $this->rgt, Criteria::LESS_THAN);
+    $criterion = $criteria->getNewCriterion(
+      QubitTerm::LFT,
+      $this->lft,
+      Criteria::GREATER_THAN
+    );
+    $criterion->addAnd($criteria->getNewCriterion(
+      QubitTerm::LFT,
+      $this->rgt,
+      Criteria::LESS_THAN
+    ));
+
+    return $criteria->add($criterion);
   }
 
   protected function updateNestedSet($connection = null)

--- a/lib/propel/builder/QubitObjectBuilder.php
+++ b/lib/propel/builder/QubitObjectBuilder.php
@@ -1969,7 +1969,18 @@ script;
 
   public function addDescendantsCriteria(Criteria \$criteria)
   {
-    return \$criteria->add({$this->getColumnConstant($this->nestedSetLeftColumn)}, \$this->{$this->getColumnVarName($this->nestedSetLeftColumn)}, Criteria::GREATER_THAN)->add({$this->getColumnConstant($this->nestedSetRightColumn)}, \$this->{$this->getColumnVarName($this->nestedSetRightColumn)}, Criteria::LESS_THAN);
+    \$criterion = \$criteria->getNewCriterion(
+      {$this->getColumnConstant($this->nestedSetLeftColumn)},
+      \$this->{$this->getColumnVarName($this->nestedSetLeftColumn)},
+      Criteria::GREATER_THAN
+    );
+    \$criterion->addAnd(\$criteria->getNewCriterion(
+      {$this->getColumnConstant($this->nestedSetLeftColumn)},
+      \$this->{$this->getColumnVarName($this->nestedSetRightColumn)},
+      Criteria::LESS_THAN
+    ));
+
+    return \$criteria->add(\$criterion);
   }
 
 script;

--- a/lib/task/digitalobject/digitalObjectRegenDerivativesTask.class.php
+++ b/lib/task/digitalobject/digitalObjectRegenDerivativesTask.class.php
@@ -116,7 +116,7 @@ EOF;
         throw new sfException("Invalid slug");
       }
 
-      array_push($whereClauses, sprintf('io.lft >= %d AND io.rgt <= %d', $row->lft, $row->rgt));
+      array_push($whereClauses, sprintf('io.lft >= %d AND io.lft <= %d', $row->lft, $row->rgt));
     }
 
     // Only regenerate derivatives for remote digital objects

--- a/lib/task/tools/deleteDescriptionTask.class.php
+++ b/lib/task/tools/deleteDescriptionTask.class.php
@@ -100,7 +100,7 @@ EOF;
       case 'QubitInformationObject':
         $confirmWarning = sprintf('WARNING: You are about to delete the record "%s" and %d descendant records.',
                                   $this->resource->getTitle(array('cultureFallback' => true)),
-                                  count($this->resource->descendants));
+                                  ($this->resource->rgt - $this->resource->lft - 1) / 2);
         break;
     }
 
@@ -140,7 +140,7 @@ EOF;
   {
     $this->logSection('delete-description', sprintf('[%s] Deleting description "%s" (slug: %s, +%d descendants)', strftime('%r'),
       $root->getTitle(array('cultureFallback' => true)),
-      $root->slug, count($root->descendants)));
+      $root->slug, ($root->rgt - $root->lft - 1) / 2));
 
     $this->nDeleted += $root->deleteFullHierarchy();
   }

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchTermPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchTermPdo.class.php
@@ -107,16 +107,6 @@ class arElasticSearchTermPdo
     return $this;
   }
 
-  public function getNumberOfDescendants()
-  {
-    $sql  = 'SELECT COUNT(*) AS count';
-    $sql .= ' FROM '.QubitTerm::TABLE_NAME;
-    $sql .= ' WHERE lft > :lft';
-    $sql .= ' AND rgt < :rgt';
-
-    return QubitPdo::fetchOne($sql, array(':lft' => $this->lft, ':rgt' => $this->rgt))->count;
-  }
-
   public function serialize()
   {
     $serialized = array();
@@ -139,7 +129,7 @@ class arElasticSearchTermPdo
     }
 
     $serialized['isProtected'] = QubitTerm::isProtected($this->id);
-    $serialized['numberOfDescendants'] = $this->getNumberOfDescendants();
+    $serialized['numberOfDescendants'] = ($this->rgt - $this->lft - 1) / 2;
 
     $serialized['createdAt'] = arElasticSearchPluginUtil::convertDate($this->created_at);
     $serialized['updatedAt'] = arElasticSearchPluginUtil::convertDate($this->updated_at);

--- a/plugins/qbAclPlugin/lib/QubitAcl.class.php
+++ b/plugins/qbAclPlugin/lib/QubitAcl.class.php
@@ -343,9 +343,9 @@ class QubitAcl
     }
 
     // Add resource hierarchy
-    if (is_object($resource) && 0 < count($resources = $resource->ancestors->andSelf()->orderBy('lft')))
+    if (is_object($resource))
     {
-      foreach ($resources as $r)
+      foreach ($resource->ancestors->andSelf()->orderBy('lft') as $r)
       {
         if (!in_array($r->id, $this->_resources))
         {

--- a/plugins/qbAclPlugin/lib/model/om/BaseAclGroup.php
+++ b/plugins/qbAclPlugin/lib/model/om/BaseAclGroup.php
@@ -911,7 +911,26 @@ abstract class BaseAclGroup implements ArrayAccess
 
   public function addAncestorsCriteria(Criteria $criteria)
   {
-    return $criteria->add(QubitAclGroup::LFT, $this->lft, Criteria::LESS_THAN)->add(QubitAclGroup::RGT, $this->rgt, Criteria::GREATER_THAN);
+    if (isset($this->parentId))
+    {
+      $condition = '= '.$this->parentId;
+    }
+    else
+    {
+      $condition = 'IS NULL';
+    }
+
+    $subquery = "acl_group.id IN (
+    	WITH RECURSIVE cte AS
+    	(
+    	  SELECT tb1.id, tb1.parent_id FROM acl_group tb1 WHERE tb1.id $condition
+    	  UNION ALL
+    	  SELECT tb2.id, tb2.parent_id FROM acl_group tb2 JOIN cte ON cte.parent_id=tb2.id
+    	)
+    	SELECT id FROM cte
+    )";
+
+    return $criteria->add('', $subquery, Criteria::CUSTOM);
   }
 
   public function addDescendantsCriteria(Criteria $criteria)

--- a/plugins/qbAclPlugin/lib/model/om/BaseAclGroup.php
+++ b/plugins/qbAclPlugin/lib/model/om/BaseAclGroup.php
@@ -935,7 +935,18 @@ abstract class BaseAclGroup implements ArrayAccess
 
   public function addDescendantsCriteria(Criteria $criteria)
   {
-    return $criteria->add(QubitAclGroup::LFT, $this->lft, Criteria::GREATER_THAN)->add(QubitAclGroup::RGT, $this->rgt, Criteria::LESS_THAN);
+    $criterion = $criteria->getNewCriterion(
+      QubitAclGroup::LFT,
+      $this->lft,
+      Criteria::GREATER_THAN
+    );
+    $criterion->addAnd($criteria->getNewCriterion(
+      QubitAclGroup::LFT,
+      $this->rgt,
+      Criteria::LESS_THAN
+    ));
+
+    return $criteria->add($criterion);
   }
 
   protected function updateNestedSet($connection = null)


### PR DESCRIPTION
**Use CTE to fetch ancestors:**

Modify the criteria from `addAncestorsCriteria` to use a recursive
CTE in order the fetch the resource's ancestors without using the
nested set columns.

**Avoid double ancestors query on ACL:**

Calling count and then looping over the results of a criteria causes the
execution of a similar query twice, once for the count and another to
fetch the objects.

In this case, the count is not needed as the ancestors criteria is
followed by `andSelf()`, which will always return at least one result.

**Use only LFT on descendants queries:**

On a nested set implementation, the LFT and RGT values of each record
will not intersect, this means that if the LFT value is in between the
LFT and RGT values of another record you could assume that the RGT
value will also be in between those values.

Using only the LFT column to find descendants on the nested set avoids
the scan over the RGT column, resulting on a performance improvement.

**Avoid query to count descendants:**

Trust on the LFT and RGT values to calculate the descendants count.

---

A full report of this enhancements can be found on the Redmine ticket:

https://projects.artefactual.com/issues/13224 