### PR TITLE
Fix --activate option in password task, refs #13398

### DIFF
--- a/lib/task/tools/resetPasswordTask.class.php
+++ b/lib/task/tools/resetPasswordTask.class.php
@@ -30,7 +30,7 @@ class resetPasswordTask extends sfBaseTask
       new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
       new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
       new sfCommandOption('connection', null, sfCommandOption::PARAMETER_REQUIRED, 'The connection name', 'propel'),
-      new sfCommandOption('activate', null, sfCommandOption::PARAMETER_OPTIONAL, 'Activate', false),
+      new sfCommandOption('activate', null, sfCommandOption::PARAMETER_NONE, 'Activate'),
     ));
 
     $this->namespace = 'tools';


### PR DESCRIPTION
This small PR fixes the `--activate` option on the `tools:reset-password` command-line task. Previously the option was set with `PARAMETER_OPTIONAL` and a default value was supplied. However, the result of this was that the option would not work unless it was passed as `--activate=`, rather than just `--activate` as expected and documented. 

I have addressed this by setting it to `PARAMETER_NONE` and removing the default param. Tested locally. 

Relates to the following issue ticket, which describes the original problem in greater detail: 

* https://projects.artefactual.com/issues/13398