### PR TITLE
Add config/app.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /config/config.php
 /config/databases.yml
 /config/propel.ini
+/config/app.yml
 
 # Internal use
 /cache/


### PR DESCRIPTION
This file needs to be modified in centos deployments to use
PASSWORD_BCRYPT instead of de the default ARGON1, as that isn't
supported in the PHP packages available in RHEL/Centos.