### PR TITLE
Refactor and fix clipboard export, refs #13395

### DIFF
--- a/lib/job/arActorExportJob.class.php
+++ b/lib/job/arActorExportJob.class.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Asynchronous job to export clipboard actor data and digital objects
+ *
+ * @package    symfony
+ * @subpackage jobs
+ */
+
+class arActorExportJob extends arExportJob
+{
+  /**
+   * @see arBaseJob::$requiredParameters
+   */
+  protected $downloadFileExtension = 'zip';
+
+  /**
+   * Create and return an ES search for clipboard actor records
+   *
+   * @param array $parameters job parameters
+   *
+   * @return \Elastica\Search ES search object
+   */
+  static public function findExportRecords($parameters)
+  {
+    $query = new arElasticSearchPluginQuery(
+      arElasticSearchPluginUtil::SCROLL_SIZE
+    );
+
+    $query->queryBool->addMust(
+      new \Elastica\Query\Terms('slug', $parameters['params']['slugs'])
+    );
+
+    return QubitSearch::getInstance()
+      ->index
+      ->getType('QubitActor')
+      ->createSearch($query->getQuery(false, false));
+  }
+
+  /**
+   * Export actor metadata and related digital objects if appropriate
+   *
+   * @param string $path to tempoarary export directory
+   */
+  protected function doExport($path)
+  {
+    $search = self::findExportRecords($this->params);
+
+    // Scroll through results then iterate through resulting IDs
+    foreach (arElasticSearchPluginUtil::getScrolledSearchResultIdentifiers($search) as $id)
+    {
+      if (null === $resource = QubitActor::getById($id))
+      {
+        $this->error($this->i18n->__(
+          'Cannot fetch actor, id: %1', array('%1' => $id)
+        ));
+
+        return;
+      }
+
+      $this->exportResource($resource, $path);
+
+      // Log progress every 1000 rows
+      if ($this->itemsExported % 1000 == 0)
+      {
+        $this->info($this->i18n->__(
+          '%1 items exported.', array('%1' => $this->itemsExported)
+        ));
+      }
+    }
+  }
+}

--- a/lib/job/arInformationObjectCsvExportJob.class.php
+++ b/lib/job/arInformationObjectCsvExportJob.class.php
@@ -23,178 +23,76 @@
  *
  * @package    symfony
  * @subpackage jobs
+ * @see arInformationObjectExportJob
  */
 
-class arInformationObjectCsvExportJob extends arExportJob
+class arInformationObjectCsvExportJob extends arInformationObjectExportJob
 {
-  /**
-   * @see arBaseJob::$requiredParameters
-   */
-  protected $extraRequiredParameters = array('params');  // Search params
-  protected $downloadFileExtension = 'zip';
-  protected $search;            // arElasticSearchPluginQuery instance
-  protected $archivalStandard;  // Which CSV export configuration to use: either "rad" or "isad"
-  protected $params = array();
-
-  public function runJob($parameters)
-  {
-    $this->params = $parameters;
-
-    $tempPath = $this->createJobTempDir();
-
-    // Export CSV to temp directory
-    $this->info($this->i18n->__('Starting export to %1.', array('%1' => $tempPath)));
-    $itemsExported = $this->exportOrCheckForResults($parameters, $tempPath, $this);
-    $this->info($this->i18n->__('Exported %1 descriptions.', array('%1' => $itemsExported)));
-
-    if ($itemsExported)
-    {
-      // Compress CSV export files as a ZIP archive
-      $this->info($this->i18n->__('Creating ZIP file %1.', array('%1' => $this->getDownloadFilePath())));
-      $errors = $this->createZipForDownload($tempPath);
-
-      if (!empty($errors))
-      {
-        $this->error($this->i18n->__('Failed to create ZIP file.') . ' : ' . implode(' : ', $errors));
-        return false;
-      }
-
-      $this->job->downloadPath = $this->getDownloadRelativeFilePath();
-      $this->info($this->i18n->__('Export and archiving complete.'));
-    }
-    else
-    {
-      $this->info($this->i18n->__('No relevant archival descriptions were found to export.'));
-    }
-
-    $this->job->setStatusCompleted();
-    $this->job->save();
-
-    return true;
-  }
+  protected $csvWriter;
 
   /**
-   * Get the current archival standard
+   * Export clipboard item metadata to a CSV file, and related digital objects
    *
-   * @return arElasticSearchPluginQuery  AtoM Elasticsearch query
-   */
-  static public function getCurrentArchivalStandard()
-  {
-    // If not using RAD, default to ISAD CSV export format
-    $archivalStandard = 'isad';
-    if (QubitSetting::getByNameAndScope('informationobject', 'default_template') == 'rad')
-    {
-      $archivalStandard = 'rad';
-    }
-
-    return $archivalStandard;
-  }
-
-  /**
-   * Create AtoM Elasticsearch query from export parameters
+   * @see arInformationObjectExportJob::doExport()
    *
-   * @param array $parameters  Export parameters
-   *
-   * @return arElasticSearchPluginQuery  AtoM Elasticsearch query
-   */
-  static public function searchFromParameters($parameters)
-  {
-    // Create query
-    $search = new arElasticSearchPluginQuery(arElasticSearchPluginUtil::SCROLL_SIZE);
-
-    if ($parameters['params']['fromClipboard'])
-    {
-      $search->queryBool->addMust(new \Elastica\Query\Terms('slug', $parameters['params']['slugs']));
-    }
-    else
-    {
-      $search->addAggFilters(InformationObjectBrowseAction::$AGGS, $parameters['params']);
-      $search->addAdvancedSearchFilters(
-        InformationObjectBrowseAction::$NAMES,
-        $parameters['params'],
-        self::getCurrentArchivalStandard()
-      );
-    }
-
-    $search->query->setSort(array('lft' => 'asc'));
-
-    return $search;
-  }
-
-  /**
-   * Return search result count and, optionally, export search results
-   *
-   * @param array $parameters  Export parameters
    * @param string $path  Path of file to write CSV data to
-   * @param arInformationObjectCsvExportJob $job  Job object for logging progress
-   *
-   * @return int  Number of descriptions exported
    */
-  static public function exportOrCheckForResults($parameters, $path = false, $job = false)
+  protected function doExport($path)
   {
-    $itemsExported = 0;
-    $public = isset($parameters['public']) && $parameters['public'];
-    $levels = isset($parameters['levels']) ? $parameters['levels'] : array();
-    $numLevels = count($levels);
+    $this->csvWriter = $this->getCsvWriter($path);
 
-    // If no path supplied, just a count of what would be exported is desired so don't actually set up an export
-    if ($path)
+    parent::doExport($path);
+  }
+
+  /**
+   * Export resource metadata and digital object (if requested)
+   *
+   * @param QubitInformationObject $resource object to export
+   * @param string $path temporary export job working directory
+   */
+  protected function exportResource($resource, $path)
+  {
+    // Don't export resource if this level of description is not allowed
+    if (!$this->isAllowedLevelId($resource->levelOfDescriptionId))
     {
-      // Exporter will create a new file each 10,000 rows
-      $writer = new csvInformationObjectExport($path, self::getCurrentArchivalStandard(), 10000);
-
-      // Store export options for use in csvInformationObjectExport
-      $writer->setOptions($parameters);
-
-      // Force loading of information object configuration, then modify writer configuration
-      $writer->loadResourceSpecificConfiguration('QubitInformationObject');
-      array_unshift($writer->columnNames, 'referenceCode');
-      array_unshift($writer->standardColumns, 'referenceCode');
+      return;
     }
 
-    $search = self::searchFromParameters($parameters);
-    $search = QubitSearch::getInstance()->index->getType('QubitInformationObject')->createSearch($search->getQuery(false, false));
+    // Append resource metadata to CSV file
+    $this->csvWriter->exportResource($resource);
 
-    // Scroll through results then iterate through resulting IDs
-    foreach (arElasticSearchPluginUtil::getScrolledSearchResultIdentifiers($search) as $id)
+    $this->addDigitalObject($resource, $path);
+
+    $this->itemsExported++;
+
+    // Export descendants if option was selected
+    if (!$this->params['current-level-only'])
     {
-      $resource = QubitInformationObject::getById($id);
-
-      // If ElasticSearch document is stale (corresponding MySQL data deleted), ignore
-      if ($resource !== null)
+      foreach ($resource->getDescendantsForExport($options) as $item)
       {
-        // Don't export draft descriptions with public option.
-        // Don't export records if level of description is not in list of selected LODs.
-        if (($public && $resource->getPublicationStatus()->statusId == QubitTerm::PUBLICATION_STATUS_DRAFT_ID) ||
-          (0 < $numLevels && !array_key_exists($resource->levelOfDescriptionId, $levels)))
-        {
-          continue;
-        }
-
-        if ($path)
-        {
-          $writer->exportResource($resource);
-
-          // Export descendants if configured
-          if (!$parameters['current-level-only'])
-          {
-            foreach ($resource->getDescendantsForExport($parameters) as $descendant)
-            {
-              $writer->exportResource($descendant);
-            }
-          }
-        }
-
-        // Log progress every 1000 rows
-        if ($job && $itemsExported && ($itemsExported % 1000 == 0))
-        {
-          $job->info($job->i18n->__('%1 items exported.', array('%1' => $itemsExported)));
-        }
-
-        $itemsExported++;
+        $this->exportResource($item, $path);
       }
     }
+  }
 
-    return $itemsExported;
+  protected function getCsvWriter($path)
+  {
+    // Exporter will create a new file each 10,000 rows
+    $writer = new csvInformationObjectExport(
+      $path,
+      self::getCurrentArchivalStandard(),
+      10000
+    );
+
+    // Store export options for use in csvInformationObjectExport
+    $writer->setOptions($this->params);
+
+    // Force loading of information object configuration, then modify writer
+    // configuration
+    $writer->loadResourceSpecificConfiguration('QubitInformationObject');
+    array_unshift($writer->columnNames, 'referenceCode');
+    array_unshift($writer->standardColumns, 'referenceCode');
+
+    return $writer;
   }
 }

--- a/lib/job/arInformationObjectExportJob.class.php
+++ b/lib/job/arInformationObjectExportJob.class.php
@@ -1,0 +1,167 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A worker to, given the HTTP GET parameters sent to advanced search,
+ * replicate the search and export the resulting descriptions to CSV.
+ *
+ * @package    symfony
+ * @subpackage jobs
+ */
+
+class arInformationObjectExportJob extends arExportJob
+{
+  /**
+   * @see arBaseJob::$requiredParameters
+   */
+  protected $extraRequiredParameters = array('params');  // Search params
+  protected $downloadFileExtension = 'zip';
+  protected $search;            // arElasticSearchPluginQuery instance
+  protected $params = array();
+
+  /**
+   * Find records for export based on export parameters
+   *
+   * @param array $parameters  Export parameters
+   *
+   * @return arElasticSearchPluginQuery  AtoM Elasticsearch query
+   */
+  static public function findExportRecords($parameters)
+  {
+    // Create ES query
+    $query = new arElasticSearchPluginQuery(
+      arElasticSearchPluginUtil::SCROLL_SIZE
+    );
+
+    if ($parameters['params']['fromClipboard'])
+    {
+      self::addClipboardCriteria($query, $parameters);
+    }
+    else
+    {
+      $query->addAggFilters(
+        InformationObjectBrowseAction::$AGGS,
+        $parameters['params']
+      );
+
+      $query->addAdvancedSearchFilters(
+        InformationObjectBrowseAction::$NAMES,
+        $parameters['params'],
+        self::getCurrentArchivalStandard()
+      );
+    }
+
+    $query->query->setSort(array('lft' => 'asc'));
+
+    return QubitSearch::getInstance()
+      ->index
+      ->getType('QubitInformationObject')
+      ->createSearch($query->getQuery(false, false));
+  }
+
+  /**
+   * Add clipboard search criteria to ES query
+   */
+  static protected function addClipboardCriteria(&$search, $parameters)
+  {
+    $search->queryBool->addMust(
+      new \Elastica\Query\Terms('slug', $parameters['params']['slugs'])
+    );
+
+    // If "public" option is set, filter out draft records
+    if (isset($parameters['public']) && $parameters['public'])
+    {
+      $search->queryBool->addMust(new \Elastica\Query\Term(
+        ['publicationStatusId' => QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID]
+      ));
+    }
+  }
+
+  /**
+   * Get the current archival standard
+   *
+   * @return arElasticSearchPluginQuery  AtoM Elasticsearch query
+   */
+  static public function getCurrentArchivalStandard()
+  {
+    if ('rad' === QubitSetting::getByNameAndScope('informationobject', 'default_template'))
+    {
+      return 'rad';
+    }
+
+    // If not using RAD, default to ISAD CSV export format
+    return 'isad';
+  }
+
+  /**
+   * Export clipboard item metadata and digital objects
+   *
+   * @param string $path temporary export job working directory
+   */
+  protected function doExport($path)
+  {
+    $search = self::findExportRecords($this->params);
+
+    if (0 == $search->count())
+    {
+      return;
+    }
+
+    // Scroll through results then iterate through resulting IDs
+    foreach (arElasticSearchPluginUtil::getScrolledSearchResultIdentifiers($search) as $id)
+    {
+      $resource = QubitInformationObject::getById($id);
+
+      // Skip if ElasticSearch document is stale (no corresponding MySQL data)
+      if (null == $resource)
+      {
+        continue;
+      }
+
+      $this->exportResource($resource, $path);
+
+      // Log progress every 1000 rows
+      if ($this->itemsExported % 1000 == 0)
+      {
+        $this->info($this->i18n->__(
+          '%1 items exported.', array('%1' => $this->itemsExported))
+        );
+
+        Qubit::clearClassCaches();
+      }
+    }
+  }
+
+  /**
+   * Test if passed level of description id is allowed for export
+   *
+   * @param int $levelId level of description id to test
+   *
+   * @return bool true if all levels are allowed, or level is in selected levels
+   */
+  protected function isAllowedLevelId($levelId)
+  {
+    // If params['levels'] is empty all levels are allowed, otherwise check
+    // that passed $levelId is in the list of selected levels
+    return (
+      empty($this->params['levels'])
+      || array_key_exists($levelId, $this->params['levels'])
+    );
+  }
+}

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -3474,4 +3474,24 @@ class QubitDigitalObject extends BaseDigitalObject
 
     return $r->has;
   }
+
+  /**
+   * Test if $usageId indicates a local file
+   *
+   * Note: returns false if $usageId is not set
+   *
+   * @return bool true if a local file is indicated
+   */
+  public function isLocalFile()
+  {
+    return isset($this->usageId) && in_array(
+      $this->usageId,
+      [
+        QubitTerm::COMPOUND_ID,
+        QubitTerm::MASTER_ID,
+        QubitTerm::REFERENCE_ID,
+        QubitTerm::THUMBNAIL_ID,
+      ]
+    );
+  }
 }


### PR DESCRIPTION
- Refactor clipboard export code to reduce duplication of code
- Fix coding  standard issues such as long lines, and trailing whitespace
- Add conditional to avoid trying to export external digital objects, and add notice to log
- Fix bug that always set the job name to "XML export" even for CSV exports
- Add more comments