### PR TITLE
Fix accession alt. ID index on save, refs #13265

### DIFF
--- a/plugins/qtAccessionPlugin/lib/model/QubitAccession.php
+++ b/plugins/qtAccessionPlugin/lib/model/QubitAccession.php
@@ -19,6 +19,9 @@
 
 class QubitAccession extends BaseAccession
 {
+  // Flag for updating search index on save
+  public $indexOnSave = true;
+
   public function __toString()
   {
     return (string) $this->identifier;
@@ -66,7 +69,10 @@ class QubitAccession extends BaseAccession
       $item->save($connection);
     }
 
-    QubitSearch::getInstance()->update($this);
+    if ($indexOnSave)
+    {
+      QubitSearch::getInstance()->update($this);
+    }
 
     return $this;
   }

--- a/plugins/qtAccessionPlugin/modules/accession/actions/editAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/editAction.class.php
@@ -402,9 +402,13 @@ class AccessionEditAction extends DefaultEditAction
 
         $this->processForm();
 
+        // Postpone search indexing until alternative IDs are added
+        $this->resource->indexOnSave = false;
         $this->resource->save();
 
         $this->alternativeIdentifiersComponent->processForm();
+
+        QubitSearch::getInstance()->update($this->resource);
 
         $this->redirect(array($this->resource, 'module' => 'accession'));
       }


### PR DESCRIPTION
Added logic to allow search indexing to be disabled when saving an
accession. Used this logic to fix issue where accession alternative
identifiers aren't indexed when accession is saved.