### PR TITLE
User Active setting fix, refs 13374

### DIFF
--- a/apps/qubit/modules/user/actions/editAction.class.php
+++ b/apps/qubit/modules/user/actions/editAction.class.php
@@ -229,7 +229,7 @@ class UserEditAction extends DefaultEditAction
         break;
 
       case 'active':
-        $this->resource->active = true;
+        $this->resource->active = $this->form->getValue('active') ? true : false;
 
         break;
 


### PR DESCRIPTION
Fix for AtoM Users edit page to allow the 'active' setting to be saved.