### PR TITLE
Use basic auth for DIP Upload regardless of authentication scheme

### DIFF
--- a/lib/myUser.class.php
+++ b/lib/myUser.class.php
@@ -131,6 +131,15 @@ class myUser extends sfBasicSecurityUser implements Zend_Acl_Role_Interface
 
   public function authenticate($username, $password)
   {
+    $authenticated = $this->authenticateWithBasicAuth($username, $password);
+    return $authenticated;
+  }
+
+  // This method is is intended to be overridable in user classes that inherit
+  // from myUser. This enables authorization schemes such as CAS to retain a
+  // basic auth option for DIP Upload that can be voided if necessary.
+  public function authenticateWithBasicAuth($username, $password)
+  {
     $authenticated = false;
     // anonymous is not a real user
     if ($username == 'anonymous')

--- a/plugins/qtSwordPlugin/lib/qtSwordPluginHttpAuthFilter.class.php
+++ b/plugins/qtSwordPlugin/lib/qtSwordPluginHttpAuthFilter.class.php
@@ -30,7 +30,7 @@ class qtSwordPluginHttpAuthFilter extends sfFilter
         exit;
       }
 
-      $authenticated = sfContext::getInstance()->user->authenticate($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
+      $authenticated = sfContext::getInstance()->user->authenticateWithBasicAuth($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
 
       if (!$authenticated)
       {


### PR DESCRIPTION
This commit adds a new `authenticateWithBasicAuth` method to AtoM's base `myUser` user class and uses the new method to allow Archivematica to authenticate for DIP Upload using basic auth even when a single sign-on method such as CAS is enabled in AtoM.

This implementation allows user classes that subclass `myUser` to retain or void the basic auth method as needed by keeping or overriding `authenticateWithBasicAuth`.

Connected to https://projects.artefactual.com/issues/13416