### PR TITLE
Update digital object metadata display, refs #13388

### DIFF
--- a/apps/qubit/modules/digitalobject/templates/_metadata.php
+++ b/apps/qubit/modules/digitalobject/templates/_metadata.php
@@ -8,68 +8,241 @@
     <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'actor'), '<h2>'.__('%1% metadata', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))).'</h2>', array($resource, 'module' => 'digitalobject', 'action' => 'edit'), array('title' => __('Edit %1%', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))))) ?>
   <?php endif; ?>
 
-  <?php if (sfConfig::get('app_toggleDigitalObjectMap') && is_numeric($latitude) && is_numeric($longitude) && $googleMapsApiKey): ?>
-    <div id="front-map" class="simple-map" data-key="<?php echo $googleMapsApiKey ?>" data-latitude="<?php echo $latitude ?>" data-longitude="<?php echo $longitude ?>"></div>
+  <?php if ($showOriginalFileMetadata || $showPreservationCopyMetadata): ?>
+
+    <fieldset class="collapsible digital-object-metadata single">
+      <legend><?php echo __('Preservation Copies') ?></legend>
+
+      <?php if ($showOriginalFileMetadata): ?>
+
+        <div class="digital-object-metadata-header">
+          <h3><?php echo __('Original file') ?> <i class="fa fa-archive<?php if (!$canAccessOriginalFile): ?> inactive<?php endif; ?>" aria-hidden="true"></i></h3>
+        </div>
+
+        <div class="digital-object-metadata-body">
+          <?php if ($showOriginalFileName): ?>
+            <?php echo render_show(__('Filename'), render_value($resource->object->originalFileName), array('fieldLabel' => 'originalFileName')) ?>
+          <?php endif; ?>
+
+          <?php if ($showOriginalFormatName): ?>
+            <?php echo render_show(__('Format name'), render_value($resource->object->formatName), array('fieldLabel' => 'originalFileFormatName')) ?>
+          <?php endif; ?>
+
+          <?php if ($showOriginalFormatVersion): ?>
+            <?php echo render_show(__('Format version'), render_value($resource->object->formatVersion), array('fieldLabel' => 'originalFileFormatVersion')) ?>
+          <?php endif; ?>
+
+          <?php if ($showOriginalFormatRegistryKey): ?>
+            <?php echo render_show(__('Format registry key'), render_value($resource->object->formatRegistryKey), array('fieldLabel' => 'originalFileFormatRegistryKey')) ?>
+          <?php endif; ?>
+
+          <?php if ($showOriginalFormatRegistryName): ?>
+            <?php echo render_show(__('Format registry name'), render_value($resource->object->formatRegistryName), array('fieldLabel' => 'originalFileFormatRegistryName')) ?>
+          <?php endif; ?>
+
+          <?php if ($showOriginalFileSize): ?>
+            <?php echo render_show(__('Filesize'), hr_filesize(intval((string)$resource->object->originalFileSize)), array('fieldLabel' => 'originalFileSize')) ?>
+          <?php endif; ?>
+
+          <?php if ($showOriginalFileIngestedAt): ?>
+            <?php echo render_show(__('Ingested'), format_date($resource->object->originalFileIngestedAt, 'f'), array('fieldLabel' => 'originalFileIngestedAt')) ?>
+          <?php endif; ?>
+
+          <?php if ($showOriginalFilePermissions): ?>
+            <?php echo render_show(__('Permissions'), render_value($accessStatement), array('fieldLabel' => 'originalFilePermissions')) ?>
+          <?php endif; ?>
+
+          <?php if ($sf_user->isAuthenticated() && $relatedToIo): ?>
+            <?php if ($storageServicePluginEnabled): ?>
+              <?php include_partial(
+                'arStorageService/aipDownload', ['resource' => $resource]
+              ) ?>
+            <?php else: // arStorageService is disabled ?>
+              <?php echo render_show(
+                __('File UUID'),
+                render_value($resource->object->objectUUID),
+                array('fieldLabel' => 'objectUUID')
+              ) ?>
+              <?php echo render_show(
+                __('AIP UUID'),
+                render_value($resource->object->aipUUID),
+                 array('fieldLabel' => 'aipUUID')
+              ) ?>
+            <?php endif; // arStorageService is disabled ?>
+          <?php endif; ?>
+
+        </div>
+
+      <?php endif; ?>
+
+      <?php if ($showPreservationCopyMetadata): ?>
+
+        <div class="digital-object-metadata-header">
+          <h3><?php echo __('Preservation copy') ?> <i class="fa fa-archive<?php if (!$canAccessPreservationCopy): ?> inactive<?php endif; ?>" aria-hidden="true"></i></h3>
+        </div>
+
+        <div class="digital-object-metadata-body">
+          <?php if ($showPreservationCopyFileName): ?>
+            <?php echo render_show(__('Filename'), render_value($resource->object->preservationCopyFileName), array('fieldLabel' => 'preservationCopyFileName')) ?>
+          <?php endif; ?>
+
+          <?php if ($showPreservationCopyFileSize): ?>
+            <?php echo render_show(__('Filesize'), hr_filesize(intval((string)$resource->object->preservationCopyFileSize)), array('fieldLabel' => 'preservationCopyFileSize')) ?>
+          <?php endif; ?>
+
+          <?php if ($showPreservationCopyNormalizedAt): ?>
+            <?php echo render_show(__('Normalized'), format_date($resource->object->preservationCopyNormalizedAt, 'f'), array('fieldLabel' => 'preservactionCopyNormalizedAt')) ?>
+          <?php endif; ?>
+
+          <?php if ($showPreservationCopyPermissions): ?>
+            <?php echo render_show(__('Permissions'), render_value($accessStatement), array('fieldLabel' => 'preservationCopyPermissions')) ?>
+          <?php endif; ?>
+
+        </div>
+
+      <?php endif; ?>
+
+    </fieldset>
+
   <?php endif; ?>
 
-  <?php if (!QubitAcl::check($resource->object, 'readReference')): ?>
-    <?php echo render_show(__('Access'), __('Restricted')) ?>
-  <?php endif; ?>
+  <?php if ($showMasterFileMetadata || $showReferenceCopyMetadata || $showThumbnailCopyMetadata): ?>
 
-  <?php if (QubitTerm::EXTERNAL_URI_ID == $resource->usageId): ?>
-    <?php if (check_field_visibility('app_element_visibility_digital_object_url')): ?>
-      <?php echo render_show(__('URL'), render_value($resource->path), array('fieldLabel' => 'url')) ?>
-    <?php endif; ?>
-  <?php else: ?>
-    <?php if (check_field_visibility('app_element_visibility_digital_object_file_name') && !$denyFileNameByPremis): ?>
-      <?php echo render_show(__('Filename'), render_value($resource->name), array('fieldLabel' => 'filename')) ?>
-    <?php endif; ?>
-  <?php endif; ?>
+    <fieldset class="collapsible digital-object-metadata single">
+      <legend><?php echo __('Access Copies') ?></legend>
 
-  <?php if (check_field_visibility('app_element_visibility_digital_object_geolocation')): ?>
-    <?php echo render_show(__('Latitude'), render_value($latitude), array('fieldLabel' => 'latitude')) ?>
-    <?php echo render_show(__('Longitude'), render_value($longitude), array('fieldLabel' => 'longitude')) ?>
-  <?php endif; ?>
+      <?php if ($showMasterFileMetadata): ?>
 
-  <?php if (check_field_visibility('app_element_visibility_digital_object_media_type')): ?>
-    <?php echo render_show(__('Media type'), render_value($resource->mediaType), array('fieldLabel' => 'mediaType')) ?>
-  <?php endif; ?>
+        <div class="digital-object-metadata-header">
+          <h3><?php echo __('Master file') ?> <i class="fa fa-file<?php if (!$canAccessMasterFile): ?> inactive<?php endif; ?>" aria-hidden="true"></i></h3>
+        </div>
 
-  <?php if (check_field_visibility('app_element_visibility_digital_object_mime_type')): ?>
-    <?php echo render_show(__('Mime-type'), render_value($resource->mimeType), array('fieldLabel' => 'mimeType')) ?>
-  <?php endif; ?>
+        <div class="digital-object-metadata-body">
+          <?php if ($showMasterFileGoogleMap): ?>
+            <div id="front-map" class="simple-map" data-key="<?php echo $googleMapsApiKey ?>" data-latitude="<?php echo $latitude ?>" data-longitude="<?php echo $longitude ?>"></div>
+          <?php endif; ?>
 
-  <?php if (check_field_visibility('app_element_visibility_digital_object_file_size')): ?>
-    <?php echo render_show(__('Filesize'), hr_filesize($resource->byteSize), array('fieldLabel' => 'filesize')) ?>
-  <?php endif; ?>
+          <?php if ($showMasterFileGeolocation): ?>
+            <?php echo render_show(__('Latitude'), render_value($latitude), array('fieldLabel' => 'latitude')) ?>
+            <?php echo render_show(__('Longitude'), render_value($longitude), array('fieldLabel' => 'longitude')) ?>
+          <?php endif; ?>
 
-  <?php if (check_field_visibility('app_element_visibility_digital_object_uploaded')): ?>
-    <?php echo render_show(__('Uploaded'), format_date($resource->createdAt, 'f'), array('fieldLabel' => 'uploaded')) ?>
-  <?php endif; ?>
+          <?php if ($showMasterFileURL): ?>
+            <?php echo render_show(__('URL'), render_value($resource->path), array('fieldLabel' => 'url')) ?>
+          <?php endif; ?>
 
-  <?php if ($sf_user->isAuthenticated() && $relatedToIo): ?>
-    <?php if ($this->context->getConfiguration()->isPluginEnabled('arStorageServicePlugin')
-      && arStorageServiceUtils::getAipDownloadEnabled()): ?>
-      <?php include_partial(
-        'arStorageService/aipDownload', ['resource' => $resource]
-      ) ?>
-    <?php else: // arStorageService is disabled ?>
-      <?php echo render_show(
-        __('Object UUID'),
-        render_value($resource->object->objectUUID),
-        array('fieldLabel' => 'objectUUID')
-      ) ?>
-      <?php echo render_show(
-        __('AIP UUID'),
-        render_value($resource->object->aipUUID),
-         array('fieldLabel' => 'aipUUID')
-      ) ?>
-    <?php endif; // arStorageService is disabled ?>
+          <?php if ($showMasterFileName): ?>
+            <?php if ($canAccessMasterFile): ?>
+              <?php echo render_show(__('Filename'), link_to(render_value_inline($resource->name), $resource->object->getDigitalObjectLink(), array('target' => '_blank')), array('fieldLabel' => 'filename')) ?>
+            <?php else: ?>
+              <?php echo render_show(__('Filename'), render_value($resource->name), array('fieldLabel' => 'filename')) ?>
+            <?php endif; ?>
+          <?php endif; ?>
 
-    <?php echo render_show(__('Format name'), render_value($resource->object->formatName), array('fieldLabel' => 'formatName')) ?>
-    <?php echo render_show(__('Format version'), render_value($resource->object->formatVersion), array('fieldLabel' => 'formatVersion')) ?>
-    <?php echo render_show(__('Format registry key'), render_value($resource->object->formatRegistryKey), array('fieldLabel' => 'formatRegistryKey')) ?>
-    <?php echo render_show(__('Format registry name'), render_value($resource->object->formatRegistryName), array('fieldLabel' => 'formatRegistryName')) ?>
+          <?php if ($showMasterFileMediaType): ?>
+            <?php echo render_show(__('Media type'), render_value($resource->mediaType), array('fieldLabel' => 'mediaType')) ?>
+          <?php endif; ?>
+
+          <?php if ($showMasterFileMimeType): ?>
+            <?php echo render_show(__('Mime-type'), render_value($resource->mimeType), array('fieldLabel' => 'mimeType')) ?>
+          <?php endif; ?>
+
+          <?php if ($showMasterFileSize): ?>
+            <?php echo render_show(__('Filesize'), hr_filesize($resource->byteSize), array('fieldLabel' => 'filesize')) ?>
+          <?php endif; ?>
+
+          <?php if ($showMasterFileCreatedAt): ?>
+            <?php echo render_show(__('Uploaded'), format_date($resource->createdAt, 'f'), array('fieldLabel' => 'uploaded')) ?>
+          <?php endif; ?>
+
+          <?php if ($showMasterFilePermissions): ?>
+            <?php echo render_show(__('Permissions'), render_value($masterFileDenyReason), array('fieldLabel' => 'masterFilePermissions')) ?>
+          <?php endif; ?>
+
+        </div>
+
+      <?php endif; ?>
+
+      <?php if (null !== $referenceCopy && $showReferenceCopyMetadata): ?>
+
+        <div class="digital-object-metadata-header">
+          <h3><?php echo __('Reference copy') ?> <i class="fa fa-file<?php if (!$canAccessReferenceCopy): ?> inactive<?php endif; ?>" aria-hidden="true"></i></h3>
+        </div>
+
+        <div class="digital-object-metadata-body">
+          <?php if ($showReferenceCopyFileName): ?>
+            <?php if ($canAccessReferenceCopy): ?>
+              <?php echo render_show(__('Filename'), link_to(render_value_inline($referenceCopy->name), $referenceCopy->getFullPath(), array('target' => '_blank')), array('fieldLabel' => 'referenceCopyFileName')) ?>
+            <?php else: ?>
+              <?php echo render_show(__('Filename'), render_value($referenceCopy->name), array('fieldLabel' => 'referenceCopyFileName')) ?>
+            <?php endif; ?>
+          <?php endif; ?>
+
+          <?php if ($showReferenceCopyMediaType): ?>
+            <?php echo render_show(__('Media type'), render_value($referenceCopy->mediaType), array('fieldLabel' => 'referenceCopyFileName')) ?>
+          <?php endif; ?>
+
+          <?php if ($showReferenceCopyMimeType): ?>
+            <?php echo render_show(__('Mime-type'), render_value($referenceCopy->mimeType), array('fieldLabel' => 'referenceCopyMimeType')) ?>
+          <?php endif; ?>
+
+          <?php if ($showReferenceCopyFileSize): ?>
+            <?php echo render_show(__('Filesize'), hr_filesize($referenceCopy->byteSize), array('fieldLabel' => 'referenceCopyFileSize')) ?>
+          <?php endif; ?>
+
+          <?php if ($showReferenceCopyCreatedAt): ?>
+            <?php echo render_show(__('Uploaded'), format_date($referenceCopy->createdAt, 'f'), array('fieldLabel' => 'referenceCopyUploaded')) ?>
+          <?php endif; ?>
+
+          <?php if ($showReferenceCopyPermissions): ?>
+            <?php echo render_show(__('Permissions'), render_value($referenceCopyDenyReason), array('fieldLabel' => 'referenceCopyPermissions')) ?>
+          <?php endif; ?>
+
+        </div>
+
+      <?php endif; ?>
+
+      <?php if (null !== $thumbnailCopy && $showThumbnailCopyMetadata): ?>
+
+        <div class="digital-object-metadata-header">
+          <h3><?php echo __('Thumbnail copy') ?> <i class="fa fa-file<?php if (!$canAccessThumbnailCopy): ?> inactive<?php endif; ?>" aria-hidden="true"></i></h3>
+        </div>
+
+        <div class="digital-object-metadata-body">
+          <?php if ($showThumbnailCopyFileName): ?>
+            <?php if ($canAccessThumbnailCopy): ?>
+              <?php echo render_show(__('Filename'), link_to(render_value_inline($thumbnailCopy->name), $thumbnailCopy->getFullPath(), array('target'=> '_blank')), array('fieldLabel' => 'thumbnailCopyFileName')) ?>
+            <?php else: ?>
+              <?php echo render_show(__('Filename'), render_value($thumbnailCopy->name), array('fieldLabel' => 'thumbnailCopyFileName')) ?>
+            <?php endif; ?>
+          <?php endif; ?>
+
+          <?php if ($showThumbnailCopyMediaType): ?>
+            <?php echo render_show(__('Media type'), render_value($thumbnailCopy->mediaType), array('fieldLabel' => 'thumbnailCopyFileName')) ?>
+          <?php endif; ?>
+
+          <?php if ($showThumbnailCopyMimeType): ?>
+            <?php echo render_show(__('Mime-type'), render_value($thumbnailCopy->mimeType), array('fieldLabel' => 'thumbnailCopyMimeType')) ?>
+          <?php endif; ?>
+
+          <?php if ($showThumbnailCopyFileSize): ?>
+            <?php echo render_show(__('Filesize'), hr_filesize($thumbnailCopy->byteSize), array('fieldLabel' => 'thumbnailCopyFileSize')) ?>
+          <?php endif; ?>
+
+          <?php if ($showThumbnailCopyCreatedAt): ?>
+            <?php echo render_show(__('Uploaded'), format_date($thumbnailCopy->createdAt, 'f'), array('fieldLabel' => 'thumbnailCopyUploaded')) ?>
+          <?php endif; ?>
+
+          <?php if (!empty($thumbnailCopyDenyReason)): ?>
+            <?php echo render_show(__('Permissions'), render_value($thumbnailCopyDenyReason), array('fieldLabel' => 'thumbnailCopyPermissions')) ?>
+          <?php endif; ?>
+
+        </div>
+
+      <?php endif; ?>
+
+    </fieldset>
+
   <?php endif; ?>
 
 </section>

--- a/apps/qubit/modules/settings/actions/permissionsAction.class.php
+++ b/apps/qubit/modules/settings/actions/permissionsAction.class.php
@@ -34,6 +34,7 @@ class SettingsPermissionsAction extends sfAction
     $this->permissionsForm = new SettingsPermissionsForm;
     $this->permissionsAccessStatementsForm = new SettingsPermissionsAccessStatementsForm;
     $this->permissionsCopyrightStatementForm = new SettingsPermissionsCopyrightStatementForm;
+    $this->permissionsPreservationSystemAccessStatementForm = new SettingsPermissionsPreservationSystemAccessStatementForm;
 
     $this->basis = array();
     foreach (QubitTaxonomy::getTermsById(QubitTaxonomy::RIGHT_BASIS_ID) as $item)
@@ -42,6 +43,9 @@ class SettingsPermissionsAction extends sfAction
     }
 
     $this->copyrightStatementSetting = QubitSetting::getByName('digitalobject_copyright_statement');
+    $this->preservationSystemAccessStatementSetting = QubitSetting::getByName(
+      'digitalobject_preservation_system_access_statement'
+    );
 
     $this->response->addJavaScript('permissionsSettings');
 
@@ -137,6 +141,43 @@ class SettingsPermissionsAction extends sfAction
           {
             $setting = new QubitSetting;
             $setting->name = 'digitalobject_copyright_statement';
+          }
+          $setting->setValue($statement);
+          $setting->save();
+        }
+      }
+
+      // Preservation system access statement
+      $this->permissionsPreservationSystemAccessStatementForm->bind($request->getPostParameters());
+      if ($this->permissionsPreservationSystemAccessStatementForm->isValid())
+      {
+        $setting = QubitSetting::getByName('digitalobject_preservation_system_access_statement_enabled');
+        if (null === $setting)
+        {
+          $setting = new QubitSetting;
+          $setting->name = 'digitalobject_preservation_system_access_statement_enabled';
+          $setting->sourceCulture = sfConfig::get('sf_default_culture');
+        }
+        $setting->setValue(
+          $this->permissionsPreservationSystemAccessStatementForm->getValue(
+            'preservationSystemAccessStatementEnabled'
+          ),
+          array('sourceCulture' => true)
+        );
+        $setting->save();
+
+        $statement = $this->permissionsPreservationSystemAccessStatementForm->getValue(
+          'preservationSystemAccessStatement'
+        );
+        $statement = QubitHtmlPurifier::getInstance()->purify($statement);
+
+        if (!empty($statement))
+        {
+          $setting = QubitSetting::getByName('digitalobject_preservation_system_access_statement');
+          if (null === $setting)
+          {
+            $setting = new QubitSetting;
+            $setting->name = 'digitalobject_preservation_system_access_statement';
           }
           $setting->setValue($statement);
           $setting->save();

--- a/apps/qubit/modules/settings/templates/permissionsSuccess.php
+++ b/apps/qubit/modules/settings/templates/permissionsSuccess.php
@@ -162,6 +162,24 @@
 
       </fieldset>
 
+      <fieldset class="collapsible" id="preservationSystemAccessStatementArea">
+
+        <legend><?php echo __('Preservation system access statement') ?></legend>
+
+        <?php echo $permissionsPreservationSystemAccessStatementForm->preservationSystemAccessStatementEnabled
+          ->label(__('Enable access statement'))
+          ->renderRow() ?>
+
+        <br />
+        <div class="alert alert-info">
+          <?php echo __('When enabled the following text will appear in the %1% metadata section to describe how a user may access the original and preservation copy of the file stored in a linked digital preservation system. The text appears in the "Permissions" field. When disabled, the "Permissions" field is not displayed.', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')))) ?>
+        </div>
+
+        <?php echo render_field($permissionsPreservationSystemAccessStatementForm->preservationSystemAccessStatement
+          ->label(__('Access statement')), $preservationSystemAccessStatementSetting, array('name' => 'value', 'class' => 'resizable')) ?>
+
+      </fieldset>
+
     </div>
 
     <section class="actions">

--- a/apps/qubit/modules/settings/templates/visibleElementsSuccess.php
+++ b/apps/qubit/modules/settings/templates/visibleElementsSuccess.php
@@ -193,23 +193,122 @@
 
         <legend><?php echo __('%1% metadata area', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))) ?></legend>
 
-        <?php foreach (array(
-          'digital_object_url' => __('URL'),
-          'digital_object_file_name' => __('File name'),
-          'digital_object_geolocation' => __('Latitude and longitude'),
-          'digital_object_media_type' => __('Media type'),
-          'digital_object_mime_type' => __('MIME type'),
-          'digital_object_file_size' => __('File size'),
-          'digital_object_uploaded' => __('Uploaded')) as $key => $value): ?>
+        <fieldset class="collapsible collapsed">
 
-          <div class="form-item form-item-checkbox">
-            <?php echo $form[$key] ?>
-            <?php echo $form[$key]
-              ->label($value)
-              ->renderLabel() ?>
-          </div>
+          <legend><?php echo __('Original file') ?></legend>
 
-        <?php endforeach; ?>
+          <?php foreach (array(
+            'digital_object_preservation_system_original_file_name' => __('File name'),
+            'digital_object_preservation_system_original_format_name' => __('Format name'),
+            'digital_object_preservation_system_original_format_version' => __('Format version'),
+            'digital_object_preservation_system_original_format_registry_key' => __('Format registry key'),
+            'digital_object_preservation_system_original_format_registry_name' => __('Format registry name'),
+            'digital_object_preservation_system_original_file_size' => __('File size'),
+            'digital_object_preservation_system_original_ingested' => __('Ingested'),
+            'digital_object_preservation_system_original_permissions' => __('Permissions')) as $key => $value): ?>
+
+            <div class="form-item form-item-checkbox">
+              <?php echo $form[$key] ?>
+              <?php echo $form[$key]
+                ->label($value)
+                ->renderLabel() ?>
+            </div>
+
+          <?php endforeach; ?>
+
+        </fieldset>
+
+        <fieldset class="collapsible collapsed">
+
+          <legend><?php echo __('Preservation copy') ?></legend>
+
+          <?php foreach (array(
+            'digital_object_preservation_system_preservation_file_name' => __('File name'),
+            'digital_object_preservation_system_preservation_file_size' => __('File size'),
+            'digital_object_preservation_system_preservation_normalized' => __('Normalized'),
+            'digital_object_preservation_system_preservation_permissions' => __('Permissions')) as $key => $value): ?>
+
+            <div class="form-item form-item-checkbox">
+              <?php echo $form[$key] ?>
+              <?php echo $form[$key]
+                ->label($value)
+                ->renderLabel() ?>
+            </div>
+
+          <?php endforeach; ?>
+
+        </fieldset>
+
+        <fieldset class="collapsible collapsed">
+
+          <legend><?php echo __('Master file') ?></legend>
+
+          <?php foreach (array(
+            'digital_object_url' => __('URL'),
+            'digital_object_file_name' => __('File name'),
+            'digital_object_geolocation' => __('Latitude and longitude'),
+            'digital_object_media_type' => __('Media type'),
+            'digital_object_mime_type' => __('MIME type'),
+            'digital_object_file_size' => __('File size'),
+            'digital_object_uploaded' => __('Uploaded'),
+            'digital_object_permissions' => _('Permissions')) as $key => $value): ?>
+
+            <div class="form-item form-item-checkbox">
+              <?php echo $form[$key] ?>
+              <?php echo $form[$key]
+                ->label($value)
+                ->renderLabel() ?>
+            </div>
+
+          <?php endforeach; ?>
+
+        </fieldset>
+
+        <fieldset class="collapsible collapsed">
+
+          <legend><?php echo __('Reference copy') ?></legend>
+
+          <?php foreach (array(
+            'digital_object_reference_file_name' => __('File name'),
+            'digital_object_reference_media_type' => __('Media type'),
+            'digital_object_reference_mime_type' => __('MIME type'),
+            'digital_object_reference_file_size' => __('File size'),
+            'digital_object_reference_uploaded' => __('Uploaded'),
+            'digital_object_reference_permissions' => _('Permissions')) as $key => $value): ?>
+
+            <div class="form-item form-item-checkbox">
+              <?php echo $form[$key] ?>
+              <?php echo $form[$key]
+                ->label($value)
+                ->renderLabel() ?>
+            </div>
+
+          <?php endforeach; ?>
+
+        </fieldset>
+
+        <fieldset class="collapsible collapsed">
+
+          <legend><?php echo __('Thumbnail copy') ?></legend>
+
+          <?php foreach (array(
+            'digital_object_thumbnail_file_name' => __('File name'),
+            'digital_object_thumbnail_media_type' => __('Media type'),
+            'digital_object_thumbnail_mime_type' => __('MIME type'),
+            'digital_object_thumbnail_file_size' => __('File size'),
+            'digital_object_thumbnail_uploaded' => __('Uploaded'),
+            'digital_object_thumbnail_permissions' => _('Permissions')) as $key => $value): ?>
+
+            <div class="form-item form-item-checkbox">
+              <?php echo $form[$key] ?>
+              <?php echo $form[$key]
+                ->label($value)
+                ->renderLabel() ?>
+            </div>
+
+          <?php endforeach; ?>
+
+        </fieldset>
 
       </fieldset>
 

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 186
+    value: 187
   milestone:
     name: milestone
     editable: 0
@@ -1123,6 +1123,106 @@ QubitSetting:
     value: 1
   Qubit_Settings_visibleElements_digitalObjectUploaded:
     name: digital_object_uploaded
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectPermissions:
+    name: digital_object_permissions
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectReferenceFileName:
+    name: digital_object_reference_file_name
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectReferenceMediaType:
+    name: digital_object_reference_media_type
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectReferenceMimeType:
+    name: digital_object_reference_mime_type
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectReferenceFilesize:
+    name: digital_object_reference_file_size
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectReferenceUploaded:
+    name: digital_object_reference_uploaded
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectReferencePermissions:
+    name: digital_object_reference_permissions
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectThumbnailFileName:
+    name: digital_object_thumbnail_file_name
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectThumbnailMediaType:
+    name: digital_object_thumbnail_media_type
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectThumbnailMimeType:
+    name: digital_object_thumbnail_mime_type
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectThumbnailFilesize:
+    name: digital_object_thumbnail_file_size
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectThumbnailUploaded:
+    name: digital_object_thumbnail_uploaded
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectThumbnailPermissions:
+    name: digital_object_thumbnail_permissions
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectPreservationSystemOriginalFileName:
+    name: digital_object_preservation_system_original_file_name
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectPreservationSystemOriginalFormatName:
+    name: digital_object_preservation_system_original_format_name
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectPreservationSystemOriginalFormatVersion:
+    name: digital_object_preservation_system_original_format_version
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectPreservationSystemOriginalFormatRegistryKey:
+    name: digital_object_preservation_system_original_format_registry_key
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectPreservationSystemOriginalFormatRegistryName:
+    name: digital_object_preservation_system_original_format_registry_name
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectPreservationSystemOriginalFilesize:
+    name: digital_object_preservation_system_original_file_size
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectPreservationSystemOriginalIngested:
+    name: digital_object_preservation_system_original_ingested
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectPreservationSystemOriginalPermission:
+    name: digital_object_preservation_system_original_permissions
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectPreservationSystemPreservationFileName:
+    name: digital_object_preservation_system_preservation_file_name
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectPreservationSystemPreservationFilesize:
+    name: digital_object_preservation_system_preservation_file_size
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectPreservationSystemPreservationNormalized:
+    name: digital_object_preservation_system_preservation_normalized
+    scope: element_visibility
+    value: 1
+  Qubit_Settings_visibleElements_digitalObjectPreservationSystemPreservationPermission:
+    name: digital_object_preservation_system_preservation_permissions
     scope: element_visibility
     value: 1
   Qubit_Settings_visibleElements_physicalStorage:

--- a/lib/form/SettingsPermissionsPreservationSystemAccessStatementForm.class.php
+++ b/lib/form/SettingsPermissionsPreservationSystemAccessStatementForm.class.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class SettingsPermissionsPreservationSystemAccessStatementForm extends sfForm
+{
+  public function configure()
+  {
+    $this->getValidatorSchema()->setOption('allow_extra_fields', true);
+
+    $this->setWidget('preservationSystemAccessStatementEnabled', new sfWidgetFormSelectRadio(array('choices'=> array(1 => 'yes', 0 => 'no')), array('class'=>'radio')));
+    $this->setValidator('preservationSystemAccessStatementEnabled', new sfValidatorInteger(array('required' => false)));
+
+    $default = false;
+    if (null !== $setting = QubitSetting::getByName('digitalobject_preservation_system_access_statement_enabled'))
+    {
+      $value = $setting->getValue(array('sourceCulture' => true));
+      if (!empty($value))
+      {
+        $default = $value;
+      }
+    }
+    $this->setDefault('preservationSystemAccessStatementEnabled', $default);
+
+    $this->setWidget('preservationSystemAccessStatement', new sfWidgetFormTextArea(array(), array('rows' => 4)));
+    $this->setValidator('preservationSystemAccessStatement', new sfValidatorString);
+    if (null !== $setting = QubitSetting::getByName('digitalobject_preservation_system_access_statement'))
+    {
+      $this->setDefault('preservationSystemAccessStatement', $setting->getValue());
+    }
+  }
+}

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -75,6 +75,12 @@ class QubitInformationObject extends BaseInformationObject
       case 'objectUUID':
       case 'aipUUID':
       case 'relativePathWithinAip':
+      case 'originalFileName':
+      case 'originalFileSize':
+      case 'originalFileIngestedAt':
+      case 'preservationCopyFileName':
+      case 'preservationCopyFileSize':
+      case 'preservationCopyNormalizedAt':
 
         if (!isset($this->values[$name]))
         {

--- a/lib/task/migrate/migrations/arMigration0187.class.php
+++ b/lib/task/migrate/migrations/arMigration0187.class.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add element visibility settings for DO metadata improvements
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0187
+{
+  const
+    VERSION = 187, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  public function up($configuration)
+  {
+    $SCOPE = 'element_visibility';
+    $VALUE = 1;
+    $settingNames = array(
+      // Master file
+      'digital_object_permissions',
+
+      // Reference copy
+      'digital_object_reference_file_name',
+      'digital_object_reference_media_type',
+      'digital_object_reference_mime_type',
+      'digital_object_reference_file_size',
+      'digital_object_reference_uploaded',
+      'digital_object_reference_permissions',
+
+      // Thumbnail copy
+      'digital_object_thumbnail_file_name',
+      'digital_object_thumbnail_media_type',
+      'digital_object_thumbnail_mime_type',
+      'digital_object_thumbnail_file_size',
+      'digital_object_thumbnail_uploaded',
+      'digital_object_thumbnail_permissions',
+
+      // Original file in preservation system
+      'digital_object_preservation_system_original_file_name',
+      'digital_object_preservation_system_original_format_name',
+      'digital_object_preservation_system_original_format_version',
+      'digital_object_preservation_system_original_format_registry_key',
+      'digital_object_preservation_system_original_format_registry_name',
+      'digital_object_preservation_system_original_file_size',
+      'digital_object_preservation_system_original_ingested',
+      'digital_object_preservation_system_original_permissions',
+
+      // Preservation copy in preservation system
+      'digital_object_preservation_system_preservation_file_name',
+      'digital_object_preservation_system_preservation_file_size',
+      'digital_object_preservation_system_preservation_normalized',
+      'digital_object_preservation_system_preservation_permissions',
+    );
+
+    foreach ($settingNames as $settingName)
+    {
+      if (null === $setting = QubitSetting::getByNameAndScope($settingName, $SCOPE))
+      {
+        $setting = new QubitSetting;
+        $setting->name  = $settingName;
+        $setting->setValue($VALUE, array('sourceCulture' => true));
+        $setting->scope = $SCOPE;
+        $setting->culture = 'en';
+        $setting->save();
+      }
+    }
+
+    return true;
+  }
+}

--- a/plugins/arDacsPlugin/modules/arDacsPlugin/config/view.yml
+++ b/plugins/arDacsPlugin/modules/arDacsPlugin/config/view.yml
@@ -24,6 +24,9 @@ indexSuccess:
   stylesheets:
     /vendor/imageflow/imageflow.packed.css: { position: first }
   javascripts:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/jquery.once.js:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/collapse:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/form:
     /vendor/imageflow/imageflow.packed.js:
     blank:
     imageflow:

--- a/plugins/arDominionPlugin/css/less/scaffolding.less
+++ b/plugins/arDominionPlugin/css/less/scaffolding.less
@@ -1243,6 +1243,95 @@ section .vcard:last-child > .field:last-child > div {
   }
 }
 
+// Digital object metadata
+
+#content {
+
+  fieldset.digital-object-metadata {
+
+    legend {
+      padding-left: 30%;
+      position: relative;
+
+      > a {
+        display: block;
+        position: relative;
+        &:after {
+          content: "»";
+          position: absolute;
+          margin-left: 4px;
+          top: -1px;
+          font-size: @baseFontSize * 1.75;
+          color: @grayLight;
+          transition-property: right;
+          transition-duration: 200ms;
+        }
+      }
+    }
+
+    .fieldset-wrapper {
+      padding: 0;
+    }
+
+    .digital-object-metadata-header {
+      float: left;
+      width: 28%;
+      text-align: right;
+
+      h3 {
+        margin: 0;
+        line-height: 20px;
+        padding: 2px 0;
+        position: relative;
+
+        .fa {
+          position: absolute;
+          top: 24px;
+          right: 0;
+          color: #000;
+          font-size: 1.5em;
+        }
+
+        .fa.inactive {
+          color: #999;
+        }
+      }
+    }
+
+    .digital-object-metadata-body {
+      margin-left: 30%;
+      margin-bottom: 10px;
+      border-left: 1px solid #f2f2f2;
+
+      .field {
+
+        > h3 {
+          float: none;
+          width: auto;
+          padding: 2px 4px;
+          margin: 0;
+          text-align: left;
+          border-right: none;
+          display: inline-block;
+        }
+
+        > div {
+          margin: 0;
+          padding: 2px 4px;
+          display: inline-block;
+
+          p {
+            margin: 0;
+          }
+        }
+
+      }
+
+    }
+
+  }
+}
+
 // Horizontal space that takes the sort dropdown or a search bar in a browser
 
 .header-options {

--- a/plugins/arStorageServicePlugin/modules/arStorageService/templates/_aipDownload.php
+++ b/plugins/arStorageServicePlugin/modules/arStorageService/templates/_aipDownload.php
@@ -1,10 +1,10 @@
 <div class="field">
-    <h3><?php echo __('Object UUID') ?></h3>
+    <h3><?php echo __('File UUID') ?></h3>
     <div class="aip-download">
         <?php echo render_value_inline($resource->object->objectUUID) ?>
         <a href="<?php echo url_for(array($resource, 'module' => 'arStorageService', 'action' => 'extractFile')) ?>" target="_blank">
           <i class="fa fa-download"></i>
-          <?php echo __('Download object') ?>
+          <?php echo __('Download file') ?>
         </a>
     </div>
 </div>

--- a/plugins/qtSwordPlugin/lib/qtPackageExtractorMETSArchivematicaDIP.class.php
+++ b/plugins/qtSwordPlugin/lib/qtPackageExtractorMETSArchivematicaDIP.class.php
@@ -202,8 +202,55 @@ class qtPackageExtractorMETSArchivematicaDIP extends qtPackageExtractorBase
       $options
     );
 
+    $this->addPreservationSystemMetadata($io, $fileId, $options);
+
     // Add a relation between this $io and the AIP record
     $io = $this->addAipRelation($io, $this->aip);
+
+    return $io;
+  }
+
+  /**
+   * Add metadata related to the preservation system
+   *
+   * @param QubitInformationObject $io target information object
+   * @param string $fileId METS FILEID
+   * @param array $options list of options to pass to QubitProperty
+   *
+   * @return QubitInformationObject with added metadata
+   */
+  protected function addPreservationSystemMetadata($io, $fileId, $options)
+  {
+    $io->addProperty(
+      'originalFileName',
+      $this->metsParser->getOriginalFilename($fileId),
+      $options
+    );
+    $io->addProperty(
+      'originalFileSize',
+      $this->metsParser->getOriginalFileSize($fileId),
+      $options
+    );
+    $io->addProperty(
+      'originalFileIngestedAt',
+      $this->metsParser->getOriginalFileIngestionTime($fileId),
+      $options
+    );
+    $io->addProperty(
+      'preservationCopyFileName',
+      $this->metsParser->getPreservationCopyFilename($fileId),
+      $options
+    );
+    $io->addProperty(
+      'preservationCopyFileSize',
+      $this->metsParser->getPreservationCopyFileSize($fileId),
+      $options
+    );
+    $io->addProperty(
+      'preservationCopyNormalizedAt',
+      $this->metsParser->getPreservationCopyCreationTime($fileId),
+      $options
+    );
 
     return $io;
   }

--- a/plugins/sfDcPlugin/modules/sfDcPlugin/config/view.yml
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/config/view.yml
@@ -23,6 +23,9 @@ indexSuccess:
   stylesheets:
     /vendor/imageflow/imageflow.packed.css: { position: first }
   javascripts:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/jquery.once.js:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/collapse:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/form:
     /vendor/imageflow/imageflow.packed.js:
     blank:
     imageflow:

--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/config/view.yml
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/config/view.yml
@@ -13,5 +13,8 @@ editSuccess:
 
 indexSuccess:
   javascripts:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/jquery.once.js:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/collapse:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/form:
     /js/sidebarPaginatedList:
     blank:

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/config/view.yml
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/config/view.yml
@@ -29,6 +29,9 @@ indexSuccess:
   stylesheets:
     /vendor/imageflow/imageflow.packed.css: { position: first }
   javascripts:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/jquery.once.js:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/collapse:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/form:
     /vendor/imageflow/imageflow.packed.js:
     blank:
     imageflow:

--- a/plugins/sfModsPlugin/modules/sfModsPlugin/config/view.yml
+++ b/plugins/sfModsPlugin/modules/sfModsPlugin/config/view.yml
@@ -23,6 +23,9 @@ indexSuccess:
   stylesheets:
     /vendor/imageflow/imageflow.packed.css: { position: first }
   javascripts:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/jquery.once.js:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/collapse:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/form:
     /vendor/imageflow/imageflow.packed.js:
     blank:
     imageflow:

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/config/view.yml
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/config/view.yml
@@ -25,6 +25,9 @@ indexSuccess:
   stylesheets:
     /vendor/imageflow/imageflow.packed.css: { position: first }
   javascripts:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/jquery.once.js:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/collapse:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/form:
     /vendor/imageflow/imageflow.packed.js:
     blank:
     imageflow:


### PR DESCRIPTION
This updates the `Digital object metadata` section of the index views with two collapsible fieldsets that look like this:

![Screenshot_2020-08-27 Beihai, Guanxi, China, 1988 - Demo site](https://user-images.githubusercontent.com/560781/91482833-efc08780-e863-11ea-9cfa-9a3139b316f4.png)

The rest of the changes include:

* New properties have been added to information objects to store METS information about the original and preservation files.
* New visibility settings have been added to control what fields are displayed in the new areas.
* A new preservation system access statement setting has been added (similar to the copyright statement) to show a message to unauthenticated users on how to get access to the preservation copies