### PR TITLE
Add DO option to clipboard export, refs #13395

### DIFF
--- a/apps/qubit/modules/default/actions/alertsComponent.class.php
+++ b/apps/qubit/modules/default/actions/alertsComponent.class.php
@@ -43,22 +43,34 @@ class DefaultAlertsComponent extends sfComponent
         if (isset($firstJobAlertSkipped[$job->id]))
         {
           // Assemble job description
-          $message = $this->context->i18n->__('%1% (started: %2%, status: %3%).', array(
-            '%1%' => (string)$job,
-            '%2%' => $job->getCreationDateString(),
-            '%3%' => $job->getStatusString()));
+          $message = $this->context->i18n->__('%1% (started: %2%, status: %3%).', 
+            array(
+              '%1%' => (string)$job,
+              '%2%' => $job->getCreationDateString(),
+              '%3%' => $job->getStatusString()
+            )
+          );
 
           // Add download path. if applicable
           if (isset($job->downloadPath) && $job->statusId == QubitTerm::JOB_STATUS_COMPLETED_ID)
           {
-            $message .= $this->context->i18n->__(' %1%Download%2% (%3% b)', array(
-              '%1%' => sprintf('<a href="%s">', sfConfig::get('app_siteBaseUrl') .'/'. $job->downloadPath),
-              '%2%' => '</a>',
-              '%3%' => hr_filesize(filesize($job->downloadPath))));
+            $message .= $this->context->i18n->__(' %1%Download%2% (%3% b)', 
+              array(
+                '%1%' => sprintf('<a href="%s">', sfConfig::get('app_siteBaseUrl') .'/'. $job->downloadPath),
+                '%2%' => '</a>',
+                '%3%' => hr_filesize(filesize($job->downloadPath))
+              )
+            );
           }
-
-          // Add refresh link
-          $message .= ' &mdash; <a href="javascript:location.reload();">refresh the page</a> for updates.';
+          else
+          {
+            $message .= ' ' . $this->context->i18n->__('%1%Refresh the page%2% for progress updates.', 
+              array(
+                '%1%' => '<a href="javascript:location.reload();">',
+                '%2%' => '</a>'
+              )
+            );
+          }
 
           // Determine alert type to show
           $alertTypes = array(

--- a/apps/qubit/modules/digitalobject/actions/viewAction.class.php
+++ b/apps/qubit/modules/digitalobject/actions/viewAction.class.php
@@ -81,40 +81,9 @@ class DigitalObjectViewAction extends sfAction
       return false;
     }
 
-    // Only if the copyright statement is enabled
-    if ('1' !== sfConfig::get('app_digitalobject_copyright_statement_enabled', false))
+    if ($this->resource->hasConditionalCopyright())
     {
-      return false;
-    }
-
-    // Check if there is any right statement associated with the object where
-    // the basis = copyright and the restriction = conditional (regardless of
-    // the Rights Act). We don't need to show the popup otherwise.
-    $sql = 'SELECT EXISTS(
-      SELECT 1
-        FROM '.QubitObject::TABLE_NAME.' o
-        JOIN '.QubitRelation::TABLE_NAME.' rel ON (rel.subject_id = o.id)
-        JOIN '.QubitGrantedRight::TABLE_NAME.' gr ON (rel.object_id = gr.rights_id)
-        JOIN '.QubitRights::TABLE_NAME.' r ON (gr.rights_id = r.id)
-      WHERE
-        o.id = ? AND
-        rel.type_id = ? AND
-        gr.restriction = ? AND
-        r.basis_id = ?
-      LIMIT 1) AS has';
-    $r = QubitPdo::fetchOne($sql, array(
-      $this->resource->object->id,
-      QubitTerm::RIGHT_ID,
-      QubitGrantedRight::CONDITIONAL_RIGHT,
-      QubitTerm::RIGHT_BASIS_COPYRIGHT_ID));
-
-    if (false === $r || !isset($r->has))
-    {
-      throw new sfException('Unexpected error');
-    }
-    if ('1' !== $r->has)
-    {
-      return false;
+      return true;
     }
 
     return false === $this->isAccessTokenValid();

--- a/apps/qubit/modules/object/actions/exportAction.class.php
+++ b/apps/qubit/modules/object/actions/exportAction.class.php
@@ -23,30 +23,113 @@ class ObjectExportAction extends DefaultEditAction
   public static
     $NAMES = array(
       'levels',
-      'objectType',
-      'format');
+      'type',
+      'format',
+      'includeDescendants',
+      'includeAllLevels',
+      'includeDigitalObjects',
+      'includeDrafts');
 
   private $choices = array();
 
   protected function earlyExecute()
   {
+    sfProjectConfiguration::getActive()->loadHelpers(array('I18N'));
+
+    // Initialize help array: messages added depending on visibility of fields
+    $this->helpMessages = array();
+
+    $this->typeChoices = array(
+      'informationObject' => sfConfig::get('app_ui_label_informationobject'),
+      'actor' => sfConfig::get('app_ui_label_actor'),
+      'repository' => sfConfig::get('app_ui_label_repository')
+    );
+
     $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
   }
 
   public function execute($request)
   {
-    $this->format = $request->getParameter('format', 'csv');
-    $this->objectType = $request->getParameter('objectType');
+
+    // Get object type and validate
+    // Currently 'switch' to process the inbound parameter, validate and set default - could be if/then if preferred
+    $this->objectType = trim(strtolower($request->getParameter('type')));
+    switch ($this->objectType)
+    {
+      case 'actor':
+        $className = 'QubitActor';
+
+        break;
+
+      case 'repository':
+        $className = 'QubitRepository';
+
+        break;
+
+      default:
+        $this->objectType = 'informationObject';
+        $className = 'QubitInformationObject';
+    }
+
+    // Stop direct access to export url or empty export attempts
+    // Check that the user has something on the clipboard for the current type - otherwise redirect back to clipboard
+    $items = $this->context->user->getClipboard()->countByType();
+    if(empty($items) || !array_key_exists($className, $items) || 1 > $items[$className])
+    {
+      $this->redirect($this->context->routing->generate(null, array('module' => 'user', 'action' => 'clipboard')) . '?type=' . $this->objectType);
+    }
+
+    // Get format and validate
+    // Currently 'switch' to process the inbound parameter, validate and set default - could be if/then if preferred
+    $this->formatType = trim(strtolower($request->getParameter('format')));
+    if(!('xml' == $this->formatType || 'csv' == $this->formatType) || 'repository' == $this->objectType)
+    {
+        $this->formatType = 'csv';
+    }
+
+    // Basic permission check to determine whether digital object export should be made available
+    $this->digitalObjectsAvailable = false;
+    if (sfConfig::get('app_clipboard_export_digitalobjects_enabled', false) && ('informationObject' == $this->objectType || ('actor' == $this->objectType && $this->context->user->isAuthenticated())))
+    {
+      $this->digitalObjectsAvailable = true;
+    }
+
+    // Show export options panel if:
+    // information object type
+    // or, if actor type and digital objects are on the clipboard
+    $this->showOptions = 'informationObject' == $this->objectType || ('actor' == $this->objectType && $this->digitalObjectsAvailable);
+
+    // Get field includeDescendants if:
+    // options enabled
+    // and, information object type
+    $this->descendantsIncluded = $this->showOptions && 'informationObject' == $this->objectType && 'on' == $request->getParameter('includeDescendants');
+
+    // get field includeAllLevels if:
+    // descendantsIncluded enabled
+    $this->descendantsAllLevels = $this->descendantsIncluded && 'on' == $request->getParameter('includeAllLevels');
+
+    // Get field includeDigitalObjects if:
+    // digital objects are on the clipboard
+    // and, information object type and descendants are not selected
+    // or, if actor type
+    $this->includeDigitalObjects = false;
+    if ($this->digitalObjectsAvailable)
+    {
+      $this->includeDigitalObjects = 'on' == $request->getParameter('includeDigitalObjects');
+    }
+
+    // Get field includeDrafts if:
+    // options enabled
+    // and, user is authenticated
+    $this->draftsIncluded = false;
+    if ($this->showOptions && $this->context->user->isAuthenticated())
+    {
+      $this->draftsIncluded = 'on' == $request->getParameter('includeDrafts');
+    }
 
     parent::execute($request);
 
     $this->response->addJavaScript('exportOptions', 'last');
-
-    $this->redirectUrl = array('module' => 'object', 'action' => 'export');
-    if (null !== $referrer = $request->getReferer())
-    {
-      $this->redirectUrl = $referrer;
-    }
 
     $this->title = $this->context->i18n->__('Export');
 
@@ -60,7 +143,7 @@ class ObjectExportAction extends DefaultEditAction
 
         $this->doBackgroundExport($request);
 
-        $this->redirect($this->redirectUrl);
+        $this->redirect($this->context->routing->generate(null, array('module' => 'user', 'action' => 'clipboard')) . '?type=' . $this->objectType);
       }
     }
   }
@@ -69,54 +152,122 @@ class ObjectExportAction extends DefaultEditAction
   {
     switch ($name)
     {
-      case 'levels':
-        $this->form->setValidator('levels', new sfValidatorPass);
+      case 'type':
+        $this->form->setValidator('type', new sfValidatorString(array('required' => true)));
+        $this->form->setWidget('type', new sfWidgetFormSelect(array('label' => __('Type'), 'choices' => $this->typeChoices)));
+        $this->form->setDefault('type', $this->objectType);
 
-        foreach (QubitTerm::getLevelsOfDescription() as $item)
+        break;
+
+      case 'format':
+        $this->form->setValidator('format', new sfValidatorString(array('required' => true)));
+        $choices = array();
+        $choices['csv'] = $this->context->i18n->__('CSV');
+        if('repository' != $this->objectType)
         {
-          $this->choices[$item->id] = $item->__toString();
+          $choices['xml'] = $this->context->i18n->__('XML');
+        }
+        $this->form->setWidget('format', new sfWidgetFormSelect(array('label' => __('Format'), 'choices' => $choices)));
+        $this->form->setDefault('format', 'actor' != $this->objectType ? 'xml' : 'csv');
+
+        break;
+
+      // Enable field includeDescendants if:
+      // options enabled
+      // and, information object type
+      case 'includeDescendants':
+        if ($this->showOptions && 'informationObject' == $this->objectType)
+        {
+          $this->form->setWidget('includeDescendants', new sfWidgetFormInputCheckbox(array('label' => __('Include descendants'))));
+          $this->form->setDefault('includeDescendants', false);
+          $this->helpMessages[] = __('Choosing "Include descendants" will include all lower-level records beneath those currently on the clipboard in the export.');
         }
 
-        $size = count($this->choices);
+        break;
+
+      // Enable field includeAllLevels if:
+      // options enabled
+      // and, information object type
+      case 'includeAllLevels':
+        if ($this->showOptions && 'informationObject' == $this->objectType)
+        {
+          $this->form->setWidget('includeAllLevels', new sfWidgetFormInputCheckbox(array('label' => __('Include all descendant levels of description'))));
+          $this->form->setDefault('includeAllLevels', true);
+        }
+
+        break;
+
+      // Enable field levels if:
+      // options enabled
+      // and, information object type
+      case 'levels':
+
+        $this->form->setValidator('levels', new sfValidatorPass);
+
+        $this->levelChoices = array();
+        foreach (QubitTerm::getLevelsOfDescription() as $item)
+        {
+          $this->levelChoices[$item->id] = $item->__toString();
+        }
+
+        $size = count($this->levelChoices);
         if ($size === 0)
         {
           $size = 4;
         }
 
-        $this->form->setWidget('levels', new sfWidgetFormSelect(array('choices' => $this->choices, 'multiple' => true), array('size' => $size)));
+        if ($this->showOptions && 'informationObject' == $this->objectType)
+        {
+          $this->form->setWidget('levels', new sfWidgetFormSelect(
+            array(
+              'label' => __('Select levels of descendant descriptions for inclusion'), 
+              'help' => __('If no levels are selected, the export will fail. You can use the control (Mac ⌘) and/or shift keys to multi-select values from the Levels of description menu. ' . 
+                           'It is necessary to include the level(s) above the desired export level, up to and including the level contained in the clipboard. ' . 
+                           'Otherwise, no records will be included in the export.'), 
+              'choices' => $this->levelChoices, 
+              'multiple' => true
+            ), 
+            array(
+              'size' => $size
+            )
+          ));
+        }
+        
+        break;
+
+      // Enable field includeDigitalObjects if:
+      // digital objects are available
+      case 'includeDigitalObjects':
+        if ($this->digitalObjectsAvailable)
+        {
+          switch ($this->objectType)
+          {
+            case 'informationObject':
+              $this->helpMessages[] = __('Note: Digital objects with restricted access or copyright will not be exported.') . ' ' . __('It is not possible to select both digital objects and descendants for export at the same time. Digital objects can only be exported for records that are on the clipboard.');
+
+              break;
+
+            case 'actor':
+              $this->helpMessages[] = __('Note: Digital objects with restricted access or copyright will not be exported.');
+
+              break;
+          }
+          $this->form->setWidget('includeDigitalObjects', new sfWidgetFormInputCheckbox(array('label' => __('Include digital objects'))));
+          $this->form->setDefault('includeDigitalObjects', true);
+        }
 
         break;
 
-      case 'objectType':
-        if (isset($this->objectType))
+      // Enable field includeDrafts if:
+      // options enabled
+      // and, user is authenticated
+      case 'includeDrafts':
+        if ($this->showOptions && $this->context->user->isAuthenticated())
         {
-          $choices = array(
-            $this->objectType => sfConfig::get('app_ui_label_'.strtolower($this->objectType))
-          );
+          $this->form->setWidget('includeDrafts', new sfWidgetFormInputCheckbox(array('label' => __('Include draft records'))));
+          $this->helpMessages[] = __('Choosing "Include draft records" will include those marked with a Draft publication status in the export. Note: if you do NOT choose this option, any descendants of a draft record will also be excluded, even if they are published.');
+          $this->form->setDefault('includeDrafts', true);
         }
-        else
-        {
-          $choices = array(
-            'informationObject' => sfConfig::get('app_ui_label_informationobject'),
-            'actor' => sfConfig::get('app_ui_label_actor'),
-            'repository' => sfConfig::get('app_ui_label_repository')
-          );
-        }
-
-        $this->form->setValidator('objectType', new sfValidatorString(array('required' => true)));
-        $this->form->setWidget('objectType', new sfWidgetFormSelect(array('choices' => $choices)));
-
-        break;
-
-      case 'format':
-        $choices = array(
-          'csv' => $this->context->i18n->__('CSV'),
-          'xml' => $this->context->i18n->__('XML')
-        );
-
-        $this->form->setDefault('format', $this->format);
-        $this->form->setValidator('format', new sfValidatorString(array('required' => true)));
-        $this->form->setWidget('format', new sfWidgetFormSelect(array('choices' => $choices)));
 
         break;
 
@@ -139,7 +290,7 @@ class ObjectExportAction extends DefaultEditAction
 
         break;
 
-      case 'objectType':
+      case 'type':
       case 'format':
         $this->$name = $this->form->getValue($name);
 
@@ -152,8 +303,9 @@ class ObjectExportAction extends DefaultEditAction
 
   protected function doBackgroundExport($request)
   {
-    // Create array of selections to pass to background job where Term ID will
-    // be key, and Term description is value.
+    // Create array of selections to pass to background job where 
+    // Term ID will be key, and Term description is value
+    $levelsOfDescription = array();
     foreach ($this->levels as $value)
     {
       $levelsOfDescription[$value] = $this->choices[$value];
@@ -161,20 +313,27 @@ class ObjectExportAction extends DefaultEditAction
 
     $options = array(
       'params' => array('fromClipboard' => true, 'slugs' => $this->context->user->getClipboard()->getAll()),
-      'current-level-only' => 'on' !== $request->getParameter('includeDescendants'),
-      'public' => 'on' !== $request->getParameter('includeDrafts'),
+      'current-level-only' => !$this->descendantsIncluded,
+      'public' => !$this->draftsIncluded,
       'objectType' => $this->objectType,
-      'levels' => $levelsOfDescription,
-      'name' => $this->context->i18n->__('CSV export')
+      'levels' => $levelsOfDescription
     );
 
-    if ('xml' === $this->format)
+    $options['name'] = $this->context->i18n->__('xml' === $this->formatType ? 'XML export' : 'CSV export' );
+
+    if($this->includeDigitalObjects)
     {
-      $options['name'] = $this->context->i18n->__('XML export');
+      $options['name'] = $this->context->i18n->__('%1% and %2%', 
+        array(
+          '%1%' => sfConfig::get('app_ui_label_digitalobject'),
+          '%2%' => $options['name']
+        )
+      );
+      $options['includeDigitalObjects'] = true;
     }
 
-    // When exporting actors, ensure aliases and relations are also exported.
-    if ('actor' === $this->objectType && 'csv' === $this->format)
+    // When exporting actors, ensure aliases and relations are also exported
+    if ('actor' === $this->objectType && 'csv' === $this->formatType)
     {
       $options['aliases'] = true;
       $options['relations'] = true;
@@ -182,16 +341,24 @@ class ObjectExportAction extends DefaultEditAction
 
     try
     {
-      // Preview export before attempting, if job supports this
-      $exportPreviewSupported = method_exists($this->getJobNameString(), 'exportOrCheckForResults');
+      $jobName = $this->getJobNameString();
 
-      if ($exportPreviewSupported && !call_user_func(array($this->getJobNameString(), 'exportOrCheckForResults'), $options))
+      // Preview export before attempting, if job supports this
+      $exportPreviewSupported = method_exists($jobName, 'exportOrCheckForResults');
+
+      if ($exportPreviewSupported && !call_user_func(array($jobName, 'exportOrCheckForResults'), $options))
       {
-        throw new sfException('Export complete - no records were exported.');
+        throw new sfException($this->context->i18n->__(
+          'No records were exported for your current selection. Please %1%refresh the page and choose different export options%2%.', 
+          array(
+            '%1%' => '<a href="javascript:location.reload();">',
+            '%2%' => '</a>',
+          )
+        ));
       }
       else
       {
-        $job = QubitJob::runJob($this->getJobNameString(), $options);
+        $job = QubitJob::runJob($jobName, $options);
 
         // If anonymous user, store job ID in session
         if (!$this->context->user->isAuthenticated())
@@ -200,21 +367,29 @@ class ObjectExportAction extends DefaultEditAction
           $manager->addJobAssociation($job);
         }
 
-        if ($this->context->user->isAuthenticated())
-        {
-          $message = $this->context->i18n->__('%1%Export initiated.%2% Check %3%job management%4% page to download the results when it has completed.', array(
-            '%1%' => '<strong>',
-            '%2%' => '</strong>',
-            '%3%' => sprintf('<a href="%s">', $this->context->routing->generate(null, array('module' => 'jobs', 'action' => 'browse'))),
-            '%4%' => '</a>'));
-        }
-        else
-        {
-          $message = $this->context->i18n->__('Export initiated. Progress will be reported, and a download link provided, in a subsequent notification &mdash; <a href="javascript:location.reload();">refresh the page</a> for updates.');
-        }
-      }
+        $message = array();
 
-      $this->context->user->setFlash('notice', $message);
+        $message[] = $this->context->i18n->__(
+          '%1%Your %2% export package is being built.%3% ' . ($this->context->user->isAuthenticated() ? 'The %4%job management page%5% will show progress and a download link when complete.' : 'Please %4%refresh the page%5% to see progress and a download link when complete.'), 
+          array(
+            '%1%' => '<strong>',
+            '%2%' => strtolower($this->typeChoices[$this->objectType]),
+            '%3%' => '</strong>',
+            '%4%' => ($this->context->user->isAuthenticated() ? sprintf('<a href="%s">', $this->context->routing->generate(null, array('module' => 'jobs', 'action' => 'browse'))) : '<a href="javascript:location.reload();">') . '<strong>',
+            '%5%' => '</strong></a>'
+          )
+        );
+
+        $message[] = $this->context->i18n->__(
+          '%1%Note:%2% AtoM may remove export packages after a period of time to free up storage space. When your export is ready you should download it as soon as possible.', 
+          array(
+            '%1%' => '<strong>',
+            '%2%' => '</strong>'
+          )
+        );
+
+      }
+      $this->context->user->setFlash('info', '<p>' . implode('</p><p>', $message) . '</p>');
     }
     catch (sfException $e)
     {
@@ -228,7 +403,7 @@ class ObjectExportAction extends DefaultEditAction
     switch ($this->objectType)
     {
       case 'informationObject':
-        if ('csv' == $this->format)
+        if ('csv' == $this->formatType)
         {
           return 'arInformationObjectCsvExportJob';
         }
@@ -238,7 +413,7 @@ class ObjectExportAction extends DefaultEditAction
         }
 
       case 'actor':
-        if ('csv' == $this->format)
+        if ('csv' == $this->formatType)
         {
           return 'arActorCsvExportJob';
         }

--- a/apps/qubit/modules/object/templates/exportSuccess.php
+++ b/apps/qubit/modules/object/templates/exportSuccess.php
@@ -18,62 +18,58 @@
     <?php echo $form->renderHiddenFields() ?>
 
     <section id="content">
+
       <div id="export-options" data-export-toggle="tooltip" data-export-title="<?php echo __('Export') ?>" data-export-alert-message="<?php echo __('Error: You must have at least one %1%Level of description%2% selected or choose %1%Include all descendant levels of description%2% to proceed.', array('%1%' => '<strong>', '%2%' => '</strong>')) ?>">
-      <fieldset class="collapsible">
+      <fieldset>
 
         <legend><?php echo __('Export options') ?></legend>
-        <div class="form-item">
-          <?php echo $form->objectType
-            ->label(__('Type'))
-            ->renderRow() ?>
-        </div>
 
-        <div class="form-item">
+        <div class="fieldset-wrapper">
+          <?php echo $form->type
+            ->renderRow() ?>
           <?php echo $form->format
-            ->label(__('Format'))
             ->renderRow() ?>
-        </div>
-
-        <div class="form-item">
+          <?php if ($showOptions): ?>
           <div class="panel panel-default" id="exportOptions">
             <div class="panel-body">
-              <div class="generic-help-box">
-                <label class="generic-help-type">
-                  <input name="includeDescendants" type="checkbox"/>
-                  <?php echo __('Include descendants') ?>
-                </label>
-                <a href="#" class="generic-help-icon" aria-expanded="false"><i class="fa fa-question-circle pull-right"></i></a>
-              </div>
-
-              <?php if ($sf_user->isAuthenticated()): ?>
-                <label>
-                  <input name="includeDrafts" type="checkbox"/>
-                  <?php echo __('Include draft records') ?>
-                </label>
+              <?php if (!empty($helpMessages)): ?>
+                <div class="generic-help-box">
+                  <a href="#" class="generic-help-icon" aria-expanded="false"><i class="fa fa-question-circle pull-right"></i></a>
+                </div>
               <?php endif; ?>
-              <label>
-                <input name="includeAllLevels" type="checkbox"/>
-                <?php echo __('Include all descendant levels of description') ?>
-              </label>
-              <div class="hidden" id="exportLevels">
-                <?php echo $form->levels
-                  ->renderLabel(__('Select levels of descendant descriptions for inclusion'), array('style' => 'font-weight: bold')) ?>
-                <?php echo $form->levels
-                  ->help(__('If no levels are selected, the export will fail. You can use the control (Mac ⌘) and/or shift keys to multi-select values from the Levels of description menu. It is necessary to include the level(s) above the desired export level, up to and including the level contained in the clipboard. Otherwise, no records will be included in the export.'))
-                  ->renderHelp() ?>
-                <?php echo $form->levels->render() ?>
-              </div>
-            </div>
-
-            <div class="alert alert-info generic-help animateNicely">
-              <p><?php echo __('Choosing "Include descendants" will include all lower-level records beneath those currently on the clipboard in the export.') ?></p>
-              <?php if ($sf_user->isAuthenticated()): ?>
-                <p><?php echo __('Choosing "Include draft records" will include those marked with a Draft publication status in the export. Note: if you do NOT choose this option, any descendants of a draft record will also be excluded, even if they are published.') ?></p>
+              <?php if (isset($form->includeDescendants)): ?>
+                <?php echo $form->includeDescendants->renderRow()?>
+              <?php endif; ?>
+              <?php if (isset($form->includeAllLevels)): ?>
+                <?php echo $form->includeAllLevels->renderRow()?>
+              <?php endif; ?>
+              <?php if (isset($form->levels)): ?>
+                <div id="exportLevels">
+                  <?php echo $form->levels->renderLabel() ?>
+                  <?php echo $form->levels->render() ?>
+                  <div class="alert alert-info">
+                  <?php echo $form->levels->renderHelp() ?>
+                  </div>
+                </div>
+              <?php endif; ?>
+              <?php if (isset($form->includeDigitalObjects)): ?>
+                <?php echo $form->includeDigitalObjects->renderRow()?>
+              <?php endif; ?>
+              <?php if (isset($form->includeDrafts)): ?>
+                <?php echo $form->includeDrafts->renderRow()?>
+              <?php endif; ?>
+              <?php if (!empty($helpMessages)): ?>
+                <div class="alert alert-info generic-help animateNicely">
+                  <?php foreach ($sf_data->getRaw('helpMessages') as $helpMessage): ?>
+                  <p><?php echo $helpMessage ?></p>
+                  <?php endforeach; ?>
+                </div>
               <?php endif; ?>
             </div>
-
           </div>
+          <?php endif; ?>
         </div>
+
       </fieldset>
       </div>
     </section>

--- a/apps/qubit/modules/settings/actions/clipboardAction.class.php
+++ b/apps/qubit/modules/settings/actions/clipboardAction.class.php
@@ -27,7 +27,8 @@ class SettingsClipboardAction extends SettingsEditAction
       'clipboard_send_url',
       'clipboard_send_button_text',
       'clipboard_send_message_html',
-      'clipboard_send_http_method'),
+      'clipboard_send_http_method',
+      'clipboard_export_digitalobjects_enabled'),
 
     $I18N = array(
       'clipboard_send_button_text',
@@ -45,7 +46,8 @@ class SettingsClipboardAction extends SettingsEditAction
       'clipboard_send_enabled' => '0',
       'clipboard_send_button_text' => $this->i18n->__('Send'),
       'clipboard_send_message_html' => $this->i18n->__('Sending...'),
-      'clipboard_send_http_method' => 'POST'
+      'clipboard_send_http_method' => 'POST',
+      'clipboard_export_digitalobjects_enabled' => '0',
     );
   }
 
@@ -65,7 +67,8 @@ class SettingsClipboardAction extends SettingsEditAction
 
       case 'clipboard_send_enabled':
       case 'clipboard_send_http_method':
-        if ($name == 'clipboard_send_enabled')
+      case 'clipboard_export_digitalobjects_enabled':
+        if ($name == 'clipboard_send_enabled' || $name == 'clipboard_export_digitalobjects_enabled')
         {
           $options = array($this->i18n->__('No'), $this->i18n->__('Yes'));
         }

--- a/apps/qubit/modules/settings/templates/clipboardSuccess.php
+++ b/apps/qubit/modules/settings/templates/clipboardSuccess.php
@@ -61,6 +61,16 @@
 
       </fieldset>
 
+      <fieldset class="collapsible">
+
+        <legend><?php echo __('Clipboard export') ?></legend>
+
+        <?php echo $form->clipboard_export_digitalobjects_enabled
+          ->label(__('Enable digital object export'))
+          ->renderRow() ?>
+
+      </fieldset>
+
     </div>
 
     <section class="actions">

--- a/apps/qubit/modules/user/templates/clipboardSuccess.php
+++ b/apps/qubit/modules/user/templates/clipboardSuccess.php
@@ -51,7 +51,7 @@
       <ul>
         <li><?php echo link_to(__('Clear %1 clipboard', array('%1' => lcfirst($uiLabels[$type]))), array('module' => 'user', 'action' => 'clipboardClear', 'type' => $entityType), array('class' => 'c-btn c-btn-delete')) ?></li>
         <li><?php echo link_to(__('Save'), array('module' => 'user', 'action' => 'clipboardSave'), array('class' => 'c-btn')) ?></li>
-        <li><?php echo link_to(__('Export'), array('module' => 'object', 'action' => 'export', 'objectType' => $type), array('class' => 'c-btn')) ?></li>
+        <li><?php echo link_to(__('Export'), array('module' => 'object', 'action' => 'export', 'type' => $type), array('class' => 'c-btn')) ?></li>
         <?php if (sfConfig::get('app_clipboard_send_enabled', false) && !empty(sfConfig::get('app_clipboard_send_url', ''))): ?>
           <li><?php echo link_to(__(sfConfig::get('app_clipboard_send_button_text', __('Send'))), array('module' => 'user', 'action' => 'clipboardSend'), array('class' => 'c-btn')) ?></li>
         <?php endif; ?>

--- a/js/exportOptions.js
+++ b/js/exportOptions.js
@@ -4,26 +4,32 @@
 
   var ExportOptions = function (element)
     {
-
       this.$element = $(element);
 
-      this.$levelDiv = this.$element.find('div[id="exportLevels"]');
-      this.$levelSelect = this.$element.find('select[id="levels"]');
-      this.$includeAllLevels = this.$element.find('input[name="includeAllLevels"]');
-      this.$includeDescendants = this.$element.find('input[name="includeDescendants"]');
-      this.$includeDrafts = this.$element.find('input[name="includeDrafts"]');
-      this.$objectType = this.$element.find('select[name="objectType"]');
-      this.$exportOptionsPanel = this.$element.find('div[id="exportOptions"]');
-      this.$exportSubmit = this.$element.find('input[id="exportSubmit"]');
-      this.$exportDiv = this.$element.find('div[id="export-options"]');
+      this.$type = this.$element.find('select[name="type"]');
       this.$formatSelect = this.$element.find('select[name="format"]');
       this.formatDescriptionCsv = this.$formatSelect.find('option[value="csv"]').text();
-      this.formatDescriptionXml = this.$formatSelect.find('option[value="xml"]').text();;
+      this.formatDescriptionXml = this.$formatSelect.find('option[value="xml"]').text();
+      this.$includeAllLevels = this.$element.find('input[name="includeAllLevels"]');
+      if (0 != this.$includeAllLevels.length)
+      {
+        this.$includeAllLevelsHolder = this.$includeAllLevels.parent().parent();
+      }
+      this.$levelDiv = this.$element.find('div[id="exportLevels"]');
+      if (0 != this.$levelDiv.length)
+      {
+        this.$levelDiv.hide();
+      }
+      this.$levelSelect = this.$element.find('select[id="levels"]');
+      this.$includeDescendants = this.$element.find('input[name="includeDescendants"]');
+      this.$includeDigitalObjects = this.$element.find('input[name="includeDigitalObjects"]');
+      this.$includeDrafts = this.$element.find('input[name="includeDrafts"]');
+      this.$exportSubmit = this.$element.find('input[id="exportSubmit"]');
+      this.$exportDiv = this.$element.find('div[id="export-options"]');
       this.$genericHelpIcon = this.$element.find('a.generic-help-icon');
-
+      this.animationMS = 250;
       this.init();
       this.listen();
-      this.onObjectTypeChange();
     };
 
 
@@ -33,46 +39,126 @@
 
     init: function()
     {
-      this.setDefaults();
+      this.resetLevelsOptions();
     },
 
     listen: function()
     {
-      this.$includeDescendants.on('change', $.proxy(this.onIncludeDescendantsChange, this));
-      this.$includeAllLevels.on('change', $.proxy(this.onIncludeAllLevelsChange, this));
-      this.$objectType.on('change', $.proxy(this.onObjectTypeChange, this));
-      this.$exportSubmit.on('click', $.proxy(this.onExportSubmit, this));
-      this.$genericHelpIcon.on('click', $.proxy(this.toggleGenericHelp, this));
-    },
-
-    setDefaults: function()
-    {
-      this.resetLevelsOptions();
-    },
-
-    onIncludeDescendantsChange: function ()
-    {
-      if (this.$includeDescendants.prop('checked'))
+      this.$type.on('change', $.proxy(this.onObjectTypeChange, this));
+      if (0 != this.$genericHelpIcon.length)
       {
-        this.$includeAllLevels.parent().show();
+        this.$genericHelpIcon.on('click', $.proxy(this.toggleGenericHelp, this));
+      }
+      if (0 != this.$includeDescendants.length)
+      {
+        this.$includeDescendants.on('change', $.proxy(this.onExclusiveChange, this, 1));
+      }
+      if (0 != this.$includeDigitalObjects.length)
+      {
+        this.$includeDigitalObjects.on('change', $.proxy(this.onExclusiveChange, this, 2));
+      }
+      if (0 != this.$includeAllLevels.length)
+      {
+        this.$includeAllLevels.on('change', $.proxy(this.onIncludeAllLevelsChange, this));
+      }
+      this.$exportSubmit.on('click', $.proxy(this.onExportSubmit, this));
+    },
+
+    onExclusiveChange: function(field)
+    {
+      var collapseLevels = false;
+      switch (field)
+      {
+        case 1:
+          if (this.$includeDescendants.prop('checked'))
+          {
+            this.setDescendantsState(true);
+            this.setDigitalObjectsState(false);
+            this.$includeAllLevelsHolder.slideDown(this.animationMS);
+          }
+          else
+          {
+            collapseLevels = true;
+            this.setDigitalObjectsState(true);
+          }
+
+          break;
+
+        default:
+          if (this.$includeDigitalObjects.prop('checked'))
+          {
+            this.setDescendantsState(false);
+            this.setDigitalObjectsState(true);
+            if (!this.$includeAllLevelsHolder.is(':animated'))
+            {
+              collapseLevels = true;
+            }
+          }
+          else
+          {
+            this.setDescendantsState(true);
+          }
+
+          break;
+      }
+      if(collapseLevels)
+      {
+        var o = this;
+        this.$includeAllLevelsHolder.slideUp(this.animationMS).promise().done(function()
+        {
+          o.resetLevelsOptions();
+        });
+      }
+    },
+
+    setDescendantsState: function(b)
+    {
+      var o = this.$includeDescendants.parent();
+      if (b)
+      {
+        o.removeClass('muted');
       }
       else
       {
-        this.resetLevelsOptions();
+        this.$includeDescendants.attr('checked', false);
+        o.addClass('muted');
+      }
+    },
+
+    setDigitalObjectsState: function(b)
+    {
+      if (0 != this.$includeDigitalObjects.length)
+      {
+        var o = this.$includeDigitalObjects.parent();
+        if (b)
+        {
+          o.removeClass('muted');
+        }
+        else
+        {
+          this.$includeDigitalObjects.attr('checked', false);
+          o.addClass('muted');
+        }
       }
     },
 
     resetLevelsOptions: function()
     {
-      this.$includeAllLevels.parent().hide();
-      this.$includeAllLevels.attr('checked', true);
-      this.$levelDiv.addClass('hidden');
-      this.$levelSelect.val('');
+      if (undefined != this.$includeAllLevelsHolder && 0 != this.$includeAllLevelsHolder.length)
+      {
+        this.$includeAllLevelsHolder.hide();
+        this.$includeAllLevels.attr('checked', true);
+      }
+      if (undefined != this.$levelDiv && 0 != this.$levelDiv.length)
+      {
+        this.$levelDiv.slideUp(this.animationMS);
+        this.$levelSelect.val('');
+      }
     },
 
     onIncludeAllLevelsChange: function ()
     {
-      this.$levelDiv.toggleClass('hidden');
+      this.$levelDiv.slideToggle(this.animationMS);
       if (this.$includeAllLevels.prop('checked'))
       {
         this.$levelSelect.val('');
@@ -81,71 +167,28 @@
 
     onObjectTypeChange: function ()
     {
-      /*
-        - Remove xml export option when exporting repos
-
-          Options are removed rather than hidden as hiding
-          select options is complicated in Internet Explorer
-      */
-      var $csvOption = jQuery('<option value="csv"></option>');
-      $csvOption.text(this.formatDescriptionCsv);
-
-      var $xmlOption = jQuery('<option value="xml"></option>');
-      $xmlOption.text(this.formatDescriptionXml);
-
-      switch (this.$objectType.val())
+      
+      var url = window.location.href.split('?')[0] + '?type=';
+      var type = this.$type.val().trim();
+      switch (type)
       {
-        case 'informationObject':
-          // select csv
-          this.$exportOptionsPanel.show();
-
-          this.$formatSelect.find('option').remove();
-          this.$formatSelect.append($csvOption);
-          this.$formatSelect.append($xmlOption);
-          this.$formatSelect.find('option[value="csv"]').prop('selected', true);
-          break;
-
         case 'actor':
-          // select xml
-          this.$formatSelect.find('option').remove();
-          this.$formatSelect.append($csvOption);
-          this.$formatSelect.append($xmlOption);
-          this.$formatSelect.find('option[value="xml"]').prop('selected', true);
-
-          this.$exportOptionsPanel.hide();
-          this.resetExportOptionsPanel();
-          break;
-
         case 'repository':
-          // don't include xml option; select csv
-          this.$formatSelect.find('option').remove();
-          this.$formatSelect.append($csvOption);
-          this.$formatSelect.find('option[value="csv"]').prop('selected', true);
+          url += type;
 
-          this.$exportOptionsPanel.hide();
-          this.resetExportOptionsPanel();
           break;
 
         default:
-          this.$exportOptionsPanel.hide();
-          this.resetExportOptionsPanel();
+          url += 'informationObject';
+
           break;
       }
-    },
-
-    resetExportOptionsPanel: function ()
-    {
-      this.$includeDescendants.attr('checked', false);
-      this.$includeDrafts.attr('checked', false);
-      this.$includeAllLevels.parent().hide();
-      this.$levelDiv.addClass('hidden');
-      this.$includeAllLevels.attr('checked', true);
-      this.$levelSelect.val('');
+      window.location.href = url;
     },
 
     onExportSubmit: function ()
     {
-      if (!this.$includeAllLevels.prop('checked') && null == this.$levelSelect.val())
+      if (0 != this.$includeDescendants.length && !this.$includeAllLevels.prop('checked') && null == this.$levelSelect.val())
       {
         event.preventDefault();
         this.showAlert();

--- a/lib/flatfile/csvActorExport.class.php
+++ b/lib/flatfile/csvActorExport.class.php
@@ -139,11 +139,16 @@ class csvActorExport extends QubitFlatfileExport
     $this->setPlaceAccessPoints();
     $this->setSubjectAccessPoints();
 
-    // Set digital object public URL
-    $this->setColumn('digitalObjectURI', $this->resource->getDigitalObjectPublicUrl());
-
-    // Grab checksum for this digital object
-    $this->setColumn('digitalObjectChecksum', $this->resource->getDigitalObjectChecksum());
+    if($this->options['includeDigitalObjectMeta'])
+    {
+      $this->setColumn('digitalObjectURI', $this->resource->getDigitalObjectPublicUrl());
+      $this->setColumn('digitalObjectChecksum', $this->resource->getDigitalObjectChecksum());
+    }
+    else
+    {
+      $this->setColumn('digitalObjectURI', '');
+      $this->setColumn('digitalObjectChecksum', '');
+    }
   }
 
   private function setMaintenanceNote()

--- a/lib/flatfile/csvInformationObjectExport.class.php
+++ b/lib/flatfile/csvInformationObjectExport.class.php
@@ -115,11 +115,18 @@ class csvInformationObjectExport extends QubitFlatfileExport
       $this->descriptionStatusTerms[$this->resource->descriptionStatusId]
     );
 
-    // Set digital object public URL
-    $this->setColumn('digitalObjectURI', $this->resource->getDigitalObjectPublicUrl());
-
-    // Grab checksum for this digital object
-    $this->setColumn('digitalObjectChecksum', $this->resource->getDigitalObjectChecksum());
+    if($this->options['includeDigitalObjectMeta'])
+    {
+      // Set digital object public URL and checksum
+      $this->setColumn('digitalObjectURI', $this->resource->getDigitalObjectPublicUrl());
+      $this->setColumn('digitalObjectChecksum', $this->resource->getDigitalObjectChecksum());
+    }
+    else
+    {
+      // Set empty columns for digital object public URL and checksum
+      $this->setColumn('digitalObjectURI', '');
+      $this->setColumn('digitalObjectChecksum', '');
+    }
 
     // Set publication status
     $this->setColumn('publicationStatus', $this->resource->getPublicationStatus());

--- a/lib/job/arActorCsvExportJob.class.php
+++ b/lib/job/arActorCsvExportJob.class.php
@@ -55,12 +55,11 @@ class arActorCsvExportJob extends arBaseJob
 
     // Compress CSV export files as a ZIP archive
     $this->info($this->i18n->__('Creating ZIP file %1', array('%1' => $this->getDownloadFilePath())));
-    $success = $this->createZipForDownload($tempPath);
+    $errors = $this->createZipForDownload($tempPath);
 
-    if ($success !== true)
+    if (!empty($errors))
     {
-      $this->error($this->i18n->__('Failed to create ZIP file.'));
-
+      $this->error($this->i18n->__('Failed to create ZIP file.') . ' : ' . implode(' : ', $errors));
       return false;
     }
 

--- a/lib/job/arActorXmlExportJob.class.php
+++ b/lib/job/arActorXmlExportJob.class.php
@@ -35,28 +35,28 @@ class arActorXmlExportJob extends arBaseJob
 
   public function runJob($parameters)
   {
+    $this->params = $parameters;
+
     // Create query increasing limit from default
     $this->search = new arElasticSearchPluginQuery(arElasticSearchPluginUtil::SCROLL_SIZE);
-    $this->params = $parameters;
 
     $this->search->queryBool->addMust(new \Elastica\Query\Terms('slug', $this->params['params']['slugs']));
 
     $tempPath = $this->createJobTempDir();
 
-    // Export CSV to temp directory
+    // Export XML to temp directory
     $this->info($this->i18n->__('Starting export to %1.', array('%1' => $tempPath)));
 
     $itemsExported = $this->exportResults($tempPath);
     $this->info($this->i18n->__('Exported %1 actors.', array('%1' => $itemsExported)));
 
-    // Compress CSV export files as a ZIP archive
+    // Compress XML export files as a ZIP archive
     $this->info($this->i18n->__('Creating ZIP file %1.', array('%1' => $this->getDownloadFilePath())));
-    $success = $this->createZipForDownload($tempPath);
+    $errors = $this->createZipForDownload($tempPath);
 
-    if ($success !== true)
+    if (!empty($errors))
     {
-      $this->error($this->i18n->__('Failed to create ZIP file.'));
-
+      $this->error($this->i18n->__('Failed to create ZIP file.') . ' : ' . implode(' : ', $errors));
       return false;
     }
 
@@ -70,9 +70,9 @@ class arActorXmlExportJob extends arBaseJob
   }
 
   /**
-   * Export search results as CSV
+   * Export search results as XML
    *
-   * @param string  Path of file to write CSV data to
+   * @param string  Path of file to write XML data to
    *
    * @return null
    */

--- a/lib/job/arBaseJob.class.php
+++ b/lib/job/arBaseJob.class.php
@@ -50,7 +50,7 @@ class arBaseJob extends Net_Gearman_Job_Common
    */
   protected $avoidParallelExecutionJobs = array('arObjectMoveJob', 'arFileImportJob');
   protected $waitForRetryTime = 10;
-  Protected $maxRetries = 10;
+  protected $maxRetries = 10;
 
   protected $dispatcher = null;
   protected $downloadFileExtension = null; // Child class should set if creating user downloads
@@ -283,35 +283,114 @@ class arBaseJob extends Net_Gearman_Job_Common
   /**
    * Create ZIP file from results
    *
-   * @param string  Path of file to write CSV data to
+   * @param string   Path of file to write CSV data to
+   * @param boolean  Optional: Whether to include digital objects
    *
-   * @return int  success bool
+   * @return array   Error messages
    */
   protected function createZipForDownload($path)
   {
+    $errors = array();
+
     if (!is_writable($this->getJobsDownloadDirectory()))
     {
-      return false;
+      $errors[] = $this->i18n->__('Cannot write to directory');
     }
-
-    $zip = new ZipArchive();
-
-    $success = $zip->open($this->getDownloadFilePath(), ZipArchive::CREATE | ZipArchive::OVERWRITE);
-
-    if ($success == true)
+    else
     {
-      foreach(scandir($path) as $file)
-      {
-        if (!is_dir($file))
-        {
-          $zip->addFile($path . DIRECTORY_SEPARATOR . $file, $file);
-        }
-      }
+      
+      $zip = new ZipArchive();
 
-      $zip->close();
+      if (true != $zip->open($this->getDownloadFilePath(), ZipArchive::CREATE | ZipArchive::OVERWRITE))
+      {
+        $errors[] = $this->i18n->__('Cannot initialize file');
+      }
+      else 
+      {
+        // Check if we need to include digital objects
+        if (array_key_exists('includeDigitalObjects', $this->params) && $this->params['includeDigitalObjects'])
+        {
+          // Keep track of digital object file names so we can append a bracketed number if any are duplicated
+          $fileNames = array();
+
+          // Get permitted digital object ids (if any) and iterate
+          foreach($this->getDigitalObjects() as $id)
+          {
+            $do = QubitDigitalObject::getById($id);
+            if (null != $do)
+            {
+              $doPath = $do->getAbsolutePath();
+              if (file_exists($doPath))
+              {
+                $fileName = basename($doPath);
+                if (!array_key_exists($fileName, $fileNames))
+                {
+                  // Filename not used yet - add to tracker
+                  $fileNames[$fileName] = 0;
+                }
+                else
+                {
+                  // Filename has been used - increment counter and add to filename
+                  $fileNames[$fileName]++;
+                  $doPathInfo = pathinfo($doPath);
+                  $fileName = "{$doPathInfo['filename']}_{$fileNames[$fileName]}.{$doPathInfo['extension']}";
+                }
+                try
+                {
+                  $zip->addFile($doPath, $fileName);
+                }
+                catch (Exception $e)
+                {
+                  if ($this->user->isAdministrator())
+                  {
+                    $errors[] = 'Exception: '.$e->getMessage();
+                  }
+                  else {
+                    $errors[] = $this->i18n->__(
+                      'Sorry, but there was an error locating a digital object (#%1%). ' . 
+                      'This has prevented any further digital objects from being exported. ' .
+                      'Please contact an administrator.' , 
+                      array(
+                        '%1%' => $id
+                      )
+                    );
+                  }
+
+                  break;
+                }
+              }
+            }
+          }
+        }
+
+        // Add exported data (files)
+        foreach (scandir($path) as $file)
+        {
+          if (!$error && !is_dir($file))
+          {
+            try
+            {
+              $zip->addFile($path . DIRECTORY_SEPARATOR . $file, $file);
+            }
+            catch (Exception $e)
+            {
+              if ($this->user->isAdministrator())
+              {
+                $errors[] = 'Exception: '.$e->getMessage();
+              }
+              else {
+                $errors[] = $this->i18n->__('Sorry, but there was an error retrieving a data file. This has stopped the export process. Please contact an administrator.');
+              }
+
+              break;
+            }
+          }
+        }
+        $zip->close();
+      }
     }
 
-    return $success;
+    return $errors;
   }
 
   /**
@@ -400,5 +479,88 @@ class arBaseJob extends Net_Gearman_Job_Common
 
     // If this job is the first one, it can be fully executed
     return $this->job->id === $runningJobs[0]['id'];
+  }
+
+  /**
+   * Return an array of digital object ids if any are attached to clipboard items
+   * and current user has permission to view masters
+   *
+   * @return array
+   */
+  protected function getDigitalObjects()
+  {
+    // Prepare array for digital object ids
+    $digitalObjects = array();
+
+    // Process if export option is set and this is a description or actor export
+    if (sfConfig::get('app_clipboard_export_digitalobjects_enabled', false) && ('informationObject' == $this->params['objectType'] || 'actor' == $this->params['objectType']))
+    {
+      // Get clipboard objects
+      $criteria = new Criteria;
+
+      // Filter on clipboard slugs
+      $criteria->add(QubitSlug::SLUG, $this->params['params']['slugs'], Criteria::IN);
+
+      switch ($this->params['objectType'])
+      {
+        case 'informationObject':
+          $criteria->addJoin(QubitInformationObject::ID, QubitSlug::OBJECT_ID);
+          // Hide drafts if necessary
+          if($this->params['public'])
+          {
+            $criteria = QubitAcl::addFilterDraftsCriteria($criteria);
+          }
+          $items = QubitInformationObject::get($criteria);
+
+          break;
+
+        case 'actor':
+          $criteria->addJoin(QubitActor::ID, QubitSlug::OBJECT_ID);
+          $items = QubitActor::get($criteria);
+
+          break;
+      }
+
+      // Iterate filtered clipboard objects
+      foreach ($items as $item)
+      {
+        $a = $item->digitalObjectsRelatedByobjectId;
+        // Look for digital objects attached to each clipboard item
+        if (0 != count($a))
+        {
+          // Get master object
+          $digitalObject = $a[0];
+          
+          // If we need to add in check for images only, then use:
+          // $digitalObject->isImage() or $digitalObject->isWebCompatibleImageFormat()
+          // ----------
+          // Do appropriate ACL check(s). Master copy of text objects are always allowed for reading
+          // QubitActor does not have a ACL check for readmaster - so only enable for authenticated users.
+          if (
+            $digitalObject->masterAccessibleViaUrl()
+            && (
+              QubitTerm::TEXT_ID == $digitalObject->mediaTypeId
+              || (
+                'actor' == $this->params['objectType']
+                && $this->user->isAuthenticated()
+                && QubitAcl::check($item, 'read')
+              )
+              || (
+                'informationObject' == $this->params['objectType']
+                && QubitAcl::check($item, 'readMaster')
+                && QubitGrantedRight::checkPremis($item->id, 'readMaster')
+                && !$digitalObject->hasConditionalCopyright()
+              )
+            )
+          )
+          {
+            // Add master image id to array
+            $digitalObjects[] = $digitalObject->id;
+          }
+        }
+      }
+    }
+
+    return $digitalObjects;
   }
 }

--- a/lib/job/arInformationObjectXmlExportJob.class.php
+++ b/lib/job/arInformationObjectXmlExportJob.class.php
@@ -65,12 +65,11 @@ class arInformationObjectXmlExportJob extends arBaseJob
 
     // Compress CSV export files as a ZIP archive
     $this->info($this->i18n->__('Creating ZIP file %1.', array('%1' => $this->getDownloadFilePath())));
-    $success = $this->createZipForDownload($tempPath);
+    $errors = $this->createZipForDownload($tempPath);
 
-    if ($success !== true)
+    if (!empty($errors))
     {
-      $this->error($this->i18n->__('Failed to create ZIP file.'));
-
+      $this->error($this->i18n->__('Failed to create ZIP file.') . ' : ' . implode(' : ', $errors));
       return false;
     }
 

--- a/lib/job/arPhysicalObjectCsvHoldingsReportJob.class.php
+++ b/lib/job/arPhysicalObjectCsvHoldingsReportJob.class.php
@@ -57,12 +57,11 @@ class arPhysicalObjectCsvHoldingsReportJob extends arBaseJob
 
     // Compress CSV export files as a ZIP archive
     $this->info($this->i18n->__('Creating ZIP file %1.', ['%1' => $this->getDownloadFilePath()]));
-    $success = $this->createZipForDownload($tempPath);
+    $errors = $this->createZipForDownload($tempPath);
 
-    if ($success !== true)
+    if (!empty($errors))
     {
-      $this->error($this->i18n->__('Failed to create ZIP file.'));
-
+      $this->error($this->i18n->__('Failed to create ZIP file.') . ' : ' . implode(' : ', $errors));
       return false;
     }
 

--- a/lib/job/arRepositoryCsvExportJob.class.php
+++ b/lib/job/arRepositoryCsvExportJob.class.php
@@ -55,7 +55,14 @@ class arRepositoryCsvExportJob extends arBaseJob
 
     // Compress CSV export files as a ZIP archive
     $this->info($this->i18n->__('Creating ZIP file %1', array('%1' => $this->getDownloadFilePath())));
-    $success = $this->createZipForDownload($tempPath);
+    $errors = $this->createZipForDownload($tempPath);
+
+    if (!empty($errors))
+    {
+      $this->error($this->i18n->__('Failed to create ZIP file.') . ' : ' . implode(' : ', $errors));
+
+      return false;
+    }
 
     // Mark job as complete and set download path
     $this->info($this->i18n->__('Export and archiving complete.'));

--- a/plugins/arDominionPlugin/css/less/scaffolding.less
+++ b/plugins/arDominionPlugin/css/less/scaffolding.less
@@ -1554,6 +1554,34 @@ body.login #content {
   }
 }
 
+// Export clipboard page
+
+#export-options {
+  .panel {
+    padding: 15px 15px 10px 15px;
+    margin-bottom: 0;
+    .generic-help-box {
+      position: relative;
+      width: auto;
+      float: right;
+      z-index: 1;
+    }
+    label {
+      display: inline-block;
+      margin-left: -6px;
+      padding: 3px 6px;
+      transition: color .25s, background-color .25s, border-color .25s, border-width .25s, padding .25s;
+      border-radius: @baseBorderRadius;
+    }
+    .muted {
+      background-color: @graySilver;
+    }
+    .alert p:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
 @media (max-width: 767px) {
   #update-check {
     margin-left: -20px;


### PR DESCRIPTION
Add a new system setting to enable export of digital objects attached to
the clipboard (information object and actor records only). All digital
object types can be exported, but only masters are exported for any
image type.

Digital objects are included in the export ZIP along with associated
metadata.

Incorporate basic user permissions checks prior to export, with further
checks for rights as part of the background job/task. Add a new method
to the digital object model to check for any conditional copyright
attached. If set, then do not export the affected digital object.

Modify the export page interface to rebuild options panel depending on
controller-based permissions checks. Also move help and other message
construction from template to controller.

Make the selection of descendant or digital objects in the export page
mutually exclusive. Add several new styling rules (LESS) to the Dominium
theme in scaffolding that apply to the options panel (#export-options).

Change some help and alert messages to improve consistency.

Build additional export form parameter validation in the controller to
mitigate attempts to manually override parameters, and also to prevent
direct access to the export page URL without objects on the clipboard.