### PR TITLE
Replace login form with CAS button, refs #13422

### DIFF
--- a/plugins/arCasPlugin/modules/user/templates/loginSuccess.php
+++ b/plugins/arCasPlugin/modules/user/templates/loginSuccess.php
@@ -1,0 +1,30 @@
+<?php decorate_with('layout_1col') ?>
+<?php use_helper('Javascript') ?>
+
+<?php slot('content') ?>
+
+  <div class="row">
+
+    <div class="offset4 span4">
+
+      <div id="content">
+
+        <?php if ('user' != $sf_request->module || 'login' != $sf_request->action): ?>
+          <h1><?php echo __('Please log in to access that page') ?></h1>
+        <?php else: ?>
+          <h1><?php echo __('Log in') ?></h1>
+        <?php endif; ?>
+
+        <?php echo $form->renderFormTag(url_for(array('module' => 'cas', 'action' => 'login'))) ?>
+
+          <button type="submit"><?php echo __('Log in with CAS') ?></button>
+
+        </form>
+
+      </div>
+
+    </div>
+
+  </div>
+
+<?php end_slot() ?>


### PR DESCRIPTION
This commit fixes a bug whereby visiting my-atom-site.com/user/login displays the standard AtoM email+password login form, even when CAS is enabled. This commit overrides the user module's `loginSuccess` template within the `arCasPlugin` to instead display a "Log in with CAS" button consistent with what is displayed in the navigational bar menu.

Connected to https://projects.artefactual.com/issues/13422