### PR TITLE
Fix carousel's thumbnail retrieval, refs #13402

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/imageflowComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/imageflowComponent.class.php
@@ -68,7 +68,7 @@ class DigitalObjectImageflowComponent extends sfComponent
         if (!QubitAcl::check($item->object, 'readThumbnail') ||
             !QubitGrantedRight::checkPremis($item->object->id, 'readThumb'))
         {
-          $thumbnail = QubitDigitalObject::getGenericRepresentation($item->mimeType);
+          $thumbnail = QubitDigitalObject::getGenericRepresentation($item->mimeType, QubitTerm::THUMBNAIL_ID);
           $thumbnail->setParent($item);
         }
         else


### PR DESCRIPTION
This adds a missing argument to the
`QubitDigitalObject::getGenericRepresentation` call in the carousel
when the user doesn't have a group or PREMIS permission to access a
digital object's thumbnail.