### PR TITLE
Fix term related resources tab text, refs #13332

### DIFF
--- a/apps/qubit/modules/term/templates/_navigateRelated.php
+++ b/apps/qubit/modules/term/templates/_navigateRelated.php
@@ -1,18 +1,18 @@
 <ul class="nav nav-tabs">
   <li class="nav-item <?php if ($sf_context->getActionName() == 'index'): ?><?php echo "active" ?><?php endif; ?>">
     <?php if ($relatedIoCount || $sf_context->getActionName() == "relatedAuthorities"): ?>
-      <?php echo link_to(__('Related Descriptions') . sprintf(' (%d)', $relatedIoCount),
-                   array($resource, 'module' => 'term', 'action' => 'index'), array('class' => 'nav-link')) ?>
+      <?php echo link_to(__('Related %1% (%2%)', ['%1%' => sfConfig::get('app_ui_label_informationobject'), '%2%' => $relatedIoCount]),
+                   [$resource, 'module' => 'term', 'action' => 'index'], ['class' => 'nav-link']) ?>
     <?php else: ?>
-      <a class="nav-link" href="#"><?php echo __('Related Descriptions') . sprintf(' (%d)', $relatedIoCount) ?></a>
+      <a class="nav-link" href="#"><?php echo __('Related %1% (%2%)', ['%1%' => sfConfig::get('app_ui_label_informationobject'), '%2%' => $relatedIoCount]) ?></a>
     <?php endif; ?>
   </li>
   <li class="nav-item <?php if ($sf_context->getActionName() != 'index'): ?><?php echo "active" ?><?php endif; ?>">
     <?php if ($relatedActorCount): ?>
-      <?php echo link_to(__('Related Authorities') . sprintf(' (%d)', $relatedActorCount),
-                   array($resource, 'module' => 'term', 'action' => 'relatedAuthorities'), array('class' => 'nav-link')) ?>
+      <?php echo link_to(__('Related %1% (%2%)', ['%1%' => sfConfig::get('app_ui_label_actor'), '%2%' => $relatedActorCount]),
+                   [$resource, 'module' => 'term', 'action' => 'relatedAuthorities'], ['class' => 'nav-link']) ?>
     <?php else: ?>
-      <a class="nav-link" href="#"><?php echo __('Related Authorities') . sprintf(' (%d)', $relatedActorCount) ?></a>
+      <a class="nav-link" href="#"><?php echo __('Related %1% (%2%)', ['%1%' => sfConfig::get('app_ui_label_actor'), '%2%' => $relatedActorCount]) ?></a>
     <?php endif; ?>
   </li>
 </ul>


### PR DESCRIPTION
Fixed minor issue on the term index and related authorities pages:
hardcoded text was being used to refer to descriptions and authority
records (aka information objects and actors). Changed to use UI label
settings.