### PR TITLE
Setup Varnish in Docker environment, refs #11556

### DIFF
--- a/docker/docker-compose.varnish.yml
+++ b/docker/docker-compose.varnish.yml
@@ -1,0 +1,11 @@
+---
+version: "2"
+
+services:
+
+  varnish:
+    image: varnish:6.0
+    volumes:
+      - ./etc/varnish/default.vcl:/etc/varnish/default.vcl:ro
+    ports:
+      - "127.0.0.1:63007:80"

--- a/docker/etc/varnish/default.vcl
+++ b/docker/etc/varnish/default.vcl
@@ -1,0 +1,25 @@
+vcl 4.1;
+
+backend default {
+  .host = "nginx";
+}
+
+sub vcl_recv {
+  unset req.http.Cookie;
+  return (hash);
+}
+
+sub vcl_backend_response {
+  unset beresp.http.Set-Cookie;
+  return (deliver);
+}
+
+sub vcl_deliver {
+  if (obj.hits > 0) {
+    set resp.http.X-Cache = "HIT";
+    set resp.http.X-Cache-Hits = obj.hits;
+  } else {
+    set resp.http.X-Cache = "MISS";
+  }
+  return (deliver);
+}


### PR DESCRIPTION
Extend Docker Compose environment with a Varnish container. Use a read
only volume for a basic configuration file to point to the Nginx
container and cache all (removing cookies and adding X-Cache headers).