### PR TITLE
Optionally show ref code in DC XML, refs #13244

### DIFF
--- a/apps/qubit/modules/settings/actions/identifierAction.class.php
+++ b/apps/qubit/modules/settings/actions/identifierAction.class.php
@@ -29,7 +29,8 @@ class SettingsIdentifierAction extends DefaultEditAction
       'identifier_mask',
       'identifier_counter',
       'separator_character',
-      'inherit_code_informationobject');
+      'inherit_code_informationobject',
+      'inherit_code_dc_xml');
 
   protected function earlyExecute()
   {
@@ -60,9 +61,10 @@ class SettingsIdentifierAction extends DefaultEditAction
       case 'accession_mask_enabled':
       case 'identifier_mask_enabled':
       case 'inherit_code_informationobject':
+      case 'inherit_code_dc_xml':
         // Determine default value
         // (accession mask enabled setting doesn't get created in DB by default)
-        $defaults = array('accession_mask_enabled' => 1);
+        $defaults = array('accession_mask_enabled' => 1, 'inherit_code_dc_xml' => 0);
 
         $default = (null !== $this->$name = QubitSetting::getByName($name))
           ? $this->$name->getValue(array('sourceCulture' => true))
@@ -90,6 +92,7 @@ class SettingsIdentifierAction extends DefaultEditAction
       case 'identifier_counter':
       case 'separator_character':
       case 'inherit_code_informationobject':
+      case 'inherit_code_dc_xml':
         if (null === $this->$name)
         {
           $this->$name = new QubitSetting;

--- a/apps/qubit/modules/settings/templates/identifierSuccess.php
+++ b/apps/qubit/modules/settings/templates/identifierSuccess.php
@@ -60,6 +60,10 @@
           ->label(__('Inherit reference code (information object)'))
           ->renderRow() ?>
 
+        <?php echo $form->inherit_code_dc_xml
+          ->label(__('Inherit reference code (DC XML)'))
+          ->renderRow() ?>
+
       </fieldset>
 
     </div>

--- a/plugins/sfDcPlugin/modules/sfDcPlugin/templates/_dc.xml.php
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/templates/_dc.xml.php
@@ -44,7 +44,11 @@
   <dc:identifier><?php echo esc_specialchars(sfConfig::get('app_siteBaseUrl') .'/'.$resource->slug) ?></dc:identifier>
 
   <?php if (!empty($resource->identifier)): ?>
-    <dc:identifier><?php echo esc_specialchars(strval($resource->identifier)) ?></dc:identifier>
+    <?php if (sfConfig::get('app_inherit_code_dc_xml', false)): ?>
+      <dc:identifier><?php echo esc_specialchars(strval($resource->getInheritedReferenceCode())) ?></dc:identifier>
+    <?php else: ?>
+      <dc:identifier><?php echo esc_specialchars(strval($resource->identifier)) ?></dc:identifier>
+    <?php endif; ?>
   <?php endif; ?>
 
   <?php if (!empty($resource->locationOfOriginals)): ?>


### PR DESCRIPTION
Added a setting that allows the user to choose to show the reference
code, instead of the local identifier (default), in Dublin Core XML.