### PR TITLE
Fix IO date sorting, refs #13230

### DIFF
--- a/apps/qubit/modules/informationobject/actions/browseAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/browseAction.class.php
@@ -548,12 +548,12 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
         break;
 
       case 'startDate':
-        $this->search->query->setSort(array('dates.startDate' => $request->sortDir));
+        $this->search->query->setSort(array('startDateSort' => $request->sortDir));
 
         break;
 
       case 'endDate':
-        $this->search->query->setSort(array('dates.endDate' => $request->sortDir));
+        $this->search->query->setSort(array('endDateSort' => $request->sortDir));
 
         break;
 

--- a/apps/qubit/modules/informationobject/actions/inventoryAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/inventoryAction.class.php
@@ -141,15 +141,15 @@ class InformationObjectInventoryAction extends DefaultBrowseAction
 
       case 'dateUp':
         $query->setSort(array(
-          'dates.startDate' => 'asc',
-          'dates.endDate' => 'asc'));
+          'startDateSort' => 'asc',
+          'endDateSort' => 'asc'));
 
         break;
 
       case 'dateDown':
         $query->setSort(array(
-          'dates.startDate' => 'desc',
-          'dates.endDate' => 'desc'));
+          'startDateSort' => 'desc',
+          'endDateSort' => 'desc'));
 
         break;
 

--- a/apps/qubit/modules/term/actions/indexAction.class.php
+++ b/apps/qubit/modules/term/actions/indexAction.class.php
@@ -291,7 +291,7 @@ EOF;
             break;
 
           case 'date':
-            $this->search->query->setSort(array('dates.startDate' => $request->sortDir));
+            $this->search->query->setSort(array('startDateSort' => $request->sortDir));
             break;
 
           case 'lastUpdated':

--- a/apps/qubit/modules/user/actions/clipboardAction.class.php
+++ b/apps/qubit/modules/user/actions/clipboardAction.class.php
@@ -145,12 +145,12 @@ class UserClipboardAction extends DefaultBrowseAction
         break;
 
       case 'startDate':
-        $this->search->query->setSort(array('dates.startDate' => $request->sortDir));
+        $this->search->query->setSort(array('startDateSort' => $request->sortDir));
 
         break;
 
       case 'endDate':
-        $this->search->query->setSort(array('dates.endDate' => $request->sortDir));
+        $this->search->query->setSort(array('endDateSort' => $request->sortDir));
 
         break;
 

--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -550,3 +550,6 @@ mapping:
             store: true
             search_analyzer: standard
             term_vector: with_positions_offsets
+      # Not nested date fields for sorting
+      start_date_sort: { type: date, include_in_all: false }
+      end_date_sort: { type: date, include_in_all: false }

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
@@ -1277,6 +1277,25 @@ class arElasticSearchInformationObjectPdo
     foreach ($this->events as $event)
     {
       $serialized['dates'][] = arElasticSearchEvent::serialize($event);
+
+      // The dates indexed above are nested objects and that complicates sorting.
+      // Additionally, we only show the first populated dates on the search
+      // results. Indexing the first populated dates on different fields makes
+      // sorting easier and more intuitive.
+      if (isset($serialized['startDateSort']) || isset($serialized['endDateSort']))
+      {
+        continue;
+      }
+
+      if (!empty($event->start_date))
+      {
+        $serialized['startDateSort'] = arElasticSearchPluginUtil::normalizeDateWithoutMonthOrDay($event->start_date);
+      }
+
+      if (!empty($event->end_date))
+      {
+        $serialized['endDateSort'] = arElasticSearchPluginUtil::normalizeDateWithoutMonthOrDay($event->end_date, true);
+      }
     }
 
     // Transcript

--- a/plugins/arRestApiPlugin/modules/api/actions/informationobjectsBrowseAction.class.php
+++ b/plugins/arRestApiPlugin/modules/api/actions/informationobjectsBrowseAction.class.php
@@ -76,7 +76,7 @@ class ApiInformationObjectsBrowseAction extends QubitApiAction
         break;
 
       case 'date':
-        $field = 'dates.startDate';
+        $field = 'startDateSort';
         $order = 'asc';
         break;
 


### PR DESCRIPTION
Add `startDateSort` and `enDateSort` fields to the ES index for IOs
and use them to sort where needed.