### PR TITLE
Copy file on DO load task, refs #13236 and #13245

### DIFF
--- a/lib/task/digitalobject/digitalObjectLoadTask.class.php
+++ b/lib/task/digitalobject/digitalObjectLoadTask.class.php
@@ -324,14 +324,8 @@ EOF;
     }
     else
     {
-      // Read file contents
-      if (false === $content = file_get_contents($path))
-      {
-        return;
-      }
-
       $do->usageId = QubitTerm::MASTER_ID;
-      $do->assets[] = new QubitAsset($filename, $content);
+      $do->assets[] = new QubitAsset($path);
     }
 
     $do->save($options['conn']);


### PR DESCRIPTION
Using the file path to create the QubitAsset avoids loading the entire
file on memory with `file_get_contents` and directly copies the file to
the uploads folder. It also avoids the use of different hashing
functions to validate the copied file.

---

We'll use https://projects.artefactual.com/issues/13283 to fix the issue in other places.