### PR TITLE
Add limit option to XML caching task, refs #13246

### DIFF
--- a/lib/QubitInformationObjectXmlCache.class.php
+++ b/lib/QubitInformationObjectXmlCache.class.php
@@ -84,27 +84,43 @@ class QubitInformationObjectXmlCache
   public function exportAll($options = array())
   {
     $skip = isset($options['skip']) ? $options['skip'] : 0;
+    $limit = isset($options['limit']) ? $options['limit'] : 0;
 
-    // Get not-root and published information objects
-    $criteria = new Criteria;
-    $criteria->add(QubitInformationObject::ID, QubitInformationObject::ROOT_ID, Criteria::NOT_EQUAL);
-    $criteria = QubitAcl::addFilterDraftsCriteria($criteria);
-    $criteria->addAscendingOrderByColumn(QubitInformationObject::ID); // sort so optional skip will be consistent
-    $criteria->setOffset($skip);
-
-    $results = QubitInformationObject::get($criteria);
+    // Get not-root and published information objects (sorted by ID so optional
+    // skip/limit will be consistent)
+    $sql = "SELECT i.id FROM ". QubitInformationObject::TABLE_NAME ." i \r
+      INNER JOIN status s ON i.id=s.object_id \r
+      WHERE i.id != :root_id \r
+      AND s.status_id=:status_id AND s.type_id=:type_id \r
+      ORDER BY i.id";
+ 
+    $params = array(
+      ':status_id' => QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID,
+      ':type_id' => QubitTerm::STATUS_TYPE_PUBLICATION_ID,
+      ':root_id' => QubitInformationObject::ROOT_ID,
+    );
 
     $exporting = 0;
+
+    // Apply skip/limit and fetch results
+    Propel::getDB()->applyLimit($sql, $skip, $limit);
+    $results = QubitPdo::fetchAll($sql, $params);
 
     if (count($results))
     {
       $this->logger->info($this->i18n->__('%1% published information objects found.', array('%1%' => count($results))));
 
-      foreach ($results as $io)
+      // Export each information object
+      foreach ($results as $row)
       {
+        $io = QubitInformationObject::getById($row->id);
+
         $exporting++;
         $this->logger->info($this->i18n->__('Exporting information object ID %1% (%2% of %3%)', array('%1%' => $io->id, '%2%' => $exporting, '%3%' => count($results))));
         $this->export($io);
+
+        // Keep caches clear to prevent memory use from ballooning
+        Qubit::clearClassCaches();
       }
     }
   }

--- a/lib/task/arCacheDescriptionXmlTask.class.php
+++ b/lib/task/arCacheDescriptionXmlTask.class.php
@@ -32,7 +32,8 @@ class arCacheDescriptionXmlTask extends arBaseTask
       new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', 'qubit'),
       new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
       new sfCommandOption('connection', null, sfCommandOption::PARAMETER_REQUIRED, 'The connection name', 'propel'),
-      new sfCommandOption('skip', null, sfCommandOption::PARAMETER_OPTIONAL, 'Number of information objects to skip', 0)
+      new sfCommandOption('skip', null, sfCommandOption::PARAMETER_OPTIONAL, 'Number of information objects to skip', 0),
+      new sfCommandOption('limit', null, sfCommandOption::PARAMETER_OPTIONAL, 'Number of information objects to export', null)
     ));
 
     $this->namespace = 'cache';
@@ -56,7 +57,7 @@ EOF;
     $logger->log('Caching XML representations of information objects...');
 
     $cache = new QubitInformationObjectXmlCache(array('logger' => $logger));
-    $cache->exportAll(array('skip' => $options['skip']));
+    $cache->exportAll(array('skip' => $options['skip'], 'limit' => $options['limit']));
 
     $logger->log('Done.');
   }


### PR DESCRIPTION
Add a limit option to the cache:xml-representations task so the number
of information objects to be exported to XML, as cache files, can be
limited.

Fetch information objects to export using SQL, rather than the ORM,
in order to speed up export and minimize memory usage.

Keep memory caches clear to prevent excessive memory use.