### PR TITLE
Show related actors: term/tax. pages, refs #13275

### DIFF
--- a/apps/qubit/config/routing.yml
+++ b/apps/qubit/config/routing.yml
@@ -69,6 +69,13 @@ informationobject/action:
     module: informationobject
     action: { pattern: 'fileList|multiFileUpload|rename|reports|slugPreview|modifications|calculateDates' }
 
+term/action:
+  url: /:slug/:action
+  class: QubitResourceRoute
+  param:
+    module: term
+    action: { pattern: 'relatedAuthorities' }
+
 oai:
   url: /;oai
   param:

--- a/apps/qubit/modules/taxonomy/actions/indexAction.class.php
+++ b/apps/qubit/modules/taxonomy/actions/indexAction.class.php
@@ -130,24 +130,28 @@ class TaxonomyIndexAction extends sfAction
       $request->sortDir = $sortDir;
     }
 
-    $this->addResultsColumn = false;
+    $this->addIoCountColumn = false;
+    $this->addActorCountColumn = false;
 
     switch ($this->resource->id)
     {
       case QubitTaxonomy::PLACE_ID:
         $this->icon = 'places';
-        $this->addResultsColumn = true;
+        $this->addIoCountColumn = true;
+        $this->addActorCountColumn = true;
 
         break;
 
       case QubitTaxonomy::SUBJECT_ID:
         $this->icon = 'subjects';
-        $this->addResultsColumn = true;
+        $this->addIoCountColumn = true;
+        $this->addActorCountColumn = true;
 
         break;
 
       case QubitTaxonomy::GENRE_ID:
-        $this->addResultsColumn = true;
+        $this->addIoCountColumn = true;
+        $this->addActorCountColumn = true;
 
         break;
     }

--- a/apps/qubit/modules/taxonomy/templates/indexSuccess.php
+++ b/apps/qubit/modules/taxonomy/templates/indexSuccess.php
@@ -56,8 +56,11 @@
         </th><th>
           <?php echo __('Scope note') ?>
         </th>
-        <?php if ($addResultsColumn): ?>
-          <th><?php echo __('Results') ?></th>
+        <?php if ($addIoCountColumn): ?>
+          <th><?php echo __('Descriptions') ?></th>
+        <?php endif; ?>
+        <?php if ($addActorCountColumn): ?>
+          <th><?php echo __('Authorities') ?></th>
         <?php endif; ?>
       </tr>
     </thead><tbody>
@@ -98,8 +101,11 @@
             <?php endif; ?>
 
           </td>
-          <?php if ($addResultsColumn): ?>
+          <?php if ($addIoCountColumn): ?>
             <td><?php echo QubitTerm::countRelatedInformationObjects($hit->getId()) ?></td>
+          <?php endif; ?>
+          <?php if ($addActorCountColumn): ?>
+            <td><?php echo TermNavigateRelatedComponent::getEsDocsRelatedToTermCount('QubitActor', $hit->getId()) ?></td>
           <?php endif; ?>
         </tr>
       <?php endforeach; ?>

--- a/apps/qubit/modules/term/actions/indexAction.class.php
+++ b/apps/qubit/modules/term/actions/indexAction.class.php
@@ -87,17 +87,7 @@ class TermIndexAction extends DefaultBrowseAction
 
   public function execute($request)
   {
-    $this->resource = $this->getRoute()->resource;
-    if (!$this->resource instanceof QubitTerm)
-    {
-      $this->forward404();
-    }
-
-    // Check that this isn't the root
-    if (!isset($this->resource->parent))
-    {
-      $this->forward404();
-    }
+    $this->setAndCheckResource();
 
     // Disallow access to locked taxonomies
     if (in_array($this->resource->taxonomyId, QubitTaxonomy::$lockedTaxonomies))
@@ -112,14 +102,7 @@ class TermIndexAction extends DefaultBrowseAction
       $this->context->user->removeAttribute('search-realm');
     }
 
-    if (isset($request->languages))
-    {
-      $this->culture = $request->languages;
-    }
-    else
-    {
-      $this->culture = $this->context->user->getCulture();
-    }
+    $this->setCulture($request);
 
     if (1 > strlen($title = $this->resource->__toString()))
     {
@@ -315,6 +298,35 @@ EOF;
         // Load list terms
         $this->loadListTerms($request);
       }
+    }
+  }
+
+  protected function setAndCheckResource()
+  {
+    $this->resource = $this->getRoute()->resource;
+
+    // Make sure resource is a term
+    if (!$this->resource instanceof QubitTerm)
+    {
+      $this->forward404();
+    }
+
+    // Make sure resource isn't the root term
+    if (!isset($this->resource->parent))
+    {
+      $this->forward404();
+    }
+  }
+
+  protected function setCulture($request)
+  {
+    if (isset($request->languages))
+    {
+      $this->culture = $request->languages;
+    }
+    else
+    {
+      $this->culture = $this->context->user->getCulture();
     }
   }
 

--- a/apps/qubit/modules/term/actions/navigateRelatedComponent.class.php
+++ b/apps/qubit/modules/term/actions/navigateRelatedComponent.class.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class TermNavigateRelatedComponent extends sfComponent
+{
+  // Arrays not allowed in class constants
+  public static
+    $TAXONOMY_ES_FIELDS = array(
+      QubitTaxonomy::PLACE_ID   => 'places.id',
+      QubitTaxonomy::SUBJECT_ID => 'subjects.id',
+      QubitTaxonomy::GENRE_ID   => 'genres.id'
+    ),
+
+    $TAXONOMY_ES_DIRECT_FIELDS = array(
+      QubitTaxonomy::PLACE_ID   => 'directPlaces',
+      QubitTaxonomy::SUBJECT_ID => 'directSubjects',
+      QubitTaxonomy::GENRE_ID   => 'directGenres'
+    );
+
+  public function execute($request)
+  {
+    if (!isset(self::$TAXONOMY_ES_FIELDS[$this->resource->taxonomyId]))
+    {
+      return sfView::NONE;
+    }
+
+    // Take note of counts of Elasticsearch documents related to term
+    $this->relatedIoCount    = self::getEsDocsRelatedToTerm('QubitInformationObject', $this->resource)->count();
+    $this->relatedActorCount = self::getEsDocsRelatedToTerm('QubitActor', $this->resource)->count();
+  }
+
+  static function getEsDocsRelatedToTerm($relatedModelClass, $term, $options = [])
+  {
+    if (!isset(self::$TAXONOMY_ES_FIELDS[$term->taxonomyId]))
+    {
+      throw new sfException('Unsupported taxonomy.');
+    }
+
+    // Allow for options to override default behavior
+    $search = !empty($options['search']) ? $options['search'] : new arElasticSearchPluginQuery();
+    $esFields = !empty($options['direct']) ? self::$TAXONOMY_ES_DIRECT_FIELDS : self::$TAXONOMY_ES_FIELDS;
+
+    // Search for related resources using appropriate field
+    $query = new \Elastica\Query\Term;
+    $query->setTerm($esFields[$term->taxonomyId], $term->id);
+    $search->query->setQuery($search->queryBool->addMust($query));
+
+    // Filter out drafts if querying descriptions
+    if ($relatedModelClass == 'QubitInformationObject')
+    {
+      QubitAclSearch::filterDrafts($search->queryBool);
+    }
+
+    return QubitSearch::getInstance()->index->getType($relatedModelClass)->search($search->getQuery(false));
+  }
+
+  static function getEsDocsRelatedToTermCount($relatedModelClass, $termId, $search = null)
+  {
+    $term = QubitTerm::getById($termId);
+
+    $resultSet = self::getEsDocsRelatedToTerm($relatedModelClass, $term, $search);
+
+    return $resultSet->count();
+  }
+}

--- a/apps/qubit/modules/term/actions/relatedAuthoritiesAction.class.php
+++ b/apps/qubit/modules/term/actions/relatedAuthoritiesAction.class.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class TermRelatedAuthoritiesAction extends TermIndexAction
+{
+  const INDEX_TYPE = 'QubitActor';
+
+  // Arrays not allowed in class constants
+  public static
+    $FILTERTAGS = array(),
+
+    $AGGS = array(
+      'languages' =>
+        array('type'  => 'term',
+              'field' => 'i18n.languages',
+              'size'  => 10),
+      'occupations' =>
+        array('type'  => 'term',
+              'field' => 'occupations.id',
+              'size'  => 10),
+      'places' =>
+        array('type'  => 'term',
+              'field' => 'places.id',
+              'size'  => 10),
+      'subjects' =>
+        array('type'  => 'term',
+              'field' => 'subjects.id',
+              'size'  => 10),
+      'direct' =>
+        array('type' => 'filter',
+              'field'  => '',
+              'populate' => false));
+
+  protected function populateAgg($name, $buckets)
+  {
+    switch ($name)
+    {
+      case 'occupations':
+      case 'places':
+      case 'subjects':
+        $ids = array_column($buckets, 'key');
+        $criteria = new Criteria;
+        $criteria->add(QubitTerm::ID, $ids, Criteria::IN);
+
+        foreach (QubitTerm::get($criteria) as $item)
+        {
+          $buckets[array_search($item->id, $ids)]['display'] = $item->getName(array('cultureFallback' => true));
+        }
+
+        break;
+
+      default:
+        return parent::populateAgg($name, $buckets);
+    }
+
+    return $buckets;
+  }
+
+  protected function setSort($request)
+  {
+    switch ($request->sort)
+    {
+      case 'alphabetic':
+        $field = sprintf('i18n.%s.authorizedFormOfName.alphasort', $this->selectedCulture);
+        $this->search->query->setSort(array($field => $request->sortDir));
+
+        break;
+
+      case 'identifier':
+        $this->search->query->setSort(array('descriptionIdentifier.untouched' => $request->sortDir));
+
+        break;
+
+      case 'lastUpdated':
+      default:
+        $this->search->query->setSort(array('updatedAt' => $request->sortDir));
+    }
+  }
+
+  protected function doSearch($request)
+  {
+    $this->setSort($request);
+
+    $options = array('search' => $this->search);
+
+    // Allow for only searching for actors directly related to term
+    if(!empty($request->onlyDirect))
+    {
+      $options['direct'] = true;
+    }
+
+    return TermNavigateRelatedComponent::getEsDocsRelatedToTerm('QubitActor', $this->resource, $options);
+  }
+
+  public function execute($request)
+  {
+    $this->setAndCheckResource();
+
+    $directField = TermNavigateRelatedComponent::$TAXONOMY_ES_DIRECT_FIELDS[$this->resource->taxonomyId];
+    $this::$AGGS['direct']['field'] = array($directField => $this->resource->id);
+
+    DefaultBrowseAction::execute($request);
+
+    // Disallow access to locked taxonomies
+    if (in_array($this->resource->taxonomyId, QubitTaxonomy::$lockedTaxonomies))
+    {
+      $this->getResponse()->setStatusCode(403);
+      return sfView::NONE;
+    }
+
+    $this->setCulture($request);
+
+    // Prepare filter tags, form, and hidden fields/values
+    $this->populateFilterTags($request);
+
+    // Take note of number of related information objects
+    $resultSet = TermNavigateRelatedComponent::getEsDocsRelatedToTerm('QubitInformationObject', $this->resource);
+    $this->relatedIoCount = $resultSet->count();
+
+    // Perform search and paging
+    $resultSet = $this->doSearch($request);
+    $this->relatedActorCount = $resultSet->count();
+
+    $this->pager = new QubitSearchPager($resultSet);
+    $this->pager->setPage($request->page ? $request->page : 1);
+    $this->pager->setMaxPerPage($this->limit);
+    $this->pager->init();
+
+    $this->populateAggs($resultSet);
+
+    // Load list terms
+    $this->loadListTerms($request);
+  }
+}

--- a/apps/qubit/modules/term/config/view.yml
+++ b/apps/qubit/modules/term/config/view.yml
@@ -22,3 +22,7 @@ listSuccess:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/collapse:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/form:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/tableheader:
+
+relatedAuthoritiesSuccess:
+  javascripts:
+    blank:

--- a/apps/qubit/modules/term/templates/_actions.php
+++ b/apps/qubit/modules/term/templates/_actions.php
@@ -1,0 +1,17 @@
+<section class="actions">
+  <ul>
+
+    <?php if ((QubitAcl::check($resource, 'update') || QubitAcl::check($resource, 'translate')) && !QubitTerm::isProtected($resource->id)): ?>
+      <li><?php echo link_to (__('Edit'), array($resource, 'module' => 'term', 'action' => 'edit'), array('class' => 'c-btn c-btn-submit')) ?></li>
+    <?php endif; ?>
+
+    <?php if (QubitAcl::check($resource, 'delete') && !QubitTerm::isProtected($resource->id)): ?>
+      <li><?php echo link_to (__('Delete'), array($resource, 'module' => 'term', 'action' => 'delete'), array('class' => 'c-btn c-btn-delete')) ?></li>
+    <?php endif; ?>
+
+    <?php if (QubitAcl::check($resource->taxonomy, 'createTerm')): ?>
+      <li><?php echo link_to(__('Add new'), array('module' => 'term', 'action' => 'add', 'parent' => url_for(array($resource, 'module' => 'term')), 'taxonomy' => url_for(array($resource->taxonomy, 'module' => 'taxonomy'))), array('class' => 'c-btn')) ?></li>
+    <?php endif; ?>
+
+  </ul>
+</section>

--- a/apps/qubit/modules/term/templates/_directTerms.php
+++ b/apps/qubit/modules/term/templates/_directTerms.php
@@ -1,0 +1,14 @@
+<?php if (!isset($sf_request->onlyDirect) && isset($aggs['direct']) && 0 < $aggs['direct']['doc_count']): ?>
+  <div class="search-result media-summary">
+    <p>
+      <?php echo __('%1% results directly related', array(
+        '%1%' => $aggs['direct']['doc_count'])) ?>
+      <?php $params = $sf_data->getRaw('sf_request')->getGetParameters() ?>
+      <?php unset($params['page']) ?>
+      <a href="<?php echo url_for(array($resource, 'module' => 'term') + $params + array('onlyDirect' => true)) ?>">
+        <i class="fa fa-search"></i>
+        <?php echo __('Exclude narrower terms') ?>
+      </a>
+    </p>
+  </div>
+<?php endif; ?>

--- a/apps/qubit/modules/term/templates/_errors.php
+++ b/apps/qubit/modules/term/templates/_errors.php
@@ -1,0 +1,9 @@
+<?php if (isset($errorSchema)): ?>
+  <div class="messages error">
+    <ul>
+      <?php foreach ($errorSchema as $error): ?>
+        <li><?php echo $error ?></li>
+      <?php endforeach; ?>
+    </ul>
+  </div>
+<?php endif; ?>

--- a/apps/qubit/modules/term/templates/_fields.php
+++ b/apps/qubit/modules/term/templates/_fields.php
@@ -1,0 +1,118 @@
+<?php echo render_show(__('Taxonomy'), link_to(render_title($resource->taxonomy), array($resource->taxonomy, 'module' => 'taxonomy'))) ?>
+
+<div class="field">
+  <h3><?php echo __('Code') ?></h3>
+  <div>
+    <?php echo $resource->code ?>
+    <?php if (!empty($resource->code) && QubitTaxonomy::PLACE_ID == $resource->taxonomy->id): ?>
+      <?php echo image_tag('https://maps.googleapis.com/maps/api/staticmap?zoom=13&size=300x300&sensor=false&center='.$resource->code,
+        array('class' => 'static-map', 'alt' => __('Map of %1%',
+        array('%1%' => truncate_text(strip_markdown($resource), 100))))) ?>
+    <?php endif; ?>
+  </div>
+</div>
+
+<div class="field">
+  <h3><?php echo __('Scope note(s)') ?></h3>
+  <div>
+    <ul>
+      <?php foreach ($resource->getNotesByType(array('noteTypeId' => QubitTerm::SCOPE_NOTE_ID)) as $item): ?>
+        <?php if ($item->sourceCulture != $sf_user->getCulture()): ?>
+          <?php continue; ?>
+        <?php endif; ?>
+        <li><?php echo render_value_inline($item->getContent(array('cultureFallback' => true))) ?></li>
+      <?php endforeach; ?>
+    </ul>
+  </div>
+</div>
+
+<div class="field">
+  <h3><?php echo __('Source note(s)') ?></h3>
+  <div>
+    <ul>
+      <?php foreach ($resource->getNotesByType(array('noteTypeId' => QubitTerm::SOURCE_NOTE_ID)) as $item): ?>
+        <li><?php echo render_value_inline($item->getContent(array('cultureFallback' => true))) ?></li>
+      <?php endforeach; ?>
+    </ul>
+  </div>
+</div>
+
+<div class="field">
+  <h3><?php echo __('Display note(s)') ?></h3>
+  <div>
+    <ul>
+      <?php foreach ($resource->getNotesByType(array('noteTypeId' => QubitTerm::DISPLAY_NOTE_ID)) as $item): ?>
+        <li><?php echo render_value_inline($item->getContent(array('cultureFallback' => true))) ?></li>
+      <?php endforeach; ?>
+    </ul>
+  </div>
+</div>
+
+<div class="field">
+  <h3><?php echo __('Hierarchical terms') ?></h3>
+  <div>
+
+    <?php if (QubitTerm::ROOT_ID != $resource->parent->id): ?>
+      <?php echo render_show(
+                   render_title($resource), __('BT %1%', array(
+                     '%1%' => link_to(render_title($resource->parent), array($resource->parent, 'module' => 'term'))))) ?>
+    <?php endif; ?>
+
+    <div class="field">
+      <h3><?php echo render_title($resource) ?></h3>
+      <div>
+        <ul>
+          <?php foreach ($resource->getChildren(array('sortBy' => 'name')) as $item): ?>
+            <li><?php echo __('NT %1%', array('%1%' => link_to(render_title($item), array($item, 'module' => 'term')))) ?></li>
+          <?php endforeach; ?>
+        </ul>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<div class="field">
+  <h3><?php echo __('Equivalent terms') ?></h3>
+  <div>
+
+    <div class="field">
+      <h3><?php echo render_title($resource) ?></h3>
+      <div>
+        <ul>
+          <?php foreach ($resource->otherNames as $item): ?>
+            <?php if ($item->sourceCulture != $sf_user->getCulture()): ?>
+              <?php continue; ?>
+            <?php endif; ?>
+            <li><?php echo __('UF %1%', array('%1%' => render_title($item))) ?></li>
+          <?php endforeach; ?>
+        </ul>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<?php if (0 < count($converseTerms = QubitRelation::getBySubjectOrObjectId($resource->id, array('typeId' => QubitTerm::CONVERSE_TERM_ID)))): ?>
+  <?php echo render_show(__('Converse term'), link_to(render_title(
+               $converseTerms[0]->getOpposedObject($resource)), array($converseTerms[0]->getOpposedObject($resource), 'module' => 'term'))) ?>
+<?php endif; ?>
+
+<div class="field">
+  <h3><?php echo __('Associated terms') ?></h3>
+  <div>
+
+    <div class="field">
+      <h3><?php echo render_title($resource) ?></h3>
+      <div>
+        <ul>
+          <?php foreach (QubitRelation::getBySubjectOrObjectId($resource->id, array('typeId' => QubitTerm::TERM_RELATION_ASSOCIATIVE_ID)) as $item): ?>
+            <li><?php echo __('RT %1%', array('%1%' => link_to(render_title(
+                        $item->getOpposedObject($resource->id)), array($item->getOpposedObject($resource->id), 'module' => 'term')))) ?></li>
+          <?php endforeach; ?>
+        </ul>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/apps/qubit/modules/term/templates/_navigateRelated.php
+++ b/apps/qubit/modules/term/templates/_navigateRelated.php
@@ -1,0 +1,18 @@
+<ul class="nav nav-tabs">
+  <li class="nav-item <?php if ($sf_context->getActionName() == 'index'): ?><?php echo "active" ?><?php endif; ?>">
+    <?php if ($relatedIoCount || $sf_context->getActionName() == "relatedAuthorities"): ?>
+      <?php echo link_to(__('Related Descriptions') . sprintf(' (%d)', $relatedIoCount),
+                   array($resource, 'module' => 'term', 'action' => 'index'), array('class' => 'nav-link')) ?>
+    <?php else: ?>
+      <a class="nav-link" href="#"><?php echo __('Related Descriptions') . sprintf(' (%d)', $relatedIoCount) ?></a>
+    <?php endif; ?>
+  </li>
+  <li class="nav-item <?php if ($sf_context->getActionName() != 'index'): ?><?php echo "active" ?><?php endif; ?>">
+    <?php if ($relatedActorCount): ?>
+      <?php echo link_to(__('Related Authorities') . sprintf(' (%d)', $relatedActorCount),
+                   array($resource, 'module' => 'term', 'action' => 'relatedAuthorities'), array('class' => 'nav-link')) ?>
+    <?php else: ?>
+      <a class="nav-link" href="#"><?php echo __('Related Authorities') . sprintf(' (%d)', $relatedActorCount) ?></a>
+    <?php endif; ?>
+  </li>
+</ul>

--- a/apps/qubit/modules/term/templates/_sidebar.php
+++ b/apps/qubit/modules/term/templates/_sidebar.php
@@ -1,0 +1,69 @@
+<div class="sidebar-lowering-sort">
+
+  <?php if (!$showTreeview): ?>
+    <?php echo get_component('term', 'treeView', array('browser' => false)) ?>
+  <?php else: ?>
+
+    <?php echo get_component('term', 'treeView', array('browser' => false, 'tabs' => true, 'pager' => $listPager)) ?>
+
+    <section id="facets">
+
+      <div class="visible-phone facets-header">
+        <a class="x-btn btn-wide">
+          <i class="fa fa-filter"></i>
+          <?php echo __('Filters') ?>
+        </a>
+      </div>
+
+      <div class="content">
+
+        <?php echo get_partial('search/aggregation', array(
+          'id' => '#facet-languages',
+          'label' => __('Language'),
+          'name' => 'languages',
+          'aggs' => $aggs,
+          'filters' => $search->filters)) ?>
+
+        <?php if (QubitTaxonomy::PLACE_ID != $resource->taxonomyId): ?>
+          <?php echo get_partial('search/aggregation', array(
+            'id' => '#facet-places',
+            'label' => sfConfig::get('app_ui_label_place'),
+            'name' => 'places',
+            'aggs' => $aggs,
+            'filters' => $search->filters)) ?>
+          <?php endif; ?>
+
+        <?php if (QubitTaxonomy::SUBJECT_ID != $resource->taxonomyId): ?>
+          <?php echo get_partial('search/aggregation', array(
+            'id' => '#facet-subjects',
+            'label' => sfConfig::get('app_ui_label_subject'),
+            'name' => 'subjects',
+            'aggs' => $aggs,
+            'filters' => $search->filters)) ?>
+        <?php endif; ?>
+
+        <?php if (QubitTaxonomy::GENRE_ID != $resource->taxonomyId): ?>
+          <?php echo get_partial('search/aggregation', array(
+            'id' => '#facet-genres',
+            'label' => sfConfig::get('app_ui_label_genre'),
+            'name' => 'genres',
+            'aggs' => $aggs,
+            'filters' => $search->filters)) ?>
+        <?php endif; ?>
+
+        <?php if (QubitTaxonomy::ACTOR_OCCUPATION_ID != $resource->taxonomyId): ?>
+          <?php echo get_partial('search/aggregation', array(
+            'id' => '#facet-occupations',
+            'label' => __('Occupation'),
+            'name' => 'occupations',
+            'aggs' => $aggs,
+            'filters' => $search->filters)) ?>
+        <?php endif; ?>
+
+      </div>
+
+    </section>
+
+  <?php endif; ?>
+
+</div>

--- a/apps/qubit/modules/term/templates/indexSuccess.php
+++ b/apps/qubit/modules/term/templates/indexSuccess.php
@@ -2,81 +2,23 @@
 <?php use_helper('Text') ?>
 
 <?php slot('sidebar') ?>
-  <div class="sidebar-lowering-sort">
 
-    <?php if (!$addBrowseElements): ?>
-      <?php echo get_component('term', 'treeView', array('browser' => false)) ?>
-    <?php else: ?>
+  <?php echo get_partial('term/sidebar', array(
+    'resource' => $resource,
+    'showTreeview' => $addBrowseElements,
+    'search' => $search,
+    'aggs' => $aggs,
+    'listPager' => $listPager)) ?>
 
-      <?php echo get_component('term', 'treeView', array('browser' => false, 'tabs' => true, 'pager' => $listPager)) ?>
-
-      <section id="facets">
-
-        <div class="visible-phone facets-header">
-          <a class="x-btn btn-wide">
-            <i class="fa fa-filter"></i>
-            <?php echo __('Filters') ?>
-          </a>
-        </div>
-
-        <div class="content">
-
-          <?php echo get_partial('search/aggregation', array(
-            'id' => '#facet-languages',
-            'label' => __('Language'),
-            'name' => 'languages',
-            'aggs' => $aggs,
-            'filters' => $search->filters)) ?>
-
-          <?php if (QubitTaxonomy::PLACE_ID != $resource->taxonomyId): ?>
-            <?php echo get_partial('search/aggregation', array(
-              'id' => '#facet-places',
-              'label' => sfConfig::get('app_ui_label_place'),
-              'name' => 'places',
-              'aggs' => $aggs,
-              'filters' => $search->filters)) ?>
-            <?php endif; ?>
-
-          <?php if (QubitTaxonomy::SUBJECT_ID != $resource->taxonomyId): ?>
-            <?php echo get_partial('search/aggregation', array(
-              'id' => '#facet-subjects',
-              'label' => sfConfig::get('app_ui_label_subject'),
-              'name' => 'subjects',
-              'aggs' => $aggs,
-              'filters' => $search->filters)) ?>
-          <?php endif; ?>
-
-          <?php if (QubitTaxonomy::GENRE_ID != $resource->taxonomyId): ?>
-            <?php echo get_partial('search/aggregation', array(
-              'id' => '#facet-genres',
-              'label' => sfConfig::get('app_ui_label_genre'),
-              'name' => 'genres',
-              'aggs' => $aggs,
-              'filters' => $search->filters)) ?>
-          <?php endif; ?>
-
-        </div>
-
-      </section>
-
-    <?php endif; ?>
-
- </div>
 <?php end_slot() ?>
 
 <?php slot('title') ?>
 
   <h1><?php echo render_title($resource) ?></h1>
 
-  <?php if (isset($errorSchema)): ?>
-    <div class="messages error">
-      <ul>
-        <?php foreach ($errorSchema as $error): ?>
-          <li><?php echo $error ?></li>
-        <?php endforeach; ?>
-      </ul>
-    </div>
-  <?php endif; ?>
+  <?php echo get_component('term', 'navigateRelated', array('resource' => $resource)) ?>
+
+  <?php echo get_partial('term/errors', array('errorSchema' => $errorSchema)) ?>
 
   <?php if (QubitTerm::ROOT_ID != $resource->parentId): ?>
     <?php echo include_partial('default/breadcrumb', array('resource' => $resource, 'objects' => $resource->getAncestors()->andSelf()->orderBy('lft'))) ?>
@@ -103,142 +45,10 @@
 <?php slot('content') ?>
 
   <div id="content">
-
-    <?php echo render_show(__('Taxonomy'), link_to(render_title($resource->taxonomy), array($resource->taxonomy, 'module' => 'taxonomy'))) ?>
-
-    <div class="field">
-      <h3><?php echo __('Code') ?></h3>
-      <div>
-        <?php echo $resource->code ?>
-        <?php if (!empty($resource->code) && QubitTaxonomy::PLACE_ID == $resource->taxonomy->id): ?>
-          <?php echo image_tag('https://maps.googleapis.com/maps/api/staticmap?zoom=13&size=300x300&sensor=false&center='.$resource->code,
-            array('class' => 'static-map', 'alt' => __('Map of %1%',
-            array('%1%' => truncate_text(strip_markdown($resource), 100))))) ?>
-        <?php endif; ?>
-      </div>
-    </div>
-
-    <div class="field">
-      <h3><?php echo __('Scope note(s)') ?></h3>
-      <div>
-        <ul>
-          <?php foreach ($resource->getNotesByType(array('noteTypeId' => QubitTerm::SCOPE_NOTE_ID)) as $item): ?>
-            <?php if ($item->sourceCulture != $sf_user->getCulture()): ?>
-              <?php continue; ?>
-            <?php endif; ?>
-            <li><?php echo render_value_inline($item->getContent(array('cultureFallback' => true))) ?></li>
-          <?php endforeach; ?>
-        </ul>
-      </div>
-    </div>
-
-    <div class="field">
-      <h3><?php echo __('Source note(s)') ?></h3>
-      <div>
-        <ul>
-          <?php foreach ($resource->getNotesByType(array('noteTypeId' => QubitTerm::SOURCE_NOTE_ID)) as $item): ?>
-            <li><?php echo render_value_inline($item->getContent(array('cultureFallback' => true))) ?></li>
-          <?php endforeach; ?>
-        </ul>
-      </div>
-    </div>
-
-    <div class="field">
-      <h3><?php echo __('Display note(s)') ?></h3>
-      <div>
-        <ul>
-          <?php foreach ($resource->getNotesByType(array('noteTypeId' => QubitTerm::DISPLAY_NOTE_ID)) as $item): ?>
-            <li><?php echo render_value_inline($item->getContent(array('cultureFallback' => true))) ?></li>
-          <?php endforeach; ?>
-        </ul>
-      </div>
-    </div>
-
-    <div class="field">
-      <h3><?php echo __('Hierarchical terms') ?></h3>
-      <div>
-
-        <?php if (QubitTerm::ROOT_ID != $resource->parent->id): ?>
-          <?php echo render_show(render_title($resource), __('BT %1%', array('%1%' => link_to(render_title($resource->parent), array($resource->parent, 'module' => 'term'))))) ?>
-        <?php endif; ?>
-
-        <div class="field">
-          <h3><?php echo render_title($resource) ?></h3>
-          <div>
-            <ul>
-              <?php foreach ($resource->getChildren(array('sortBy' => 'name')) as $item): ?>
-                <li><?php echo __('NT %1%', array('%1%' => link_to(render_title($item), array($item, 'module' => 'term')))) ?></li>
-              <?php endforeach; ?>
-            </ul>
-          </div>
-        </div>
-
-      </div>
-    </div>
-
-    <div class="field">
-      <h3><?php echo __('Equivalent terms') ?></h3>
-      <div>
-
-        <div class="field">
-          <h3><?php echo render_title($resource) ?></h3>
-          <div>
-            <ul>
-              <?php foreach ($resource->otherNames as $item): ?>
-                <?php if ($item->sourceCulture != $sf_user->getCulture()): ?>
-                  <?php continue; ?>
-                <?php endif; ?>
-                <li><?php echo __('UF %1%', array('%1%' => render_title($item))) ?></li>
-              <?php endforeach; ?>
-            </ul>
-          </div>
-        </div>
-
-      </div>
-    </div>
-
-    <?php if (0 < count($converseTerms = QubitRelation::getBySubjectOrObjectId($resource->id, array('typeId' => QubitTerm::CONVERSE_TERM_ID)))): ?>
-      <?php echo render_show(__('Converse term'), link_to(render_title($converseTerms[0]->getOpposedObject($resource)), array($converseTerms[0]->getOpposedObject($resource), 'module' => 'term'))) ?>
-    <?php endif; ?>
-
-    <div class="field">
-      <h3><?php echo __('Associated terms') ?></h3>
-      <div>
-
-        <div class="field">
-          <h3><?php echo render_title($resource) ?></h3>
-          <div>
-            <ul>
-              <?php foreach (QubitRelation::getBySubjectOrObjectId($resource->id, array('typeId' => QubitTerm::TERM_RELATION_ASSOCIATIVE_ID)) as $item): ?>
-                <li><?php echo __('RT %1%', array('%1%' => link_to(render_title($item->getOpposedObject($resource->id)), array($item->getOpposedObject($resource->id), 'module' => 'term')))) ?></li>
-              <?php endforeach; ?>
-            </ul>
-          </div>
-        </div>
-
-      </div>
-    </div>
+    <?php echo get_partial('term/fields', array('resource' => $resource)) ?>
   </div>
 
-  <section class="actions">
-
-    <ul>
-
-      <?php if ((QubitAcl::check($resource, 'update') || QubitAcl::check($resource, 'translate')) && !QubitTerm::isProtected($resource->id)): ?>
-        <li><?php echo link_to (__('Edit'), array($resource, 'module' => 'term', 'action' => 'edit'), array('class' => 'c-btn c-btn-submit')) ?></li>
-      <?php endif; ?>
-
-      <?php if (QubitAcl::check($resource, 'delete') && !QubitTerm::isProtected($resource->id)): ?>
-        <li><?php echo link_to (__('Delete'), array($resource, 'module' => 'term', 'action' => 'delete'), array('class' => 'c-btn c-btn-delete')) ?></li>
-      <?php endif; ?>
-
-      <?php if (QubitAcl::check($resource->taxonomy, 'createTerm')): ?>
-        <li><?php echo link_to(__('Add new'), array('module' => 'term', 'action' => 'add', 'parent' => url_for(array($resource, 'module' => 'term')), 'taxonomy' => url_for(array($resource->taxonomy, 'module' => 'taxonomy'))), array('class' => 'c-btn')) ?></li>
-      <?php endif; ?>
-
-    </ul>
-
-  </section>
+  <?php echo get_partial('term/actions', array('resource' => $resource)) ?>
 
   <?php if ($addBrowseElements): ?>
     <h1><?php echo __('%1% %2% results for %3%', array('%1%' => $pager->getNbResults(), '%2%' => sfConfig::get('app_ui_label_informationobject'), '%3%' => render_title($resource))) ?></h1>
@@ -266,20 +76,9 @@
 
     <div id="content">
 
-      <?php if (!isset($sf_request->onlyDirect) && isset($aggs['direct']) && 0 < $aggs['direct']['doc_count']): ?>
-        <div class="search-result media-summary">
-          <p>
-            <?php echo __('%1% results directly related', array(
-              '%1%' => $aggs['direct']['doc_count'])) ?>
-            <?php $params = $sf_data->getRaw('sf_request')->getGetParameters() ?>
-            <?php unset($params['page']) ?>
-            <a href="<?php echo url_for(array($resource, 'module' => 'term') + $params + array('onlyDirect' => true)) ?>">
-              <i class="fa fa-search"></i>
-              <?php echo __('Exclude narrower terms') ?>
-            </a>
-          </p>
-        </div>
-      <?php endif; ?>
+      <?php echo get_partial('term/directTerms', array(
+        'resource' => $resource,
+        'aggs' => $aggs)) ?>
 
       <?php echo get_partial('search/searchResults', array('pager' => $pager, 'culture' => $culture)) ?>
 

--- a/apps/qubit/modules/term/templates/relatedAuthoritiesSuccess.php
+++ b/apps/qubit/modules/term/templates/relatedAuthoritiesSuccess.php
@@ -1,0 +1,105 @@
+<?php decorate_with('layout_3col') ?> 
+<?php use_helper('Date') ?>
+
+<?php slot('sidebar') ?>
+
+  <?php echo get_partial('term/sidebar', array(
+    'resource' => $resource,
+    'showTreeview' => true,
+    'search' => $search,
+    'aggs' => $aggs,
+    'listPager' => $listPager)) ?>
+
+<?php end_slot() ?>
+
+<?php slot('title') ?>
+
+  <h1><?php echo render_title($resource) ?></h1>
+
+  <?php echo get_component('term', 'navigateRelated', array('resource' => $resource)) ?>
+
+  <?php echo get_partial('term/errors', array('errorSchema' => $errorSchema)) ?>
+
+  <?php if (QubitTerm::ROOT_ID != $resource->parentId): ?>
+    <?php echo include_partial('default/breadcrumb',
+                 array('resource' => $resource, 'objects' => $resource->getAncestors()->andSelf()->orderBy('lft'))) ?>
+  <?php endif; ?>
+
+<?php end_slot() ?>
+
+<?php slot('before-content') ?>
+  <?php echo get_component('default', 'translationLinks', array('resource' => $resource)) ?>
+<?php end_slot() ?>
+
+<?php slot('context-menu') ?>
+
+  <div class="sidebar">
+    <?php echo get_partial('term/format', array('resource' => $resource)) ?>
+
+    <?php echo get_partial('term/rightContextMenu', array('resource' => $resource, 'results' => $pager->getNbResults())) ?>
+  </div>
+
+<?php end_slot() ?>
+
+<?php slot('content') ?>
+
+  <div id="content">
+    <?php echo get_partial('term/fields', array('resource' => $resource)) ?>
+  </div>
+
+  <?php echo get_partial('term/actions', array('resource' => $resource)) ?>
+
+  <h1><?php echo __('%1% %2% results for %3%',
+                   array('%1%' => $pager->getNbResults(), '%2%' => sfConfig::get('app_ui_label_actor'), '%3%' => render_title($resource))) ?></h1>
+
+  <section class="header-options">
+
+    <?php if (isset($sf_request->onlyDirect)): ?>
+      <span class="search-filter">
+        <?php echo __('Only results directly related') ?>
+        <?php $params = $sf_data->getRaw('sf_request')->getGetParameters() ?>
+        <?php unset($params['onlyDirect']) ?>
+        <?php unset($params['page']) ?>
+        <a href="<?php echo url_for(array($resource, 'module' => 'term') + $params) ?>" class="remove-filter"><i class="fa fa-times"></i></a>
+      </span>
+    <?php endif; ?>
+
+    <div class="pickers">
+      <?php echo get_partial('default/sortPickers',
+        array(
+          'options' => array(
+            'lastUpdated' => __('Date modified'),
+            'alphabetic'  => __('Name'),
+            'identifier'  => __('Identifier')))) ?>
+    </div>
+
+  </section>
+
+  <div id="content">
+
+    <?php echo get_partial('term/directTerms', array(
+      'resource' => $resource,
+      'aggs' => $aggs)) ?>
+
+    <?php if ($pager->getNbResults()): ?>
+
+      <?php foreach ($pager->getResults() as $hit): ?>
+        <?php $doc = $hit->getData() ?>
+        <?php echo include_partial('actor/searchResult', array('doc' => $doc, 'pager' => $pager, 'culture' => $selectedCulture)) ?>
+      <?php endforeach; ?>
+
+    <?php else: ?>
+
+      <div>
+        <h2><?php echo __('We couldn\'t find any results matching your search.') ?></h2>
+      </div>
+
+    <?php endif; ?>
+
+  </div>
+
+<?php end_slot() ?>
+
+<?php slot('after-content') ?>
+  <?php echo get_partial('default/pager', array('pager' => $pager)) ?>
+<?php end_slot() ?>

--- a/lib/model/QubitTerm.php
+++ b/lib/model/QubitTerm.php
@@ -745,11 +745,10 @@ class QubitTerm extends BaseTerm
   }
 
   /**
-   * Get a count of objects related via q_object_term_relation that have a
-   * class_name = $objectClassName (i.e. only 'QubitInformationObject's)
+   * Get a count of related information objects
    *
-   * @param string $objectClassName related object class_name column value
-   * @return integer count of related object.
+   * @param integer  ID of term
+   * @return integer  count of related information objects
    */
   public static function countRelatedInformationObjects($id)
   {


### PR DESCRIPTION
Added functionality to, among other things, display info about related
authority records on term index and taxonomy browse pages.

Term page related changes:

* Added page to show actors related to a term

* Refactored term index action and template so functionality from it
  can be reused on above page

Changes to subject, place, and genre taxonomy index pages:

* Added column with count of information objects related to a term

* Added column with count of actors related to a term

* Created component to show tabs to navigate between a term's index and
  related actors pages