### PR TITLE
Remove user admin options for CAS, refs #13413

### DIFF
--- a/plugins/arCasPlugin/modules/user/actions/editAction.class.php
+++ b/plugins/arCasPlugin/modules/user/actions/editAction.class.php
@@ -1,0 +1,315 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class UserEditAction extends DefaultEditAction
+{
+  // Arrays not allowed in class constants
+  public static
+    $NAMES = array(
+      'active',
+      'groups',
+      'translate',
+      'restApiKey',
+      'oaiApiKey');
+
+  protected function earlyExecute()
+  {
+    $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
+
+    $this->resource = new QubitUser;
+    if (isset($this->getRoute()->resource))
+    {
+      $this->resource = $this->getRoute()->resource;
+    }
+
+    // HACK: because $this->user->getAclPermissions() is erroneously calling
+    // QubitObject::getaclPermissionsById()
+    $this->permissions = null;
+    if (isset($this->resource->id))
+    {
+      $permissions = QubitUser::getaclPermissionsById($this->resource->id, array('self' => $this))->orderBy('constants')->orderBy('object_id');
+
+      foreach ($permissions as $item)
+      {
+        $repository = $item->getConstants(array('name' => 'repository'));
+        $this->permissions[$repository][$item->objectId][$item->action] = $item->grantDeny;
+      }
+    }
+
+    // List of actions without translate
+    $this->basicActions = QubitInformationObjectAcl::$ACTIONS;
+    unset($this->basicActions['translate']);
+  }
+
+  protected function addField($name)
+  {
+    switch ($name)
+    {
+      case 'active':
+        if (isset($this->resource->id))
+        {
+          $this->form->setDefault('active', (bool)$this->resource->active);
+        }
+        else
+        {
+          $this->form->setDefault('active', true);
+        }
+
+
+        $this->form->setValidator('active', new sfValidatorBoolean);
+        $this->form->setWidget('active', new sfWidgetFormInputCheckbox);
+
+        break;
+
+      case 'groups':
+        $values = array();
+        $criteria = new Criteria;
+        $criteria->add(QubitAclUserGroup::USER_ID, $this->resource->id);
+        foreach (QubitAclUserGroup::get($criteria) as $item)
+        {
+          $values[] = $item->groupId;
+        }
+
+        $choices = array();
+        $criteria = new Criteria;
+        $criteria->add(QubitAclGroup::ID, 99, Criteria::GREATER_THAN);
+        foreach (QubitAclGroup::get($criteria) as $item)
+        {
+          $choices[$item->id] = $item->getName(array('cultureFallback' => true));
+        }
+
+        $this->form->setDefault('groups', $values);
+        $this->form->setValidator('groups', new sfValidatorPass);
+        $this->form->setWidget('groups', new sfWidgetFormSelect(array('choices' => $choices, 'multiple' => true)));
+
+        break;
+
+      case 'translate':
+        $c = sfCultureInfo::getInstance($this->context->user->getCulture());
+        $languages = $c->getLanguages();
+        $choices = array();
+
+        foreach (sfConfig::get('app_i18n_languages') as $item)
+        {
+          $choices[$item] = $languages[$item];
+        }
+
+        // Find existing translate permissions
+        $criteria = new Criteria;
+        $criteria->add(QubitAclPermission::USER_ID, $this->resource->id);
+        $criteria->add(QubitAclPermission::ACTION, 'translate');
+
+        $defaults = null;
+        if (null !== $permission = QubitAclPermission::getOne($criteria))
+        {
+          $defaults = $permission->getConstants(array('name' => 'languages'));
+        }
+
+        $this->form->setDefault('translate', $defaults);
+        $this->form->setValidator('translate', new sfValidatorPass);
+        $this->form->setWidget('translate', new sfWidgetFormSelect(array('choices'  => $choices, 'multiple' => true)));
+
+        break;
+
+      case 'restApiKey':
+      case 'oaiApiKey':
+        // Give user option of (re)generating or deleting API key
+        $choices = array(
+          ''         => $this->context->i18n->__('-- Select action --'),
+          'generate' => $this->context->i18n->__('(Re)generate API key'),
+          'delete'   => $this->context->i18n->__('Delete API key')
+        );
+
+        $this->form->setValidator($name, new sfValidatorString());
+        $this->form->setWidget($name, new sfWidgetFormSelect(array('choices' => $choices)));
+
+        // Expose API key value to template if one exists
+        $apiKey = QubitProperty::getOneByObjectIdAndName($this->resource->id, sfInflector::camelize($name));
+        if (null != $apiKey)
+        {
+          $this->$name = $apiKey->value;
+        }
+
+        // Expose whether or not API is enabled
+        if ($name == 'oaiApiKey')
+        {
+          $this->oaiEnabled = $this->context->getConfiguration()->isPluginEnabled('arOaiPlugin');
+        }
+        else
+        {
+          $this->restEnabled = $this->context->getConfiguration()->isPluginEnabled('arRestApiPlugin');
+        }
+
+        break;
+    }
+  }
+
+  protected function processField($field)
+  {
+    switch ($name = $field->getName())
+    {
+      case 'active':
+        $this->resource->active = $this->form->getValue('active') ? true : false;
+
+        break;
+
+      case 'groups':
+        $newGroupIds = $formGroupIds = array();
+
+        if (null != ($groups = $this->form->getValue('groups')))
+        {
+          foreach ($groups as $item)
+          {
+            $newGroupIds[$item] = $formGroupIds[$item] = $item;
+          }
+        }
+        else
+        {
+          $newGroupIds = $formGroupIds = array();
+        }
+
+        // Don't re-add existing groups + delete exiting groups that are no longer
+        // in groups list
+        foreach ($this->resource->aclUserGroups as $item)
+        {
+          if (in_array($item->groupId, $formGroupIds))
+          {
+            unset($newGroupIds[$item->groupId]);
+          }
+          else
+          {
+            $item->delete();
+          }
+        }
+
+        foreach ($newGroupIds as $item)
+        {
+          $userGroup = new QubitAclUserGroup;
+          $userGroup->groupId = $item;
+
+          $this->resource->aclUserGroups[] = $userGroup;
+        }
+
+        break;
+
+      case 'restApiKey':
+      case 'oaiApiKey':
+        $keyAction = $this->form->getValue($name);
+        $apiKey = QubitProperty::getOneByObjectIdAndName($this->resource->id, sfInflector::camelize($name));
+
+        switch ($keyAction)
+        {
+          case 'generate':
+            // Create user OAI-PMH key property if it doesn't exist
+            if (null === $apiKey)
+            {
+              $apiKey = new QubitProperty;
+              $apiKey->name = sfInflector::camelize($name);
+            }
+
+            // Generate new OAI-PMH API key
+            $apiKey->value = bin2hex(openssl_random_pseudo_bytes(8));
+
+            if (!isset($apiKey->id))
+            {
+              $this->resource->propertys[] = $apiKey;
+            }
+            else
+            {
+              $apiKey->save();
+            }
+
+            break;
+
+          case 'delete':
+            // Delete user OAI-PMH key property if it exists
+            if (null != $apiKey)
+            {
+              $apiKey->delete();
+            }
+
+            break;
+        }
+
+        break;
+
+      default:
+        $this->resource[$name] = $this->form->getValue($name);
+    }
+  }
+
+  public function execute($request)
+  {
+    parent::execute($request);
+
+    if ($request->isMethod('post'))
+    {
+      $this->form->bind($request->getPostParameters());
+
+      if ($this->form->isValid())
+      {
+        if ($this->resource !== sfContext::getInstance()->getUser()->user)
+        {
+          $this->resource->active = 0;
+        }
+
+        $this->processForm();
+
+        $this->resource->save();
+
+        // Allowed languages for translation must be saved after the user is created
+        $languages = $this->form->getValue('translate');
+
+        $criteria = new Criteria;
+        $criteria->add(QubitAclPermission::USER_ID, $this->resource->id);
+        $criteria->addAnd(QubitAclPermission::USER_ID, null, Criteria::ISNOTNULL);
+        $criteria->add(QubitAclPermission::ACTION, 'translate');
+
+        if (null === $permission = QubitAclPermission::getOne($criteria))
+        {
+          $permission = new QubitAclPermission;
+          $permission->userId = $this->resource->id;
+          $permission->action = 'translate';
+          $permission->grantDeny = 1;
+          $permission->conditional = 'in_array(%p[language], %k[languages])';
+        }
+        else if (!is_array($languages))
+        {
+          // If $languages is not an array, then remove the translate permission
+          $permission->delete();
+        }
+
+        if (is_array($languages))
+        {
+          $permission->setConstants(array('languages' => $languages));
+          $permission->save();
+        }
+
+        if ($this->context->getViewCacheManager() !== null)
+        {
+          // We just need to remove the cache for this user but sf_cache_key
+          // contents also the culture code, it worth the try? I don't think so
+          $this->context->getViewCacheManager()->remove('@sf_cache_partial?module=menu&action=_mainMenu&sf_cache_key=*');
+        }
+
+        $this->redirect(array($this->resource, 'module' => 'user'));
+      }
+    }
+  }
+}

--- a/plugins/arCasPlugin/modules/user/templates/_showActions.php
+++ b/plugins/arCasPlugin/modules/user/templates/_showActions.php
@@ -1,0 +1,19 @@
+<section class="actions">
+
+  <ul>
+
+    <?php if (QubitAcl::check($resource, 'update')): ?>
+      <li><?php echo link_to (__('Edit'), array($resource, 'module' => 'user', 'action' => str_replace('index', 'edit', $sf_context->getActionName())), array('class' => 'c-btn')) ?></li>
+    <?php endif; ?>
+
+    <?php if ($sf_user->user != $resource && 0 == count($resource->notes) && QubitAcl::check($resource, 'delete')): ?>
+      <li><?php echo link_to (__('Delete'), array($resource, 'module' => 'user', 'action' => 'delete'), array('class' => 'c-btn c-btn-delete')) ?></li>
+    <?php endif; ?>
+    
+    <?php if (QubitAcl::check($resource, 'list')): ?>
+      <li><?php echo link_to (__('Return to user list'), array('module' => 'user', 'action' => 'list'), array('class' => 'c-btn')) ?></li>
+    <?php endif; ?>
+
+  </ul>
+
+</section>

--- a/plugins/arCasPlugin/modules/user/templates/editSuccess.php
+++ b/plugins/arCasPlugin/modules/user/templates/editSuccess.php
@@ -1,0 +1,73 @@
+<?php decorate_with('layout_1col.php') ?>
+<?php use_helper('Javascript') ?>
+
+<?php slot('title') ?>
+  <h1><?php echo __('User %1%', array('%1%' => render_title($resource))) ?></h1>
+<?php end_slot() ?>
+
+<?php slot('content') ?>
+
+  <?php echo $form->renderGlobalErrors(); ?>
+
+  <?php if (isset($sf_request->getAttribute('sf_route')->resource)): ?>
+    <?php echo $form->renderFormTag(url_for(array($resource, 'module' => 'user', 'action' => 'edit')), array('id' => 'editForm')) ?>
+  <?php else: ?>
+    <?php echo $form->renderFormTag(url_for(array('module' => 'user', 'action' => 'add')), array('id' => 'editForm')) ?>
+  <?php endif; ?>
+
+    <section id="content">
+
+      <?php if ($sf_user->user != $resource): ?>
+        <fieldset class="collapsible" id="basicInfo">
+
+          <legend><?php echo __('Basic info') ?></legend>
+          
+            <?php echo $form->active
+              ->label(__('Active'))
+              ->renderRow() ?>
+
+        </fieldset> <!-- /#basicInfo -->
+      <?php endif; ?>
+
+      <fieldset class="collapsible" id="groupsAndPermissions">
+
+        <legend><?php echo __('Access control')?></legend>
+
+        <?php echo $form->groups
+          ->label(__('User groups'))
+          ->renderRow(array('class' => 'form-autocomplete')) ?>
+
+        <?php echo $form->translate
+          ->label(__('Allowed languages for translation'))
+          ->renderRow(array('class' => 'form-autocomplete')) ?>
+
+        <?php if ($restEnabled): ?>
+          <?php echo $form->restApiKey
+            ->label(__('REST API access key'. ((isset($restApiKey)) ? ': <code>'. $restApiKey .'</code>' : '')))
+            ->renderRow() ?>
+        <?php endif; ?>
+
+        <?php if ($oaiEnabled): ?>
+          <?php echo $form->oaiApiKey
+            ->label(__('OAI-PMH API access key'. ((isset($oaiApiKey)) ? ': <code>'. $oaiApiKey .'</code>' : '')))
+            ->renderRow() ?>
+        <?php endif; ?>
+
+      </fieldset> <!-- /#groupsAndPermissions -->
+
+    </section>
+
+    <section class="actions">
+      <ul>
+        <?php if (isset($sf_request->getAttribute('sf_route')->resource)): ?>
+          <li><?php echo link_to(__('Cancel'), array($resource, 'module' => 'user'), array('class' => 'c-btn')) ?></li>
+          <li><input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Save') ?>"/></li>
+        <?php else: ?>
+          <li><?php echo link_to(__('Cancel'), array('module' => 'user', 'action' => 'list'), array('class' => 'c-btn')) ?></li>
+        <?php endif; ?>
+      </ul>
+    </section>
+
+  </form>
+
+<?php end_slot() ?>

--- a/plugins/arCasPlugin/modules/user/templates/indexSuccess.php
+++ b/plugins/arCasPlugin/modules/user/templates/indexSuccess.php
@@ -1,0 +1,119 @@
+<h1><?php echo __('User %1%', array('%1%' => render_title($resource))) ?></h1>
+
+<?php echo get_component('user', 'aclMenu') ?>
+
+<?php if (!$resource->active): ?>
+  <div class="messages error">
+    <ul>
+      <?php if (!$resource->active): ?>
+        <li><?php echo __('This user is inactive') ?></li>
+      <?php endif; ?>
+    </ul>
+  </div>
+<?php endif; ?>
+
+<section id="content">
+
+  <section id="userDetails">
+
+    <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('User details').'</h2>', array($resource, 'module' => 'user', 'action' => 'edit')) ?>
+
+    <?php echo render_show(__('User name'), render_value($resource->username.($sf_user->user === $resource ? ' ('.__('you').')' : ''))) ?>
+
+    <?php if (0 < count($groups = $resource->getAclGroups())): ?>
+      <div class="field">
+        <h3><?php echo __('User groups') ?></h3>
+        <div>
+          <ul>
+            <?php foreach ($groups as $item): ?>
+              <?php if (100 <= $item->id): ?>
+                <li><?php echo $item->__toString() ?></li>
+              <?php else: ?>
+                <li><span class="note2"><?php echo $item->__toString() ?></li>
+              <?php endif; ?>
+            <?php endforeach; ?>
+          </ul>
+        </div>
+      </div>
+    <?php endif; ?>
+
+    <?php if (sfConfig::get('app_multi_repository')): ?>
+      <?php if (0 < count($repositories = $resource->getRepositories())): ?>
+        <div class="field">
+          <h3><?php echo __('Repository affiliation') ?></h3>
+          <div>
+            <ul>
+              <?php foreach ($repositories as $item): ?>
+                <li><?php echo render_title($item) ?></li>
+              <?php endforeach; ?>
+            </ul>
+          </div>
+        </div>
+      <?php endif; ?>
+    <?php endif; ?>
+
+    <?php if ($sf_context->getConfiguration()->isPluginEnabled('arRestApiPlugin')): ?>
+      <div class="field">
+        <h3><?php echo __('REST API key') ?></h3>
+        <div>
+          <?php if (isset($restApiKey)): ?>
+            <code><?php echo $restApiKey ?></code>
+          <?php else: ?>
+            <?php echo __('Not generated yet.') ?>
+          <?php endif; ?>
+        </div>
+      </div>
+    <?php endif; ?>
+
+    <?php if ($sf_context->getConfiguration()->isPluginEnabled('arOaiPlugin')): ?>
+      <div class="field">
+        <h3><?php echo __('OAI-PMH API key') ?></h3>
+        <div>
+          <?php if (isset($oaiApiKey)): ?>
+            <code><?php echo $oaiApiKey ?></code>
+          <?php else: ?>
+            <?php echo __('Not generated yet.') ?>
+          <?php endif; ?>
+        </div>
+      </div>
+    <?php endif; ?>
+
+    <?php if (sfConfig::get('app_audit_log_enabled', false)): ?>
+      <div id="editing-history-wrapper">
+        <fieldset class="collapsible collapsed hidden" id="editingHistory">
+          <legend>
+            <?php echo __('Editing history') ?>
+            <?php echo image_tag('/vendor/jstree/themes/default/throbber.gif', array('id' => 'editingHistoryActivityIndicator', 'class' => 'hidden', 'alt' => __('Loading ...'))) ?>
+          </legend>
+
+          <table class="table table-bordered table-striped sticky-enabled">
+            <thead>
+              <tr>
+                <th>
+                  <?php echo __('Title') ?>
+                </th>
+                <th>
+                  <?php echo __('Date') ?>
+                </th>
+                <th>
+                  <?php echo __('Type') ?>
+                </th>
+              </tr>
+            </thead>
+            <tbody id="editingHistoryRows">
+            </tbody>
+          </table>
+
+          <div class="text-right">
+            <input class="btn" type="button" id='previousButton' value='<?php echo __('Previous') ?>'>
+            <input class="btn" type="button" id='nextButton' value='<?php echo __('Next') ?>'>
+          </div>
+
+        </fieldset>
+      </div>
+    <?php endif; ?>
+
+  </section>
+</section>
+
+<?php echo get_partial('showActions', array('resource' => $resource)) ?>

--- a/plugins/arCasPlugin/modules/user/templates/listSuccess.php
+++ b/plugins/arCasPlugin/modules/user/templates/listSuccess.php
@@ -1,0 +1,54 @@
+<h1><?php echo __('List users') ?></h1>
+
+<section class="header-options">
+  <div class="row">
+    <div class="span6">
+      <?php echo get_component('search', 'inlineSearch', array(
+        'label' => __('Search users'),
+        'route' => url_for(array('module' => 'user', 'action' => 'list')))) ?>
+    </div>
+  </div>
+</section>
+
+<ul class="nav nav-pills">
+  <li<?php if ('onlyInactive' != $sf_request->filter): ?> class="active"<?php endif; ?>><?php echo link_to(__('Show active only'), array('filter' => 'onlyActive') + $sf_data->getRaw('sf_request')->getParameterHolder()->getAll()) ?></li>
+  <li<?php if ('onlyInactive' == $sf_request->filter): ?> class="active"<?php endif; ?>><?php echo link_to(__('Show inactive only'), array('filter' => 'onlyInactive') + $sf_data->getRaw('sf_request')->getParameterHolder()->getAll()) ?></li>
+</ul>
+
+<table class="table table-bordered sticky-enabled">
+  <thead>
+    <tr>
+      <th>
+        <?php echo __('User name') ?>
+      </th><th>
+        <?php echo __('Email') ?>
+      </th><th>
+        <?php echo __('User groups') ?>
+      </th>
+    </tr>
+  </thead><tbody>
+    <?php foreach ($users as $item): ?>
+      <tr>
+        <td>
+          <?php echo link_to($item->username, array($item, 'module' => 'user')) ?>
+          <?php if (!$item->active): ?>
+            (<?php echo __('inactive') ?>)
+          <?php endif; ?>
+          <?php if ($sf_user->user === $item): ?>
+            (<?php echo __('you') ?>)
+          <?php endif; ?>
+        </td><td>
+          <?php echo $item->email ?>
+        </td><td>
+          <ul>
+            <?php foreach ($item->getAclGroups() as $group): ?>
+              <li><?php echo render_title($group) ?></li>
+            <?php endforeach; ?>
+          </ul>
+        </td>
+      </tr>
+    <?php endforeach; ?>
+  </tbody>
+</table>
+
+<?php echo get_partial('default/pager', array('pager' => $pager)) ?>


### PR DESCRIPTION
This commit removes AtoM user management UI options that are made redundant by CAS authentication when the `arCasPlugin` is enabled. This includes the Reset password link, the option to create new users from within the AtoM GUI, and the option to the username, email, and password fields from the Edit user screen. Other Edit profile options such as marking users as active or inactive, API key generation, translation languages, and group management are retained.

When the `arCasPlugin`'s `set_groups_from_attributes` is enabled, user groups are reset on each login based on values in CAS attributes and so any changes made to group membership in the AtoM GUI will be nullified the next time the user logs in. This should be noted in the AtoM docs. See: https://github.com/artefactual/atom-docs/pull/162.

Connected to https://projects.artefactual.com/issues/13413