### PR TITLE
Add accession events, refs #13315

### DIFF
--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 184
+    value: 185
   milestone:
     name: milestone
     editable: 0

--- a/data/fixtures/taxonomyTerms.yml
+++ b/data/fixtures/taxonomyTerms.yml
@@ -1543,6 +1543,12 @@ QubitTaxonomy:
     name:
       en: 'Accession alternative identifier type'
       pt_BR: 'Incorporação do tipo de identificador alternativo'
+  QubitTaxonomy_accession_event_types:
+    id: 83
+    parent_id: QubitTaxonomy_root
+    source_culture: en
+    name:
+      en: 'Accession event type'
 QubitTerm:
   QubitTerm_110:
     taxonomy_id: 30
@@ -4203,6 +4209,20 @@ QubitTerm:
     name:
       en: 'Accession alternative identifier'
       pt_BR: 'Incorporação de identificador alternativo'
+  QubitTerm_accession_event_type_physical_transfer:
+    id: 193
+    parent_id: QubitTerm_110
+    taxonomy_id: QubitTaxonomy_accession_event_types
+    source_culture: en
+    name:
+      en: 'Physical transfer'
+  QubitTerm_accession_event_note:
+    id: 194
+    parent_id: QubitTerm_110
+    taxonomy_id: QubitTaxonomy_7
+    source_culture: en
+    name:
+      en: 'Accession event note'
   QubitTerm_actor_relationship_is_the_superior_of:
     taxonomy_id: QubitTaxonomy_actor_relation_type
     parent_id: QubitTerm_actor_relationship_hierarchical

--- a/data/sql/plugins.qtAccessionPlugin.lib.model.schema.sql
+++ b/data/sql/plugins.qtAccessionPlugin.lib.model.schema.sql
@@ -78,6 +78,56 @@ CREATE TABLE `accession_i18n`
 )Engine=InnoDB;
 
 #-----------------------------------------------------------------------------
+#-- accession_event
+#-----------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS `accession_event`;
+
+
+CREATE TABLE `accession_event`
+(
+	`id` INTEGER  NOT NULL,
+	`type_id` INTEGER,
+	`accession_id` INTEGER,
+	`date` DATE,
+	`source_culture` VARCHAR(16)  NOT NULL,
+	PRIMARY KEY (`id`),
+	CONSTRAINT `accession_event_FK_1`
+		FOREIGN KEY (`id`)
+		REFERENCES `object` (`id`)
+		ON DELETE CASCADE,
+	INDEX `accession_event_FI_2` (`type_id`),
+	CONSTRAINT `accession_event_FK_2`
+		FOREIGN KEY (`type_id`)
+		REFERENCES `term` (`id`)
+		ON DELETE SET NULL,
+	INDEX `accession_event_FI_3` (`accession_id`),
+	CONSTRAINT `accession_event_FK_3`
+		FOREIGN KEY (`accession_id`)
+		REFERENCES `accession` (`id`)
+		ON DELETE CASCADE
+)Engine=InnoDB;
+
+#-----------------------------------------------------------------------------
+#-- accession_event_i18n
+#-----------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS `accession_event_i18n`;
+
+
+CREATE TABLE `accession_event_i18n`
+(
+	`agent` VARCHAR(255),
+	`id` INTEGER  NOT NULL,
+	`culture` VARCHAR(16)  NOT NULL,
+	PRIMARY KEY (`id`,`culture`),
+	CONSTRAINT `accession_event_i18n_FK_1`
+		FOREIGN KEY (`id`)
+		REFERENCES `accession_event` (`id`)
+		ON DELETE CASCADE
+)Engine=InnoDB;
+
+#-----------------------------------------------------------------------------
 #-- deaccession
 #-----------------------------------------------------------------------------
 

--- a/lib/model/QubitTaxonomy.php
+++ b/lib/model/QubitTaxonomy.php
@@ -92,7 +92,9 @@ class QubitTaxonomy extends BaseTaxonomy
 
     USER_ACTION_ID = 81,
 
-    ACCESSION_ALTERNATIVE_IDENTIFIER_TYPE_ID = 82;
+    ACCESSION_ALTERNATIVE_IDENTIFIER_TYPE_ID = 82,
+
+    ACCESSION_EVENT_TYPE_ID = 83;
 
   public static
     $lockedTaxonomies = array(

--- a/lib/model/QubitTerm.php
+++ b/lib/model/QubitTerm.php
@@ -178,7 +178,13 @@ class QubitTerm extends BaseTerm
     EXTERNAL_FILE_ID = 191,
 
     // Accession alternative identifier taxonomy
-    ACCESSION_ALTERNATIVE_IDENTIFIER_DEFAULT_TYPE_ID = 192;
+    ACCESSION_ALTERNATIVE_IDENTIFIER_DEFAULT_TYPE_ID = 192,
+
+    // Accession event type: physical transfer
+    ACCESSION_EVENT_PHYSICAL_TRANSFER_ID = 193,
+
+    // Accession event note
+    ACCESSION_EVENT_NOTE_ID = 194;
 
   public static function isProtected($id)
   {
@@ -248,7 +254,9 @@ class QubitTerm extends BaseTerm
       QubitTerm::JOB_STATUS_IN_PROGRESS_ID,
       QubitTerm::JOB_STATUS_COMPLETED_ID,
       QubitTerm::JOB_STATUS_ERROR_ID,
-      QubitTerm::ACTOR_OCCUPATION_NOTE_ID));
+      QubitTerm::ACTOR_OCCUPATION_NOTE_ID,
+      QubitTerm::ACCESSION_EVENT_PHYSICAL_TRANSFER_ID,
+      QubitTerm::ACCESSION_EVENT_NOTE_ID));
   }
 
   public function __toString()

--- a/lib/model/map/ObjectTableMap.php
+++ b/lib/model/map/ObjectTableMap.php
@@ -50,6 +50,7 @@ class ObjectTableMap extends TableMap {
 	public function buildRelations()
 	{
     $this->addRelation('accession', 'accession', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
+    $this->addRelation('accessionEvent', 'accessionEvent', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('deaccession', 'deaccession', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('aclPermission', 'aclPermission', RelationMap::ONE_TO_MANY, array('id' => 'object_id', ), 'CASCADE', null);
     $this->addRelation('accessLog', 'accessLog', RelationMap::ONE_TO_MANY, array('id' => 'object_id', ), 'CASCADE', null);

--- a/lib/model/map/TermTableMap.php
+++ b/lib/model/map/TermTableMap.php
@@ -58,6 +58,7 @@ class TermTableMap extends TableMap {
     $this->addRelation('accessionRelatedByprocessingPriorityId', 'accession', RelationMap::ONE_TO_MANY, array('id' => 'processing_priority_id', ), 'SET NULL', null);
     $this->addRelation('accessionRelatedByprocessingStatusId', 'accession', RelationMap::ONE_TO_MANY, array('id' => 'processing_status_id', ), 'SET NULL', null);
     $this->addRelation('accessionRelatedByresourceTypeId', 'accession', RelationMap::ONE_TO_MANY, array('id' => 'resource_type_id', ), 'SET NULL', null);
+    $this->addRelation('accessionEvent', 'accessionEvent', RelationMap::ONE_TO_MANY, array('id' => 'type_id', ), 'SET NULL', null);
     $this->addRelation('deaccession', 'deaccession', RelationMap::ONE_TO_MANY, array('id' => 'scope_id', ), 'SET NULL', null);
     $this->addRelation('actorRelatedByentityTypeId', 'actor', RelationMap::ONE_TO_MANY, array('id' => 'entity_type_id', ), 'SET NULL', null);
     $this->addRelation('actorRelatedBydescriptionStatusId', 'actor', RelationMap::ONE_TO_MANY, array('id' => 'description_status_id', ), 'SET NULL', null);

--- a/lib/model/om/BaseTerm.php
+++ b/lib/model/om/BaseTerm.php
@@ -129,6 +129,11 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
       return true;
     }
 
+    if ('accessionEvents' == $name)
+    {
+      return true;
+    }
+
     if ('deaccessions' == $name)
     {
       return true;
@@ -404,6 +409,23 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
       }
 
       return $this->refFkValues['accessionsRelatedByresourceTypeId'];
+    }
+
+    if ('accessionEvents' == $name)
+    {
+      if (!isset($this->refFkValues['accessionEvents']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['accessionEvents'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['accessionEvents'] = self::getaccessionEventsById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['accessionEvents'];
     }
 
     if ('deaccessions' == $name)
@@ -1273,6 +1295,26 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
   public function addaccessionsRelatedByresourceTypeIdCriteria(Criteria $criteria)
   {
     return self::addaccessionsRelatedByresourceTypeIdCriteriaById($criteria, $this->id);
+  }
+
+  public static function addaccessionEventsCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitAccessionEvent::TYPE_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getaccessionEventsById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addaccessionEventsCriteriaById($criteria, $id);
+
+    return QubitAccessionEvent::get($criteria, $options);
+  }
+
+  public function addaccessionEventsCriteria(Criteria $criteria)
+  {
+    return self::addaccessionEventsCriteriaById($criteria, $this->id);
   }
 
   public static function adddeaccessionsCriteriaById(Criteria $criteria, $id)

--- a/lib/task/migrate/migrations/arMigration0185.class.php
+++ b/lib/task/migrate/migrations/arMigration0185.class.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add tables, taxonomy, and terms that relate to accession events
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0185
+{
+  const
+    VERSION = 185, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  public function up($configuration)
+  {
+    // Add accession_event table
+    $sql = <<<sql
+
+CREATE TABLE IF NOT EXISTS `accession_event`
+(
+        `id` INTEGER  NOT NULL,
+        `type_id` INTEGER,
+        `accession_id` INTEGER,
+        `date` DATE,
+        `source_culture` VARCHAR(16)  NOT NULL,
+        PRIMARY KEY (`id`),
+        CONSTRAINT `accession_event_FK_1`
+                FOREIGN KEY (`id`)
+                REFERENCES `object` (`id`)
+                ON DELETE CASCADE,
+        INDEX `accession_event_FI_2` (`type_id`),
+        CONSTRAINT `accession_event_FK_2`
+                FOREIGN KEY (`type_id`)
+                REFERENCES `term` (`id`)
+                ON DELETE SET NULL,
+        INDEX `accession_event_FI_3` (`accession_id`),
+        CONSTRAINT `accession_event_FK_3`
+                FOREIGN KEY (`accession_id`)
+                REFERENCES `accession` (`id`)
+                ON DELETE CASCADE
+)Engine=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `accession_event_i18n`
+(
+        `agent` VARCHAR(255),
+        `id` INTEGER  NOT NULL,
+        `culture` VARCHAR(16)  NOT NULL,
+        PRIMARY KEY (`id`,`culture`),
+        CONSTRAINT `accession_event_i18n_FK_1`
+                FOREIGN KEY (`id`)
+                REFERENCES `accession_event` (`id`)
+                ON DELETE CASCADE
+)Engine=InnoDB;
+
+sql;
+
+    QubitPdo::modify($sql);
+
+    // Add accession event type taxonomy if it doesn't exist
+    if (null == QubitTaxonomy::getById(QubitTaxonomy::ACCESSION_EVENT_TYPE_ID))
+    {
+      QubitMigrate::bumpTaxonomy(QubitTaxonomy::ACCESSION_EVENT_TYPE_ID, $configuration);
+      $taxonomy = new QubitTaxonomy;
+      $taxonomy->id = QubitTaxonomy::ACCESSION_EVENT_TYPE_ID;
+      $taxonomy->parentId = QubitTaxonomy::ROOT_ID;
+      $taxonomy->sourceCulture = 'en';
+      $taxonomy->setName('Accession event type', array('culture' => 'en'));
+      $taxonomy->save();
+    }
+
+    // Add physical transfer accession event type if it doesn't exist
+    $sql = "SELECT * FROM ".QubitTerm::TABLE_NAME." t
+              INNER JOIN ".QubitTermI18n::TABLE_NAME." ti
+              WHERE ti.name='Physical transfer'
+              AND t.taxonomy_id=?
+              AND ti.culture='en'
+              AND t.id=?";
+
+    if (null == QubitPdo::fetchOne($sql, array(QubitTaxonomy::ACCESSION_EVENT_TYPE_ID, QubitTerm::ACCESSION_EVENT_PHYSICAL_TRANSFER_ID)))
+    {
+      // Add physical transfer accession event type term
+      QubitMigrate::bumpTerm(QubitTerm::ACCESSION_EVENT_PHYSICAL_TRANSFER_ID, $configuration);
+      $term = new QubitTerm;
+      $term->id = QubitTerm::ACCESSION_EVENT_PHYSICAL_TRANSFER_ID;
+      $term->parentId = QubitTerm::ROOT_ID;
+      $term->taxonomyId = QubitTaxonomy::ACCESSION_EVENT_TYPE_ID;
+      $term->sourceCulture = 'en';
+      $term->setName('Physical transfer', array('culture' => 'en'));
+      $term->save();
+    }
+
+    // Add accession event note type term if it doesn't exist
+    $sql = "SELECT * FROM ".QubitTerm::TABLE_NAME." t
+              INNER JOIN ".QubitTermI18n::TABLE_NAME." ti
+              WHERE ti.name='Accession event note'
+              AND t.taxonomy_id=?
+              AND ti.culture='en'
+              AND t.id=?";
+
+    if (null == QubitPdo::fetchOne($sql, array(QubitTaxonomy::NOTE_TYPE_ID, QubitTerm::ACCESSION_EVENT_NOTE_ID)))
+    {
+      // Add accession event note type term
+      QubitMigrate::bumpTerm(QubitTerm::ACCESSION_EVENT_NOTE_ID, $configuration);
+      $term = new QubitTerm;
+      $term->id = QubitTerm::ACCESSION_EVENT_NOTE_ID;
+      $term->parentId = QubitTerm::ROOT_ID;
+      $term->taxonomyId = QubitTaxonomy::NOTE_TYPE_ID;
+      $term->sourceCulture = 'en';
+      $term->setName('Accession event note', array('culture' => 'en'));
+      $term->save();
+    }
+
+    return true;
+  }
+}

--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -78,6 +78,22 @@ mapping:
       subject_id: { type: integer, include_in_all: false }
       type_id: { type: integer, include_in_all: false }
 
+  accession_event:
+    _attributes:
+      i18n: true
+      nested_only: true
+    _partial_foreign_types:
+      type:
+        _i18nFields: [name]
+        dynamic: strict
+      notes:
+        _i18nFields: [content]
+        dynamic: strict
+    dynamic: strict
+    properties:
+      date: { type: date, include_in_all: false }
+      date_string: { type: keyword }
+
   donor:
     _attributes:
       i18nExtra: [actor]
@@ -390,6 +406,7 @@ mapping:
       rawFields:  [title]
       sortFields: [title]
     _foreign_types:
+      accession_events: accession_event
       alternative_identifiers: other_name
       donors: donor
       creators: actor

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchModelBase.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchModelBase.class.php
@@ -126,8 +126,8 @@ abstract class arElasticSearchModelBase
       }
     }
 
-    // Remove duplicated cultures
-    $i18ns['languages'] = array_unique($i18ns['languages']);
+    // Remove duplicated cultures from language values
+    $i18ns['languages'] = array_unique(array_values($i18ns['languages']));
 
     return $i18ns;
   }

--- a/plugins/qtAccessionPlugin/config/schema.yml
+++ b/plugins/qtAccessionPlugin/config/schema.yml
@@ -23,6 +23,15 @@ propel:
     source_of_acquisition: longvarchar
     title: varchar(255)
 
+  accession_event:
+    id: { type: integer, required: true, primaryKey: true, foreignTable: object, foreignReference: id, onDelete: cascade, inheritanceKey: true }
+    type_id: { type: integer, foreignTable: term, foreignReference: id, onDelete: setnull }
+    accession_id: { type: integer, foreignTable: accession, foreignReference: id, onDelete: cascade }
+    date: bu_date
+
+  accession_event_i18n:
+    agent: varchar(255)
+
   deaccession:
     id: { type: integer, required: true, primaryKey: true, foreignTable: object, foreignReference: id, onDelete: cascade, inheritanceKey: true }
     accession_id: { type: integer, foreignTable: accession, foreignReference: id, onDelete: cascade }

--- a/plugins/qtAccessionPlugin/lib/model/QubitAccessionEvent.php
+++ b/plugins/qtAccessionPlugin/lib/model/QubitAccessionEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class QubitAccessionEvent extends BaseAccessionEvent
+{
+  public function getNote()
+  {
+    $criteria = new Criteria;
+
+    $criteria->add(QubitNote::TYPE_ID, QubitTerm::ACCESSION_EVENT_NOTE_ID);
+    $criteria->add(QubitNote::OBJECT_ID, $this->id);
+
+    return QubitNote::getOne($criteria);
+  }
+} // QubitAccessionEvent

--- a/plugins/qtAccessionPlugin/lib/model/QubitAccessionEventI18n.php
+++ b/plugins/qtAccessionPlugin/lib/model/QubitAccessionEventI18n.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class QubitAccessionEventI18n extends BaseAccessionEventI18n
+{
+} // QubitAccessionEventI18n

--- a/plugins/qtAccessionPlugin/lib/model/map/AccessionEventI18nTableMap.php
+++ b/plugins/qtAccessionPlugin/lib/model/map/AccessionEventI18nTableMap.php
@@ -1,0 +1,53 @@
+<?php
+
+
+/**
+ * This class defines the structure of the 'accession_event_i18n' table.
+ *
+ *
+ *
+ * This map class is used by Propel to do runtime db structure discovery.
+ * For example, the createSelectSql() method checks the type of a given column used in an
+ * ORDER BY clause to know whether it needs to apply SQL to make the ORDER BY case-insensitive
+ * (i.e. if it's a text column type).
+ *
+ * @package    plugins.qtAccessionPlugin.lib.model.map
+ */
+class AccessionEventI18nTableMap extends TableMap {
+
+	/**
+	 * The (dot-path) name of this class
+	 */
+	const CLASS_NAME = 'plugins.qtAccessionPlugin.lib.model.map.AccessionEventI18nTableMap';
+
+	/**
+	 * Initialize the table attributes, columns and validators
+	 * Relations are not initialized by this method since they are lazy loaded
+	 *
+	 * @return     void
+	 * @throws     PropelException
+	 */
+	public function initialize()
+	{
+	  // attributes
+		$this->setName('accession_event_i18n');
+		$this->setPhpName('accessionEventI18n');
+		$this->setClassname('QubitAccessionEventI18n');
+		$this->setPackage('plugins.qtAccessionPlugin.lib.model');
+		$this->setUseIdGenerator(false);
+		// columns
+		$this->addColumn('AGENT', 'agent', 'VARCHAR', false, 255, null);
+		$this->addForeignPrimaryKey('ID', 'id', 'INTEGER' , 'accession_event', 'ID', true, null, null);
+		$this->addPrimaryKey('CULTURE', 'culture', 'VARCHAR', true, 16, null);
+		// validators
+	} // initialize()
+
+	/**
+	 * Build the RelationMap objects for this table relationships
+	 */
+	public function buildRelations()
+	{
+    $this->addRelation('accessionEvent', 'accessionEvent', RelationMap::MANY_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
+	} // buildRelations()
+
+} // AccessionEventI18nTableMap

--- a/plugins/qtAccessionPlugin/lib/model/map/AccessionEventTableMap.php
+++ b/plugins/qtAccessionPlugin/lib/model/map/AccessionEventTableMap.php
@@ -1,0 +1,58 @@
+<?php
+
+
+/**
+ * This class defines the structure of the 'accession_event' table.
+ *
+ *
+ *
+ * This map class is used by Propel to do runtime db structure discovery.
+ * For example, the createSelectSql() method checks the type of a given column used in an
+ * ORDER BY clause to know whether it needs to apply SQL to make the ORDER BY case-insensitive
+ * (i.e. if it's a text column type).
+ *
+ * @package    plugins.qtAccessionPlugin.lib.model.map
+ */
+class AccessionEventTableMap extends TableMap {
+
+	/**
+	 * The (dot-path) name of this class
+	 */
+	const CLASS_NAME = 'plugins.qtAccessionPlugin.lib.model.map.AccessionEventTableMap';
+
+	/**
+	 * Initialize the table attributes, columns and validators
+	 * Relations are not initialized by this method since they are lazy loaded
+	 *
+	 * @return     void
+	 * @throws     PropelException
+	 */
+	public function initialize()
+	{
+	  // attributes
+		$this->setName('accession_event');
+		$this->setPhpName('accessionEvent');
+		$this->setClassname('QubitAccessionEvent');
+		$this->setPackage('plugins.qtAccessionPlugin.lib.model');
+		$this->setUseIdGenerator(false);
+		// columns
+		$this->addForeignPrimaryKey('ID', 'id', 'INTEGER' , 'object', 'ID', true, null, null);
+		$this->addForeignKey('TYPE_ID', 'typeId', 'INTEGER', 'term', 'ID', false, null, null);
+		$this->addForeignKey('ACCESSION_ID', 'accessionId', 'INTEGER', 'accession', 'ID', false, null, null);
+		$this->addColumn('DATE', 'date', 'DATE', false, null, null);
+		$this->addColumn('SOURCE_CULTURE', 'sourceCulture', 'VARCHAR', true, 16, null);
+		// validators
+	} // initialize()
+
+	/**
+	 * Build the RelationMap objects for this table relationships
+	 */
+	public function buildRelations()
+	{
+    $this->addRelation('object', 'object', RelationMap::MANY_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
+    $this->addRelation('term', 'term', RelationMap::MANY_TO_ONE, array('type_id' => 'id', ), 'SET NULL', null);
+    $this->addRelation('accession', 'accession', RelationMap::MANY_TO_ONE, array('accession_id' => 'id', ), 'CASCADE', null);
+    $this->addRelation('accessionEventI18n', 'accessionEventI18n', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null);
+	} // buildRelations()
+
+} // AccessionEventTableMap

--- a/plugins/qtAccessionPlugin/lib/model/map/AccessionTableMap.php
+++ b/plugins/qtAccessionPlugin/lib/model/map/AccessionTableMap.php
@@ -60,6 +60,7 @@ class AccessionTableMap extends TableMap {
     $this->addRelation('termRelatedByprocessingStatusId', 'term', RelationMap::MANY_TO_ONE, array('processing_status_id' => 'id', ), 'SET NULL', null);
     $this->addRelation('termRelatedByresourceTypeId', 'term', RelationMap::MANY_TO_ONE, array('resource_type_id' => 'id', ), 'SET NULL', null);
     $this->addRelation('accessionI18n', 'accessionI18n', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null);
+    $this->addRelation('accessionEvent', 'accessionEvent', RelationMap::ONE_TO_MANY, array('id' => 'accession_id', ), 'CASCADE', null);
     $this->addRelation('deaccession', 'deaccession', RelationMap::ONE_TO_MANY, array('id' => 'accession_id', ), 'CASCADE', null);
 	} // buildRelations()
 

--- a/plugins/qtAccessionPlugin/lib/model/om/BaseAccession.php
+++ b/plugins/qtAccessionPlugin/lib/model/om/BaseAccession.php
@@ -103,6 +103,11 @@ abstract class BaseAccession extends QubitObject implements ArrayAccess
       return true;
     }
 
+    if ('accessionEvents' == $name)
+    {
+      return true;
+    }
+
     if ('deaccessions' == $name)
     {
       return true;
@@ -157,6 +162,23 @@ abstract class BaseAccession extends QubitObject implements ArrayAccess
       }
 
       return $this->refFkValues['accessionI18ns'];
+    }
+
+    if ('accessionEvents' == $name)
+    {
+      if (!isset($this->refFkValues['accessionEvents']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['accessionEvents'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['accessionEvents'] = self::getaccessionEventsById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['accessionEvents'];
     }
 
     if ('deaccessions' == $name)
@@ -296,6 +318,26 @@ abstract class BaseAccession extends QubitObject implements ArrayAccess
   public function addaccessionI18nsCriteria(Criteria $criteria)
   {
     return self::addaccessionI18nsCriteriaById($criteria, $this->id);
+  }
+
+  public static function addaccessionEventsCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitAccessionEvent::ACCESSION_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getaccessionEventsById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addaccessionEventsCriteriaById($criteria, $id);
+
+    return QubitAccessionEvent::get($criteria, $options);
+  }
+
+  public function addaccessionEventsCriteria(Criteria $criteria)
+  {
+    return self::addaccessionEventsCriteriaById($criteria, $this->id);
   }
 
   public static function adddeaccessionsCriteriaById(Criteria $criteria, $id)

--- a/plugins/qtAccessionPlugin/lib/model/om/BaseAccessionEvent.php
+++ b/plugins/qtAccessionPlugin/lib/model/om/BaseAccessionEvent.php
@@ -1,0 +1,275 @@
+<?php
+
+abstract class BaseAccessionEvent extends QubitObject implements ArrayAccess
+{
+  const
+    DATABASE_NAME = 'propel',
+
+    TABLE_NAME = 'accession_event',
+
+    ID = 'accession_event.ID',
+    TYPE_ID = 'accession_event.TYPE_ID',
+    ACCESSION_ID = 'accession_event.ACCESSION_ID',
+    DATE = 'accession_event.DATE',
+    SOURCE_CULTURE = 'accession_event.SOURCE_CULTURE';
+
+  public static function addSelectColumns(Criteria $criteria)
+  {
+    parent::addSelectColumns($criteria);
+
+    $criteria->addJoin(QubitAccessionEvent::ID, QubitObject::ID);
+
+    $criteria->addSelectColumn(QubitAccessionEvent::ID);
+    $criteria->addSelectColumn(QubitAccessionEvent::TYPE_ID);
+    $criteria->addSelectColumn(QubitAccessionEvent::ACCESSION_ID);
+    $criteria->addSelectColumn(QubitAccessionEvent::DATE);
+    $criteria->addSelectColumn(QubitAccessionEvent::SOURCE_CULTURE);
+
+    return $criteria;
+  }
+
+  public static function get(Criteria $criteria, array $options = array())
+  {
+    if (!isset($options['connection']))
+    {
+      $options['connection'] = Propel::getConnection(QubitAccessionEvent::DATABASE_NAME);
+    }
+
+    self::addSelectColumns($criteria);
+
+    return QubitQuery::createFromCriteria($criteria, 'QubitAccessionEvent', $options);
+  }
+
+  public static function getAll(array $options = array())
+  {
+    return self::get(new Criteria, $options);
+  }
+
+  public static function getOne(Criteria $criteria, array $options = array())
+  {
+    $criteria->setLimit(1);
+
+    return self::get($criteria, $options)->__get(0, array('defaultValue' => null));
+  }
+
+  public static function getById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    $criteria->add(QubitAccessionEvent::ID, $id);
+
+    if (1 == count($query = self::get($criteria, $options)))
+    {
+      return $query[0];
+    }
+  }
+
+  public function __construct()
+  {
+    parent::__construct();
+
+    $this->tables[] = Propel::getDatabaseMap(QubitAccessionEvent::DATABASE_NAME)->getTable(QubitAccessionEvent::TABLE_NAME);
+  }
+
+  public function __isset($name)
+  {
+    $args = func_get_args();
+
+    $options = array();
+    if (1 < count($args))
+    {
+      $options = $args[1];
+    }
+
+    try
+    {
+      return call_user_func_array(array($this, 'QubitObject::__isset'), $args);
+    }
+    catch (sfException $e)
+    {
+    }
+
+    if ('accessionEventI18ns' == $name)
+    {
+      return true;
+    }
+
+    try
+    {
+      if (!$value = call_user_func_array(array($this->getCurrentaccessionEventI18n($options), '__isset'), $args) && !empty($options['cultureFallback']))
+      {
+        return call_user_func_array(array($this->getCurrentaccessionEventI18n(array('sourceCulture' => true) + $options), '__isset'), $args);
+      }
+
+      return $value;
+    }
+    catch (sfException $e)
+    {
+    }
+
+    throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
+  }
+
+  public function __get($name)
+  {
+    $args = func_get_args();
+
+    $options = array();
+    if (1 < count($args))
+    {
+      $options = $args[1];
+    }
+
+    try
+    {
+      return call_user_func_array(array($this, 'QubitObject::__get'), $args);
+    }
+    catch (sfException $e)
+    {
+    }
+
+    if ('accessionEventI18ns' == $name)
+    {
+      if (!isset($this->refFkValues['accessionEventI18ns']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['accessionEventI18ns'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['accessionEventI18ns'] = self::getaccessionEventI18nsById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['accessionEventI18ns'];
+    }
+
+    try
+    {
+      if (1 > strlen($value = call_user_func_array(array($this->getCurrentaccessionEventI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      {
+        return call_user_func_array(array($this->getCurrentaccessionEventI18n(array('sourceCulture' => true) + $options), '__get'), $args);
+      }
+
+      return $value;
+    }
+    catch (sfException $e)
+    {
+    }
+
+    throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
+  }
+
+  public function __set($name, $value)
+  {
+    $args = func_get_args();
+
+    $options = array();
+    if (2 < count($args))
+    {
+      $options = $args[2];
+    }
+
+    call_user_func_array(array($this, 'QubitObject::__set'), $args);
+
+    call_user_func_array(array($this->getCurrentaccessionEventI18n($options), '__set'), $args);
+
+    return $this;
+  }
+
+  public function __unset($name)
+  {
+    $args = func_get_args();
+
+    $options = array();
+    if (1 < count($args))
+    {
+      $options = $args[1];
+    }
+
+    call_user_func_array(array($this, 'QubitObject::__unset'), $args);
+
+    call_user_func_array(array($this->getCurrentaccessionEventI18n($options), '__unset'), $args);
+
+    return $this;
+  }
+
+  public function clear()
+  {
+    foreach ($this->accessionEventI18ns as $accessionEventI18n)
+    {
+      $accessionEventI18n->clear();
+    }
+
+    return parent::clear();
+  }
+
+  public function save($connection = null)
+  {
+    parent::save($connection);
+
+    foreach ($this->accessionEventI18ns as $accessionEventI18n)
+    {
+      $accessionEventI18n->id = $this->id;
+
+      $accessionEventI18n->save($connection);
+    }
+
+    return $this;
+  }
+
+  public static function addJointypeCriteria(Criteria $criteria)
+  {
+    $criteria->addJoin(QubitAccessionEvent::TYPE_ID, QubitTerm::ID);
+
+    return $criteria;
+  }
+
+  public static function addJoinaccessionCriteria(Criteria $criteria)
+  {
+    $criteria->addJoin(QubitAccessionEvent::ACCESSION_ID, QubitAccession::ID);
+
+    return $criteria;
+  }
+
+  public static function addaccessionEventI18nsCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitAccessionEventI18n::ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getaccessionEventI18nsById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addaccessionEventI18nsCriteriaById($criteria, $id);
+
+    return QubitAccessionEventI18n::get($criteria, $options);
+  }
+
+  public function addaccessionEventI18nsCriteria(Criteria $criteria)
+  {
+    return self::addaccessionEventI18nsCriteriaById($criteria, $this->id);
+  }
+
+  public function getCurrentaccessionEventI18n(array $options = array())
+  {
+    if (!empty($options['sourceCulture']))
+    {
+      $options['culture'] = $this->sourceCulture;
+    }
+
+    if (!isset($options['culture']))
+    {
+      $options['culture'] = sfPropel::getDefaultCulture();
+    }
+
+    $accessionEventI18ns = $this->accessionEventI18ns->indexBy('culture');
+    if (!isset($accessionEventI18ns[$options['culture']]))
+    {
+      $accessionEventI18ns[$options['culture']] = new QubitAccessionEventI18n;
+    }
+
+    return $accessionEventI18ns[$options['culture']];
+  }
+}

--- a/plugins/qtAccessionPlugin/lib/model/om/BaseAccessionEventI18n.php
+++ b/plugins/qtAccessionPlugin/lib/model/om/BaseAccessionEventI18n.php
@@ -1,0 +1,582 @@
+<?php
+
+abstract class BaseAccessionEventI18n implements ArrayAccess
+{
+  const
+    DATABASE_NAME = 'propel',
+
+    TABLE_NAME = 'accession_event_i18n',
+
+    AGENT = 'accession_event_i18n.AGENT',
+    ID = 'accession_event_i18n.ID',
+    CULTURE = 'accession_event_i18n.CULTURE';
+
+  public static function addSelectColumns(Criteria $criteria)
+  {
+    $criteria->addSelectColumn(QubitAccessionEventI18n::AGENT);
+    $criteria->addSelectColumn(QubitAccessionEventI18n::ID);
+    $criteria->addSelectColumn(QubitAccessionEventI18n::CULTURE);
+
+    return $criteria;
+  }
+
+  protected static
+    $accessionEventI18ns = array();
+
+  protected
+    $keys = array(),
+    $row = array();
+
+  public static function getFromRow(array $row)
+  {
+    $keys = array();
+    $keys['id'] = $row[1];
+    $keys['culture'] = $row[2];
+
+    $key = serialize($keys);
+    if (!isset(self::$accessionEventI18ns[$key]))
+    {
+      $accessionEventI18n = new QubitAccessionEventI18n;
+
+      $accessionEventI18n->keys = $keys;
+      $accessionEventI18n->row = $row;
+
+      $accessionEventI18n->new = false;
+
+      self::$accessionEventI18ns[$key] = $accessionEventI18n;
+    }
+
+    return self::$accessionEventI18ns[$key];
+  }
+
+  public static function clearCache()
+  {
+    self::$accessionEventI18ns = array();
+  }
+
+  public static function get(Criteria $criteria, array $options = array())
+  {
+    if (!isset($options['connection']))
+    {
+      $options['connection'] = Propel::getConnection(QubitAccessionEventI18n::DATABASE_NAME);
+    }
+
+    self::addSelectColumns($criteria);
+
+    return QubitQuery::createFromCriteria($criteria, 'QubitAccessionEventI18n', $options);
+  }
+
+  public static function getAll(array $options = array())
+  {
+    return self::get(new Criteria, $options);
+  }
+
+  public static function getOne(Criteria $criteria, array $options = array())
+  {
+    $criteria->setLimit(1);
+
+    return self::get($criteria, $options)->__get(0, array('defaultValue' => null));
+  }
+
+  public static function getByIdAndCulture($id, $culture, array $options = array())
+  {
+    $criteria = new Criteria;
+    $criteria->add(QubitAccessionEventI18n::ID, $id);
+    $criteria->add(QubitAccessionEventI18n::CULTURE, $culture);
+
+    if (1 == count($query = self::get($criteria, $options)))
+    {
+      return $query[0];
+    }
+  }
+
+  public static function doDelete(Criteria $criteria, $connection = null)
+  {
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $affectedRows = 0;
+
+    $affectedRows += BasePeer::doDelete($criteria, $connection);
+
+    return $affectedRows;
+  }
+
+  protected
+    $tables = array();
+
+  public function __construct()
+  {
+    $this->tables[] = Propel::getDatabaseMap(QubitAccessionEventI18n::DATABASE_NAME)->getTable(QubitAccessionEventI18n::TABLE_NAME);
+  }
+
+  protected
+    $values = array(),
+    $refFkValues = array();
+
+  protected function rowOffsetGet($name, $offset, $options)
+  {
+    if (empty($options['clean']) && array_key_exists($name, $this->values))
+    {
+      return $this->values[$name];
+    }
+
+    if (array_key_exists($name, $this->keys))
+    {
+      return $this->keys[$name];
+    }
+
+    if (!array_key_exists($offset, $this->row))
+    {
+      if ($this->new)
+      {
+        return;
+      }
+
+      if (!isset($options['connection']))
+      {
+        $options['connection'] = Propel::getConnection(QubitAccessionEventI18n::DATABASE_NAME);
+      }
+
+      $criteria = new Criteria;
+      $criteria->add(QubitAccessionEventI18n::ID, $this->id);
+      $criteria->add(QubitAccessionEventI18n::CULTURE, $this->culture);
+
+      call_user_func(array(get_class($this), 'addSelectColumns'), $criteria);
+
+      $statement = BasePeer::doSelect($criteria, $options['connection']);
+      $this->row = $statement->fetch();
+    }
+
+    return $this->row[$offset];
+  }
+
+  public function __isset($name)
+  {
+    $args = func_get_args();
+
+    $options = array();
+    if (1 < count($args))
+    {
+      $options = $args[1];
+    }
+
+    $offset = 0;
+    foreach ($this->tables as $table)
+    {
+      foreach ($table->getColumns() as $column)
+      {
+        if ($name == $column->getPhpName())
+        {
+          return null !== $this->rowOffsetGet($name, $offset, $options);
+        }
+
+        if ("{$name}Id" == $column->getPhpName())
+        {
+          return null !== $this->rowOffsetGet("{$name}Id", $offset, $options);
+        }
+
+        $offset++;
+      }
+    }
+
+    throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
+  }
+
+  public function offsetExists($offset)
+  {
+    $args = func_get_args();
+
+    return call_user_func_array(array($this, '__isset'), $args);
+  }
+
+  public function __get($name)
+  {
+    $args = func_get_args();
+
+    $options = array();
+    if (1 < count($args))
+    {
+      $options = $args[1];
+    }
+
+    $offset = 0;
+    foreach ($this->tables as $table)
+    {
+      foreach ($table->getColumns() as $column)
+      {
+        if ($name == $column->getPhpName())
+        {
+          return $this->rowOffsetGet($name, $offset, $options);
+        }
+
+        if ("{$name}Id" == $column->getPhpName())
+        {
+          $relatedTable = $column->getTable()->getDatabaseMap()->getTable($column->getRelatedTableName());
+
+          return call_user_func(array($relatedTable->getClassName(), 'getBy'.ucfirst($relatedTable->getColumn($column->getRelatedColumnName())->getPhpName())), $this->rowOffsetGet("{$name}Id", $offset, $options));
+        }
+
+        $offset++;
+      }
+    }
+
+    throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
+  }
+
+  public function offsetGet($offset)
+  {
+    $args = func_get_args();
+
+    return call_user_func_array(array($this, '__get'), $args);
+  }
+
+  public function __set($name, $value)
+  {
+    $args = func_get_args();
+
+    $options = array();
+    if (2 < count($args))
+    {
+      $options = $args[2];
+    }
+
+    $offset = 0;
+    foreach ($this->tables as $table)
+    {
+      foreach ($table->getColumns() as $column)
+      {
+        // Foreign key column name
+        $nameId = $name.'Id';
+
+        // Set local column values
+        if ($name === $column->getPhpName())
+        {
+          $this->values[$name] = $value;
+        }
+
+        // If this is a foreign key column then get primary key from related table
+        else if ($nameId === $column->getPhpName())
+        {
+          if(!empty($value))
+          {
+            $relatedTable = $column->getTable()->getDatabaseMap()->getTable($column->getRelatedTableName());
+
+            $this->values[$nameId] = $value->__get($relatedTable->getColumn($column->getRelatedColumnName())->getPhpName(), $options);
+          }
+          else
+          {
+            // If $value is null, then don't try and fetch related object for primary key
+            $this->values[$nameId] = null;
+          }
+        }
+
+        $offset++;
+      }
+    }
+
+    return $this;
+  }
+
+  public function offsetSet($offset, $value)
+  {
+    $args = func_get_args();
+
+    return call_user_func_array(array($this, '__set'), $args);
+  }
+
+  public function __unset($name)
+  {
+    $offset = 0;
+    foreach ($this->tables as $table)
+    {
+      foreach ($table->getColumns() as $column)
+      {
+        if ($name == $column->getPhpName())
+        {
+          $this->values[$name] = null;
+        }
+
+        if ("{$name}Id" == $column->getPhpName())
+        {
+          $this->values["{$name}Id"] = null;
+        }
+
+        $offset++;
+      }
+    }
+
+    return $this;
+  }
+
+  public function offsetUnset($offset)
+  {
+    $args = func_get_args();
+
+    return call_user_func_array(array($this, '__unset'), $args);
+  }
+
+  public function clear()
+  {
+    $this->row = $this->values = array();
+
+    return $this;
+  }
+
+  protected
+    $new = true;
+
+  protected
+    $deleted = false;
+
+  public function save($connection = null)
+  {
+    if ($this->deleted)
+    {
+      throw new PropelException('You cannot save an object that has been deleted.');
+    }
+
+    if ($this->new)
+    {
+      $this->insert($connection);
+    }
+    else
+    {
+      $this->update($connection);
+    }
+
+    $offset = 0;
+    foreach ($this->tables as $table)
+    {
+      foreach ($table->getColumns() as $column)
+      {
+        if (array_key_exists($column->getPhpName(), $this->values))
+        {
+          $this->row[$offset] = $this->values[$column->getPhpName()];
+        }
+
+        if ($this->new && $column->isPrimaryKey())
+        {
+          $this->keys[$column->getPhpName()] = $this->values[$column->getPhpName()];
+        }
+
+        $offset++;
+      }
+    }
+
+    $this->new = false;
+    $this->values = array();
+
+    return $this;
+  }
+
+  protected function param($column)
+  {
+    $value = $this->values[$column->getPhpName()];
+
+    // Convert to DateTime or SQL zero special case
+    if (isset($value) && $column->isTemporal() && !$value instanceof DateTime)
+    {
+      // Year only: one or more digits.  Convert to SQL zero special case
+      if (preg_match('/^\d+$/', $value))
+      {
+        $value .= '-0-0';
+      }
+
+      // Year and month only: one or more digits, plus separator, plus
+      // one or more digits.  Convert to SQL zero special case
+      else if (preg_match('/^\d+[-\/]\d+$/', $value))
+      {
+        $value .= '-0';
+      }
+
+      // Convert to DateTime if not SQL zero special case: year plus
+      // separator plus zero to twelve (possibly zero padded) plus
+      // separator plus one or more zeros
+      if (!preg_match('/^\d+[-\/]0*(?:1[0-2]|\d)[-\/]0+$/', $value))
+      {
+        try
+        {
+          $value = new DateTime($value);
+        }
+        catch (Exception $e)
+        {
+          return null;
+        }
+      }
+    }
+
+    return $value;
+  }
+
+  protected function insert($connection = null)
+  {
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $offset = 0;
+    foreach ($this->tables as $table)
+    {
+      $criteria = new Criteria;
+      foreach ($table->getColumns() as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $this->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $this->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $this->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $this->values))
+        {
+          if (null !== $param = $this->param($column))
+          {
+            $criteria->add($column->getFullyQualifiedName(), $param);
+          }
+        }
+
+        $offset++;
+      }
+
+      if (null !== $id = BasePeer::doInsert($criteria, $connection))
+      {
+        // Guess that the first primary key of the first table is auto
+        // incremented
+        if ($this->tables[0] == $table)
+        {
+          $columns = $table->getPrimaryKeyColumns();
+          $this->values[$columns[0]->getPhpName()] = $this->keys[$columns[0]->getPhpName()] = $id;
+        }
+      }
+    }
+
+    return $this;
+  }
+
+  protected function update($connection = null)
+  {
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $offset = 0;
+    foreach ($this->tables as $table)
+    {
+      $criteria = new Criteria;
+      $selectCriteria = new Criteria;
+      foreach ($table->getColumns() as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $this->values))
+        {
+          if ('updatedAt' == $column->getPhpName())
+          {
+            $this->values['updatedAt'] = new DateTime;
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $this->values))
+        {
+          if ('serialNumber' == $column->getPhpName())
+          {
+            $selectCriteria->add($column->getFullyQualifiedName(), $this->values[$column->getPhpName()]++);
+          }
+
+          $criteria->add($column->getFullyQualifiedName(), $this->param($column));
+        }
+
+        if ($column->isPrimaryKey())
+        {
+          $selectCriteria->add($column->getFullyQualifiedName(), $this->keys[$column->getPhpName()]);
+        }
+
+        $offset++;
+      }
+
+      if (0 < $criteria->size())
+      {
+        BasePeer::doUpdate($selectCriteria, $criteria, $connection);
+      }
+    }
+
+    return $this;
+  }
+
+  public function delete($connection = null)
+  {
+    if ($this->deleted)
+    {
+      throw new PropelException('This object has already been deleted.');
+    }
+
+    $criteria = new Criteria;
+    $criteria->add(QubitAccessionEventI18n::ID, $this->id);
+    $criteria->add(QubitAccessionEventI18n::CULTURE, $this->culture);
+
+    self::doDelete($criteria, $connection);
+
+    $this->deleted = true;
+
+    return $this;
+  }
+
+	/**
+	 * Returns the composite primary key for this object.
+	 * The array elements will be in same order as specified in XML.
+	 * @return     array
+	 */
+	public function getPrimaryKey()
+	{
+		$pks = array();
+
+		$pks[0] = $this->getid();
+
+		$pks[1] = $this->getculture();
+
+		return $pks;
+	}
+
+	/**
+	 * Set the [composite] primary key.
+	 *
+	 * @param      array $keys The elements of the composite key (order must match the order in XML file).
+	 * @return     void
+	 */
+	public function setPrimaryKey($keys)
+	{
+
+		$this->setid($keys[0]);
+
+		$this->setculture($keys[1]);
+
+	}
+
+  public static function addJoinaccessionEventCriteria(Criteria $criteria)
+  {
+    $criteria->addJoin(QubitAccessionEventI18n::ID, QubitAccessionEvent::ID);
+
+    return $criteria;
+  }
+
+  public function __call($name, $args)
+  {
+    if ('get' == substr($name, 0, 3) || 'set' == substr($name, 0, 3))
+    {
+      $args = array_merge(array(strtolower(substr($name, 3, 1)).substr($name, 4)), $args);
+
+      return call_user_func_array(array($this, '__'.substr($name, 0, 3)), $args);
+    }
+
+    throw new sfException('Call to undefined method '.get_class($this)."::$name");
+  }
+}

--- a/plugins/qtAccessionPlugin/modules/accession/actions/browseAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/browseAction.class.php
@@ -119,10 +119,14 @@ class AccessionBrowseAction extends sfAction
         'alternativeIdentifiers.i18n.%s.name',
         'creators.i18n.%s.authorizedFormOfName',
         'alternativeIdentifiers.i18n.%s.note',
-        'alternativeIdentifiers.type.i18n.%s.name'), null, $boost);
+        'alternativeIdentifiers.type.i18n.%s.name'),
+        'accessionEvents.i18n.%s.agent',
+        'accessionEvents.type.i18n.%s.name',
+        'accessionEvents.notes.i18n.%s.content'), null, $boost);
 
       $fields[] = 'identifier^10';
       $fields[] = 'donors.contactInformations.contactPerson';
+      $fields[] = 'accessionEvents.dateString';
 
       $queryString->setFields($fields);
 

--- a/plugins/qtAccessionPlugin/modules/accession/actions/editAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/editAction.class.php
@@ -372,6 +372,11 @@ class AccessionEditAction extends DefaultEditAction
     $this->alternativeIdentifiersComponent->resource = $this->resource;
     $this->alternativeIdentifiersComponent->execute($this->request);
 
+    // Handle accession events
+    $this->eventsComponent = new AccessionEventsComponent($this->context, 'accession', 'events');
+    $this->eventsComponent->resource = $this->resource;
+    $this->eventsComponent->execute($this->request);
+
     if ($request->isMethod('post'))
     {
       $this->form->bind($request->getPostParameters());
@@ -407,6 +412,7 @@ class AccessionEditAction extends DefaultEditAction
         $this->resource->save();
 
         $this->alternativeIdentifiersComponent->processForm();
+        $this->eventsComponent->processForm();
 
         QubitSearch::getInstance()->update($this->resource);
 

--- a/plugins/qtAccessionPlugin/modules/accession/actions/eventsComponent.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/eventsComponent.class.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class AccessionEventsComponent extends sfComponent
+{
+  public function execute($request)
+  {
+    // Cache accession event types (used in each event's type select form field)
+    $criteria = new Criteria;
+    $criteria->add(QubitTerm::TAXONOMY_ID, QubitTaxonomy::ACCESSION_EVENT_TYPE_ID);
+
+    $this->eventTypes = [];
+    foreach (QubitTerm::get($criteria) as $term)
+    {
+      $this->eventTypes[$term->id] = $term->getName(['cultureFallback' => true]);
+    }
+
+    // Define form used to add/edit events
+    $this->form = new sfForm;
+    $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
+
+    $this->addField('eventType');
+    $this->addField('date');
+    $this->addField('agent');
+    $this->addField('note');
+
+    // Summarize/cache existing accession event data
+    $this->eventData = [];
+
+    foreach ($this->resource->accessionEvents as $event)
+    {
+      $note = $event->getNote();
+
+      $this->eventData[] = [
+        'id' => $event->id,
+        'typeId' => $event->typeId,
+        'date' => $event->getDate(['sourceCulture' => true]),
+        'agent' => $event->getAgent(),
+        'object' => $event,
+        'note' => $note,
+        'accessionId' => $this->resource->id
+      ];
+    }
+  }
+
+  protected function addField($name)
+  {
+    switch ($name)
+    {
+    case 'eventType':
+        $this->form->setValidator($name, new sfValidatorInteger);
+        $this->form->setWidget($name, new sfWidgetFormSelect(['choices' => $this->eventTypes]));
+
+        break;
+
+      case 'date':
+        $this->form->setValidator($name, new sfValidatorString);
+        $widget = new sfWidgetFormInput(['label' => false]);  
+        $this->form->setWidget($name, $widget);
+
+        break;
+
+      case 'agent':
+        $this->form->setValidator($name, new sfValidatorString);
+        $widget = new sfWidgetFormInput(['label' => false]);
+        $this->form->setWidget($name, $widget);
+
+        break;
+
+      case 'note':
+        $this->form->setValidator($name, new sfValidatorString);
+        $widget = new sfWidgetFormTextarea(['label' => false]);
+        $widget->setAttribute('placeholder', $this->context->i18n->__('Notes'));
+        $this->form->setWidget($name, $widget);
+
+        break;
+    }
+  }
+
+  public function processForm()
+  {
+    $finalEvents = [];
+
+    if (is_array($this->request->events))
+    {
+      foreach ($this->request->events as $item)
+      {
+        // Continue only if event type is populated
+        if (empty($item['eventType']) || empty($item['date']))
+        {
+          continue;
+        }
+
+        // Fetch or create new accession event object
+        if (!empty($item['id']))
+        {
+          $finalEvents[] = $item['id'];
+
+          $event = QubitAccessionEvent::getById($item['id']);
+        }
+        else
+        {
+          $event = new QubitAccessionEvent;
+        }
+
+        $event->accessionId = $this->resource->id;
+        $event->typeId = $item['eventType'];
+        $event->date = empty($item['date']) ? null : $item['date'];
+        $event->agent = $item['agent'];
+        $event->save();
+
+        // Store note
+        if (null === $note = $event->getNote())
+        {
+          $note = new QubitNote;
+          $note->objectId = $this->resource->id;
+          $note->typeId = QubitTerm::ACCESSION_EVENT_NOTE_ID;
+        }
+
+        $note->objectId = $event->id;
+        $note->content = $item['note'];
+        $note->save();
+      }
+    }
+
+    // Delete the old accession events if they don't appear in the table (removed by multiRow.js)
+    foreach ($this->eventData as $item)
+    {
+      if (false === array_search($item['id'], $finalEvents))
+      {
+        $event = QubitAccessionEvent::getById($item['id']);
+        $event->delete();
+      }
+    }
+  }
+}

--- a/plugins/qtAccessionPlugin/modules/accession/templates/_events.php
+++ b/plugins/qtAccessionPlugin/modules/accession/templates/_events.php
@@ -1,0 +1,90 @@
+<div class="section">
+
+  <h3><?php echo __('Events(s)') ?></h3>
+
+  <table class="table table-bordered multiRow">
+    <thead>
+      <tr>
+        <th style="width: 33%">
+          <?php echo __('Type') ?>
+        </th><th style="width: 210px">
+          <?php echo __('Date') ?>
+        </th><th>
+          <?php echo __('Agent') ?>
+        </th>
+      </tr>
+    </thead><tbody>
+
+    <?php $i = 0; foreach ($eventData as $event): ?>
+      <?php $form->getWidgetSchema()->setNameFormat("events[$i][%s]") ?>
+
+      <tr class="<?php echo 0 == $i % 2 ? 'even' : 'odd' ?> related_obj_<?php echo $event['id'] ?>">
+        <td>
+          <div class="animateNicely">
+            <input type="hidden" name="events[<?php echo $i ?>][id]" value="<?php echo $event['id'] ?>"/>
+            <?php $form->setDefault('eventType', $event['typeId']); ?>
+            <?php echo $form->eventType ?>
+          </div>
+        </td><td>
+          <div class="animateNicely">
+            <?php $form->setDefault('date', $event['date']); ?>
+            <?php echo $form->date->renderRow(['class' => 'date-widget', 'icon' => image_path('calendar.png')]) ?>
+          </div>
+        </td><td>
+          <div class="animateNicely">
+            <?php $form->setDefault('agent', $event['agent']); ?>
+            <?php echo render_field($form->agent, $event['object']) ?>
+          </div>
+          <div class="animateNicely">
+            <?php $form->setDefault('note', $event['note']->getContent()); ?>
+            <?php echo render_field($form->note, $event['note'], ['name' => 'content']) ?>
+          </div>
+        </td>
+      </tr>
+
+      <?php $i++ ?>
+    <?php endforeach; ?>
+
+    <?php $form->getWidgetSchema()->setNameFormat("events[$i][%s]") ?>
+
+      <tr class="<?php echo 0 == $i % 2 ? 'even' : 'odd' ?>">
+        <td>
+          <div class="animateNicely">
+            <?php $form->setDefault('eventType', ''); ?>
+            <?php echo $form->eventType ?>
+          </div>
+        </td><td>
+          <div class="animateNicely">
+            <?php $form->setDefault('date', ''); ?>
+            <?php echo $form->date->renderRow(['class' => 'date-widget', 'icon' => image_path('calendar.png')]) ?>
+          </div>
+         </td><td>
+          <div class="animateNicely">
+            <?php $form->setDefault('agent', ''); ?>
+            <?php echo $form->agent ?>
+          </div>
+          <div id="event-note-new" class="animateNicely">
+            <?php $form->setDefault('note', ''); ?>
+            <?php echo $form->note ?>
+          </div>
+        </td>
+      </tr>
+
+    </tbody>
+
+    <tfoot>
+      <tr>
+        <td colspan="4"><a href="#" class="multiRowAddButton"><?php echo __('Add new') ?></a></td>
+      </tr>
+    </tfoot>
+
+  </table>
+
+  <div class="description">
+    <?php echo __('%1%Type:%2% Select the type of the event.%3%', ['%1%' => '<strong>', '%2%' => '</strong>', '%3%' => '<br/>']) ?>
+    <?php echo __('%1%Date:%2% Enter the date of the event.%3%', ['%1%' => '<strong>', '%2%' => '</strong>', '%3%' => '<br/>']) ?>
+    <?php echo __('%1%Agent:%2% Enter the agent associated with the event.%3%', ['%1%' => '<strong>', '%2%' => '</strong>', '%3%' => '<br/>']) ?>
+    <?php echo __('%1%Note:%2% Enter notes associated with the event.%3%', ['%1%' => '<strong>', '%2%' => '</strong>', '%3%' => '<br/>']) ?>
+  </div>
+
+</div>

--- a/plugins/qtAccessionPlugin/modules/accession/templates/editSuccess.php
+++ b/plugins/qtAccessionPlugin/modules/accession/templates/editSuccess.php
@@ -97,6 +97,8 @@
 
         <?php echo get_partial('sfIsadPlugin/event', $sf_data->getRaw('eventComponent')->getVarHolder()->getAll() + array('help' => __('"Identify and record the date(s) of the unit of description. Identify the type of date given. Record as a single date or a range of dates as appropriate.” (ISAD 3.1.3). The Date display field can be used to enter free-text date information, including typographical marks to express approximation, uncertainty, or qualification. Use the start and end fields to make the dates searchable. Do not use any qualifiers or typographical symbols to express uncertainty. Acceptable date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM, YYYY.'))) ?>
 
+        <?php echo get_component('accession', 'events', array('resource' => $resource)) ?>
+
         <?php echo render_field($form->archivalHistory
           ->help(__('Information on the history of the accession. When the accession is acquired directly from the creator, do not record an archival history but record the information as the Immediate Source of Acquisition.'))
           ->label(__('Archival/Custodial history')), $resource, array('class' => 'resizable')) ?>

--- a/plugins/qtAccessionPlugin/modules/accession/templates/indexSuccess.php
+++ b/plugins/qtAccessionPlugin/modules/accession/templates/indexSuccess.php
@@ -95,6 +95,23 @@
     </div>
   </div>
 
+  <div class="field">
+    <h3><?php echo __('Event(s)') ?></h3>
+    <div>
+      <ul>
+        <?php foreach ($resource->accessionEvents as $event): ?>
+          <li>
+            <?php echo $event->getDate() ?> (<?php echo $event->type->getName(array('cultureFallback' => true)) ?>): <?php echo $event->getAgent(array('cultureFallback' => true)) ?>
+            <?php $note = $event->getNote() ?>
+            <?php if ($note !== null && !empty($noteText = $note->getContent(array('cultureFallback' => true)))): ?>
+              <p><?php echo $noteText ?></p>
+            <?php endif; ?>
+          </li>
+        <?php endforeach; ?>
+      </ul>
+    </div>
+  </div>
+
   <?php echo render_show(__('Archival/Custodial history'), render_value($resource->getArchivalHistory(array('cultureFallback' => true)))) ?>
 
   <?php echo render_show(__('Scope and content'), render_value($resource->getScopeAndContent(array('cultureFallback' => true)))) ?>


### PR DESCRIPTION
This adds support for accession events, based on the Canadian Archival
Accession Information Standard (CAAIS).

* Add new AtoM object type: accession events
* Add accession event type taxonomy
* Add "Physical transfer" accession event type term
* Add method to accession model to get an accession's accession events
* Add ability to add/edit accession events via the web UI
* Add Elasticsearch document type for accession events
* Update accession search/indexing to incorporate accession event
  types, dates, agents, and notes