### PR TITLE
Normalize hierarchy deletion, refs #13239

### DIFF
--- a/apps/qubit/modules/term/actions/deleteAction.class.php
+++ b/apps/qubit/modules/term/actions/deleteAction.class.php
@@ -45,13 +45,7 @@ class TermDeleteAction extends sfAction
 
     if ($request->isMethod('delete'))
     {
-      foreach ($this->resource->descendants->andSelf()->orderBy('rgt') as $item)
-      {
-        if (QubitAcl::check($item, 'delete'))
-        {
-          $item->delete();
-        }
-      }
+      $this->resource->deleteFullHierarchy();
 
       if (isset($this->resource->taxonomy))
       {
@@ -61,6 +55,10 @@ class TermDeleteAction extends sfAction
       $this->redirect(array('module' => 'taxonomy', 'action' => 'list'));
     }
 
-    $this->descendantsCount = ($this->resource->rgt - $this->resource->lft - 1) / 2;
+    // Apparently we can't slice a QubitQuery. `previewSize` is shared with
+    // the template so we can break the loop when desired.
+    $this->count = ($this->resource->rgt - $this->resource->lft - 1) / 2;
+    $this->previewSize = (int)sfConfig::get('app_hits_per_page', 10);
+    $this->previewIsLimited = $this->count > $this->previewSize;
   }
 }

--- a/apps/qubit/modules/term/templates/deleteSuccess.php
+++ b/apps/qubit/modules/term/templates/deleteSuccess.php
@@ -30,14 +30,24 @@
         </div>
       <?php endif; ?>
 
-      <?php if (0 < $descendantsCount): ?>
-        <h2><?php echo __('It has %1% descendants that will also be deleted', array('%1%' => $descendantsCount)) ?><h2>
+      <?php if (0 < $count): ?>
+        <h2><?php echo __('It has %1% descendants that will also be deleted', array('%1%' => $count)) ?></h2>
         <div class="delete-list">
+
           <ul>
-            <?php foreach ($resource->descendants as $item): ?>
+            <?php foreach ($resource->descendants as $index => $item): ?>
               <li><?php echo link_to(render_title($item), array($item, 'module' => 'term')) ?></li>
+              <?php if ($index + 1 == $previewSize) break; ?>
             <?php endforeach; ?>
           </ul>
+
+          <?php if ($previewIsLimited): ?>
+            <hr />
+            <p>
+              <?php echo __('Only %1% terms were shown.', array('%1%' => $previewSize)) ?>
+            </p>
+          <?php endif; ?>
+
         </div>
       <?php endif; ?>
 

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -3221,39 +3221,6 @@ class QubitInformationObject extends BaseInformationObject
   }
 
   /**
-   * Delete this information object as well as all children information objects.
-   *
-   * @return int  Number of QubitInformationObjects deleted.
-   */
-  public function deleteFullHierarchy()
-  {
-    $n = 0;
-
-    foreach ($this->descendants->andSelf()->orderBy('rgt') as $item)
-    {
-      // Avoid nested set update until the last deletion:
-      // The queries used to update the nested may be time expensive
-      // as they update all the descriptions above the deleted description,
-      // including those outside the deleted tree and those that are inside and
-      // will be deleted after. When the `deleteFromNestedSet` function from
-      // `BaseInformationObject` is called, the delta used to update the LFT and
-      // RGT values is calculated from the resource's RGT -LFT difference.
-      // Considering that this operation is normally run inside a transaction
-      // (otherwise it should), updating the nested set only once at the end
-      // should be enough.
-      if ($this->id !== $item->id)
-      {
-        $item->disableNestedSetUpdating = true;
-      }
-
-      $item->delete();
-      $n++;
-    }
-
-    return $n;
-  }
-
-  /**
    * Get current identifier counter for identifier mask from database.
    *
    * @return QubitSetting  The identifier counter setting (use ->value to get value).

--- a/lib/task/tools/deleteDescriptionTask.class.php
+++ b/lib/task/tools/deleteDescriptionTask.class.php
@@ -142,7 +142,21 @@ EOF;
       $root->getTitle(array('cultureFallback' => true)),
       $root->slug, ($root->rgt - $root->lft - 1) / 2));
 
-    $this->nDeleted += $root->deleteFullHierarchy();
+    $conn = Propel::getConnection();
+    $conn->beginTransaction();
+
+    try
+    {
+      $this->nDeleted += $root->deleteFullHierarchy();
+
+      $conn->commit();
+    }
+    catch (Exception $e)
+    {
+      $conn->rollBack();
+
+      throw $e;
+    }
   }
 
   /**


### PR DESCRIPTION
Avoid nested set update until the end of the full tree deletion to avoid
unnecessary nested set updates.

- Normalize `deleteFullHierarchy()` in QubitObject.
- Check that it's only called from QubitInformationObject and QubitTerm.
- Run hierarchy deletion within transaction in delete description task.
- Use `deleteFullHierarchy()` on term deletion.
- Don't show all descendants on term deletion page.