### PR TITLE
Add ID to actor relation export, refs #13329

### DIFF
--- a/lib/flatfile/csvActorExport.class.php
+++ b/lib/flatfile/csvActorExport.class.php
@@ -83,6 +83,7 @@ class csvActorExport extends QubitFlatfileExport
       }
 
       $rows[] = array(
+        'legacyId'                    => $relation->id,
         'objectAuthorizedFormOfName'  => $resource->authorizedFormOfName,
         'subjectAuthorizedFormOfName' => $relatedEntity->authorizedFormOfName,
         'relationType'                => (string)$relationType, // Return string representation for QubitTerm


### PR DESCRIPTION
Changed the authority record relation export logic, in the
csv:authority-export task, so there's a "legacyId" column and it gets
set to a relation's ID.