### PR TITLE
Fix generate identifier counter, refs #13418

### DIFF
--- a/apps/qubit/modules/informationobject/templates/_identifierOptions.php
+++ b/apps/qubit/modules/informationobject/templates/_identifierOptions.php
@@ -13,6 +13,6 @@
   <?php endif; ?>
 </div>
 
-<?php if (!empty($mask)): ?>
+<?php if (isset($mask)): ?>
   <input name="usingMask" id="using-identifier-mask" type="hidden" value="<?php echo $mask ?>"/>
 <?php endif; ?>


### PR DESCRIPTION
Add "usingMask" input even when the identifier mask is not enabled as
this field is modified when the "Generate identifier" link is used to
indicate that the counter needs to be incremented.