### PR TITLE
Idempotent accession alt. ID migrate, refs #13254                    …

### DIFF
--- a/lib/task/migrate/migrations/arMigration0179.class.php
+++ b/lib/task/migrate/migrations/arMigration0179.class.php
@@ -31,22 +31,37 @@ class arMigration0179
 
   public function up($configuration)
   {
-    QubitMigrate::bumpTaxonomy(QubitTaxonomy::ACCESSION_ALTERNATIVE_IDENTIFIER_TYPE_ID, $configuration);
-    $taxonomy = new QubitTaxonomy;
-    $taxonomy->id = QubitTaxonomy::ACCESSION_ALTERNATIVE_IDENTIFIER_TYPE_ID;
-    $taxonomy->parentId = QubitTaxonomy::ROOT_ID;
-    $taxonomy->sourceCulture = 'en';
-    $taxonomy->setName('Accession alternative identifier type', array('culture' => 'en'));
-    $taxonomy->save();
+    // Add accession alternative identifier type taxonomy if it doesn't exist
+    if (null == QubitTaxonomy::getById(QubitTaxonomy::ACCESSION_ALTERNATIVE_IDENTIFIER_TYPE_ID))
+    {
+      QubitMigrate::bumpTaxonomy(QubitTaxonomy::ACCESSION_ALTERNATIVE_IDENTIFIER_TYPE_ID, $configuration);
+      $taxonomy = new QubitTaxonomy;
+      $taxonomy->id = QubitTaxonomy::ACCESSION_ALTERNATIVE_IDENTIFIER_TYPE_ID;
+      $taxonomy->parentId = QubitTaxonomy::ROOT_ID;
+      $taxonomy->sourceCulture = 'en';
+      $taxonomy->setName('Accession alternative identifier type', array('culture' => 'en'));
+      $taxonomy->save();
+    }
 
-    QubitMigrate::bumpTerm(QubitTerm::ACCESSION_ALTERNATIVE_IDENTIFIER_DEFAULT_TYPE_ID, $configuration);
-    $term = new QubitTerm;
-    $term->id = QubitTerm::ACCESSION_ALTERNATIVE_IDENTIFIER_DEFAULT_TYPE_ID;
-    $term->parentId = QubitTerm::ROOT_ID;
-    $term->taxonomyId = QubitTaxonomy::ACCESSION_ALTERNATIVE_IDENTIFIER_TYPE_ID;
-    $term->sourceCulture = 'en';
-    $term->setName('Accession alternative identifier', array('culture' => 'en'));
-    $term->save();
+    // Add default accession alternative identifier type term if it doesn't exist
+    $sql = "SELECT * FROM ".QubitTerm::TABLE_NAME." t
+              INNER JOIN ".QubitTermI18n::TABLE_NAME." ti
+              WHERE ti.name='Accession alternative identifier'
+              AND t.taxonomy_id=?
+              AND ti.culture='en'
+              AND t.id=?";
+
+    if (null == QubitPdo::fetchOne($sql, array(QubitTaxonomy::ACCESSION_ALTERNATIVE_IDENTIFIER_TYPE_ID, QubitTerm::ACCESSION_ALTERNATIVE_IDENTIFIER_DEFAULT_TYPE_ID)))
+    {
+      QubitMigrate::bumpTerm(QubitTerm::ACCESSION_ALTERNATIVE_IDENTIFIER_DEFAULT_TYPE_ID, $configuration);
+      $term = new QubitTerm;
+      $term->id = QubitTerm::ACCESSION_ALTERNATIVE_IDENTIFIER_DEFAULT_TYPE_ID;
+      $term->parentId = QubitTerm::ROOT_ID;
+      $term->taxonomyId = QubitTaxonomy::ACCESSION_ALTERNATIVE_IDENTIFIER_TYPE_ID;
+      $term->sourceCulture = 'en';
+      $term->setName('Accession alternative identifier', array('culture' => 'en'));
+      $term->save();
+    }
 
     return true;
   }


### PR DESCRIPTION
Makes the migration that adds the accession alternative identifier
taxonomy, and default term, idempotent.