### PR TITLE
Localize preservation event datetimes, refs #13417

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/metadataComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/metadataComponent.class.php
@@ -128,7 +128,7 @@ class DigitalObjectMetadataComponent extends sfComponent
 
   protected function isEmpty($value)
   {
-    return (null === $value || '' === (string)$value);
+    return (null === $value || '' === (string) $value);
   }
 
   protected function setMasterFileShowProperties()
@@ -307,9 +307,13 @@ class DigitalObjectMetadataComponent extends sfComponent
       check_field_visibility('app_element_visibility_digital_object_preservation_system_original_file_size')
       && !$this->isEmpty($this->resource->object->originalFileSize)
     );
+    // Convert this UTC string property to local time
+    $this->originalFileIngestedAt = $this->localizeUTCDateTime(
+      (string) $this->resource->object->originalFileIngestedAt
+    );
     $this->showOriginalFileIngestedAt = (
       check_field_visibility('app_element_visibility_digital_object_preservation_system_original_ingested')
-      && !$this->isEmpty($this->resource->object->originalFileIngestedAt)
+      && !$this->isEmpty($this->originalFileIngestedAt)
     );
     $this->showOriginalFilePermissions = (
       check_field_visibility('app_element_visibility_digital_object_preservation_system_original_permissions')
@@ -336,9 +340,13 @@ class DigitalObjectMetadataComponent extends sfComponent
       check_field_visibility('app_element_visibility_digital_object_preservation_system_preservation_file_size')
       && !$this->isEmpty($this->resource->object->preservationCopyFileSize)
     );
+    // Convert this UTC string property to local time
+    $this->preservationCopyNormalizedAt = $this->localizeUTCDateTime(
+      (string) $this->resource->object->preservationCopyNormalizedAt
+    );
     $this->showPreservationCopyNormalizedAt = (
       check_field_visibility('app_element_visibility_digital_object_preservation_system_preservation_normalized')
-      && !$this->isEmpty($this->resource->object->preservationCopyNormalizedAt)
+      && !$this->isEmpty($this->preservationCopyNormalizedAt)
     );
     $this->showPreservationCopyPermissions = (
       check_field_visibility('app_element_visibility_digital_object_preservation_system_preservation_permissions')
@@ -349,6 +357,14 @@ class DigitalObjectMetadataComponent extends sfComponent
       || $this->showPreservationCopyFileSize
       || $this->showPreservationCopyNormalizedAt
     );
+  }
+
+  protected function localizeUTCDateTime($dateTime)
+  {
+    if (false !== $timestamp = strtotime($dateTime))
+    {
+      return date('Y-m-d\TH:i:s\Z', $timestamp);
+    }
   }
 
 }

--- a/apps/qubit/modules/digitalobject/templates/_metadata.php
+++ b/apps/qubit/modules/digitalobject/templates/_metadata.php
@@ -45,7 +45,7 @@
           <?php endif; ?>
 
           <?php if ($showOriginalFileIngestedAt): ?>
-            <?php echo render_show(__('Ingested'), format_date($resource->object->originalFileIngestedAt, 'f'), array('fieldLabel' => 'originalFileIngestedAt')) ?>
+            <?php echo render_show(__('Ingested'), format_date($originalFileIngestedAt, 'f'), array('fieldLabel' => 'originalFileIngestedAt')) ?>
           <?php endif; ?>
 
           <?php if ($showOriginalFilePermissions): ?>
@@ -91,7 +91,7 @@
           <?php endif; ?>
 
           <?php if ($showPreservationCopyNormalizedAt): ?>
-            <?php echo render_show(__('Normalized'), format_date($resource->object->preservationCopyNormalizedAt, 'f'), array('fieldLabel' => 'preservactionCopyNormalizedAt')) ?>
+            <?php echo render_show(__('Normalized'), format_date($preservationCopyNormalizedAt, 'f'), array('fieldLabel' => 'preservactionCopyNormalizedAt')) ?>
           <?php endif; ?>
 
           <?php if ($showPreservationCopyPermissions): ?>

--- a/plugins/qtSwordPlugin/lib/qtPackageExtractorMETSArchivematicaDIP.class.php
+++ b/plugins/qtSwordPlugin/lib/qtPackageExtractorMETSArchivematicaDIP.class.php
@@ -211,7 +211,11 @@ class qtPackageExtractorMETSArchivematicaDIP extends qtPackageExtractorBase
   }
 
   /**
-   * Add metadata related to the preservation system
+   * Add metadata related to the preservation system.
+   *
+   * These PREMIS event timestamps were retrieved from the METS.xml file as strings in UTC format.
+   * After internal review it was decided to store them in their original UTC format in the AtoM database
+   * and to convert them to the local time set for the AtoM server when displaying these values in AtoM templates.
    *
    * @param QubitInformationObject $io target information object
    * @param string $fileId METS FILEID


### PR DESCRIPTION
Archivematica uses UTC datetimes for the events in the METS. This
updates the DO metadata component to localize those values on display.
