### PR TITLE
Fix non-object filter tag issue, refs #13347

### DIFF
--- a/apps/qubit/modules/search/actions/filterTagComponent.class.php
+++ b/apps/qubit/modules/search/actions/filterTagComponent.class.php
@@ -30,6 +30,12 @@ class SearchFilterTagComponent extends sfComponent
       return sfView::NONE;
     }
 
+    // If filter has neither a label nor an object, display nothing
+    if (empty($this->options['label']) && empty($this->options['object']))
+    {
+      return sfView::NONE;
+    }
+
     // Remove selected parameter from the current GET parameters
     $this->unsetParams();
 


### PR DESCRIPTION
Filter tags can have label text either set manually or be derived from
an AtoM object (displaying the AtoM object's title). For filter tags
that have neither manually set label text nor an AtoM object the filter
tag was showing with label text of "Untitled". Added logic so the
filter tag isn't displayed at all if neither label text nor an AtoM
object is set.