### PR TITLE
Fix D.O. linking page issue, refs #13243

### DIFF
--- a/apps/qubit/modules/object/actions/addDigitalObjectAction.class.php
+++ b/apps/qubit/modules/object/actions/addDigitalObjectAction.class.php
@@ -69,6 +69,25 @@ class ObjectAddDigitalObjectAction extends sfAction
       $this->forward404();
     }
 
+    // Assemble resource description
+    sfContext::getInstance()->getConfiguration()->loadHelpers(array('Qubit'));
+
+    if ($this->resource instanceof QubitActor)
+    {
+       $this->resourceDescription = render_title($this->resource);
+    }
+    elseif ($this->resource instanceof QubitInformationObject)
+    {
+      $this->resourceDescription = '';
+
+      if (isset($this->resource->identifier))
+      {
+        $this->resourceDescription .= $this->resource->identifier . ' - ';
+      }
+
+      $this->resourceDescription .= render_title(new sfIsadPlugin($this->resource));
+    }
+
     // Check if already exists a digital object
     if (null !== $digitalObject = $this->resource->getDigitalObjectRelatedByobjectId())
     {

--- a/apps/qubit/modules/object/templates/addDigitalObjectSuccess.php
+++ b/apps/qubit/modules/object/templates/addDigitalObjectSuccess.php
@@ -3,12 +3,7 @@
 <?php slot('title') ?>
   <h1 class="multiline">
     <?php echo __('Link %1%', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))) ?>
-
-    <?php if ($resource instanceof QubitActor): ?>
-      <span class="sub"><?php echo render_title($resource) ?></span>
-    <?php elseif ($resource instanceof QubitInformationObject): ?>
-      <span class="sub"><?php echo render_title(new sfIsadPlugin($resource)) ?></span>
-    <?php endif; ?>
+    <span class="sub"><?php echo $resourceDescription ?></span>
   </h1>
 <?php end_slot() ?>
 


### PR DESCRIPTION
    Fix D.O. linking page issue, refs #13243
    
    This fix was made to reintroduce functionality that had stopped working
    due to two issues. The functionality lost was display of a resource's
    identifier and title on the AtoM page used to link digital objects to a
    resource.
    
    The two issues that led to the regression:
    
    1. Use of "instanceof" in HTML templates works differently than it used
    to due to the escaping strategy now "wrapping" objects in templates
    (containing them in sfOutputEscaperObjectDecorator objects).
    
    2. Text returned by casting an sfIsadPlugin object as a string was
    changed in a previous commit. Casting an sfIsadPlugin object as a
    string used to result in a string that included the identifier and
    title of a resource, but this has changed. Doing so now doesn't include
    the identifier. This change was made so that title can be parsed as Markdown
    but not the identifier.
    
    The fixes:
    
    Fixing issue 1 involved moving functionality relying on "instanceof"
    from the HTML template into the Symfony comment corresponding to it.
    
    Fixing issue 2 involved adding additional logic to the Symphony
    component to add the identifier to the text description of the resource
    created by casting an sfIsadPlugin object as a string.