### PR TITLE
Create plugin i18n folders, refs #13426

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -159,7 +159,7 @@
   <!-- ===================================================================== -->
 
   <target name="i18n-push-translations"
-    depends="i18n-clean-tx, i18n-prepare, i18n-extract, i18n-consolidate-translations"
+    depends="i18n-clean-tx, i18n-cleanup-create-plugin-i18n-folders-if-missing, i18n-prepare, i18n-extract, i18n-consolidate-translations"
     description="Extract translations from AtoM"/>
 
   <target name="i18n-consolidate-translations">
@@ -210,14 +210,8 @@
     <exec command="php symfony i18n:update-fixtures apps/qubit/i18n/" dir="${phing.dir}" checkreturn="true"/>
   </target>
 
-  <target name="i18n-cleanup">
+  <target name="i18n-cleanup" depends="i18n-cleanup-create-plugin-i18n-folders-if-missing">
     <!-- The extract task is part of Symfony, but fails if a plugin doesn't have an i18n subdirectory -->
-    <foreach param="plugin" target="i18n-cleanup-create-plugin-subdirs-subtask">
-      <fileset dir="plugins/">
-        <type type="dir"/>
-        <depth max="0" min="0"/>
-      </fileset>
-    </foreach>
     <foreach param="lang" target="i18n-cleanup-extract-subtask">
       <fileset dir="apps/qubit/i18n/">
         <type type="dir"/>
@@ -231,14 +225,23 @@
       </fileset>
     </foreach>
   </target>
-  <target name="i18n-cleanup-create-plugin-subdirs-subtask">
-    <exec command="mkdir plugins/${plugin}/i18n" dir="${phing.dir}"/>
-  </target>
   <target name="i18n-cleanup-extract-subtask">
     <exec command="php symfony i18n:extract --auto-save --auto-delete --plugins ${lang}" dir="${phing.dir}" checkreturn="true"/>
   </target>
   <target name="i18n-cleanup-remove-empty-plugin-subdirs-subtask">
     <exec command="rmdir plugins/${plugin}/i18n" dir="${phing.dir}"/>
+  </target>
+
+  <target name="i18n-cleanup-create-plugin-i18n-folders-if-missing">
+    <foreach param="plugin" target="i18n-cleanup-create-plugin-subdirs-subtask">
+      <fileset dir="plugins/">
+        <type type="dir"/>
+        <depth max="0" min="0"/>
+      </fileset>
+    </foreach>
+  </target>
+  <target name="i18n-cleanup-create-plugin-subdirs-subtask">
+    <exec command="mkdir plugins/${plugin}/i18n" dir="${phing.dir}"/>
   </target>
 
 </project>


### PR DESCRIPTION
This commit ensures that plugin folders contain an i18n folder
before extracting strings from AtoM. It fixes an error where AtoM's
i18n extract task was failing if a plugin did not contain an i18n
folder.