### PR TITLE
Enhance enabled languages access, refs #13238

### DIFF
--- a/apps/qubit/modules/menu/actions/changeLanguageMenuComponent.class.php
+++ b/apps/qubit/modules/menu/actions/changeLanguageMenuComponent.class.php
@@ -21,34 +21,10 @@ class MenuChangeLanguageMenuComponent extends sfComponent
 {
   public function execute($request)
   {
-    // The following snippet populates a list of language codes based on the
-    // languages that the administrator have made available via settings. We're
-    // using sfConfig as it's a cached source. An alternative would be to cache
-    // the component and use QubitSetting instead but we discarded that option
-    // in the past for some reason that I can't remember now.
-
-    $this->langCodes = array();
-
-    $prefix = 'app_i18n_languages';
-    $prefixLength = strlen($prefix);
-    $suffix = '__source';
-    $suffixLength = strlen($suffix);
-
-    foreach (sfConfig::getAll() as $name => $value)
-    {
-      // Omit if prefix does not match
-      if ($prefix !== substr($name, 0, $prefixLength))
-      {
-        continue;
-      }
-
-      // Omit if suffix does not match
-      if (substr_compare($name, $suffix, strlen($name) - $suffixLength, $suffixLength) === 0)
-      {
-        continue;
-      }
-
-      $this->langCodes[] = $value;
-    }
+    // While we could access sfConfig directly in the template now,
+    // we were collecting the enabled languages in here and we'll
+    // keep this assignment to avoid changes in existing themes
+    // that overwrite the related partial.
+    $this->langCodes = sfConfig::get('app_i18n_languages');
   }
 }

--- a/apps/qubit/modules/staticpage/actions/deleteAction.class.php
+++ b/apps/qubit/modules/staticpage/actions/deleteAction.class.php
@@ -38,8 +38,7 @@ class StaticPageDeleteAction extends sfAction
       // Invalidate static page content cache entry
       if (null !== $cache = QubitCache::getInstance())
       {
-        $languages = QubitSetting::getByScope('i18n_languages');
-        foreach ($languages as $culture)
+        foreach (sfConfig::get('app_i18n_languages') as $culture)
         {
           $cacheKey = 'staticpage:'.$this->resource->id.':'.$culture;
           $cache->remove($cacheKey);

--- a/apps/qubit/modules/staticpage/actions/editAction.class.php
+++ b/apps/qubit/modules/staticpage/actions/editAction.class.php
@@ -115,8 +115,7 @@ class StaticPageEditAction extends DefaultEditAction
         // Invalidate static page content cache entry
         if (!$this->new && null !== $cache = QubitCache::getInstance())
         {
-          $languages = QubitSetting::getByScope('i18n_languages');
-          foreach ($languages as $culture)
+          foreach (sfConfig::get('app_i18n_languages') as $culture)
           {
             $cacheKey = 'staticpage:'.$this->resource->id.':'.$culture;
             $cache->remove($cacheKey);

--- a/apps/qubit/modules/user/actions/editAction.class.php
+++ b/apps/qubit/modules/user/actions/editAction.class.php
@@ -154,14 +154,11 @@ class UserEditAction extends DefaultEditAction
       case 'translate':
         $c = sfCultureInfo::getInstance($this->context->user->getCulture());
         $languages = $c->getLanguages();
-
         $choices = array();
-        if (0 < count($langSettings = QubitSetting::getByScope('i18n_languages')))
+
+        foreach (sfConfig::get('app_i18n_languages') as $item)
         {
-          foreach ($langSettings as $item)
-          {
-            $choices[$item->name] = $languages[$item->name];
-          }
+          $choices[$item] = $languages[$item];
         }
 
         // Find existing translate permissions

--- a/lib/model/QubitSetting.php
+++ b/lib/model/QubitSetting.php
@@ -84,13 +84,21 @@ class QubitSetting extends BaseSetting
       LEFT JOIN '.QubitSettingI18n::TABLE_NAME.' source
         ON (setting.ID = source.id AND source.CULTURE = setting.SOURCE_CULTURE)';
 
-    $settings = array();
+    $settings = $i18nLanguages = array();
     $culture = sfContext::getInstance()->user->getCulture();
 
     foreach (QubitPdo::fetchAll($sql, array($culture)) as $qubitSetting)
     {
       if ($qubitSetting->scope)
       {
+        // Collect enabled languages into a single setting
+        if ($qubitSetting->scope == 'i18n_languages')
+        {
+          $i18nLanguages[] = $qubitSetting->value_source;
+
+          continue;
+        }
+
         $key = 'app_'.$qubitSetting->scope.'_'.$qubitSetting->name;
       }
       else
@@ -102,6 +110,8 @@ class QubitSetting extends BaseSetting
 
       $settings[$key.'__source'] = $qubitSetting->value_source;
     }
+
+    $settings['app_i18n_languages'] = $i18nLanguages;
 
     return $settings;
   }

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchMapping.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchMapping.class.php
@@ -232,7 +232,7 @@ class arElasticSearchMapping
       switch ($attributeName)
       {
         case 'i18n':
-          $languages = QubitSetting::getByScope('i18n_languages');
+          $languages = sfConfig::get('app_i18n_languages');
           if (1 > count($languages))
           {
             throw new sfException('No i18n_languages in database settings.');
@@ -373,7 +373,7 @@ class arElasticSearchMapping
 
       if (isset($mapping['_i18nFields']))
       {
-        $languages = QubitSetting::getByScope('i18n_languages');
+        $languages = sfConfig::get('app_i18n_languages');
         if (1 > count($languages))
         {
           throw new sfException('The database settings don\'t content any language.');
@@ -457,10 +457,8 @@ class arElasticSearchMapping
   protected function getNestedI18nObjects($languages, $nestedI18nFields)
   {
     $mapping = array();
-    foreach ($languages as $setting)
+    foreach ($languages as $culture)
     {
-      $culture = $setting->getValue(array('sourceCulture' => true));
-
       // Iterate each field and assign a custom standard analyzer (e.g.
       // std_french in search.yml) based in the language being used. The default
       // analyzer is standard, which does not provide a stopwords list.

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
@@ -97,22 +97,6 @@ class arElasticSearchPluginUtil
   }
 
   /**
-   * Get all available language codes that are enabled in the administrator settings.
-   *
-   * @return array  An array containing the above language codes as strings.
-   */
-  private static function getAvailableLanguages()
-  {
-    $cultures = array();
-    foreach (QubitSetting::getByScope('i18n_languages') as $setting)
-    {
-      $cultures[] = $setting->getValue(array('sourceCulture' => true));
-    }
-
-    return $cultures;
-  }
-
-  /**
    * Retrieve the default template type given a specified ES index type.
    *
    * @return string  The default template (e.g. isad)
@@ -141,11 +125,7 @@ class arElasticSearchPluginUtil
   {
     // Create array with relations (hidden field => ES mapping field) for the actual template and cultures
     $relations = array();
-    $cultures = array();
-    foreach (QubitSetting::getByScope('i18n_languages') as $setting)
-    {
-      $cultures[] = $setting->getValue(array('sourceCulture' => true));
-    }
+    $cultures = sfConfig::get('app_i18n_languages');
 
     if (null !== $template = self::getTemplate('informationObject'))
     {
@@ -230,7 +210,7 @@ class arElasticSearchPluginUtil
       throw new sfException('Unrecognized index type: ' . $indexType);
     }
 
-    $cultures = self::getAvailableLanguages();
+    $cultures = sfConfig::get('app_i18n_languages');
     $i18nIncludeInAll = null;
 
     if ($indexType === 'informationObject')
@@ -488,17 +468,7 @@ class arElasticSearchPluginUtil
     // Get all available cultures if $cultures isn't set
     if (empty($cultures))
     {
-      $cultures = array();
-      foreach (QubitSetting::getByScope('i18n_languages') as $setting)
-      {
-        $cultures[] = $setting->getValue(array('sourceCulture' => true));
-      }
-    }
-
-    // Make sure cultures is an array
-    if (!is_array($cultures))
-    {
-      $cultures = array($cultures);
+      $cultures = sfConfig::get('app_i18n_languages');
     }
 
     // Make sure fields is an array

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchModelBase.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchModelBase.class.php
@@ -70,12 +70,8 @@ abstract class arElasticSearchModelBase
       throw new sfException('At least one class name must be passed.');
     }
 
-    // Build an array of i18n languages
-    $allowedLanguages = array();
-    foreach (QubitSetting::getByScope('i18n_languages') as $setting)
-    {
-      $allowedLanguages[] = $setting->getValue(array('sourceCulture' => true));
-    }
+    // Get an array of i18n languages
+    $allowedLanguages = sfConfig::get('app_i18n_languages');
 
     // Properties
     $i18ns = array();

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchRepository.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchRepository.class.php
@@ -118,10 +118,8 @@ class arElasticSearchRepository extends arElasticSearchModelBase
    */
   private static function addExtraSortInfo(&$i18n, $object)
   {
-    foreach (QubitSetting::getByScope('i18n_languages') as $setting)
+    foreach (sfConfig::get('app_i18n_languages') as $lang)
     {
-      $lang = $setting->getValue(array('sourceCulture' => true));
-
       if ($object->getCity(array('culture' => $lang)))
       {
         $i18n[$lang]['city'] = $object->getCity(array('culture' => $lang));

--- a/plugins/sfSkosPlugin/lib/sfSkosPlugin.class.php
+++ b/plugins/sfSkosPlugin/lib/sfSkosPlugin.class.php
@@ -64,11 +64,7 @@ class sfSkosPlugin
 
     $this->graph = new EasyRdf_Graph;
 
-    $this->languages = array();
-    foreach (QubitSetting::getByScope('i18n_languages') as $item)
-    {
-      $this->languages[] = $item->getName();
-    }
+    $this->languages = sfConfig::get('app_i18n_languages');
   }
 
   public static function import($resource, $taxonomyId, $parentId = null)


### PR DESCRIPTION
Accessing the enabled languages through QubitSetting causes an expensive
query because the settings have to be filtered by the `scope` column.
As all the settings, these languages get added to sfConfig for quick
access, but they are added with different keys (e.g.:
`app_i18n_languages_en__source`, `app_i18n_languages_es__source`).

Whit this changes, the enabled languages are added directly as an array
to a single sfConfig key (`app_i18n_languages`), which is now used in
all the places that were using QubitSetting before.