### PR TITLE
Hide AIP Download links, refs #13351

### DIFF
--- a/apps/qubit/modules/digitalobject/templates/_metadata.php
+++ b/apps/qubit/modules/digitalobject/templates/_metadata.php
@@ -66,7 +66,7 @@
               <?php echo render_show(
                 __('AIP UUID'),
                 render_value($resource->object->aipUUID),
-                 array('fieldLabel' => 'aipUUID')
+                array('fieldLabel' => 'aipUUID')
               ) ?>
             <?php endif; // arStorageService is disabled ?>
           <?php endif; ?>

--- a/plugins/arStorageServicePlugin/modules/arStorageService/templates/_aipDownload.php
+++ b/plugins/arStorageServicePlugin/modules/arStorageService/templates/_aipDownload.php
@@ -2,10 +2,12 @@
     <h3><?php echo __('File UUID') ?></h3>
     <div class="aip-download">
         <?php echo render_value_inline($resource->object->objectUUID) ?>
-        <a href="<?php echo url_for(array($resource, 'module' => 'arStorageService', 'action' => 'extractFile')) ?>" target="_blank">
-          <i class="fa fa-download"></i>
-          <?php echo __('Download file') ?>
-        </a>
+        <?php if ($sf_user->checkModuleActionAccess('arStorageService', 'extractFile')): ?>
+          <a href="<?php echo url_for(array($resource, 'module' => 'arStorageService', 'action' => 'extractFile')) ?>" target="_blank">
+            <i class="fa fa-download"></i>
+            <?php echo __('Download file') ?>
+          </a>
+        <?php endif; ?>
     </div>
 </div>
 
@@ -13,9 +15,11 @@
     <h3><?php echo __('AIP UUID') ?></h3>
     <div class="aip-download">
         <?php echo render_value_inline($resource->object->aipUUID) ?>
-        <a href="<?php echo url_for(array($resource, 'module' => 'arStorageService', 'action' => 'download')) ?>" target="_blank">
-          <i class="fa fa-download"></i>
-          <?php echo __('Download AIP') ?>
-        </a>
+        <?php if ($sf_user->checkModuleActionAccess('arStorageService', 'download')): ?>
+          <a href="<?php echo url_for(array($resource, 'module' => 'arStorageService', 'action' => 'download')) ?>" target="_blank">
+            <i class="fa fa-download"></i>
+            <?php echo __('Download AIP') ?>
+          </a>
+        <?php endif; ?>
     </div>
 </div>


### PR DESCRIPTION
This commit fixes an issue where the aip and file download links
were still being displayed for authenticated users even when the
arStorageService security.yml credentials should prevent this.

A check has been added to prevent display of these download links
when a user's group is not in the credentials section of the
arStorageService plugin security.yml file.