### PR TITLE
Remove redundant QubitObject method

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/editAction.class.php
+++ b/apps/qubit/modules/digitalobject/actions/editAction.class.php
@@ -50,7 +50,7 @@ class DigitalObjectEditAction extends sfAction
     {
       foreach ($this->object->getChildren() as $item)
       {
-        if (null !== $item->getDigitalObjectRelatedByobjectId())
+        if (null !== $item->getDigitalObject())
         {
           $this->showCompoundObjectToggle = true;
 

--- a/apps/qubit/modules/object/actions/addDigitalObjectAction.class.php
+++ b/apps/qubit/modules/object/actions/addDigitalObjectAction.class.php
@@ -89,7 +89,7 @@ class ObjectAddDigitalObjectAction extends sfAction
     }
 
     // Check if already exists a digital object
-    if (null !== $digitalObject = $this->resource->getDigitalObjectRelatedByobjectId())
+    if (null !== $digitalObject = $this->resource->getDigitalObject())
     {
       $this->redirect(array($digitalObject, 'module' => 'digitalobject', 'action' => 'edit'));
     }

--- a/lib/model/QubitObject.php
+++ b/lib/model/QubitObject.php
@@ -390,24 +390,14 @@ class QubitObject extends BaseObject implements Zend_Acl_Resource_Interface
    */
   public function getDigitalObject()
   {
-    $digitalObjects = $this->getDigitalObjectsRelatedByobjectId();
+    $digitalObjects = $this->digitalObjectsRelatedByobjectId;
+
     if (count($digitalObjects) > 0)
     {
       return $digitalObjects[0];
     }
-    else
-    {
-      return null;
-    }
-  }
 
-  public function getDigitalObjectRelatedByobjectId()
-  {
-    $digitalObjects = $this->getDigitalObjectsRelatedByobjectId();
-    if (0 < count($digitalObjects))
-    {
-      return $digitalObjects[0];
-    }
+    return null;
   }
 
   /**
@@ -453,7 +443,7 @@ class QubitObject extends BaseObject implements Zend_Acl_Resource_Interface
    */
   public function getDigitalObjectChecksum()
   {
-    if (null !== $do = $this->getDigitalObjectRelatedByobjectId())
+    if (null !== $do = $this->getDigitalObject())
     {
       return $do->getChecksum();
     }

--- a/lib/task/import/csvImportBaseTask.class.php
+++ b/lib/task/import/csvImportBaseTask.class.php
@@ -143,7 +143,7 @@ abstract class csvImportBaseTask extends arBaseTask
       && !$self->keepDigitalObjects)
     {
       // Retrieve any digital objects that exist for this information object
-      $do = $self->object->getDigitalObjectRelatedByobjectId();
+      $do = $self->object->getDigitalObject();
 
       if (null !== $do)
       {


### PR DESCRIPTION
Remove QubitObject::getDigitalObjectRelatedByobjectId() method which duplicates
QubitObject::getDigitalObject() functionality