### PR TITLE
Increase treeview items per page max, refs #13320

### DIFF
--- a/apps/qubit/modules/settings/actions/treeviewAction.class.php
+++ b/apps/qubit/modules/settings/actions/treeviewAction.class.php
@@ -129,7 +129,12 @@ class SettingsTreeviewAction extends DefaultEditAction
         }
         $this->form->setDefault($name, $default);
 
-        $this->form->setValidator($name, new sfValidatorInteger(array('min' => 10, 'max' => 1000)));
+        $this->form->setValidator($name, new sfValidatorInteger(
+          array(
+            'min' => 10,
+            'max' => sfConfig::get('app_treeview_items_per_page_max', 10000)
+          )
+        ));
         $this->form->setWidget($name, new sfWidgetFormInput);
 
         break;

--- a/apps/qubit/modules/settings/templates/treeviewSuccess.php
+++ b/apps/qubit/modules/settings/templates/treeviewSuccess.php
@@ -1,3 +1,5 @@
+<?php use_helper('Number') ?>
+
 <?php decorate_with('layout_2col.php') ?>
 
 <?php slot('sidebar') ?>
@@ -87,7 +89,16 @@
         <p>
             <?php echo $form->fullItemsPerPage
               ->label(__('Items per page'))
-              ->help(__('Items per page can be a minimum of 10 and a maximum of 1000'))
+              ->help(
+                  __('Items per page can be a minimum of %1% and a maximum of %2%',
+                    array(
+                      '%1%' => format_number(10),
+                      '%2%' => format_number(
+                        sfConfig::get('app_treeview_items_per_page_max', 10000)
+                      )
+                    )
+                  )
+                )
               ->renderRow() ?>
         </p>
 

--- a/config/app.yml
+++ b/config/app.yml
@@ -56,3 +56,6 @@ all:
   # Specify password_hash algorithm options (as JSON)
   # See: https://www.php.net/manual/en/function.password-hash.php
   password_hash_algorithm_options: {"memory_cost": "2048", "time_cost": "4", "threads": "3"}
+
+  # Maximum allowed value for full-width treeview "items per page" setting
+  treeview_items_per_page_max: 10000


### PR DESCRIPTION
- Add config/app.yml variable for maximum allowed "items per page" value
  for the fullwidth treeview with a default value of 10 000
- Use the "treeview_items_per_page_max" config variable for the treeview
  settings page help text and form validation
- Use the symfony number_format() function to localize digit grouping
- If "treeview_items_per_page_max" var is not set, default to a max of 10 000