### PR TITLE
Authority record search by relation, refs #13302

### DIFF
--- a/apps/qubit/modules/actor/config/view.yml
+++ b/apps/qubit/modules/actor/config/view.yml
@@ -5,3 +5,8 @@ browseSuccess:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/ui/ui.datepicker.js:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/jquery.once.js:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/tableheader:
+
+    /vendor/yui/connection/connection-min:
+    /vendor/yui/datasource/datasource-min:
+    /vendor/yui/autocomplete/autocomplete-min:
+    autocomplete:

--- a/apps/qubit/modules/actor/templates/_advancedSearch.php
+++ b/apps/qubit/modules/actor/templates/_advancedSearch.php
@@ -127,6 +127,29 @@
         </div>
       </div>
 
+      <p><?php echo __('Find results where:') ?></p>
+
+      <div class="criteria">
+
+        <div class="filter-row">
+
+          <div class="filter-left relation">
+            <?php echo $form->relatedType
+              ->label(__('Relationship'))
+              ->renderRow() ?>
+          </div>
+
+          <div class="filter-right relation">
+            <?php echo $form->relatedAuthority
+              ->label(__('Related [%1%]', array('%1%' => sfConfig::get('app_ui_label_actor'))))
+              ->renderLabel() ?>
+            <?php echo $form->relatedAuthority->render(array('class' => 'form-autocomplete')) ?>
+            <input class="list" type="hidden" value="<?php echo url_for(array('module' => 'actor', 'action' => 'autocomplete')) ?>"/>
+          </div>
+
+        </div>
+      </div>
+
       <section class="actions">
         <input type="submit" class="c-btn c-btn-submit" value="<?php echo __('Search') ?>"/>
         <input type="button" class="reset c-btn c-btn-delete" value="<?php echo __('Reset') ?>"/>

--- a/config/gearman.yml
+++ b/config/gearman.yml
@@ -7,6 +7,8 @@ all:
       - arFindingAidJob
     acl:
       - arInheritRightsJob
+    actor_relations:
+      - arUpdateEsActorRelationsJob
     calculate_dates:
       - arCalculateDescendantDatesJob
     move:

--- a/lib/job/arUpdateEsActorRelationsJob.class.php
+++ b/lib/job/arUpdateEsActorRelationsJob.class.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Updates actor document relationships in the Elasticsearch index
+ *
+ * @package    symfony
+ * @subpackage jobs
+ */
+
+class arUpdateEsActorRelationsJob extends arBaseJob
+{
+  /**
+   * @see arBaseJob::$requiredParameters
+   */
+  protected $extraRequiredParameters = ['actorIds'];
+
+  public function runJob($parameters)
+  {
+    if (empty($parameters['actorIds']))
+    {
+      $this->error($this->i18n->__('Called arUpdateEsActorRelationsJob without specifying what needs to be updated.'));
+
+      return false;
+    }
+
+    $message = $this->i18n->__('Updating the relationships of %1 actor(s).', ['%1' => count($parameters['actorIds'])]);
+
+    $this->job->addNoteText($message);
+    $this->info($message);
+
+    $count = 0;
+    foreach ($parameters['actorIds'] as $id)
+    {
+      if (null === $object = QubitActor::getById($id))
+      {
+        $this->info($this->i18n->__('Invalid actor id: %1', ['%1' => $id]));
+
+        continue;
+      }
+      
+      // Don't count invalid description ids
+      $count++;
+
+      self::updateActorRelationships($object);
+      $message = $this->i18n->__('Updated %1 actors(s).', ['%1' => $count]);
+
+      // Minimize memory use in case we're dealing with a large number of information objects
+      Qubit::clearClassCaches();
+
+      // Status update every 100 descriptions
+      if (0 == $count % 100)
+      {
+        $this->info($message);
+      }
+    }
+
+    // Final status update, if total count is not a multiple of 100
+    if (0 != $count % 100)
+    {
+      $this->info($message);
+    }
+
+    $this->job->setStatusCompleted();
+    $this->job->save();
+
+    return true;
+  }
+
+  public static function updateActorRelationships($actor)
+  {
+    $relationData = arElasticSearchActorPdo::serializeObjectRelations($actor->id);
+    QubitSearch::getInstance()->partialUpdate($actor, ['actorRelations' => $relationData]);
+  }
+
+  public static function previousRelationActorIds($actorId)
+  {
+    // Get actor's previously indexed relations from Elasticsearch
+    $doc = QubitSearch::getInstance()->index->getType('QubitActor')->getDocument($actorId);
+
+    return self::uniqueIdsFromRelationData($doc->getData()['actorRelations']);
+  }
+
+  public static function relationActorIds($actorId)
+  {
+    // Get actor's current relations from database
+    $relationData = arElasticSearchActorPdo::serializeObjectRelations($actorId);
+
+    return self::uniqueIdsFromRelationData($relationData);
+  }
+
+  public static function uniqueIdsFromRelationData($relationData)
+  {
+    // Parse out unique actor IDs
+    $actors = [];
+
+    foreach($relationData as $relation)
+    {
+      $actors[] = $relation['objectId'];
+      $actors[] = $relation['subjectId'];
+    }
+
+    return array_unique($actors);
+  }
+}

--- a/plugins/arDominionPlugin/css/less/search.less
+++ b/plugins/arDominionPlugin/css/less/search.less
@@ -217,11 +217,19 @@ h1 {
       .filter-left {
         width: 49%;
         float: left;
+
+        &.relation {
+          width: 33%;
+        }
       }
 
       .filter-right {
         width: 49%;
         float: right;
+
+        &.relation {
+          width: 66%;
+        }
       }
 
       .lod-filter {

--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -64,6 +64,16 @@ mapping:
       type_id: { type: integer, include_in_all: false }
       actor_id: { type: integer, include_in_all: false }
 
+  relation:
+    _attributes:
+      nested_only: true
+    dynamic: strict
+    type: nested
+    properties:
+      object_id: { type: integer, include_in_all: false }
+      subject_id: { type: integer, include_in_all: false }
+      type_id: { type: integer, include_in_all: false }
+
   donor:
     _attributes:
       i18nExtra: [actor]
@@ -338,6 +348,7 @@ mapping:
       standardized_names: other_name
       subjects: term
       places: term
+      actor_relations: relation
     _partial_foreign_types:
       occupations:
         _i18nFields: [name, content]

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchActorPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchActorPdo.class.php
@@ -262,6 +262,9 @@ class arElasticSearchActorPdo
       array(QubitTaxonomy::PLACE_ID, QubitTaxonomy::SUBJECT_ID)
     );
 
+    // Related objects
+    $serialized['actorRelations'] = self::serializeObjectRelations($this->id);
+
     // Places
     if (isset($relatedTerms[QubitTaxonomy::PLACE_ID]))
     {
@@ -347,6 +350,17 @@ class arElasticSearchActorPdo
     }
 
     return $serialized;
+  }
+
+  public static function serializeObjectRelations($actorId)
+  {
+    $sql = "SELECT r.object_id AS objectId, r.subject_id AS subjectId, r.type_id AS typeId
+             FROM ".QubitRelation::TABLE_NAME." r
+             INNER JOIN ".QubitTerm::TABLE_NAME." t ON r.type_id=t.id
+             WHERE t.taxonomy_id=".QubitTaxonomy::ACTOR_RELATION_TYPE_ID."
+             AND object_id=? OR r.subject_id=?";
+
+    return QubitPdo::fetchAll($sql, array($actorId, $actorId), array('fetchMode' => PDO::FETCH_ASSOC));
   }
 
   protected function getProperty($name)


### PR DESCRIPTION
Add the ability to filter authority record searches by relationship
type.

* Add Elasticsearch indexing of authority record relations
* Add related type field to authority record search form
* Add related authority record field to authority record search form
* Add filter tag for relation types
* Code cleanup/validation tightening