### PR TITLE
Fix description change paging, refs #13258

### DIFF
--- a/apps/qubit/modules/search/actions/descriptionUpdatesAction.class.php
+++ b/apps/qubit/modules/search/actions/descriptionUpdatesAction.class.php
@@ -223,6 +223,8 @@ class SearchDescriptionUpdatesAction extends sfAction
 
     // Page results
     $limit = sfConfig::get('app_hits_per_page');
+
+    $request = $this->getRequest();
     $page = (isset($request->page) && ctype_digit($request->page)) ? $request->page : 1;
 
     $this->pager = new QubitPager('QubitAuditLog');


### PR DESCRIPTION
When description change logging was enabled there was an issue that
would prevent the description update page from paging. Fixed.