### PR TITLE
Fix actor relation import via web UI, refs #13329

### DIFF
--- a/lib/QubitCsvImport.class.php
+++ b/lib/QubitCsvImport.class.php
@@ -66,6 +66,8 @@ class QubitCsvImport
     }
 
     // Find the proper task
+    $sourceNameAllowed = true;
+
     switch ($type)
     {
       case 'accession':
@@ -80,6 +82,7 @@ class QubitCsvImport
 
       case 'authorityRecordRelationship':
         $taskClassName = 'csv:authority-relation-import';
+        $sourceNameAllowed = false;
 
         break;
 
@@ -147,7 +150,11 @@ class QubitCsvImport
     else
     {
       // Example: php symfony csv:import /tmp/foobar
-      $command = sprintf('php %s %s %s %s %s %s %s --quiet %s --source-name=%s %s',
+      $commandTemplate = 'php %s %s %s %s %s %s %s --quiet %s ';
+      $commandTemplate .= $sourceNameAllowed ? sprintf('--source-name=%s ', escapeshellarg($csvOrigFileName)) : '';
+      $commandTemplate .= ' %s';
+
+      $command = sprintf($commandTemplate,
         escapeshellarg(sfConfig::get('sf_root_dir').DIRECTORY_SEPARATOR.'symfony'),
         escapeshellarg($taskClassName),
         $commandIndexFlag,
@@ -156,7 +163,6 @@ class QubitCsvImport
         $commandSkipUnmatched,
         $commandSkipMatched,
         $commandUser,
-        escapeshellarg($csvOrigFileName),
         escapeshellarg($transformedFile ? $transformedFile : $csvFile));
     }
 

--- a/lib/flatfile/config/QubitRelation-actor.yml
+++ b/lib/flatfile/config/QubitRelation-actor.yml
@@ -1,6 +1,5 @@
 # Columns that should be included in the actor relation import
 columnNames:
- - legacyId
  - objectAuthorizedFormOfName
  - subjectAuthorizedFormOfName
  - relationType

--- a/lib/task/import/csvAuthorityRecordRelationImportTask.class.php
+++ b/lib/task/import/csvAuthorityRecordRelationImportTask.class.php
@@ -45,8 +45,6 @@ class csvAuthorityRecordRelationImportTask extends csvImportBaseTask
       new sfCommandOption('connection', null,
         sfCommandOption::PARAMETER_REQUIRED, 'The connection name', 'propel'),
 
-      new sfCommandOption('source-name', null,
-        sfCommandOption::PARAMETER_OPTIONAL, 'Source name to use when inserting keymap entries.'),
       new sfCommandOption('index', null,
         sfCommandOption::PARAMETER_NONE, 'Index for search during import.'),
       new sfCommandOption('update', null,
@@ -73,13 +71,12 @@ EOF;
 
     $this->log('Importing relations...');
 
-    $sourceName = $options['source-name'] ?: basename($arguments['filename']);
-    $this->import($arguments['filename'], $sourceName, $options['index'], $options['update']);
+    $this->import($arguments['filename'], $options['index'], $options['update']);
 
     $this->log('Done.');
   }
 
-  private function import($filepath, $sourceName, $indexDuringImport = false, $updateMode = false)
+  private function import($filepath, $indexDuringImport = false, $updateMode = false)
   {
     if (false === $fh = fopen($filepath, 'rb'))
     {
@@ -96,13 +93,11 @@ EOF;
 
       'status' => [
         'updateMode'         => $updateMode,
-        'sourceName'         => $sourceName,
         'actorRelationTypes' => $termData['actorRelationTypes'],
         'actorIds'           => [],
       ],
 
       'variableColumns' => [
-        'legacyId',
         'objectAuthorizedFormOfName',
         'subjectAuthorizedFormOfName',
         'relationType',
@@ -254,12 +249,6 @@ EOF;
     $relation->save();
 
     $this->addUpdatedActorIds([$sourceActorId, $targetActorId]);
-
-    // Add keymap entry
-    if (!empty($this->import->columnValue('legacyId')))
-    {
-      $this->import->createKeymapEntry($this->import->getStatus('sourceName'), $this->import->columnValue('legacyId'), $relation);
-    }
   }
 
   /**

--- a/lib/task/import/example/authority_records/example_authority_record_relationships.csv
+++ b/lib/task/import/example/authority_records/example_authority_record_relationships.csv
@@ -1,2 +1,2 @@
-legacyId,subjectAuthorizedFormOfName,relationType,objectAuthorizedFormOfName,description,date,startDate,endDate,culture
-1,Example person (ISAAR 5.1.2),is controlled by,Example Corporation (ISAAR 5.1.2),Example Person worked at Example Corporation (ISAAR 5.3.3),2010 - 2015 (ISAAR 5.3.4),2010-01-01,2015-12-31,en
+subjectAuthorizedFormOfName,relationType,objectAuthorizedFormOfName,description,date,startDate,endDate,culture
+Example person (ISAAR 5.1.2),is controlled by,Example Corporation (ISAAR 5.1.2),Example Person worked at Example Corporation (ISAAR 5.3.3),2010 - 2015 (ISAAR 5.3.4),2010-01-01,2015-12-31,en


### PR DESCRIPTION
* Remove --source-name option from authority record relation import
  task
* Modified QubitCsvImport class so the --source-name option isn't added
  for authority record relation imports
* Remove keymap entry creation during authority record relation import
* Remove legacyId column from authority record relation example CSV