### PR TITLE
Fix D.O.-related regression, refs #13251

### DIFF
--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -1391,7 +1391,7 @@ class QubitInformationObject extends BaseInformationObject
    */
   public function getDigitalObject()
   {
-    $digitalObjects = $this->getDigitalObjectRelatedByobjectId();
+    $digitalObjects = $this->getDigitalObjectsRelatedByobjectId();
     if (count($digitalObjects) > 0)
     {
       return $digitalObjects[0];


### PR DESCRIPTION
Fixed issue with method for fetching an information object's digital
object. The method was partially working, in that it could be used to
tell if an I.O. has a D.O., but when an I.O. has a D.O. it was fetching
a derivative D.O. rather than the D.O. at root level.