### PR TITLE
Don't suppress errors with "@", refs #13307

### DIFF
--- a/plugins/qtSwordPlugin/lib/qtPackageExtractorBase.class.php
+++ b/plugins/qtSwordPlugin/lib/qtPackageExtractorBase.class.php
@@ -234,6 +234,9 @@ class qtPackageExtractorBase
   {
     preg_match_all('/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/', $subject, $matches);
 
-    return @end(@$matches[0]);
+    if (isset($matches[0]) && is_array($matches[0]))
+    {
+      return end($matches[0]);
+    }
   }
 }


### PR DESCRIPTION
The @ operator on the first argument of the end() function was throwing
the following error in PHP 7.3.17

PHP Fatal error:  Only variables can be passed by reference in
/usr/share/nginx/atom/plugins/qtSwordPlugin/lib/qtPackageExtractorBase.class.php
on line 237