### PR TITLE
DIP Upload METS parsing issue, refs #13351

### DIFF
--- a/plugins/qtSwordPlugin/lib/qtPackageExtractorMETSArchivematicaDIP.class.php
+++ b/plugins/qtSwordPlugin/lib/qtPackageExtractorMETSArchivematicaDIP.class.php
@@ -223,8 +223,8 @@ class qtPackageExtractorMETSArchivematicaDIP extends qtPackageExtractorBase
   {
     if (
       isset($this->mappings['dmdMapping'][$fileId])
-      && null !== $dmdId = $this->mappings['dmdMapping'][$fileId]
-      && null !== $dmdSec = $this->metsParser->getDmdSec($dmdId)
+      && (null !== $dmdId = $this->mappings['dmdMapping'][$fileId])
+      && (null !== $dmdSec = $this->metsParser->getDmdSec($dmdId))
     ) {
       $io = $this->metsParser->processDmdSec($dmdSec, $io);
     }


### PR DESCRIPTION
This commit fixes an issue where the dmdSec value was not being
properly assigned resulting in an error during DIP upload. This
issue affected transfers that include metadata.

The $dmdSec value is dependent on the $dmdId being assigned in
the preceeding conditions - parentheses added to ensure the
clauses are evaluated in the correct order.