### PR TITLE
Add version to search status output, refs #13257

### DIFF
--- a/lib/task/search/arSearchStatusTask.class.php
+++ b/lib/task/search/arSearchStatusTask.class.php
@@ -49,8 +49,9 @@ EOF;
     $config = arElasticSearchPluginConfiguration::$config;
 
     $this->log("Elasticsearch server information:");
+    $this->log(sprintf(" - Version: %s", QubitSearch::getInstance()->client->getVersion()));
     $this->log(sprintf(" - Host: %s", $config['server']['host']));
-    $this->log(sprintf(" - port: %s", $config['server']['port']));
+    $this->log(sprintf(" - Port: %s", $config['server']['port']));
     $this->log(sprintf(" - Index name: %s", $config['index']['name']));
     $this->log(null);
 


### PR DESCRIPTION
Added display of the Elasticsearch server's version to the search
status task's output.