### PR TITLE
Fix non-use of UI label settings, refs #13332

### DIFF
--- a/apps/qubit/modules/taxonomy/templates/indexSuccess.php
+++ b/apps/qubit/modules/taxonomy/templates/indexSuccess.php
@@ -57,10 +57,10 @@
           <?php echo __('Scope note') ?>
         </th>
         <?php if ($addIoCountColumn): ?>
-          <th><?php echo __('Descriptions') ?></th>
+          <th><?php echo __('%1 count', array('%1' => sfConfig::get('app_ui_label_informationobject'))) ?></th>
         <?php endif; ?>
         <?php if ($addActorCountColumn): ?>
-          <th><?php echo __('Authorities') ?></th>
+          <th><?php echo __('%1 count', array('%1' => sfConfig::get('app_ui_label_actor'))) ?></th>
         <?php endif; ?>
       </tr>
     </thead><tbody>


### PR DESCRIPTION
On the taxonomy index page select terms have extra columns added to the
results to show associated descriptions and authority records. The
column names, however, couldn't be changed by label settings. Fixed so
now they can be.