### PR TITLE
Optimize updates via physical object import

### DIFF
--- a/lib/QubitTimer.class.php
+++ b/lib/QubitTimer.class.php
@@ -52,14 +52,19 @@ class QubitTimer
 
   public function elapsed($rnd = 2)
   {
-    $end = (isset($this->end)) ? $this->end : microtime(true);
+    if (empty($this->end))
+    {
+      $this->add(true);
+    }
 
-    return round($end - $this->start, $rnd);
+    return round($this->total, $rnd);
   }
 
   public function add($continue = false)
   {
-    $this->total += $this->stop()->elapsed();
+    $this->stop();
+
+    $this->total += $this->end - $this->start;
 
     if ($continue)
     {

--- a/lib/model/QubitObject.php
+++ b/lib/model/QubitObject.php
@@ -286,6 +286,26 @@ class QubitObject extends BaseObject implements Zend_Acl_Resource_Interface
     return $this->id;
   }
 
+  public function updateUpdatedAt($connection = null)
+  {
+    if (!isset($connection))
+    {
+      $connection = QubitTransactionFilter::getConnection(
+        QubitObject::DATABASE_NAME);
+    }
+
+    if (!isset($this->id))
+    {
+      throw new sfException('QubitObject->id must be set');
+    }
+
+    $sth = $connection->prepare('UPDATE ' . self::TABLE_NAME
+      . ' SET ' . self::UPDATED_AT . ' = NOW() WHERE id = :id'
+    );
+
+    return $sth->execute([':id' => $this->id]);
+  }
+
   /********************
         Status
   *********************/

--- a/lib/task/import/csvPhysicalobjectImportTask.class.php
+++ b/lib/task/import/csvPhysicalobjectImportTask.class.php
@@ -53,6 +53,10 @@ class csvPhysicalobjectImportTask extends arBaseTask
         'ISO 639-1 Code for rows without an explicit culture',
         'en'
       ),
+      new sfCommandOption('debug', 'd',
+        sfCommandOption::PARAMETER_NONE,
+        'Enable debug mode'
+      ),
       new sfCommandOption('empty-overwrite', 'e',
         sfCommandOption::PARAMETER_NONE,
         'When set an empty CSV value will overwrite existing data (update only)'
@@ -142,10 +146,12 @@ EOF;
 
     $importer->doImport();
 
-    $this->log(sprintf(PHP_EOL.'Done! Imported %u of %u rows in %01.2fs.',
+    $this->log(sprintf(PHP_EOL.'Done! Imported %u of %u rows.'.PHP_EOL,
       $importer->countRowsImported(),
-      $importer->countRowsTotal(),
-      $importer->timer->elapsed()));
+      $importer->countRowsTotal())
+    );
+
+    $this->log($importer->reportTimes());
   }
 
   protected function getDbConnection()
@@ -163,6 +169,7 @@ EOF;
 
     $keymap = [
       'culture'           => 'defaultCulture',
+      'debug'             => 'debug',
       'empty-overwrite'   => 'overwriteWithEmpty',
       'error-log'         => 'errorLog',
       'header'            => 'header',


### PR DESCRIPTION
Improve preformance when updating physical object data via csv importer

- Add --debug (-d) flag to importer and CLI task
- Output timing data for various subroutines when debug flag set
- Add quickUpdate() method to QubitPhysicalObject model
- Improve unit tests and code testability