### PR TITLE
Fix storage report cancel button, refs #13372

### DIFF
--- a/apps/qubit/modules/physicalobject/templates/holdingsReportExportSuccess.php
+++ b/apps/qubit/modules/physicalobject/templates/holdingsReportExportSuccess.php
@@ -41,7 +41,7 @@
     <section class="actions">
       <ul>
         <li><input class="c-btn c-btn-submit" type="submit" id="exportSubmit" value="<?php echo __('Export') ?>"/></li>
-        <li><?php echo link_to(__('Cancel'), !empty($sf_request->getReferer()) ? $sf_request->getReferer() : array('module' => 'user', 'action' => 'clipboard'), array('class' => 'c-btn')) ?></li>
+        <li><?php echo link_to(__('Cancel'), array('module' => 'physicalobject', 'action' => 'browse'), array('class' => 'c-btn')) ?></li>
       </ul>
     </section>
 


### PR DESCRIPTION
Make the export storage report cancel button go to the physical storage
browse page rather than the referrer.