### PR TITLE
Stop index update on uploadLimit save, refs #13412

### DIFF
--- a/apps/qubit/modules/repository/actions/editUploadLimitAction.class.php
+++ b/apps/qubit/modules/repository/actions/editUploadLimitAction.class.php
@@ -52,6 +52,9 @@ class RepositoryEditUploadLimitAction extends sfAction
         break;
     }
 
+    // Don't update the repository search index document
+    $this->resource->indexOnSave = false;
+
     $this->resource->save();
   }
 }

--- a/lib/model/QubitRepository.php
+++ b/lib/model/QubitRepository.php
@@ -114,11 +114,24 @@ class QubitRepository extends BaseRepository
   {
     parent::save($connection);
 
+    if ($this->indexOnSave)
+    {
+      $this->updateSearchIndex();
+    }
+
+    return $this;
+  }
+
+  public function updateSearchIndex()
+  {
     QubitSearch::getInstance()->update($this);
 
     // Trigger updating of associated information objects, if any
     $operationDescription = sfContext::getInstance()->i18n->__('updated');
-    $this->updateInformationObjects($this->getRelatedInformationObjectIds(), $operationDescription);
+    $this->updateInformationObjects(
+      $this->getRelatedInformationObjectIds(),
+      $operationDescription
+    );
 
     // Remove adv. search repository options from cache
     QubitCache::getInstance()->removePattern('search:list-of-repositories:*');


### PR DESCRIPTION
- In `QubitRepository::save()` only update search index if `$indexOnSave` is true
- In `RepositoryEditUploadLimitAction` set `$indexOnSave` to false before saving
  `QubitRepository` changes