### PR TITLE
Remove hard cap on nodeLimit, refs #13320

### DIFF
--- a/apps/qubit/modules/browse/actions/hierarchyDataAction.class.php
+++ b/apps/qubit/modules/browse/actions/hierarchyDataAction.class.php
@@ -43,9 +43,10 @@ class BrowseHierarchyDataAction extends DefaultFullTreeViewAction
     }
 
     // Impose limit to what nodeLimit parameter can be set to
-    if (!ctype_digit($request->nodeLimit) || $request->nodeLimit > 1000)
+    $maxItemsPerPage = sfConfig::get('app_treeview_items_per_page_max', 10000);
+    if (!ctype_digit($request->nodeLimit) || $request->nodeLimit > $maxItemsPerPage)
     {
-      $request->nodeLimit = 1000;
+      $request->nodeLimit = $maxItemsPerPage;
     }
 
     // Do ordering during query as we need to page through the results

--- a/apps/qubit/modules/informationobject/actions/fullWidthTreeViewAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/fullWidthTreeViewAction.class.php
@@ -45,9 +45,10 @@ class InformationObjectFullWidthTreeViewAction extends DefaultFullTreeViewAction
     }
 
     // Impose limit to what nodeLimit parameter can be set to
-    if (!ctype_digit($request->nodeLimit) || $request->nodeLimit > 1000)
+    $maxItemsPerPage = sfConfig::get('app_treeview_items_per_page_max', 10000);
+    if (!ctype_digit($request->nodeLimit) || $request->nodeLimit > $maxItemsPerPage)
     {
-      $request->nodeLimit = 1000;
+      $request->nodeLimit = $maxItemsPerPage;
     }
 
     $baseReferenceCode = '';


### PR DESCRIPTION
Remove hard cap of 1000 on nodeLimit paramater for fullwidth treeview and
hierarchy browser.