### PR TITLE
Dev/issue 13351 download aip

### DIFF
--- a/apps/qubit/modules/digitalobject/templates/_metadata.php
+++ b/apps/qubit/modules/digitalobject/templates/_metadata.php
@@ -48,8 +48,24 @@
   <?php endif; ?>
 
   <?php if ($sf_user->isAuthenticated() && $relatedToIo): ?>
-    <?php echo render_show(__('Object UUID'), render_value($resource->object->objectUUID), array('fieldLabel' => 'objectUUID')) ?>
-    <?php echo render_show(__('AIP UUID'), render_value($resource->object->aipUUID), array('fieldLabel' => 'aipUUID')) ?>
+    <?php if ($this->context->getConfiguration()->isPluginEnabled('arStorageServicePlugin')
+      && arStorageServiceUtils::getAipDownloadEnabled()): ?>
+      <?php include_partial(
+        'arStorageService/aipDownload', ['resource' => $resource]
+      ) ?>
+    <?php else: // arStorageService is disabled ?>
+      <?php echo render_show(
+        __('Object UUID'),
+        render_value($resource->object->objectUUID),
+        array('fieldLabel' => 'objectUUID')
+      ) ?>
+      <?php echo render_show(
+        __('AIP UUID'),
+        render_value($resource->object->aipUUID),
+         array('fieldLabel' => 'aipUUID')
+      ) ?>
+    <?php endif; // arStorageService is disabled ?>
+
     <?php echo render_show(__('Format name'), render_value($resource->object->formatName), array('fieldLabel' => 'formatName')) ?>
     <?php echo render_show(__('Format version'), render_value($resource->object->formatVersion), array('fieldLabel' => 'formatVersion')) ?>
     <?php echo render_show(__('Format registry key'), render_value($resource->object->formatRegistryKey), array('fieldLabel' => 'formatRegistryKey')) ?>

--- a/apps/qubit/modules/settings/actions/editAction.class.php
+++ b/apps/qubit/modules/settings/actions/editAction.class.php
@@ -106,7 +106,10 @@ class SettingsEditAction extends DefaultEditAction
           $this->getUser()->setFlash('notice', $this->updateMessage);
         }
 
-        $this->redirect(array('module' => 'settings', 'action' => $this->getContext()->getActionName()));
+        $this->redirect(array(
+          'module' => $this->getContext()->getModuleName(),
+          'action' => $this->getContext()->getActionName()
+        ));
       }
     }
 

--- a/apps/qubit/modules/settings/actions/menuComponent.class.php
+++ b/apps/qubit/modules/settings/actions/menuComponent.class.php
@@ -95,6 +95,14 @@ class SettingsMenuComponent extends sfComponent
       array(
         'label' => $i18n->__('Clipboard'),
         'action' => 'clipboard'
+      ),
+      array(
+        'label' => $i18n->__('Storage service'),
+        'module' => 'arStorageServiceSettings',
+        'action' => 'settings',
+        'hide' => !$this->context->getConfiguration()->isPluginEnabled(
+          'arStorageServicePlugin'
+        )
       )
     );
 
@@ -121,7 +129,7 @@ class SettingsMenuComponent extends sfComponent
 
     // Sort alphabetically
     usort($this->nodes, function($el1, $el2) {
-      return strnatcmp( $el1['label'], $el2['label']);
+      return strnatcmp($el1['label'], $el2['label']);
     });
   }
 }

--- a/apps/qubit/modules/settings/templates/_menu.php
+++ b/apps/qubit/modules/settings/templates/_menu.php
@@ -8,7 +8,10 @@
           <tr>
         <?php endif; ?>
           <td>
-            <?php echo link_to($node['label'], array('module' => 'settings', 'action' => $node['action'])) ?>
+            <?php echo link_to($node['label'], array(
+              'module' => $node['module'] ?? 'settings',
+              'action' => $node['action']
+            )) ?>
           </td>
         </tr>
       <?php endforeach; ?>

--- a/css/classic.css
+++ b/css/classic.css
@@ -37,6 +37,7 @@ form .field > div
 }
 
 form .field > h3
+form .field > label
 {
   /* Reset h3 */
 

--- a/lib/model/QubitAip.php
+++ b/lib/model/QubitAip.php
@@ -46,4 +46,19 @@ class QubitAip extends BaseAip
 
     return $this;
   }
+
+  /**
+   * Get AIP by UUID
+   *
+   * @param string $uuid AIP UUID
+   *
+   * @return QubitQuery resultset object
+   */
+  public static function getByUuid($uuid)
+  {
+    $c = new Criteria;
+    $c->add(self::UUID, $uuid);
+
+    return self::getOne($c);
+  }
 }

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -74,6 +74,7 @@ class QubitInformationObject extends BaseInformationObject
       case 'formatRegistryName':
       case 'objectUUID':
       case 'aipUUID':
+      case 'relativePathWithinAip':
 
         if (!isset($this->values[$name]))
         {

--- a/plugins/arDominionPlugin/css/less/scaffolding.less
+++ b/plugins/arDominionPlugin/css/less/scaffolding.less
@@ -1620,6 +1620,24 @@ body.login #content {
   }
 }
 
+// Storage Service AIP and object download links
+
+.aip-download {
+  > a {
+    padding-left: 5px;
+
+    i {
+      font-size: 15px;
+      padding-right: 3px;
+      color: @grayLight;
+    }
+
+    &:hover > i {
+      color: @orange;
+    }
+  }
+}
+
 // Plugin manager (sfPluginAdminPlugin/plugins)
 
 .plugin-name {

--- a/plugins/arStorageServicePlugin/config/arStorageServicePluginConfiguration.class.php
+++ b/plugins/arStorageServicePlugin/config/arStorageServicePluginConfiguration.class.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class arStorageServicePluginConfiguration extends sfPluginConfiguration
+{
+  public static
+    $summary = 'Archivematica Storage Service integration plugin',
+    $version = '1.0.0';
+
+  public function initialize()
+  {
+    $enabledModules = sfConfig::get('sf_enabled_modules');
+    array_push($enabledModules, 'arStorageServiceSettings', 'arStorageService');
+    sfConfig::set('sf_enabled_modules', $enabledModules);
+  }
+}

--- a/plugins/arStorageServicePlugin/config/view.yml
+++ b/plugins/arStorageServicePlugin/config/view.yml
@@ -1,0 +1,5 @@
+all:
+    javascripts:
+      /plugins/sfDrupalPlugin/vendor/drupal/misc/jquery.once.js:
+      /plugins/sfDrupalPlugin/vendor/drupal/misc/collapse:
+      /plugins/sfDrupalPlugin/vendor/drupal/misc/form:

--- a/plugins/arStorageServicePlugin/lib/arStorageServiceUtils.class.php
+++ b/plugins/arStorageServicePlugin/lib/arStorageServiceUtils.class.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class arStorageServiceUtils
+{
+  const STORAGE_SERVICE_PACKAGE_PATH = 'file';
+
+  /**
+   * Use phpcurl to request a URL and pass the header and stream back to
+   * the browser.
+   *
+   */
+  public static function getFileFromStorageService($url)
+  {
+    $ch = curl_init();
+
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 500);
+    curl_setopt($ch, CURLOPT_WRITEFUNCTION, function($ch, $data) {
+        echo $data;
+
+        return strlen($data);
+    });
+
+    curl_setopt($ch, CURLOPT_HEADERFUNCTION, function($ch, $header) {
+        header($header);
+
+        return strlen($header);
+    });
+
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1); // Storage service redirects
+    curl_setopt($ch, CURLOPT_FAILONERROR, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+      sprintf(
+        'Authorization: ApiKey %s:%s',
+        (string) QubitSetting::getByName('storage_service_username'),
+        (string) QubitSetting::getByName('storage_service_api_key')
+      ),
+      'User-Agent: DRMC',
+    ));
+
+    curl_exec($ch);
+    $status = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+
+    curl_close($ch);
+
+    return $status;
+  }
+
+  /**
+   * Return true if plugin is enabled and feature is activated.
+   *
+   */
+  public static function getAipDownloadEnabled()
+  {
+    $configuration = ProjectConfiguration::getActive();
+
+    if ($configuration->isPluginEnabled('arStorageServicePlugin')
+      && null !== $setting = QubitSetting::getByName('download_aip_enabled'))
+    {
+      return boolval($setting->getValue(array('sourceCulture' => true)));
+    }
+  }
+
+  public static function getStorageServiceException($status)
+  {
+    switch ($status)
+    {
+      case '400':
+        return new QubitApiBadRequestException("Storage service bad request");
+
+      case '404':
+        return new QubitApi404Exception("Storage service resource not found");
+
+      case '401':
+        return new QubitApiNotAuthorizedException("Storage service resource not authorized");
+
+      case '403':
+        return new QubitApiForbiddenException("Storage service resource forbidden");
+
+      default:
+        return new Exception(sprintf('Storage service error %s', (string)$status));
+    }
+  }
+}

--- a/plugins/arStorageServicePlugin/modules/arStorageService/actions/downloadAction.class.php
+++ b/plugins/arStorageServicePlugin/modules/arStorageService/actions/downloadAction.class.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class arStorageServiceDownloadAction extends sfAction
+{
+  public function execute($request)
+  {
+    $view = sfView::NONE;
+
+    $this->resource = $this->getRoute()->resource;
+
+    // Check that object exists and that it is not the root
+    if (!isset($this->resource))
+    {
+      $this->forward404();
+    }
+
+    try
+    {
+      $status = $this->downloadAip($request);
+    }
+    catch (QubitApi404Exception $e)
+    {
+      $this->response->setStatusCode(404, $e->getMessage());
+      throw $e;
+    }
+    catch (QubitApiNotAuthorizedException $e)
+    {
+      $this->response->setStatusCode(401, $e->getMessage());
+      throw $e;
+    }
+    catch (QubitApiForbiddenException $e)
+    {
+      $this->response->setStatusCode(403, $e->getMessage());
+      throw $e;
+    }
+    catch (QubitApiBadRequestException $e)
+    {
+      $this->response->setStatusCode(400, $e->getMessage());
+      throw $e;
+    }
+    catch (Exception $e)
+    {
+      $this->response->setStatusCode(500, $e->getMessage());
+      throw $e;
+    }
+
+    return $view;
+  }
+
+  /**
+   * Build the request URL for the Storage Service API's 'download' endpoint
+   * and make the request. Ensure if there is an error that the Storage Service
+   * return status is passed back to the browser.
+   *
+   */
+  protected function downloadAip($request)
+  {
+    if (!arStorageServiceUtils::getAipDownloadEnabled())
+    {
+      throw new QubitApiForbiddenException('AIP Download disabled');
+    }
+
+    if (null === $aipUUID = $this->resource->object->aipUUID)
+    {
+      throw new QubitApiBadRequestException('Missing parameter: aipuuid');
+    }
+
+    if (null === $baseUrl = QubitSetting::getByName('storage_service_api_url'))
+    {
+      throw new QubitApiBadRequestException('Missing setting: storage_service_api_url');
+    }
+
+    $url = sprintf('%s/%s/%s/download/',
+      trim($baseUrl, "/"),
+      arStorageServiceUtils::STORAGE_SERVICE_PACKAGE_PATH,
+      $aipUUID
+    );
+
+    // Check return status from Storage Service
+    if (200 !== $status = arStorageServiceUtils::getFileFromStorageService($url))
+    {
+      $ex = arStorageServiceUtils::getStorageServiceException($status);
+      throw $ex;
+    }
+
+    exit;
+  }
+}

--- a/plugins/arStorageServicePlugin/modules/arStorageService/actions/extractFileAction.class.php
+++ b/plugins/arStorageServicePlugin/modules/arStorageService/actions/extractFileAction.class.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class arStorageServiceExtractFileAction extends sfAction
+{
+  public function execute($request)
+  {
+    $view = sfView::NONE;
+
+    $this->resource = $this->getRoute()->resource;
+
+    // Check that object exists and that it is not the root
+    if (!isset($this->resource))
+    {
+      $this->forward404();
+    }
+
+    try
+    {
+      $status = $this->extractFile($request);
+    }
+    catch (QubitApi404Exception $e)
+    {
+      $this->response->setStatusCode(404, $e->getMessage());
+      throw $e;
+    }
+    catch (QubitApiNotAuthorizedException $e)
+    {
+      $this->response->setStatusCode(401, $e->getMessage());
+      throw $e;
+    }
+    catch (QubitApiForbiddenException $e)
+    {
+      $this->response->setStatusCode(403, $e->getMessage());
+      throw $e;
+    }
+    catch (QubitApiBadRequestException $e)
+    {
+      $this->response->setStatusCode(400, $e->getMessage());
+      throw $e;
+    }
+    catch (Exception $e)
+    {
+      $this->response->setStatusCode(500, $e->getMessage());
+      throw $e;
+    }
+
+    return $view;
+  }
+
+  /**
+   * Build the request URL for the Storage Service API's 'extractFile' endpoint
+   * and make the request. Ensure if there is an error that the Storage Service
+   * return status is passed back to the browser.
+   *
+   */
+  protected function extractFile($request)
+  {
+    if (!arStorageServiceUtils::getAipDownloadEnabled())
+    {
+      throw new QubitApiForbiddenException('AIP Download disabled');
+    }
+
+    if (null === $aipUUID = $this->resource->object->aipUUID)
+    {
+      throw new QubitApiBadRequestException('Missing parameter: aipuuid');
+    }
+
+    if (null === $relativePath = $this->resource->object->relativePathWithinAip)
+    {
+      throw new QubitApiBadRequestException('Missing parameter: relativepath');
+    }
+
+    if (null === $baseUrl = QubitSetting::getByName('storage_service_api_url'))
+    {
+      throw new QubitApiBadRequestException('Missing setting: storage_service_api_url');
+    }
+
+    if (null === $aip = QubitAip::getByUuid($aipUUID))
+    {
+      throw new QubitApiBadRequestException('AIP not found: $aipUUID');
+    }
+
+    $url = sprintf('%s/%s/%s/extract_file/?relative_path_to_file=%s-%s/data/%s',
+      trim($baseUrl, "/"),
+      arStorageServiceUtils::STORAGE_SERVICE_PACKAGE_PATH,
+      $aipUUID,
+      $aip->filename,
+      $aip->uuid,
+      $relativePath
+    );
+
+    // Check return status from Storage Service
+    if (200 !== $status = arStorageServiceUtils::getFileFromStorageService($url))
+    {
+      $ex = arStorageServiceUtils::getStorageServiceException($status);
+      throw $ex;
+    }
+
+    exit;
+  }
+}

--- a/plugins/arStorageServicePlugin/modules/arStorageService/config/security.yml
+++ b/plugins/arStorageServicePlugin/modules/arStorageService/config/security.yml
@@ -1,0 +1,3 @@
+all:
+  is_secure: true
+  credentials: administrator

--- a/plugins/arStorageServicePlugin/modules/arStorageService/templates/_aipDownload.php
+++ b/plugins/arStorageServicePlugin/modules/arStorageService/templates/_aipDownload.php
@@ -1,0 +1,21 @@
+<div class="field">
+    <h3><?php echo __('Object UUID') ?></h3>
+    <div class="aip-download">
+        <?php echo render_value_inline($resource->object->objectUUID) ?>
+        <a href="<?php echo url_for(array($resource, 'module' => 'arStorageService', 'action' => 'extractFile')) ?>" target="_blank">
+          <i class="fa fa-download"></i>
+          <?php echo __('Download object') ?>
+        </a>
+    </div>
+</div>
+
+<div class="field">
+    <h3><?php echo __('AIP UUID') ?></h3>
+    <div class="aip-download">
+        <?php echo render_value_inline($resource->object->aipUUID) ?>
+        <a href="<?php echo url_for(array($resource, 'module' => 'arStorageService', 'action' => 'download')) ?>" target="_blank">
+          <i class="fa fa-download"></i>
+          <?php echo __('Download AIP') ?>
+        </a>
+    </div>
+</div>

--- a/plugins/arStorageServicePlugin/modules/arStorageServiceSettings/actions/settingsAction.class.php
+++ b/plugins/arStorageServicePlugin/modules/arStorageServiceSettings/actions/settingsAction.class.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class arStorageServiceSettingsSettingsAction extends SettingsEditAction
+{
+  // Arrays not allowed in class constants
+  public static
+    $NAMES = array(
+      'storage_service_api_url',
+      'storage_service_username',
+      'storage_service_api_key',
+      'download_aip_enabled',
+    );
+
+  public function earlyExecute()
+  {
+    parent::earlyExecute();
+
+    $this->updateMessage = $this->i18n->__('Storage service settings saved.');
+
+    $this->settingDefaults = array(
+      'download_aip_enabled' => '0',
+    );
+  }
+
+  protected function addField($name)
+  {
+    // Set form field format
+    switch ($name)
+    {
+      case 'storage_service_api_url':
+      case 'storage_service_username':
+      case 'storage_service_api_key':
+        $this->form->setValidator($name, new sfValidatorString());
+        $this->form->setWidget($name, new sfWidgetFormInput);
+
+        break;
+
+      case 'download_aip_enabled':
+        $options = array(
+          '0' => $this->i18n->__('Disabled'),
+          '1' => $this->i18n->__('Enabled')
+        );
+
+        $this->form->setValidator($name, new sfValidatorString(
+          array('required' => false)
+        ));
+        $this->form->setWidget($name, new sfWidgetFormSelectRadio(
+          array('choices' => $options), array('class' => 'radio')
+        ));
+
+        break;
+    }
+  }
+}

--- a/plugins/arStorageServicePlugin/modules/arStorageServiceSettings/config/security.yml
+++ b/plugins/arStorageServicePlugin/modules/arStorageServiceSettings/config/security.yml
@@ -1,0 +1,3 @@
+settings:
+  is_secure: true
+  credentials: administrator

--- a/plugins/arStorageServicePlugin/modules/arStorageServiceSettings/templates/settingsSuccess.php
+++ b/plugins/arStorageServicePlugin/modules/arStorageServiceSettings/templates/settingsSuccess.php
@@ -1,0 +1,74 @@
+<?php decorate_with('layout_2col.php') ?>
+
+<?php slot('sidebar') ?>
+
+  <?php echo get_component('settings', 'menu') ?>
+
+<?php end_slot() ?>
+
+<?php slot('title') ?>
+
+  <h1><?php echo __('Storage Service settings') ?></h1>
+
+<?php end_slot() ?>
+
+<?php slot('content') ?>
+
+  <?php echo $form->renderFormTag(url_for(
+    array('module' => 'arStorageServiceSettings', 'action' => 'settings')
+  )) ?>
+
+    <div id="content">
+
+      <fieldset class="collapsible">
+
+        <legend><?php echo __('Storage Service credentials') ?></legend>
+
+        <?php echo $form->storage_service_api_url
+          ->label(__(
+            'Storage Service API endpoint, e.g. "http://localhost:62081/api/v2"'
+          ))
+          ->renderRow() ?>
+
+        <?php echo $form->storage_service_username
+          ->label(__('Storage Service username, e.g. "atom"'))
+          ->renderRow() ?>
+
+        <?php echo $form->storage_service_api_key
+          ->label(__(
+            'Storage Service API key, e.g.'
+            . '"2ef7bde608ce5404e97d5f042f95f89f1c232871"'
+          ))
+          ->renderRow() ?>
+
+      </fieldset>
+
+      <fieldset class="collapsible">
+
+        <legend><?php echo __('AIP download') ?></legend>
+
+        <?php echo $form->download_aip_enabled
+          ->label(__('Enable AIP download'))
+          ->help(__(
+            'Allow authorized users to download a linked AIP or AIP file from'
+            . ' the configured Archivematica Storage Service'
+          ))
+          ->renderRow() ?>
+
+      </fieldset>
+
+    </div>
+
+    <section class="actions">
+      <ul>
+        <li>
+          <input class="c-btn c-btn-submit" type="submit"
+            value="<?php echo __('Save') ?>"
+          />
+        </li>
+      </ul>
+    </section>
+
+  </form>
+
+<?php end_slot() ?>


### PR DESCRIPTION
This commit adds Storage Service integration to AtoM for the purpose of downloading AIPs and objects
from within those AIPs. AIP and Object downloading is only available to users in specific user groups - 
by default this is the administrator group only.

Group access is handled by adding groups directly into the security.yml file in the arStorageServicePlugin's  arStorageService module.
