### PR TITLE
Fix build SQL culture column sizing, refs #13222

### DIFF
--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/addon/sfPropelDatabaseSchema.class.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/addon/sfPropelDatabaseSchema.class.php
@@ -589,7 +589,7 @@ class sfPropelDatabaseSchema
 	  // Add source_culture column to main table
 	  $this->setIfNotSet($this->database[$main_table], 'source_culture', array(
 	    'required' => true,
-	    'size' => 7,
+	    'size' => 16,
 	    'type' => 'varchar'));
 
           // set id and culture columns for i18n table
@@ -604,7 +604,7 @@ class sfPropelDatabaseSchema
           $this->setIfNotSet($this->database[$i18n_table], 'culture', array(
             'isCulture'  => true,
             'type'       => 'varchar',
-            'size'       => '7',
+            'size'       => 16,
             'required'   => true,
             'primaryKey' => true,
           ));


### PR DESCRIPTION
Changed logic, that renders the AtoM schema to XML, so culture columns
have a size of 16 rather than 7.