### PR TITLE
Fix repeated rows in CSV export, refs #13395

### DIFF
--- a/lib/job/arActorExportJob.class.php
+++ b/lib/job/arActorExportJob.class.php
@@ -76,14 +76,7 @@ class arActorExportJob extends arExportJob
       }
 
       $this->exportResource($resource, $path);
-
-      // Log progress every 1000 rows
-      if ($this->itemsExported % 1000 == 0)
-      {
-        $this->info($this->i18n->__(
-          '%1 items exported.', array('%1' => $this->itemsExported)
-        ));
-      }
+      $this->logExportProgress();
     }
   }
 }

--- a/lib/job/arActorXmlExportJob.class.php
+++ b/lib/job/arActorXmlExportJob.class.php
@@ -83,5 +83,7 @@ class arActorXmlExportJob extends arActorExportJob
     }
 
     $this->addDigitalObject($resource, $path);
+
+    $this->itemsExported++;
   }
 }

--- a/lib/job/arExportJob.class.php
+++ b/lib/job/arExportJob.class.php
@@ -27,6 +27,9 @@
 
 class arExportJob extends arBaseJob
 {
+  // Log progress every n rows
+  const LOG_INTERVAL = 100;
+
   // Child class should set this if creating user downloads
   protected $downloadFileExtension = null;
 
@@ -363,5 +366,22 @@ class arExportJob extends arBaseJob
       $this->filenames[$filename]++,
       $pathinfo['extension']
     );
+  }
+
+  /**
+   * Log export progress every LOG_INTERVAL rows and clear Qubit class caches
+   *
+   * @return void
+   */
+  protected function logExportProgress()
+  {
+    if ($this->itemsExported % self::LOG_INTERVAL == 0)
+    {
+      $this->info($this->i18n->__(
+        'Exported %1 items...', array('%1' => $this->itemsExported))
+      );
+
+      Qubit::clearClassCaches();
+    }
   }
 }

--- a/lib/job/arInformationObjectCsvExportJob.class.php
+++ b/lib/job/arInformationObjectCsvExportJob.class.php
@@ -58,21 +58,33 @@ class arInformationObjectCsvExportJob extends arInformationObjectExportJob
       return;
     }
 
-    // Append resource metadata to CSV file
-    $this->csvWriter->exportResource($resource);
-
-    $this->addDigitalObject($resource, $path);
-
-    $this->itemsExported++;
+    $this->exportDataAndDigitalObject($resource, $path);
 
     // Export descendants if option was selected
     if (!$this->params['current-level-only'])
     {
       foreach ($resource->getDescendantsForExport($options) as $item)
       {
-        $this->exportResource($item, $path);
+        $this->exportDataAndDigitalObject($item, $path);
       }
     }
+  }
+
+  /**
+   * Export resource metadata and associated digital object
+   *
+   * @param QubitInformationObject $resource object to export
+   * @param string $path temporary export job working directory
+   */
+  protected function exportDataAndDigitalObject($resource, $path)
+  {
+    // Append resource metadata to CSV file
+    $this->csvWriter->exportResource($resource);
+
+    $this->addDigitalObject($resource, $path);
+
+    $this->itemsExported++;
+    $this->logExportProgress();
   }
 
   protected function getCsvWriter($path)

--- a/lib/job/arInformationObjectExportJob.class.php
+++ b/lib/job/arInformationObjectExportJob.class.php
@@ -123,6 +123,10 @@ class arInformationObjectExportJob extends arExportJob
       return;
     }
 
+    $this->info($this->i18n->__(
+      'Exporting %1 clipboard item(s).', array('%1' => $search->count())
+    ));
+
     // Scroll through results then iterate through resulting IDs
     foreach (arElasticSearchPluginUtil::getScrolledSearchResultIdentifiers($search) as $id)
     {
@@ -135,16 +139,6 @@ class arInformationObjectExportJob extends arExportJob
       }
 
       $this->exportResource($resource, $path);
-
-      // Log progress every 1000 rows
-      if ($this->itemsExported % 1000 == 0)
-      {
-        $this->info($this->i18n->__(
-          '%1 items exported.', array('%1' => $this->itemsExported))
-        );
-
-        Qubit::clearClassCaches();
-      }
     }
   }
 

--- a/lib/job/arInformationObjectXmlExportJob.class.php
+++ b/lib/job/arInformationObjectXmlExportJob.class.php
@@ -112,5 +112,6 @@ class arInformationObjectXmlExportJob extends arInformationObjectExportJob
     $this->addDigitalObject($resource, $path, $errors);
 
     $this->itemsExported++;
+    $this->logExportProgress();
   }
 }


### PR DESCRIPTION
- getDescendantsForExport() was being called recursively for each
  descendant, exponentially increasing the number of rows exported
  for information object CSV exports with descendants
- Normalize export progress log code
- Log number of items found (without descendants) at start of the job
  to help debugging