### PR TITLE
Add lang facet fix, refs #13299

### DIFF
--- a/apps/qubit/modules/search/templates/_aggregation.php
+++ b/apps/qubit/modules/search/templates/_aggregation.php
@@ -1,4 +1,4 @@
-<?php if (!isset($aggs[$name]) || (!isset($filters[$name]) && count($aggs[$name]) < 2)) return ?>
+<?php if (!isset($aggs[$name]) || (!isset($filters[$name]) && (count($aggs[$name]) < 2 || ($name == 'languages' && count($aggs[$name]) < 3)))) return ?>
 <?php $openned = (isset($sf_request->$name) || (isset($open) && $open && 0 < count($aggs[$name]))) ?>
 
 <section class="facet <?php if ($openned) echo 'open' ?>">


### PR DESCRIPTION
This fix has been collaboratively prepared by Monica Wood (Library Systems, University of Tasmania) and Artefactual Systems (input from @jraddaoui). The relevant discussion can be seen in the user forum, here: 

* https://groups.google.com/d/msg/ica-atom-users/134crsm9gEs/Ppi70Z1nBAAJ

Currently with other facets in AtoM's information object search/browse page, any facet filter with less than 2 populated facets will be automatically hidden, since 0 or 1 facet results does not in fact provide users with a useful means of limiting the results. However, currently the language facet filter will always be displayed (even in a monolingual site), because it includes a count of unique records in addition to any language count - meaning there are always at least 2 facets available, and the facet filter is not hidden. 

This fix, propposed by Monica Wood and refined by @jraddaoui, inserts a new custom condition for displaying the language facet into line 1 of `apps/qubit/modules/search/templates/_aggregation.php`, raising the required facet count for displaying the language facet filter from 2 to 3 results. 