### PR TITLE
Allow disabling copyright pop-up, refs #13399

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/viewAction.class.php
+++ b/apps/qubit/modules/digitalobject/actions/viewAction.class.php
@@ -75,17 +75,14 @@ class DigitalObjectViewAction extends sfAction
 
   protected function needsPopup($action)
   {
-    // Only if the user is reading the master digital object
-    if ($action !== 'readMaster')
+    // Only if the user is reading the master digital object, and the resource
+    // has a PREMIS conditional copyright restriction
+    if ($action != 'readMaster' || !$this->resource->hasConditionalCopyright())
     {
       return false;
     }
 
-    if ($this->resource->hasConditionalCopyright())
-    {
-      return true;
-    }
-
+    // Show the pop-up if a valid access token was not submitted
     return false === $this->isAccessTokenValid();
   }
 

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -3425,8 +3425,9 @@ class QubitDigitalObject extends BaseDigitalObject
   public function hasConditionalCopyright()
   {
     // Only if this is a master image and copyright statement is enabled
-    if (QubitTerm::MASTER_ID != $this->usageId || !sfConfig::get('app_digitalobject_copyright_statement_enabled', false))
-    {
+    if (QubitTerm::MASTER_ID != $this->usageId
+      || !sfConfig::get('app_digitalobject_copyright_statement_enabled', false)
+    ) {
       return false;
     }
 


### PR DESCRIPTION
Fix a regression introduced in commit 676305b that displayed the conditional
copyright pop-up whenever a "master" digital object is requested.

The error was introduced by inverting the `hasConditionalCopyright()` check to
return true on success, instead of returning false (thus avoiding the following
valid token check) when `hasConditionalCopyring()` returned false.