### PR TITLE
i18n rectify plugin fix, refs #13427

### DIFF
--- a/lib/task/i18n/i18nRectifyTask.class.php
+++ b/lib/task/i18n/i18nRectifyTask.class.php
@@ -99,7 +99,7 @@ EOF;
       {
         foreach ($translations as $key => &$value)
         {
-          if (0 == strlen(trim($value[0])) && isset($currentMessages[$key]))
+          if (isset($currentMessages[$key]))
           {
             $messageSource->update($key, $currentMessages[$key][0], $value[2]);
           }


### PR DESCRIPTION
Update AtoM's i18n rectify task to allow an existing translation to be
overwritten when updated translations are imported from Weblate.