### PR TITLE
Fix METS format metadata on DIP upload, refs #13401

### DIFF
--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 187
+    value: 188
   milestone:
     name: milestone
     editable: 0

--- a/lib/QubitMetsParser.class.php
+++ b/lib/QubitMetsParser.class.php
@@ -929,28 +929,28 @@ class QubitMetsParser
     $format = array();
 
     $fields = array(
-      'name' => array(
+      'formatName' => array(
         'xpath' => $this->objectXpath.'p:objectCharacteristics/p:format/p:formatDesignation/p:formatName',
         'type' => 'string'),
-      'version' => array(
+      'formatVersion' => array(
         'xpath' => $this->objectXpath.'p:objectCharacteristics/p:format/p:formatDesignation/p:formatVersion',
         'type' => 'string'),
-      'registryName' => array(
+      'formatRegistryName' => array(
         'xpath' => $this->objectXpath.'p:objectCharacteristics/p:format/p:formatRegistry/p:formatRegistryName',
         'type' => 'string'),
-      'registryKey' => array(
+      'formatRegistryKey' => array(
         'xpath' => $this->objectXpath.'p:objectCharacteristics/p:format/p:formatRegistry/p:formatRegistryKey',
         'type' => 'string'));
 
     foreach ($fields as $fieldName => $options)
     {
       // Allow empty values in format data
-      $format[$fieldName] = $value = $this->getFieldValue($this->document, $options['xpath'], $options['type']);
-    }
-
-    if (!empty($format))
-    {
-      QubitProperty::addUnique($this->resource->id, 'format', serialize($format), array('scope' => 'premisData', 'indexOnSave' => false));
+      QubitProperty::addUnique(
+        $this->resource->id,
+        $fieldName,
+        $this->getFieldValue($this->document, $options['xpath'], $options['type']),
+        array('scope' => 'premisData', 'indexOnSave' => false)
+      );
     }
   }
 

--- a/lib/task/migrate/migrations/arMigration0188.class.php
+++ b/lib/task/migrate/migrations/arMigration0188.class.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add separate properties for existing serialized DO format information.
+ * The names of the new properties match what is expected by QubitInformationObject.
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0188
+{
+  const
+    VERSION = 188, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  public function up($configuration)
+  {
+    // This maps existing names to the ones expected by QubitInformationObject
+    $propertyNamesMap = array(
+      'name' => 'formatName',
+      'version' => 'formatVersion',
+      'registryName' => 'formatRegistryName',
+      'registryKey' => 'formatRegistryKey'
+    );
+
+    // Criteria for getting all the QubitProperty objects with format metadata
+    $propertyName = 'format';
+    $propertyScope = 'premisData';
+    $criteria = new Criteria;
+    $criteria->add(QubitProperty::NAME, $propertyName);
+    $criteria->add(QubitProperty::SCOPE, $propertyScope);
+
+    // Traverse all the existing QubitProperty objects and:
+    //   1. Unserialize their value
+    //   2. Create new properties using the updated names
+    //   3. Delete the existing property
+    foreach (QubitProperty::get($criteria) as $property)
+    {
+      if (null !== $value = $property->getValue(array('sourceCulture' => true)))
+      {
+        $data = unserialize($value);
+        if (is_array($data))
+        {
+          $objectId = $property->getObject()->id;
+          foreach ($propertyNamesMap as $oldName => $newName)
+          {
+            if (array_key_exists($oldName, $data))
+            {
+              QubitProperty::addUnique(
+                $objectId,
+                $newName,
+                $data[$oldName],
+                array('scope' => $propertyScope, 'indexOnSave' => false)
+              );
+            }
+          }
+        }
+      }
+
+      // Always delete the existing property
+      $property->indexOnDelete = false;
+      $property->delete();
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
This converts the serialized `format` QubitProperty that stores METS
format metadata into separate QubitProperty objects with the name
expected by QubitObjectInformation.

A new migration has also been added to update and delete existing
properties.