### PR TITLE
Add repo upload limits setting, refs #13411

### DIFF
--- a/apps/qubit/modules/repository/actions/contextMenuComponent.class.php
+++ b/apps/qubit/modules/repository/actions/contextMenuComponent.class.php
@@ -21,12 +21,15 @@ class RepositoryContextMenuComponent extends sfComponent
 {
   public function execute($request)
   {
-    if (!isset($request->getAttribute('sf_route')->resource))
+    $this->resource = $request->getAttribute('sf_route')->resource;
+
+    if (null === $this->resource)
     {
       return sfView::NONE;
     }
 
-    $this->resource = $request->getAttribute('sf_route')->resource;
+    // Get resource class here because in the template get_class($resource)
+    // returns the symfony decorator class
     $this->class = get_class($this->resource);
   }
 }

--- a/apps/qubit/modules/repository/actions/uploadLimitComponent.class.php
+++ b/apps/qubit/modules/repository/actions/uploadLimitComponent.class.php
@@ -21,6 +21,12 @@ class RepositoryUploadLimitComponent extends sfComponent
 {
   public function execute($request)
   {
+    // If repository quotas are disabled, don't show this component
+    if (!sfConfig::get('app_enable_repository_quotas', true))
+    {
+      return sfView::NONE;
+    }
+
     $this->resource = $request->getAttribute('sf_route')->resource;
 
     if (isset($this->resource) && 'QubitInformationObject' == get_class($this->resource))
@@ -28,12 +34,7 @@ class RepositoryUploadLimitComponent extends sfComponent
       $this->resource = $this->resource->getRepository(array('inherit' => true));
     }
 
-    if (!isset($this->resource))
-    {
-      return sfView::NONE;
-    }
-
-    if (!$this->getUser()->isAuthenticated())
+    if (!isset($this->resource) || !QubitAcl::check($this->resource, 'update'))
     {
       return sfView::NONE;
     }

--- a/apps/qubit/modules/repository/templates/_contextMenu.php
+++ b/apps/qubit/modules/repository/templates/_contextMenu.php
@@ -1,18 +1,19 @@
-<?php if (isset($resource) && ($class === 'QubitRepository') && sfConfig::get('app_enable_institutional_scoping')): ?>
-  <?php include_component('repository', 'holdingsInstitution', array('resource' => $resource)) ?>
-  <?php include_component('repository', 'holdingsList', array('resource' => $resource)) ?>
-  <?php if (QubitAcl::check($resource, 'update')): ?>
-    <?php include_component('repository', 'uploadLimit', array('resource' => $resource)) ?>
-  <?php endif; ?>
+<?php
+  // If $resource is not a repository, just show the repository logo
+  if ($class !== 'QubitRepository'):
+?>
+  <?php include_component('repository', 'logo') ?>
 <?php else: ?>
-  <?php echo get_component('repository', 'logo') ?>
 
-  <?php if ($class === 'QubitRepository'): ?>
-    <?php if (QubitAcl::check($resource, 'update')): ?>
-      <?php include_component('repository', 'uploadLimit', array('resource' => $resource)) ?>
-    <?php endif; ?>
-
+  <?php if (sfConfig::get('app_enable_institutional_scoping')): ?>
+    <?php include_component('repository', 'holdingsInstitution', array('resource' => $resource)) ?>
+    <?php include_component('repository', 'holdingsList', array('resource' => $resource)) ?>
+    <?php include_component('repository', 'uploadLimit', array('resource' => $resource)) ?>
+  <?php else: ?>
+    <?php include_component('repository', 'logo') ?>
+    <?php include_component('repository', 'uploadLimit', array('resource' => $resource)) ?>
     <?php include_component('repository', 'holdings', array('resource' => $resource)) ?>
     <?php include_component('repository', 'holdingsList', array('resource' => $resource)) ?>
-  <?php endif; ?>
-<?php endif; ?>
+  <?php endif; // sfConfig::get('app_enable_institutional_scoping') ?>
+
+<?php endif; // $class !== 'QubitRepository' ?>

--- a/apps/qubit/modules/settings/actions/globalAction.class.php
+++ b/apps/qubit/modules/settings/actions/globalAction.class.php
@@ -83,9 +83,7 @@ class SettingsGlobalAction extends sfAction
     $defaultRepositoryView = QubitSetting::getByName('default_repository_browse_view');
     $defaultArchivalDescriptionView = QubitSetting::getByName('default_archival_description_browse_view');
     $multiRepository = QubitSetting::getByName('multi_repository');
-    $repositoryQuota = QubitSetting::getByName('repository_quota');
     $auditLogEnabled = QubitSetting::getByName('audit_log_enabled');
-    $explodeMultipageFiles = QubitSetting::getByName('explode_multipage_files');
     $showTooltips = QubitSetting::getByName('show_tooltips');
     $defaultPubStatus = QubitSetting::getByName('defaultPubStatus');
     $draftNotificationEnabled = QubitSetting::getByName('draft_notification_enabled');
@@ -108,9 +106,7 @@ class SettingsGlobalAction extends sfAction
       'default_repository_browse_view' => (isset($defaultRepositoryView)) ? $defaultRepositoryView->getValue(array('sourceCulture' => true)) : 'card',
       'default_archival_description_browse_view' => (isset($defaultArchivalDescriptionView)) ? $defaultArchivalDescriptionView->getValue(array('sourceCulture' => true)) : 'table',
       'multi_repository' => (isset($multiRepository)) ? intval($multiRepository->getValue(array('sourceCulture'=>true))) : 1,
-      'repository_quota' => (isset($repositoryQuota)) ? $repositoryQuota->getValue(array('sourceCulture'=>true)) : 0,
       'audit_log_enabled' => (isset($auditLogEnabled)) ? intval($auditLogEnabled->getValue(array('sourceCulture'=>true))) : 0,
-      'explode_multipage_files' => (isset($explodeMultipageFiles)) ? intval($explodeMultipageFiles->getValue(array('sourceCulture'=>true))) : 1,
       'slug_basis_informationobject' => (isset($slugTypeInformationObject)) ? intval($slugTypeInformationObject->getValue(array('sourceCulture'=>true))) : QubitSlug::SLUG_BASIS_TITLE,
       'permissive_slug_creation' => (isset($permissiveSlugCreation)) ? intval($permissiveSlugCreation->getValue(array('sourceCulture'=>true))) : QubitSlug::SLUG_RESTRICTIVE,
       'show_tooltips' => (isset($showTooltips)) ? intval($showTooltips->getValue(array('sourceCulture'=>true))) : 1,
@@ -228,23 +224,6 @@ class SettingsGlobalAction extends sfAction
       $setting->save();
     }
 
-    // Repository upload quota
-    if (null !== $multiRepositoryValue = $thisForm->getValue('repository_quota'))
-    {
-      $setting = QubitSetting::getByName('repository_quota');
-
-      // Add setting if it's not already in the sampleData.yml file for
-      // backwards compatiblity with v1.0.3 sampleData.yml file
-      if (null === $setting)
-      {
-        $setting = QubitSetting::createNewSetting('repository_quota', null, array('deleteable'=>false));
-      }
-
-      // Force sourceCulture update to prevent discrepency in settings between cultures
-      $setting->setValue($multiRepositoryValue, array('sourceCulture'=>true));
-      $setting->save();
-    }
-
     // Audit log enabled
     if (null !== $auditLogEnabled = $thisForm->getValue('audit_log_enabled'))
     {
@@ -256,16 +235,6 @@ class SettingsGlobalAction extends sfAction
 
       // Force sourceCulture update to prevent discrepency in settings between cultures
       $setting->setValue($auditLogEnabled, array('sourceCulture' => true));
-      $setting->save();
-    }
-
-    // Upload multi-page files as multiple descriptions
-    if (null !== $explodeMultipageFiles = $thisForm->getValue('explode_multipage_files'))
-    {
-      $setting = QubitSetting::getByName('explode_multipage_files');
-
-      // Force sourceCulture update to prevent discrepency in settings between cultures
-      $setting->setValue($explodeMultipageFiles, array('sourceCulture' => true));
       $setting->save();
     }
 

--- a/apps/qubit/modules/settings/actions/menuComponent.class.php
+++ b/apps/qubit/modules/settings/actions/menuComponent.class.php
@@ -24,12 +24,8 @@ class SettingsMenuComponent extends sfComponent
     $i18n = $this->context->i18n;
     $this->nodes = array(
       array(
-        'label' => $i18n->__('Global'),
-        'action' => 'global'
-      ),
-      array(
-        'label' => $i18n->__('Site information'),
-        'action' => 'siteInformation'
+        'label' => $i18n->__('Clipboard'),
+        'action' => 'clipboard'
       ),
       array(
         'label' => $i18n->__('Default page elements'),
@@ -40,8 +36,20 @@ class SettingsMenuComponent extends sfComponent
         'action' => 'template'
       ),
       array(
-        'label' => $i18n->__('User interface labels'),
-        'action' => 'interfaceLabel'
+        'label' => $i18n->__('Digital object derivatives'),
+        'action' => 'digitalObjectDerivatives'
+      ),
+      array(
+        'label' => $i18n->__('DIP upload'),
+        'action' => 'dipUpload'
+      ),
+      array(
+        'label' => $i18n->__('Finding Aid'),
+        'action' => 'findingAid'
+      ),
+      array(
+        'label' => $i18n->__('Global'),
+        'action' => 'global'
       ),
       array(
         'label' => $i18n->__('I18n languages'),
@@ -52,49 +60,39 @@ class SettingsMenuComponent extends sfComponent
         'action' => 'identifier'
       ),
       array(
-        'label' => $i18n->__('OAI repository'),
-        'action' => 'oai',
-        'hide' => !$this->context->getConfiguration()->isPluginEnabled('arOaiPlugin')
-      ),
-      array(
-        'label' => $i18n->__('Finding Aid'),
-        'action' => 'findingAid'
-      ),
-      array(
-        'label' => $i18n->__('Security'),
-        'action' => 'security'
-      ),
-      array(
-        'label' => $i18n->__('Permissions'),
-        'action' => 'permissions'
-      ),
-      array(
         'label' => $i18n->__('Inventory'),
         'action' => 'inventory'
       ),
+      // Only show LDAP authentication settings if LDAP authentication's used
       array(
-        'label' => $i18n->__('Digital object derivatives'),
-        'action' => 'digitalObjectDerivatives'
-      ),
-      array(
-        'label' => $i18n->__('DIP upload'),
-        'action' => 'dipUpload'
-      ),
-      array(
-        'label' => $i18n->__('Treeview'),
-        'action' => 'treeview'
+        'label' => $i18n->__('LDAP Authentication'),
+        'action' => 'ldap',
+        'hide' => !($this->context->user instanceof ldapUser)
       ),
       array(
         'label' => $i18n->__('Markdown'),
         'action' => 'markdown'
       ),
       array(
+        'label' => $i18n->__('OAI repository'),
+        'action' => 'oai',
+        'hide' => !$this->context->getConfiguration()->isPluginEnabled('arOaiPlugin')
+      ),
+      array(
+        'label' => $i18n->__('Permissions'),
+        'action' => 'permissions'
+      ),
+      array(
         'label' => $i18n->__('Privacy Notification'),
         'action' => 'privacyNotification'
       ),
       array(
-        'label' => $i18n->__('Clipboard'),
-        'action' => 'clipboard'
+        'label' => $i18n->__('Security'),
+        'action' => 'security'
+      ),
+      array(
+        'label' => $i18n->__('Site information'),
+        'action' => 'siteInformation'
       ),
       array(
         'label' => $i18n->__('Storage service'),
@@ -103,17 +101,20 @@ class SettingsMenuComponent extends sfComponent
         'hide' => !$this->context->getConfiguration()->isPluginEnabled(
           'arStorageServicePlugin'
         )
-      )
+      ),
+      array(
+        'label' => $i18n->__('Treeview'),
+        'action' => 'treeview'
+      ),
+      array(
+        'label' => $i18n->__('Uploads'),
+        'action' => 'uploads'
+      ),
+      array(
+        'label' => $i18n->__('User interface labels'),
+        'action' => 'interfaceLabel'
+      ),
     );
-
-    // Only show LDAP authentication settings if LDAP authentication's used
-    if ($this->context->user instanceof ldapUser)
-    {
-      array_push($this->nodes, array(
-        'label' => $i18n->__('LDAP Authentication'),
-        'action' => 'ldap'
-      ));
-    }
 
     foreach ($this->nodes as $i => &$node)
     {

--- a/apps/qubit/modules/settings/actions/uploadsAction.class.php
+++ b/apps/qubit/modules/settings/actions/uploadsAction.class.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class SettingsUploadsAction extends SettingsEditAction
+{
+  // Arrays not allowed in class constants
+  public static $NAMES = [
+    'enable_repository_quotas',
+    'explode_multipage_files',
+    'repository_quota',
+    'upload_quota',
+  ];
+
+  public function earlyExecute()
+  {
+    parent::earlyExecute();
+
+    $this->updateMessage = $this->i18n->__('Uploads settings saved.');
+
+    $this->settingDefaults = [
+      'enable_repository_quotas' => 1,
+      'explode_multipage_files' => 0,
+      'repository_quota' => 0,
+      'upload_quota' => -1,
+    ];
+
+    // Set form decorator
+    $this->form->getWidgetSchema()->addFormFormatter(
+      'list',
+      new QubitWidgetFormSchemaFormatterList($this->form->getWidgetSchema())
+    );
+    $this->form->getWidgetSchema()->setFormFormatterName('list');
+  }
+
+  protected function addField($name)
+  {
+    // Set form field format
+    switch ($name)
+    {
+      case 'enable_repository_quotas':
+        $this->form->setValidator($name, new sfValidatorBoolean(
+          ['required' => true]
+        ));
+        $this->form->setWidget($name, new sfWidgetFormSelectRadio(
+          ['choices' => [
+            0 => $this->i18n->__('Disabled'), 1 => $this->i18n->__('Enabled')
+          ]],
+          ['class' => 'radio']
+        ));
+
+        break;
+
+      case 'explode_multipage_files':
+        $this->form->setValidator($name, new sfValidatorBoolean(
+          ['required' => true]
+        ));
+        $this->form->setWidget($name, new sfWidgetFormSelectRadio(
+          ['choices' => [
+            0 => $this->i18n->__('No'), 1 => $this->i18n->__('Yes')
+          ]],
+          ['class' => 'radio']
+        ));
+
+        break;
+
+      case 'repository_quota':
+        $this->form->setValidator($name, new sfValidatorNumber(
+          ['required' => true, 'min' => -1],
+          ['min' => $this->i18n->__('Minimum value is "%min%"')]
+        ));
+        $this->form->setWidget($name, new sfWidgetFormInput);
+
+        break;
+
+      case 'upload_quota':
+        // No validator, because the global quota is set via config file
+        // and can't be changed in the UI
+        $this->form->setWidget($name, new arWidgetFormUploadQuota);
+
+        break;
+    }
+  }
+}

--- a/apps/qubit/modules/settings/templates/uploadsSuccess.php
+++ b/apps/qubit/modules/settings/templates/uploadsSuccess.php
@@ -1,0 +1,99 @@
+<?php decorate_with('layout_2col.php') ?>
+
+<?php slot('sidebar') ?>
+
+  <?php echo get_component('settings', 'menu') ?>
+
+<?php end_slot() ?>
+
+<?php slot('title') ?>
+
+  <h1><?php echo __('Uploads settings') ?></h1>
+
+<?php end_slot() ?>
+
+<?php slot('content') ?>
+
+  <?php echo $form->renderFormTag(url_for(
+    ['module' => 'settings', 'action' => 'uploads']
+  )) ?>
+
+    <div id="content">
+
+      <table class="table sticky-enabled">
+        <thead>
+          <tr>
+            <th><?php echo __('Name')?></th>
+            <th><?php echo __('Value')?></th>
+          </tr>
+        </thead>
+
+        <tbody>
+
+          <?php echo $form
+            ->upload_quota
+            ->label(__('Total space available for uploads'))
+            ->renderRow()
+          ?>
+
+          <?php echo $form
+            ->enable_repository_quotas
+            ->label(
+                __('%1% upload limits',
+                [
+                  '%1%' => sfConfig::get('app_ui_label_repository')
+                ]
+              ))
+              ->help(__(
+                'When enabled, an &quot;Upload limit&quot; meter is displayed'
+                . ' for authenticated users on the %1% view page, and'
+                . ' administrators can limit the disk space each %1% is allowed'
+                . ' for %2% uploads',
+                [
+                  '%1%' => strtolower(sfConfig::get('app_ui_label_repository')),
+                  '%2%' => strtolower(sfConfig::get('app_ui_label_digitalobject')),
+                ]
+              ))
+            ->renderRow()
+          ?>
+
+          <?php echo $form
+            ->repository_quota
+            ->label(__(
+              'Default %1% upload limit (GB)',
+              ['%1%' => strtolower(sfConfig::get('app_ui_label_repository'))]
+            ))
+            ->help(__(
+                'Default %1% upload limit for a new %2%.  A value of &quot;0'
+                . '&quot; (zero) disables file upload.  A value of &quot;-1'
+                . '&quot; allows unlimited uploads',
+                [
+                  '%1%' => strtolower(sfConfig::get('app_ui_label_digitalobject')),
+                  '%2%' => strtolower(sfConfig::get('app_ui_label_repository'))
+                ]
+              ))
+            ->renderRow()
+          ?>
+
+          <?php echo $form
+            ->explode_multipage_files
+            ->label(__('Upload multi-page files as multiple descriptions'))
+            ->renderRow()
+          ?>
+
+        </tbody>
+      </table>
+
+    </div>
+
+    <section class="actions">
+      <ul>
+        <li>
+          <input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Save') ?>"/>
+        </li>
+      </ul>
+    </section>
+
+  </form>
+
+<?php end_slot() ?>

--- a/lib/form/SettingsGlobalForm.class.php
+++ b/lib/form/SettingsGlobalForm.class.php
@@ -46,10 +46,7 @@ class SettingsGlobalForm extends sfForm
       'default_archival_description_browse_view' => new sfWidgetFormSelectRadio(array('choices' => array('card' => $this->i18n->__('card'), 'table' => $this->i18n->__('table'))), array('class' => 'radio')),
       'multi_repository' => new sfWidgetFormSelectRadio(array('choices' => array(1 => 'yes', 0 => 'no')), array('class' => 'radio')),
       'enable_institutional_scoping' => new sfWidgetFormSelectRadio(array('choices'=>array(1=>'yes', 0=>'no')), array('class'=>'radio')),
-      'repository_quota' => new sfWidgetFormInput,
-      'upload_quota' => new arWidgetFormUploadQuota,
       'audit_log_enabled' => new sfWidgetFormSelectRadio(array('choices' => array(1 => 'yes', 0 => 'no')), array('class' => 'radio')),
-      'explode_multipage_files' => new sfWidgetFormSelectRadio(array('choices' => array(1 => 'yes', 0 => 'no')), array('class' => 'radio')),
       'show_tooltips' => new sfWidgetFormSelectRadio(array('choices' => array(1 => 'yes', 0 => 'no')), array('class' => 'radio')),
       'slug_basis_informationobject' => $this->getSlugBasisInformationObjectWidget(),
       'permissive_slug_creation' => new sfWidgetFormSelectRadio(array('choices' => array(QubitSlug::SLUG_PERMISSIVE => 'yes', QubitSlug::SLUG_RESTRICTIVE => 'no')), array('class' => 'radio')),
@@ -73,10 +70,7 @@ class SettingsGlobalForm extends sfForm
       'default_archival_description_browse_view' => $this->i18n->__('Default archival description browse view'),
       'multi_repository' => $this->i18n->__('Multiple repositories'),
       'enable_institutional_scoping' => $this->i18n->__('Enable institutional scoping'),
-      'repository_quota' => $this->i18n->__('Default %1% upload limit (GB)', array('%1%' => strtolower(sfConfig::get('app_ui_label_repository')))),
-      'upload_quota' => $this->i18n->__('Total space available for uploads'),
       'audit_log_enabled' => $this->i18n->__('Enable description change logging'),
-      'explode_multipage_files' => $this->i18n->__('Upload multi-page files as multiple descriptions'),
       'show_tooltips' => $this->i18n->__('Show tooltips'),
       'defaultPubStatus' => $this->i18n->__('Default publication status'),
       'draft_notification_enabled' => $this->i18n->__('Show available drafts notification upon user login'),
@@ -102,12 +96,10 @@ class SettingsGlobalForm extends sfForm
       'escape_queries' => $this->i18n->__('A list of special chars, separated by coma, to be escaped in string queries'),
       'multi_repository' => $this->i18n->__('When set to &quot;no&quot;, the repository name is excluded from certain displays because it will be too repetitive'),
       'enable_institutional_scoping' => $this->i18n->__('Applies to multi-repository sites only. When set to &quot;yes&quot;, additional search and browse options will be available at the repository level'),
-      'repository_quota' => $this->i18n->__('Default %1% upload limit for a new %2%.  A value of &quot;0&quot; (zero) disables file upload.  A value of &quot;-1&quot; allows unlimited uploads', array('%1%' => strtolower(sfConfig::get('app_ui_label_digitalobject')), '%2%' => strtolower(sfConfig::get('app_ui_label_repository')))),
       'defaultPubStatus' => $this->i18n->__('Default publication status for newly created or imported %1%', array('%1%' => sfConfig::get('app_ui_label_informationobject'))),
       'slug_basis_informationobject' => $this->i18n->__('Choose whether permalinks for descriptions are generated from reference code or title'),
       'permissive_slug_creation' => $this->i18n->__('Allow any valid URI PATH segment character to appear in a slug, including UTF-8 glyphs. Restricted IRI characters ( /?#{} ) and literal spaces will be replaced with dashes'),
       'audit_log_enabled' => $this->i18n->__('Log creation and change of descriptions'),
-      // 'explode_multipage_files' => $this->i18n->__('')
       // 'show_tooltips' => $this->i18n->__('')
       // 'sword_deposit_dir' => $this->i18n->__('')
     ));
@@ -137,11 +129,7 @@ class SettingsGlobalForm extends sfForm
     $this->validatorSchema['default_archival_description_browse_view'] = new sfValidatorString(array('required' => false));
     $this->validatorSchema['slug_basis_informationobject'] = $this->getSlugBasisInformationObjectValidator();
     $this->validatorSchema['permissive_slug_creation'] = new sfValidatorInteger(array('required' => false));
-    $this->validatorSchema['repository_quota'] = new sfValidatorNumber(
-      array('required' => true, 'min' => -1),
-      array('min' => $this->i18n->__('Minimum value is "%min%"')));
     $this->validatorSchema['audit_log_enabled'] = new sfValidatorInteger(array('required' => false));
-    $this->validatorSchema['explode_multipage_files'] = new sfValidatorInteger(array('required' => false));
     $this->validatorSchema['show_tooltips'] = new sfValidatorInteger(array('required' => false));
     $this->validatorSchema['defaultPubStatus'] = new sfValidatorChoice(array('choices' => array(QubitTerm::PUBLICATION_STATUS_DRAFT_ID, QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID)));
     $this->validatorSchema['draft_notification_enabled'] = new sfValidatorInteger(array('required' => false));

--- a/lib/form/arWidgetFormUploadQuota.class.php
+++ b/lib/form/arWidgetFormUploadQuota.class.php
@@ -26,7 +26,7 @@ class arWidgetFormUploadQuota extends sfWidgetFormInput
 
   public function render($name, $value = null, $attributes = array(), $errors = array())
   {
-    $uploadLimit = (int)sfConfig::get('app_upload_limit');
+    $uploadLimit = (int) sfConfig::get('app_upload_limit');
 
     if ($uploadLimit === 0)
     {


### PR DESCRIPTION
- Create a new "Uploads" setting page, and move three existing settings
  from the "Global" page
- Add a setting to allow disabling per repository "Upload limits"
- Don't load the "Upload limits" component when it is disabled in the
  settings
- Move the QubitAcl check for displaying the `uploadLimit` component
  from the `_contextMenu.php` template to the `uploadLimit` controller
- Cosmetic: Sort settings menu array alphabetically by label
- Add additional comments