### PR TITLE
Remove actor identifier Markdown, refs #13173

### DIFF
--- a/apps/qubit/modules/actor/templates/_searchResult.php
+++ b/apps/qubit/modules/actor/templates/_searchResult.php
@@ -31,7 +31,7 @@
     <ul class="result-details">
 
       <?php if (!empty($doc['descriptionIdentifier'])): ?>
-        <li class="reference-code"><?php echo render_value_inline($doc['descriptionIdentifier']) ?></li>
+        <li class="reference-code"><?php echo $doc['descriptionIdentifier'] ?></li>
       <?php endif; ?>
 
       <?php if (!empty($doc['entityTypeId']) && null !== $term = QubitTerm::getById($doc['entityTypeId'])): ?>

--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/indexSuccess.php
@@ -105,7 +105,7 @@
     </div>
   </div>
 
-  <?php echo render_show(__('Identifiers for corporate bodies'), render_value($resource->corporateBodyIdentifiers)) ?>
+  <?php echo render_show(__('Identifiers for corporate bodies'), $resource->corporateBodyIdentifiers) ?>
 
 </section> <!-- /section#identityArea -->
 
@@ -204,7 +204,7 @@
 
   <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Control area').'</h2>', array($resource, 'module' => 'actor', 'action' => 'edit'), array('anchor' => 'controlArea', 'title' => __('Edit control area'))) ?>
 
-  <?php echo render_show(__('Authority record identifier'), render_value($resource->descriptionIdentifier)) ?>
+  <?php echo render_show(__('Authority record identifier'), $resource->descriptionIdentifier) ?>
 
   <?php if (null !== $repository = $resource->getMaintainingRepository()): ?>
     <?php echo render_show(__('Maintained by'), link_to(render_title($repository), array($repository, 'module' => 'repository'))) ?>


### PR DESCRIPTION
Got rid of Markdown parsing of identifiers on actor browse and detail
pages.