### PR TITLE
Prevent duplicate actor identifiers, refs #13373

### DIFF
--- a/apps/qubit/modules/settings/actions/identifierAction.class.php
+++ b/apps/qubit/modules/settings/actions/identifierAction.class.php
@@ -30,7 +30,9 @@ class SettingsIdentifierAction extends DefaultEditAction
       'identifier_counter',
       'separator_character',
       'inherit_code_informationobject',
-      'inherit_code_dc_xml');
+      'inherit_code_dc_xml',
+      'prevent_duplicate_actor_identifiers'
+    );
 
   protected function earlyExecute()
   {
@@ -62,9 +64,14 @@ class SettingsIdentifierAction extends DefaultEditAction
       case 'identifier_mask_enabled':
       case 'inherit_code_informationobject':
       case 'inherit_code_dc_xml':
+      case 'prevent_duplicate_actor_identifiers':
         // Determine default value
         // (accession mask enabled setting doesn't get created in DB by default)
-        $defaults = array('accession_mask_enabled' => 1, 'inherit_code_dc_xml' => 0);
+        $defaults = array(
+          'accession_mask_enabled' => 1,
+          'inherit_code_dc_xml' => 0,
+          'prevent_duplicate_actor_identifiers' => 0
+        );
 
         $default = (null !== $this->$name = QubitSetting::getByName($name))
           ? $this->$name->getValue(array('sourceCulture' => true))
@@ -93,6 +100,7 @@ class SettingsIdentifierAction extends DefaultEditAction
       case 'separator_character':
       case 'inherit_code_informationobject':
       case 'inherit_code_dc_xml':
+      case 'prevent_duplicate_actor_identifiers':
         if (null === $this->$name)
         {
           $this->$name = new QubitSetting;

--- a/apps/qubit/modules/settings/templates/identifierSuccess.php
+++ b/apps/qubit/modules/settings/templates/identifierSuccess.php
@@ -64,6 +64,13 @@
           ->label(__('Inherit reference code (DC XML)'))
           ->renderRow() ?>
 
+        <?php echo $form->prevent_duplicate_actor_identifiers
+          ->label(__(
+              '%1% identifiers: prevent entry/import of duplicates',
+              array('%1%' => sfConfig::get('app_ui_label_actor'))
+            ))
+          ->renderRow() ?>
+
       </fieldset>
 
     </div>

--- a/lib/task/import/csvAuthorityRecordImportTask.class.php
+++ b/lib/task/import/csvAuthorityRecordImportTask.class.php
@@ -234,11 +234,29 @@ EOF;
       {
         if ($self->object)
         {
-          // Warn if identifier's already been used
+          // Warn or abort if identifier's already been used
           if (!empty($identifier = $self->columnValue('descriptionIdentifier'))
               && QubitValidatorActorDescriptionIdentifier::identifierUsedByAnotherActor($identifier, $self->object))
           {
-            print $self->logError(sprintf('Authority record identifier "%s" not unique.', $identifier));
+            $error = sfContext::getInstance()
+                       ->i18n
+                       ->__(
+                         '%1% identifier "%2%" not unique.',
+                         array(
+                           '%1%' => sfConfig::get('app_ui_label_actor'),
+                           '%2%' => $identifier
+                         )
+                       );
+
+            if (sfConfig::get('app_prevent_duplicate_actor_identifiers', false))
+            {
+              $error .= sfContext::getInstance()->i18n->__(' Import aborted.');
+              throw new sfException($error);
+            }
+            else
+            {
+              echo $self->logError($error);
+            }
           }
 
           if (

--- a/plugins/sfEacPlugin/lib/sfEacPlugin.class.php
+++ b/plugins/sfEacPlugin/lib/sfEacPlugin.class.php
@@ -501,7 +501,19 @@ return;
 
     $this->resource->sourceStandard = 'http://eac.staatsbibliothek-berlin.de/schema/cpf.xsd';
 
-    $this->resource->descriptionIdentifier = $fd->find('eac:control/eac:recordId')->text();
+    $identifier = $fd->find('eac:control/eac:recordId')->text();
+    $this->resource->descriptionIdentifier = $identifier;
+
+    // Abort import if identifier isn't unique
+    if (!empty($identifier) && sfConfig::get('app_prevent_duplicate_actor_identifiers', false)
+        && QubitValidatorActorDescriptionIdentifier::identifierUsedByAnotherActor($identifier, $this->resource))
+    {
+      $error = sfContext::getInstance()->i18n->__(
+                 'Import aborted: %1% identifier "%2%" not unique.',
+                 array('%1%' => sfConfig::get('app_ui_label_actor'), '%2%' => $identifier));
+
+      throw new sfException($error);
+    }
 
     //$fd->find('eac:control/eac:otherRecordId');
 

--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/actions/editAction.class.php
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/actions/editAction.class.php
@@ -100,6 +100,22 @@ class sfIsaarPluginEditAction extends ActorEditAction
 
         break;
 
+      case 'descriptionIdentifier':
+
+        if (sfConfig::get('app_prevent_duplicate_actor_identifiers', false))
+        {
+          $this->form->setDefault($name, $this->resource[$name]);
+          $identifierValidator = new QubitValidatorActorDescriptionIdentifier(array('resource' => $this->resource));
+          $this->form->setValidator($name, $identifierValidator);
+          $this->form->setWidget($name, new sfWidgetFormInput);
+        }
+        else
+        {
+          return parent::addField($name);
+        }
+
+        break;
+
       default:
 
         return parent::addField($name);


### PR DESCRIPTION
* Added setting to enable prevention of duplicate authority record identifiers
* If setting is enabled: prevent entry of duplicates via the web GUI
* If setting is enabled: prevent import of duplicates via CSV and XML import