### PR TITLE
Add Google Tag Manager tracking, refs #13284

### DIFF
--- a/apps/qubit/modules/default/actions/tagManagerComponent.class.php
+++ b/apps/qubit/modules/default/actions/tagManagerComponent.class.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class DefaultTagManagerComponent extends sfComponent
+{
+  public function execute($request)
+  {
+    $config = sfConfig::get('app_google_tag_manager_container_id', '');
+    if (empty($config) || !isset($this->code) || empty($this->code)) {
+      return sfView::NONE;
+    }
+    $this->containerId = $config;
+  }
+}

--- a/apps/qubit/modules/default/templates/_tagManager.php
+++ b/apps/qubit/modules/default/templates/_tagManager.php
@@ -1,0 +1,14 @@
+<?php if ('script' === $code): ?>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','<?php echo $containerId ?>');</script>
+<!-- End Google Tag Manager -->
+<?php elseif ('noscript' === $code): ?>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<?php echo $containerId ?>"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+<?php endif; ?>

--- a/apps/qubit/templates/layout.php
+++ b/apps/qubit/templates/layout.php
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="<?php echo $sf_user->getCulture() ?>" dir="<?php echo sfCultureInfo::getInstance($sf_user->getCulture())->direction ?>">
   <head>
+    <?php echo get_component('default', 'tagManager', array('code' => 'script')) ?>
     <?php include_http_metas() ?>
     <?php include_metas() ?>
     <?php include_title() ?>
@@ -15,6 +16,8 @@
     <?php include_javascripts() ?>
   </head>
   <body class="yui-skin-sam <?php echo $sf_context->getModuleName() ?> <?php echo $sf_context->getActionName() ?>">
+
+    <?php echo get_component('default', 'tagManager', array('code' => 'noscript')) ?>
 
     <?php echo get_partial('header') ?>
 

--- a/apps/qubit/templates/layout_1col.php
+++ b/apps/qubit/templates/layout_1col.php
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="<?php echo $sf_user->getCulture() ?>" dir="<?php echo sfCultureInfo::getInstance($sf_user->getCulture())->direction ?>">
   <head>
+    <?php echo get_component('default', 'tagManager', array('code' => 'script')) ?>
     <?php include_http_metas() ?>
     <?php include_metas() ?>
     <?php include_title() ?>
@@ -15,6 +16,8 @@
     <?php include_javascripts() ?>
   </head>
   <body class="yui-skin-sam <?php echo $sf_context->getModuleName() ?> <?php echo $sf_context->getActionName() ?>">
+
+    <?php echo get_component('default', 'tagManager', array('code' => 'noscript')) ?>
 
     <?php echo get_partial('header') ?>
 

--- a/apps/qubit/templates/layout_2col.php
+++ b/apps/qubit/templates/layout_2col.php
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="<?php echo $sf_user->getCulture() ?>" dir="<?php echo sfCultureInfo::getInstance($sf_user->getCulture())->direction ?>">
   <head>
+    <?php echo get_component('default', 'tagManager', array('code' => 'script')) ?>
     <?php include_http_metas() ?>
     <?php include_metas() ?>
     <?php include_title() ?>
@@ -15,6 +16,8 @@
     <?php include_javascripts() ?>
   </head>
   <body class="yui-skin-sam <?php echo $sf_context->getModuleName() ?> <?php echo $sf_context->getActionName() ?>">
+
+    <?php echo get_component('default', 'tagManager', array('code' => 'noscript')) ?>
 
     <?php echo get_partial('header') ?>
 

--- a/apps/qubit/templates/layout_3col.php
+++ b/apps/qubit/templates/layout_3col.php
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="<?php echo $sf_user->getCulture() ?>" dir="<?php echo sfCultureInfo::getInstance($sf_user->getCulture())->direction ?>">
   <head>
+    <?php echo get_component('default', 'tagManager', array('code' => 'script')) ?>
     <?php include_http_metas() ?>
     <?php include_metas() ?>
     <?php include_title() ?>
@@ -15,6 +16,8 @@
     <?php include_javascripts() ?>
   </head>
   <body class="yui-skin-sam <?php echo $sf_context->getModuleName() ?> <?php echo $sf_context->getActionName() ?>">
+
+    <?php echo get_component('default', 'tagManager', array('code' => 'noscript')) ?>
 
     <?php echo get_partial('header') ?>
 

--- a/apps/qubit/templates/layout_basic.php
+++ b/apps/qubit/templates/layout_basic.php
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="<?php echo $sf_user->getCulture() ?>" dir="<?php echo sfCultureInfo::getInstance($sf_user->getCulture())->direction ?>">
   <head>
+    <?php echo get_component('default', 'tagManager', array('code' => 'script')) ?>
     <?php include_http_metas() ?>
     <?php include_metas() ?>
     <?php include_title() ?>
@@ -15,6 +16,8 @@
     <?php include_javascripts() ?>
   </head>
   <body class="yui-skin-sam <?php echo $sf_context->getModuleName() ?> <?php echo $sf_context->getActionName() ?>">
+
+    <?php echo get_component('default', 'tagManager', array('code' => 'noscript')) ?>
 
     <?php echo get_component('default', 'alerts') ?>
 

--- a/apps/qubit/templates/layout_wide.php
+++ b/apps/qubit/templates/layout_wide.php
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="<?php echo $sf_user->getCulture() ?>" dir="<?php echo sfCultureInfo::getInstance($sf_user->getCulture())->direction ?>">
   <head>
+    <?php echo get_component('default', 'tagManager', array('code' => 'script')) ?>
     <?php include_http_metas() ?>
     <?php include_metas() ?>
     <?php include_title() ?>
@@ -15,6 +16,8 @@
     <?php include_javascripts() ?>
   </head>
   <body class="yui-skin-sam <?php echo $sf_context->getModuleName() ?> <?php echo $sf_context->getActionName() ?>">
+
+    <?php echo get_component('default', 'tagManager', array('code' => 'noscript')) ?>
 
     <?php echo get_partial('header') ?>
 

--- a/config/app.yml
+++ b/config/app.yml
@@ -29,6 +29,9 @@ all:
   # of IOs, actors and repos index pages.
   # E.g.: 1
   google_analytics_institutions_dimension_index:
+  # Set a Google Tag Manager container ID
+  # E.g.: GTM-1234
+  google_tag_manager_container_id:
 
   # htmlpurifier is used in static pages, disabled by default
   htmlpurifier_enabled: false


### PR DESCRIPTION
- Add config setting in 'config/app.yml':
    
Enables tracking through a container ID. See
https://developers.google.com/tag-manager/quickstart
    
- Add tag manager component:
    
Called from all the layout templates (except install) to render the
script and noscript snippets at the suggested points in the HTML.