### PR TITLE
Add accession alternative IDs, refs #13254

### DIFF
--- a/apps/qubit/modules/informationobject/templates/_identifierOptions.php
+++ b/apps/qubit/modules/informationobject/templates/_identifierOptions.php
@@ -1,14 +1,18 @@
 <div class="section">
-  <?php if (!isset($hideAltIdButton)): // Some templates don't have alt id support yet ?>
+  <?php if (empty($hideAltIdButton)): // Some templates don't have alternative identifiers ?>
     <a href="#" class="identifier-action" id="alternative-identifiers">
       <?php echo __('Add alternative identifier(s)') ?>
     </a>
   <?php endif; ?>
 
-  <a href="#" class="identifier-action" id="generate-identifier"
-    data-generate-identifier-url="<?php echo url_for(array('module' => 'informationobject', 'action' => 'generateIdentifier')) ?>">
-    <?php echo __('Generate identifier') ?>
-  </a>
+  <?php if (empty($hideGenerateButton)): // Some AtoM data types don't support ID generation ?>
+    <a href="#" class="identifier-action" id="generate-identifier"
+      data-generate-identifier-url="<?php echo url_for(array('module' => 'informationobject', 'action' => 'generateIdentifier')) ?>">
+      <?php echo __('Generate identifier') ?>
+    </a>
+  <?php endif; ?>
 </div>
 
-<input name="usingMask" id="using-identifier-mask" type="hidden" value="<?php echo $mask ?>"/>
+<?php if (!empty($mask)): ?>
+  <input name="usingMask" id="using-identifier-mask" type="hidden" value="<?php echo $mask ?>"/>
+<?php endif; ?>

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 178
+    value: 179
   milestone:
     name: milestone
     editable: 0

--- a/data/fixtures/taxonomyTerms.yml
+++ b/data/fixtures/taxonomyTerms.yml
@@ -1487,6 +1487,12 @@ QubitTaxonomy:
       fr: 'Actions des utilisateurs'
       id: 'Tindakan pengguna'
       sv: Användaråtgärder
+  QubitTaxonomy_accession_alternative_identifier:
+    source_culture: en
+    id: 82
+    parent_id: QubitTaxonomy_root
+    name:
+      en: 'Accession alternative identifier type'
 QubitTerm:
   QubitTerm_110:
     taxonomy_id: 30
@@ -4057,6 +4063,13 @@ QubitTerm:
       pt-BR: Modificação
       sr: Промена
       sv: Modifiering
+  QubitTerm_accession_alternative_identifier:
+    id: 192
+    taxonomy_id: QubitTaxonomy_accession_alternative_identifier
+    parent_id: QubitTerm_110
+    source_culture: en
+    name:
+      en: 'Accession alternative identifier'
   QubitTerm_actor_relationship_is_the_superior_of:
     taxonomy_id: QubitTaxonomy_actor_relation_type
     parent_id: QubitTerm_actor_relationship_hierarchical

--- a/lib/model/QubitTaxonomy.php
+++ b/lib/model/QubitTaxonomy.php
@@ -90,7 +90,9 @@ class QubitTaxonomy extends BaseTaxonomy
 
     ACTOR_OCCUPATION_ID = 80,
 
-    USER_ACTION_ID = 81;
+    USER_ACTION_ID = 81,
+
+    ACCESSION_ALTERNATIVE_IDENTIFIER_TYPE_ID = 82;
 
   public static
     $lockedTaxonomies = array(

--- a/lib/model/QubitTerm.php
+++ b/lib/model/QubitTerm.php
@@ -175,7 +175,10 @@ class QubitTerm extends BaseTerm
     USER_ACTION_MODIFICATION_ID = 190,
 
     // Digital object usage taxonomy (addition)
-    EXTERNAL_FILE_ID = 191;
+    EXTERNAL_FILE_ID = 191,
+
+    // Accession alternative identifier taxonomy
+    ACCESSION_ALTERNATIVE_IDENTIFIER_DEFAULT_TYPE_ID = 192;
 
   public static function isProtected($id)
   {

--- a/lib/task/migrate/migrations/arMigration0179.class.php
+++ b/lib/task/migrate/migrations/arMigration0179.class.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add taxonomy and terms for accession alternative identifier types
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0179
+{
+  const
+    VERSION = 179, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  public function up($configuration)
+  {
+    QubitMigrate::bumpTaxonomy(QubitTaxonomy::ACCESSION_ALTERNATIVE_IDENTIFIER_TYPE_ID, $configuration);
+    $taxonomy = new QubitTaxonomy;
+    $taxonomy->id = QubitTaxonomy::ACCESSION_ALTERNATIVE_IDENTIFIER_TYPE_ID;
+    $taxonomy->parentId = QubitTaxonomy::ROOT_ID;
+    $taxonomy->sourceCulture = 'en';
+    $taxonomy->setName('Accession alternative identifier type', array('culture' => 'en'));
+    $taxonomy->save();
+
+    QubitMigrate::bumpTerm(QubitTerm::ACCESSION_ALTERNATIVE_IDENTIFIER_DEFAULT_TYPE_ID, $configuration);
+    $term = new QubitTerm;
+    $term->id = QubitTerm::ACCESSION_ALTERNATIVE_IDENTIFIER_DEFAULT_TYPE_ID;
+    $term->parentId = QubitTerm::ROOT_ID;
+    $term->taxonomyId = QubitTaxonomy::ACCESSION_ALTERNATIVE_IDENTIFIER_TYPE_ID;
+    $term->sourceCulture = 'en';
+    $term->setName('Accession alternative identifier', array('culture' => 'en'));
+    $term->save();
+
+    return true;
+  }
+}

--- a/plugins/qtAccessionPlugin/lib/model/QubitAccession.php
+++ b/plugins/qtAccessionPlugin/lib/model/QubitAccession.php
@@ -200,4 +200,24 @@ class QubitAccession extends BaseAccession
 
     return QubitEvent::get($criteria);
   }
+
+  /**
+   * Get alternative identifiers
+   */
+  public function getAlternativeIdentifiers()
+  {
+    $otherNames = [];
+
+    $criteria = new Criteria;
+    $criteria->add(QubitOtherName::OBJECT_ID, $this->id);
+    $criteria->addJoin(QubitOtherName::TYPE_ID, QubitTerm::ID);
+    $criteria->add(QubitTerm::TAXONOMY_ID, QubitTaxonomy::ACCESSION_ALTERNATIVE_IDENTIFIER_TYPE_ID);
+
+    foreach (QubitOtherName::get($criteria) as $otherName)
+    {
+      $otherNames[] = $otherName;
+    }
+
+    return $otherNames;
+  }
 }

--- a/plugins/qtAccessionPlugin/modules/accession/actions/alternativeIdentifiersComponent.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/alternativeIdentifiersComponent.class.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class AccessionAlternativeIdentifiersComponent extends sfComponent
+{
+  public function execute($request)
+  {
+    // Cache alternative identifier types (used in each identifier's type select form field)
+    $criteria = new Criteria;
+    $criteria->add(QubitTerm::TAXONOMY_ID, QubitTaxonomy::ACCESSION_ALTERNATIVE_IDENTIFIER_TYPE_ID);
+
+    $this->identifierTypes = [];
+    foreach (QubitTerm::get($criteria) as $term)
+    {
+      $this->identifierTypes[$term->id] = $term->getName(['cultureFallback' => true]);
+    }
+
+    // Define form used to add/edit identifiers
+    $this->form = new sfForm;
+    $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
+
+    $this->addField('identifierType');
+    $this->addField('identifier');
+    $this->addField('note');
+
+    // Summarize/cache existing alternative identifier data
+    $this->alternativeIdentifierData = [];
+
+    foreach ($this->resource->getAlternativeIdentifiers() as $identifier)
+    {
+      $this->alternativeIdentifierData[] = [
+        'id' => $identifier->id,
+        'value' => $identifier->getName(['sourceCulture' => true]),
+        'typeId' => $identifier->typeId,
+        'hasNote' => !empty($identifier->getNote(['cultureFallback' => true])),
+        'note' => $identifier->getNote(),
+        'object' => $identifier
+      ];
+    }
+  }
+
+  protected function addField($name)
+  {
+    switch ($name)
+    {
+    case 'identifierType':
+        $this->form->setValidator($name, new sfValidatorInteger);
+        $this->form->setWidget($name, new sfWidgetFormSelect(['choices' => $this->identifierTypes]));
+
+        break;
+
+      case 'identifier':
+        $this->form->setValidator($name, new sfValidatorString);
+        $this->form->setWidget($name, new sfWidgetFormInput);
+
+        break;
+
+      case 'note':
+        $this->form->setValidator($name, new sfValidatorString);
+        $widget = new sfWidgetFormTextarea(['label' => false]);
+        $widget->setAttribute('placeholder', $this->context->i18n->__('Notes'));
+        $this->form->setWidget($name, $widget);
+
+        break;
+    }
+  }
+
+  public function processForm()
+  {
+    $finalAlternativeIdentifiers = [];
+
+    if (is_array($this->request->alternativeIdentifiers))
+    {
+      foreach ($this->request->alternativeIdentifiers as $item)
+      {
+        // Continue only if both fields are populated
+        if (1 > strlen($item['identifierType']) || 1 > strlen($item['identifier']))
+        {
+          continue;
+        }
+
+        if (!empty($item['id']))
+        {
+          $finalAlternativeIdentifiers[] = $item['id'];
+
+          $otherName = QubitOtherName::getById($item['id']);
+        }
+        else
+        {
+          $otherName = new QubitOtherName;
+        }
+
+        $otherName->object = $this->resource;
+        $otherName->typeId = $item['identifierType'];
+        $otherName->name = $item['identifier'];
+        $otherName->note = $item['note'];
+        $otherName->save();
+      }
+    }
+
+    // Delete the old alternative identifiers if they don't appear in the table (removed by multiRow.js)
+    foreach ($this->alternativeIdentifierData as $identifier)
+    {
+      if (false === array_search($identifier['id'], $finalAlternativeIdentifiers))
+      {
+        $identifier['object']->delete();
+      }
+    }
+  }
+}

--- a/plugins/qtAccessionPlugin/modules/accession/actions/editAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/editAction.class.php
@@ -367,6 +367,11 @@ class AccessionEditAction extends DefaultEditAction
       }
     }
 
+    // Handle alternative identifiers
+    $this->alternativeIdentifiersComponent = new AccessionAlternativeIdentifiersComponent($this->context, 'accession', 'alternativeIdentifiers');
+    $this->alternativeIdentifiersComponent->resource = $this->resource;
+    $this->alternativeIdentifiersComponent->execute($this->request);
+
     if ($request->isMethod('post'))
     {
       $this->form->bind($request->getPostParameters());
@@ -398,6 +403,8 @@ class AccessionEditAction extends DefaultEditAction
         $this->processForm();
 
         $this->resource->save();
+
+        $this->alternativeIdentifiersComponent->processForm();
 
         $this->redirect(array($this->resource, 'module' => 'accession'));
       }

--- a/plugins/qtAccessionPlugin/modules/accession/templates/_alternativeIdentifiers.php
+++ b/plugins/qtAccessionPlugin/modules/accession/templates/_alternativeIdentifiers.php
@@ -1,0 +1,75 @@
+<div class="section" id="alternative-identifiers-table"<?php echo 0 < count($alternativeIdentifierData) ? '' : 'style="display:none"' ?>>
+
+  <h3><?php echo __('Alternative identifier(s)') ?></h3>
+
+  <table class="table table-bordered multiRow">
+    <thead>
+      <tr>
+        <th style="width: 50%">
+          <?php echo __('Type') ?>
+        </th><th style="width: 50%">
+          <?php echo __('Identifier') ?>
+        </th>
+      </tr>
+    </thead><tbody>
+
+      <?php $i = 0; foreach ($alternativeIdentifierData as $identifier): ?>
+        <?php $form->getWidgetSchema()->setNameFormat("alternativeIdentifiers[$i][%s]") ?>
+
+        <tr class="<?php echo 0 == $i % 2 ? 'even' : 'odd' ?> related_obj_<?php echo $identifier['id'] ?>">
+          <td>
+            <div class="animateNicely">
+              <input type="hidden" name="alternativeIdentifiers[<?php echo $i ?>][id]" value="<?php echo $identifier['id'] ?>"/>
+              <?php $form->setDefault('identifierType', $identifier['typeId']); ?>
+              <?php echo $form->identifierType ?>
+            </div>
+          </td><td>
+            <div class="animateNicely">
+              <?php $form->setDefault('identifier', $identifier['value']); ?>
+              <?php echo $form->identifier ?>
+            </div>
+            <div class="animateNicely">
+              <?php $form->setDefault('note', $identifier['note']); ?>
+              <?php echo render_field($form->note, $identifier['object']) ?>
+            </div>
+          </td>
+        </tr>
+
+        <?php $i++ ?>
+      <?php endforeach; ?>
+
+      <?php $form->getWidgetSchema()->setNameFormat("alternativeIdentifiers[$i][%s]") ?>
+
+      <tr class="<?php echo 0 == $i % 2 ? 'even' : 'odd' ?>">
+        <td>
+          <div class="animateNicely">
+            <?php $form->setDefault('identifierType', ''); ?>
+            <?php echo $form->identifierType ?>
+          </div>
+        </td><td>
+          <div class="animateNicely">
+            <?php $form->setDefault('identifier', ''); ?>
+            <?php echo $form->identifier ?>
+	  </div>
+          <div class="animateNicely">
+            <?php $form->setDefault('note', ''); ?>
+            <?php echo $form->note ?>
+          </div>
+        </td>
+      </tr>
+
+    </tbody>
+
+    <tfoot>
+      <tr>
+        <td colspan="3"><a href="#" class="multiRowAddButton"><?php echo __('Add new') ?></a></td>
+      </tr>
+    </tfoot>
+
+  </table>
+
+  <div class="description">
+    <?php echo __('<strong>Type:</strong> Enter a name for the alternative identifier field that indicates its purpose and usage.<br/><strong>Identifier:</strong> Enter a legacy reference code, alternative identifier, or any other alpha-numeric string associated with the record.') ?>
+  </div>
+
+</div>

--- a/plugins/qtAccessionPlugin/modules/accession/templates/_alternativeIdentifiersIndex.php
+++ b/plugins/qtAccessionPlugin/modules/accession/templates/_alternativeIdentifiersIndex.php
@@ -1,0 +1,14 @@
+<div class="field">
+  
+  <h3><?php echo __('Alternative identifier(s)') ?></h3>
+
+  <div>
+    <?php foreach ($resource->getAlternativeIdentifiers() as $item): ?>
+      <?php echo render_show(render_value_inline($item->getType(['cultureFallback' => true])), $item->getName(['cultureFallback' => true])) ?>
+      <?php if (!empty($note = $item->getNote(['cultureFallback' => true]))): ?>
+        <?php echo render_value($note) ?>
+      <?php endif; ?>
+    <?php endforeach; ?>
+  </div>
+
+</div>

--- a/plugins/qtAccessionPlugin/modules/accession/templates/editSuccess.php
+++ b/plugins/qtAccessionPlugin/modules/accession/templates/editSuccess.php
@@ -40,6 +40,9 @@
 
         <div id="identifier-check-server-error" class="alert alert-danger hidden"><?php echo __('Server error while checking identifer availability.') ?></div>
 
+        <?php echo get_partial('informationobject/identifierOptions', array('hideGenerateButton' => true)) ?>
+        <?php echo get_component('accession', 'alternativeIdentifiers', array('resource' => $resource)) ?>
+
         <?php echo $form->date
           ->help(__('Accession date represents the date of receipt of the materials and is added during the donation process.'))
           ->label(__('Acquisition date').' <span class="form-required" title="'.__('This is a mandatory element.').'">*</span>')

--- a/plugins/qtAccessionPlugin/modules/accession/templates/indexSuccess.php
+++ b/plugins/qtAccessionPlugin/modules/accession/templates/indexSuccess.php
@@ -25,6 +25,8 @@
 
 <?php echo render_show(__('Accession number'), $resource->identifier) ?>
 
+<?php echo get_partial('accession/alternativeIdentifiersIndex', array('resource' => $resource)) ?>
+
 <?php echo render_show(__('Acquisition date'), render_value(Qubit::renderDate($resource->date))) ?>
 
 <?php echo render_show(__('Immediate source of acquisition'), render_value($resource->getSourceOfAcquisition(array('cultureFallback' => true)))) ?>


### PR DESCRIPTION
Add support for alternative identifiers to the accession plugin:

* Add new taxonomy for accession alternative identifier types
* Allow adding/editing of accession alternative identifiers during
  editing
* Display alternative identifiers of accession detail page