### PR TITLE
Fix error viewing actor with DO, refs #13388

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/metadataComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/metadataComponent.class.php
@@ -98,9 +98,16 @@ class DigitalObjectMetadataComponent extends sfComponent
     // Statement shown as the Permissions field for preservation copies
     $this->accessStatement = $this->getPreservationSystemAccessStatement();
 
-    // What metadata sections should be shown
-    $this->showOriginalFileMetadata = $this->setOriginalFileShowProperties();
-    $this->showPreservationCopyMetadata = $this->setPreservationCopyShowProperties();
+    // Determine which metadata sections should be shown
+    if ($this->relatedToIo)
+    {
+      // Only an information object can have Archivematica "original file" and
+      // "preservation copy" metadata
+      $this->showOriginalFileMetadata = $this->setOriginalFileShowProperties();
+      $this->showPreservationCopyMetadata = $this->setPreservationCopyShowProperties();
+    }
+
+    // Metadata for information objects and actors
     $this->showMasterFileMetadata = $this->setMasterFileShowProperties();
     $this->showReferenceCopyMetadata = $this->setReferenceCopyShowProperties();
     $this->showThumbnailCopyMetadata = $this->setThumbnailCopyShowProperties();


### PR DESCRIPTION
Fix 500 error when authenticated and viewing an actor with a digital
object.  Actors will never have Archivematica AIP digital object
metadata (i.e. original file and preservation copy) so avoid checking
if these metadata exist.
