### PR TITLE
Remove extraneous ')' from array, refs #13429

### DIFF
--- a/plugins/qtAccessionPlugin/modules/accession/actions/browseAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/browseAction.class.php
@@ -105,24 +105,29 @@ class AccessionBrowseAction extends sfAction
         'i18n.%s.sourceOfAcquisition' => 5,
         'i18n.%s.archivalHistory' => 5);
 
-      $fields = arElasticSearchPluginUtil::getI18nFieldNames(array(
-        'donors.i18n.%s.authorizedFormOfName',
-        'i18n.%s.title',
-        'i18n.%s.scopeAndContent',
-        'i18n.%s.locationInformation',
-        'i18n.%s.processingNotes',
-        'i18n.%s.sourceOfAcquisition',
-        'i18n.%s.archivalHistory',
-        'i18n.%s.appraisal',
-        'i18n.%s.physicalCharacteristics',
-        'i18n.%s.receivedExtentUnits',
-        'alternativeIdentifiers.i18n.%s.name',
-        'creators.i18n.%s.authorizedFormOfName',
-        'alternativeIdentifiers.i18n.%s.note',
-        'alternativeIdentifiers.type.i18n.%s.name'),
-        'accessionEvents.i18n.%s.agent',
-        'accessionEvents.type.i18n.%s.name',
-        'accessionEvents.notes.i18n.%s.content'), null, $boost);
+      $fields = arElasticSearchPluginUtil::getI18nFieldNames(
+        array(
+          'donors.i18n.%s.authorizedFormOfName',
+          'i18n.%s.title',
+          'i18n.%s.scopeAndContent',
+          'i18n.%s.locationInformation',
+          'i18n.%s.processingNotes',
+          'i18n.%s.sourceOfAcquisition',
+          'i18n.%s.archivalHistory',
+          'i18n.%s.appraisal',
+          'i18n.%s.physicalCharacteristics',
+          'i18n.%s.receivedExtentUnits',
+          'alternativeIdentifiers.i18n.%s.name',
+          'creators.i18n.%s.authorizedFormOfName',
+          'alternativeIdentifiers.i18n.%s.note',
+          'alternativeIdentifiers.type.i18n.%s.name',
+          'accessionEvents.i18n.%s.agent',
+          'accessionEvents.type.i18n.%s.name',
+          'accessionEvents.notes.i18n.%s.content'
+        ),
+        null,
+        $boost
+      );
 
       $fields[] = 'identifier^10';
       $fields[] = 'donors.contactInformations.contactPerson';


### PR DESCRIPTION
With thanks to https://github.com/xojc for finding the error and
suggesting the fix.

Cosmetic: reformat code to make it easier to distinguish between array
elements and the arguments of the `getI18nFieldNames()` method.