### PR TITLE
Fix date range in description updates, refs #13292

### DIFF
--- a/apps/qubit/modules/search/actions/descriptionUpdatesAction.class.php
+++ b/apps/qubit/modules/search/actions/descriptionUpdatesAction.class.php
@@ -216,7 +216,7 @@ class SearchDescriptionUpdatesAction extends sfAction
     // Add date restriction
     $criteria->add(QubitAuditLog::CREATED_AT , $this->form->getValue('startDate'), Criteria::GREATER_EQUAL);
     $endDateTime = new DateTime($this->form->getValue('endDate'));
-    $criteria->add(QubitAuditLog::CREATED_AT, $endDateTime->modify('+1 day')->format('Y-m-d'), Criteria::LESS_THAN);
+    $criteria->addAnd(QubitAuditLog::CREATED_AT, $endDateTime->modify('+1 day')->format('Y-m-d'), Criteria::LESS_THAN);
 
     // Sort in reverse chronological order
     $criteria->addDescendingOrderByColumn(QubitAuditLog::CREATED_AT);


### PR DESCRIPTION
When description change logging is enabled the criteria for
QubitAuditLog::CREATED_AT is first set with the startDate but gets
immediately overwritten with the endDate.

This changes the criteria to result in an AND in the WHERE clause.