### PR TITLE
Allow updating in search index task, refs #13253

### DIFF
--- a/lib/task/search/arPopulateTask.class.php
+++ b/lib/task/search/arPopulateTask.class.php
@@ -33,7 +33,8 @@ class arSearchPopulateTask extends sfBaseTask
       new sfCommandOption('slug', null, sfCommandOption::PARAMETER_OPTIONAL, 'Slug of resource to index (ignoring exclude-types option).'),
       new sfCommandOption('ignore-descendants', null, sfCommandOption::PARAMETER_NONE, "Don't index resource's descendants (applies to --slug option only)."),
       new sfCommandOption('exclude-types', null, sfCommandOption::PARAMETER_OPTIONAL, 'Exclude document type(s) (command-separated) from indexing'),
-      new sfCommandOption('show-types', null, sfCommandOption::PARAMETER_NONE, 'Show available document type(s), that can be excluded, before indexing')));
+      new sfCommandOption('show-types', null, sfCommandOption::PARAMETER_NONE, 'Show available document type(s), that can be excluded, before indexing'),
+      new sfCommandOption('update', null, sfCommandOption::PARAMETER_NONE, "Don't delete existing records before indexing.")));
 
     $this->namespace = 'search';
     $this->name = 'populate';
@@ -73,9 +74,11 @@ EOF;
     }
     else
     {
-      $excludeTypes = (!empty($options['exclude-types'])) ? explode(',', strtolower($options['exclude-types'])) : null;
+      $populateOptions = array();
+      $populateOptions['excludeTypes'] = (!empty($options['exclude-types'])) ? explode(',', strtolower($options['exclude-types'])) : null;
+      $populateOptions['update'] = $options['update'];
 
-      QubitSearch::getInstance()->populate($excludeTypes);
+      QubitSearch::getInstance()->populate($populateOptions);
     }
   }
 

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPlugin.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPlugin.class.php
@@ -312,12 +312,14 @@ class arElasticSearchPlugin extends QubitSearchEngine
   /**
    * Populate index
    */
-  public function populate($excludeTypes = null)
+  public function populate($options = array())
   {
-    $excludeTypes = (!empty($excludeTypes)) ? $excludeTypes : array();
+    $excludeTypes = (!empty($options['excludeTypes'])) ? $options['excludeTypes'] : array();
+    $update = (!empty($options['update'])) ? $options['update'] : false;
 
-    // Delete index and initialize again if all document types are to be indexed
-    if (!count($excludeTypes))
+    // Delete index and initialize again if all document types are to be
+    // indexed and not updating
+    if (!count($excludeTypes) && !$update)
     {
       $this->flush();
       $this->log('Index erased.');
@@ -349,8 +351,9 @@ class arElasticSearchPlugin extends QubitSearchEngine
         $camelizedTypeName = sfInflector::camelize($typeName);
         $className = 'arElasticSearch'.$camelizedTypeName;
 
-        // If excluding types then index as a whole hasn't been flushed: delete type's documents
-        if (count($excludeTypes))
+        // If excluding types then index as a whole hasn't been flushed: delete
+        // type's documents if not updating
+        if (count($excludeTypes) && !$update)
         {
           $this->index->getType('Qubit'. $camelizedTypeName)->deleteByQuery(new \Elastica\Query\MatchAll);
         }


### PR DESCRIPTION
Added command line option, to the search index populate task, to allow
updating of existing ElasticSearch documents rather than deleting first
then indexing.