### PR TITLE
Physical object holdings report fixes, refs #13269

### DIFF
--- a/lib/job/arPhysicalObjectCsvHoldingsReportJob.class.php
+++ b/lib/job/arPhysicalObjectCsvHoldingsReportJob.class.php
@@ -34,7 +34,7 @@ class arPhysicalObjectCsvHoldingsReportJob extends arBaseJob
   public function runJob($parameters)
   {
     // Indicate beginning of export and describe parameters provided
-    $this->info($this->i18n->__('Starting physical object holdings report CSV export.'));
+    $this->info($this->i18n->__('Starting physical storage holdings report CSV export.'));
 
     if (!empty($parameters['suppressEmpty']))
     {
@@ -44,7 +44,7 @@ class arPhysicalObjectCsvHoldingsReportJob extends arBaseJob
     if (!empty($parameters['holdingType']))
     {
       $this->info($this->i18n->__(
-        'Only including physical storage exclusively containing holding type: %1.',
+        'Including physical storage containing holding type: %1.',
         ['%1' => $parameters['holdingType']]));
     }
 

--- a/test/mock/QubitAccession.php
+++ b/test/mock/QubitAccession.php
@@ -19,14 +19,13 @@
 
 namespace AccessToMemory\test\mock;
 
-class QubitInformationObject
+class QubitAccession
 {
   public $id;
 
   protected static $slugToIdMap = [
-    'test-fonds-1'     => 111111,
-    'test-collection'  => 222222,
-    'Mixed-Case-Fonds' => 333333,
+    'accession-1' => 444,
+    'accession-2' => 555,
   ];
 
   public static function getById($id)
@@ -39,7 +38,6 @@ class QubitInformationObject
 
   public static function getBySlug($slug)
   {
-
     if (array_key_exists($slug, self::$slugToIdMap))
     {
       $obj = new self();
@@ -51,7 +49,7 @@ class QubitInformationObject
 
   public static function getTitle($options)
   {
-    return "Information Object";
+    return "Accession";
   }
 
   public static function getIdentifier()
@@ -59,15 +57,8 @@ class QubitInformationObject
     return "IDENTIFIER";
   }
 
-  public static function getLevelOfDescription()
+  public function getSlug()
   {
-    $term = new QubitTerm();
-
-    return $term;
-  }
-
-  public static function getSlug()
-  {
-    return "information-object";
+    return "accession";
   }
 }

--- a/test/mock/QubitTerm.php
+++ b/test/mock/QubitTerm.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace AccessToMemory\test\mock;
+
+class QubitTerm
+{
+  public static function getName($options)
+  {
+    return "Term";
+  }
+}

--- a/test/phpunit/PhysicalObjectCsvHoldingsReportTest.php
+++ b/test/phpunit/PhysicalObjectCsvHoldingsReportTest.php
@@ -235,10 +235,10 @@ class PhysicalObjectCsvHoldingsReportTest extends \PHPUnit\Framework\TestCase
     $report->writePhysicalObjectAndHoldings($writer, $rowStart, $holdingsData);
 
     $expectedOutput = <<<EOM
-"Example Box","Example Box Location",Box,description,IDENTIFIER,"Information Object",information-object
-"Example Box","Example Box Location",Box,description,IDENTIFIER,"Information Object",information-object
-"Example Box","Example Box Location",Box,accession,IDENTIFIER,Accession,accession
-"Example Box","Example Box Location",Box,accession,IDENTIFIER,Accession,accession\n
+"Example Box","Example Box Location",Box,description,IDENTIFIER,"Information Object",Term,information-object
+"Example Box","Example Box Location",Box,description,IDENTIFIER,"Information Object",Term,information-object
+"Example Box","Example Box Location",Box,accession,IDENTIFIER,Accession,,accession
+"Example Box","Example Box Location",Box,accession,IDENTIFIER,Accession,,accession\n
 EOM;
 
     $this->assertSame($expectedOutput, $writer->getContent());
@@ -247,23 +247,59 @@ EOM;
   /**
    * @dataProvider mixedHoldingsDataProvider
    */
-  public function testWritePhysicalObjectAndMixedHoldingsForDifferentHoldingTypes($holdingsData)
+  public function testWritePhysicalObjectAndMixedHoldingsForInformationObjectHoldingType($holdingsData)
   {
+    $writer = \League\Csv\Writer::createFromString('');
     $report = new QubitPhysicalObjectCsvHoldingsReport();
+    $report->setOrmClasses($this->ormClasses);
     $report->setTypeMap($this->typeMap);
+    $report->setOption('holdingType', \AccessToMemory\test\mock\QubitInformationObject::class);
+    $rowStart = ['Example Box', 'Example Box Location', 'Box'];
+    $report->writePhysicalObjectAndHoldings($writer, $rowStart, $holdingsData);
 
-    foreach ($report->allowedHoldingTypes() as $holdingType)
-    {
-      $writer = \League\Csv\Writer::createFromString('');
-      $report = new QubitPhysicalObjectCsvHoldingsReport();
-      $report->setOrmClasses($this->ormClasses);
-      $report->setTypeMap($this->typeMap);
-      $report->setOption('holdingType', $holdingType);
-      $rowStart = ['Example Box', 'Example Box Location', 'Box'];
-      $report->writePhysicalObjectAndHoldings($writer, $rowStart, $holdingsData);
+    $expectedOutput = <<<EOM
+"Example Box","Example Box Location",Box,description,IDENTIFIER,"Information Object",Term,information-object
+"Example Box","Example Box Location",Box,description,IDENTIFIER,"Information Object",Term,information-object\n
+EOM;
 
-      $this->assertSame('', $writer->getContent());
-    }
+    $this->assertSame($expectedOutput, $writer->getContent());
+  }
+
+  /**
+   * @dataProvider mixedHoldingsDataProvider
+   */
+  public function testWritePhysicalObjectAndMixedHoldingsForAccessionHoldingType($holdingsData)
+  {
+    $writer = \League\Csv\Writer::createFromString('');
+    $report = new QubitPhysicalObjectCsvHoldingsReport();
+    $report->setOrmClasses($this->ormClasses);
+    $report->setTypeMap($this->typeMap);
+    $report->setOption('holdingType', \AccessToMemory\test\mock\QubitAccession::class);
+    $rowStart = ['Example Box', 'Example Box Location', 'Box'];
+    $report->writePhysicalObjectAndHoldings($writer, $rowStart, $holdingsData);
+
+    $expectedOutput = <<<EOM
+"Example Box","Example Box Location",Box,accession,IDENTIFIER,Accession,,accession
+"Example Box","Example Box Location",Box,accession,IDENTIFIER,Accession,,accession\n
+EOM;
+
+    $this->assertSame($expectedOutput, $writer->getContent());
+  }
+
+  /**
+   * @dataProvider mixedHoldingsDataProvider
+   */
+  public function testWritePhysicalObjectAndMixedHoldingsForNoneHoldingType($holdingsData)
+  {
+    $writer = \League\Csv\Writer::createFromString('');
+    $report = new QubitPhysicalObjectCsvHoldingsReport();
+    $report->setOrmClasses($this->ormClasses);
+    $report->setTypeMap($this->typeMap);
+    $report->setOption('holdingType', 'none');
+    $rowStart = ['Example Box', 'Example Box Location', 'Box'];
+    $report->writePhysicalObjectAndHoldings($writer, $rowStart, $holdingsData);
+
+    $this->assertSame('', $writer->getContent());
   }
 
   /**
@@ -280,8 +316,8 @@ EOM;
     $report->writePhysicalObjectAndHoldings($writer, $rowStart, $holdingsData);
 
     $expectedOutput = <<<EOM
-"Example Box","Example Box Location",Box,description,IDENTIFIER,"Information Object",information-object
-"Example Box","Example Box Location",Box,description,IDENTIFIER,"Information Object",information-object\n
+"Example Box","Example Box Location",Box,description,IDENTIFIER,"Information Object",Term,information-object
+"Example Box","Example Box Location",Box,description,IDENTIFIER,"Information Object",Term,information-object\n
 EOM;
 
     $this->assertSame($expectedOutput, $writer->getContent());


### PR DESCRIPTION
* Change holding type filtering to be inclusive rather than exclusive
* Sort export rows by physical object's source culture name
* Add level of description column
* Improve CLI task help
* Wording changes
* Update unit tests