### PR TITLE
Fix actor relation type search, refs #13326

### DIFF
--- a/apps/qubit/modules/actor/actions/browseAction.class.php
+++ b/apps/qubit/modules/actor/actions/browseAction.class.php
@@ -395,12 +395,11 @@ class ActorBrowseAction extends DefaultBrowseAction
     }
     else if (!empty($this->request->relatedType))
     {
-      // Include actors with a relation of a specified type
-      $queryBool = new \Elastica\Query\BoolQuery;
+      // Include actors with a direct relation of a specified type
+      $queryField = new \Elastica\Query\Term;
+      $queryField->setTerm('actorDirectRelationTypes', $request->relatedType);
 
-      $queryBool->addMust($this->actorRelationsQueryForType($this->request->relatedType));
-
-      $this->search->queryBool->addMust($this->actorRelationsNestedQuery($queryBool));
+      $this->search->queryBool->addMust($queryField);
     }
 
     // Filter out results if a specific field isn't empty

--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -368,6 +368,7 @@ mapping:
       maintaining_repository_id: { type: integer, include_in_all: false }
       direct_subjects: { type: integer, include_in_all: false }
       direct_places: { type: integer, include_in_all: false }
+      actor_direct_relation_types: { type: integer, include_in_all: false }
       has_digital_object: { type: boolean, include_in_all: false }
       digital_object:
         type: object


### PR DESCRIPTION
Changed how authority record search by relation type works so only the
relation type directly related to an authority record is returned.