### PR TITLE
Do ACL check sooner in OAI GetRecord, refs #12387

### DIFF
--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -462,11 +462,6 @@ class QubitInformationObject extends BaseInformationObject
       $options['set']->apply($criteria);
     }
 
-    if (!empty($options['filterDrafts']))
-    {
-      $criteria = QubitAcl::addFilterDraftsCriteria($criteria);
-    }
-
     if (!empty($options['topLevel']))
     {
       $criteria->add(QubitInformationObject::PARENT_ID, QubitInformationObject::ROOT_ID);

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/actions/listIdentifiersComponent.class.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/actions/listIdentifiersComponent.class.php
@@ -30,8 +30,6 @@ class arOaiPluginListIdentifiersComponent extends arOaiPluginComponent
   {
     $this->setUpdateParametersFromRequest($request);
 
-    $options = array('filterDrafts' => true);
-
     // Restrict to top-level descriptions for EAD given children get nested
     if ($request->metadataPrefix == 'oai_ead')
     {

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_getRecord.xml.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_getRecord.xml.php
@@ -1,25 +1,23 @@
 <?php if ($errorCode): ?>
   <error code="<?php echo $errorCode ?>"><?php echo $errorMsg ?></error>
 <?php else: ?>
-  <?php if (QubitAcl::check($record, 'read')): ?>
-    <GetRecord>
-      <record>
-        <header>
-          <identifier><?php echo $record->getOaiIdentifier() ?></identifier>
-          <datestamp><?php echo QubitOai::getDate($record->getUpdatedAt())?></datestamp>
-          <setSpec><?php echo $record->getCollectionRoot()->getOaiIdentifier()?></setSpec>
-        </header>
-        <metadata>
-          <?php if ($metadataPrefix == 'oai_dc' && !arOaiPluginComponent::checkDisplayCachedMetadata($record, $metadataPrefix)): ?>
-            <?php echo get_component('sfDcPlugin', 'dc', array('resource' => $record)) ?>
-          <?php else: ?>
-            <?php arOaiPluginComponent::includeCachedMetadata($record, $metadataPrefix) ?>
-          <?php endif; ?>
-        </metadata>
-        <?php if (count($record->digitalObjectsRelatedByobjectId)): ?>
-          <?php include('_about.xml.php') ?>
+  <GetRecord>
+    <record>
+      <header>
+        <identifier><?php echo $record->getOaiIdentifier() ?></identifier>
+        <datestamp><?php echo QubitOai::getDate($record->getUpdatedAt())?></datestamp>
+        <setSpec><?php echo $record->getCollectionRoot()->getOaiIdentifier()?></setSpec>
+      </header>
+      <metadata>
+        <?php if ($metadataPrefix == 'oai_dc' && !arOaiPluginComponent::checkDisplayCachedMetadata($record, $metadataPrefix)): ?>
+          <?php echo get_component('sfDcPlugin', 'dc', array('resource' => $record)) ?>
+        <?php else: ?>
+          <?php arOaiPluginComponent::includeCachedMetadata($record, $metadataPrefix) ?>
         <?php endif; ?>
-      </record>
-    </GetRecord>
-  <?php endif; ?>
+      </metadata>
+      <?php if (count($record->digitalObjectsRelatedByobjectId)): ?>
+        <?php include('_about.xml.php') ?>
+      <?php endif; ?>
+    </record>
+  </GetRecord>
 <?php endif; ?>


### PR DESCRIPTION
Also, do not display drafts for consistency with other verbs and remove
redundant draft filter from IO's getUpdatedRecords method.