### PR TITLE
Authority relation ES indexing fix, refs #13302

### DIFF
--- a/lib/job/arUpdateEsActorRelationsJob.class.php
+++ b/lib/job/arUpdateEsActorRelationsJob.class.php
@@ -91,10 +91,17 @@ class arUpdateEsActorRelationsJob extends arBaseJob
 
   public static function previousRelationActorIds($actorId)
   {
-    // Get actor's previously indexed relations from Elasticsearch
-    $doc = QubitSearch::getInstance()->index->getType('QubitActor')->getDocument($actorId);
+    try
+    {
+      // Get actor's previously indexed relations from Elasticsearch
+      $doc = QubitSearch::getInstance()->index->getType('QubitActor')->getDocument($actorId);
 
-    return self::uniqueIdsFromRelationData($doc->getData()['actorRelations']);
+      return self::uniqueIdsFromRelationData($doc->getData()['actorRelations']);
+    }
+    catch (\Elastica\Exception\NotFoundException $e)
+    {
+      return [];
+    }
   }
 
   public static function relationActorIds($actorId)


### PR DESCRIPTION
Fixed issue where looking up actor relations in Elasticsearch, for an
actor that hasn't been indexed, would throw an exception.