### PR TITLE
Remove old libraries from COPYRIGHT

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -31,16 +31,6 @@ vendor/symfony/licenses
 
 Access to Memory (AtoM) also uses the following symfony plugins:
 
-sfLucenePlugin
---------------
-Copyright: Carl Vondrick
-License:   MIT
-
-sfSearchPlugin
---------------
-Copyright: Carl Vondrick
-License:   MIT
-
 sfThumbnailPlugin
 -----------------
 Copyright: Fabien Potencer

--- a/config/package.xml
+++ b/config/package.xml
@@ -38,8 +38,6 @@ The goal is to provide an easy-to-use, flexible toolkit that complies with open 
     <file name="uploads//*" role="data"/>
     <file name="downloads//*" role="data"/>
     <file name="plugins/sfDrupalPlugin//*" role="data"/>
-    <file name="plugins/sfLucenePlugin//*" role="data"/>
-    <file name="plugins/sfSearchPlugin//*" role="data"/>
     <file name="plugins/sfFormExtraPlugin//*" role="data"/>
     <file name="plugins/sfWebBrowserPlugin//*" role="data"/>
     <file name="plugins/sfThumbnailPlugin//*" role="data"/>


### PR DESCRIPTION
Remove Copyright statements for sfLucenePlugin and sfSearchPlugin,
which are no longer used by AtoM or included in the distribution.