### PR TITLE
Get treeview data from Elasticsearch, refs #13423

### DIFF
--- a/apps/qubit/modules/browse/actions/hierarchyDataAction.class.php
+++ b/apps/qubit/modules/browse/actions/hierarchyDataAction.class.php
@@ -30,17 +30,7 @@ class BrowseHierarchyDataAction extends DefaultFullTreeViewAction
   {
     parent::execute($request);
 
-    $this->resource = QubitInformationObject::getById(QubitInformationObject::ROOT_ID);
-
-    $baseReferenceCode = '';
-
-    // Given the current resource is the root information object, if doesn't
-    // have an identifier so just send boolean true to indicate we want
-    // indentifiers to be displayed
-    if ($this->showIdentifier === 'referenceCode')
-    {
-      $baseReferenceCode = true;
-    }
+    $this->resource = QubitInformationObject::getRoot();
 
     // Impose limit to what nodeLimit parameter can be set to
     $maxItemsPerPage = sfConfig::get('app_treeview_items_per_page_max', 10000);
@@ -51,13 +41,14 @@ class BrowseHierarchyDataAction extends DefaultFullTreeViewAction
 
     // Do ordering during query as we need to page through the results
     $options = array(
-      'orderColumn' => 'current_i18n.title',
+      'orderColumn' => 'title',
       'memorySort' => true,
       'skip' => $request->skip,
       'limit' => $request->nodeLimit
     );
 
-    $data = $this->getNodeOrChildrenNodes($this->resource->id, $baseReferenceCode, $children = true, $options);
+    // Load the children of the root node (top-level descriptions)
+    $data = $this->getChildren($this->resource->id, $options);
 
     return $this->renderText(json_encode($data));
   }

--- a/apps/qubit/modules/default/actions/fullTreeViewAction.class.php
+++ b/apps/qubit/modules/default/actions/fullTreeViewAction.class.php
@@ -37,48 +37,43 @@ class DefaultFullTreeViewAction extends sfAction
     $this->getResponse()->setContentType('application/json');
   }
 
-  protected function getNodeOrChildrenNodes($id, $baseReferenceCode, $children = false, $options = array())
+  /**
+   * Get treeview node data for a description or it's children
+   *
+   * @param int $id information_object.id value
+   * @param string $baseReferenceCode reference code of parent node
+   * @param bool $children return children of target node when true
+   * @param array $options optional parameters
+   *
+   * @return array full width treeview data
+   */
+  protected function getNodeOrChildrenNodes(
+    $id,
+    $baseReferenceCode,
+    $children = false,
+    $options = array()
+  )
   {
-    $i18n = sfContext::getInstance()->i18n;
-    $culture = $this->getUser()->getCulture();
+    // Hide drafts from unauthenticated users
+    $draftsSql = $this->getDraftsCriteria();
 
-    if (sfConfig::get('app_markdown_enabled', true))
-    {
-      $untitled = '_'.$i18n->__('Untitled').'_';
-    }
-    else
-    {
-      $untitled = '<em>'.$i18n->__('Untitled').'</em>';
-    }
+    // Get current node data (for the collection root on the first load) or
+    // children data
+    $condition = $children ? 'io.parent_id = :id' : 'io.id = :id';
 
-    // Remove drafts for unauthenticated users
-    $draftsSql = !$this->getUser()->user ? 'AND status.status_id <> ' . QubitTerm::PUBLICATION_STATUS_DRAFT_ID : '' ;
+    // Sort column
+    $orderColumn = (isset($options['orderColumn'])) ?
+      $options['orderColumn'] : 'io.lft';
 
-    // Get current node data (for the collection root on the first load) or children data
-    $condition = $children ? 'io.parent_id = :id' : 'io.id = :id' ;
-
-    // Determine ordering
-    $orderColumn = (isset($options['orderColumn'])) ? $options['orderColumn'] : 'io.lft';
-
-    // If we're currently fetching children and paging options are set,
-    // use paging options to assemble LIMIT clause
-    $limitClause = "";
-    $skip = (isset($options['skip'])) ? $options['skip'] : null;
-    $limit = (isset($options['limit'])) ? $options['limit'] : null;
-
-    if ($children && (ctype_digit($skip) || ctype_digit($limit)))
-    {
-      $limitClause = "LIMIT ";
-      $limitClause .= (ctype_digit($skip)) ? $skip : "0";
-      $limitClause .= (ctype_digit($limit)) ? ", ". $limit : "";
-    }
+    // Limit results based on paging $options[skip, limit]
+    $limitClause = $this->getLimitClause($children, $options);
 
     $sql = "SELECT SQL_CALC_FOUND_ROWS
       io.id, io.lft, io.rgt,
       io.source_culture,
       io.identifier,
       current_i18n.title AS current_title,
-      IFNULL(source_i18n.title, '$untitled') as text,
+      source_i18n.title as source_title,
       io.parent_id AS parent,
       slug.slug,
       IFNULL(lod.name, '') AS lod,
@@ -86,11 +81,16 @@ class DefaultFullTreeViewAction extends sfAction
       status.status_id AS status_id
       FROM
         information_object io
-        LEFT JOIN information_object_i18n current_i18n ON io.id = current_i18n.id AND current_i18n.culture = :culture
-        LEFT JOIN information_object_i18n source_i18n ON io.id = source_i18n.id AND source_i18n.culture = io.source_culture
-        LEFT JOIN term_i18n lod ON io.level_of_description_id = lod.id AND lod.culture = :culture
-        LEFT JOIN status ON io.id = status.object_id AND status.type_id = :pubStatus
-        LEFT JOIN term_i18n st_i18n ON status.status_id = st_i18n.id AND st_i18n.culture = :culture
+        LEFT JOIN information_object_i18n current_i18n
+          ON io.id = current_i18n.id AND current_i18n.culture = :culture
+        LEFT JOIN information_object_i18n source_i18n
+          ON io.id = source_i18n.id AND source_i18n.culture = io.source_culture
+        LEFT JOIN term_i18n lod
+          ON io.level_of_description_id = lod.id AND lod.culture = :culture
+        LEFT JOIN status
+          ON io.id = status.object_id AND status.type_id = :statusTypeId
+        LEFT JOIN term_i18n st_i18n
+          ON status.status_id = st_i18n.id AND st_i18n.culture = :culture
         LEFT JOIN slug ON io.id = slug.object_id
       WHERE
         $condition
@@ -98,116 +98,47 @@ class DefaultFullTreeViewAction extends sfAction
       ORDER BY $orderColumn
       $limitClause;";
 
-    $params = array(
-      ':culture' => $culture,
-      ':pubStatus' => QubitTerm::STATUS_TYPE_PUBLICATION_ID,
-      ':id' => $id
+    $results = QubitPdo::fetchAll(
+      $sql,
+      [
+        ':id' => $id,
+        ':culture' => $this->getUser()->getCulture(),
+        ':statusTypeId' => QubitTerm::STATUS_TYPE_PUBLICATION_ID,
+      ],
+      ['fetchMode' => PDO::FETCH_ASSOC]
     );
-
-    $results = QubitPdo::fetchAll($sql, $params, array('fetchMode' => PDO::FETCH_ASSOC));
 
     // Get non-limited count of resulting rows
     $totalCount = QubitPdo::fetchColumn("select found_rows();");
 
+    // Get the treeview data in the structure expected by the display code
+    $data = $this->getTreeviewData($results, $baseReferenceCode, $children, $options);
+
+    // Order data in-memory by "text" attribute of each node, when
+    // $option['memorySort'] is true
+    if (isset($options['memorySort']) && $options['memorySort'])
+    {
+      $this->memorySort($data);
+    }
+
+    return array('nodes' => $data, 'total' => $totalCount);
+  }
+
+  /**
+   * Format found data for full width treeview javascript
+   *
+   * @param array $results data from SQL query
+   *
+   * @return array data for treeview
+   */
+  protected function getTreeviewData($results, $baseReferenceCode, $children, $options)
+  {
     $data = array();
 
     foreach ($results as $result)
     {
-      $result['text'] = render_value_inline($result['text']);
-
-      // Overwrite source culture title if the current culture title is populated
-      if ($this->getUser()->getCulture() != $result['source_culture'] && !empty($result['current_title']))
-      {
-        $result['text'] = render_value_inline($result['current_title']);
-      }
-
-      // Add identifier based on setting
-      if ($this->showIdentifier === 'identifier' && !empty($result['identifier']))
-      {
-        $result['text'] = $result['identifier'] .' - '. $result['text'];
-      }
-
-      // Add reference code based on setting
-      if ($this->showIdentifier === 'referenceCode' && !empty($baseReferenceCode))
-      {
-        if ($result['parent'] == QubitInformationObject::ROOT_ID)
-        {
-          // If this is a top-level node, the passed reference will be "true" so
-          // replace it with the description identifier
-          $result['referenceCode'] = render_value_inline($result['identifier']);
-        }
-        else
-        {
-          // Start with reference code passed to the function
-          $result['referenceCode'] = $baseReferenceCode;
-
-          // Append result identifier to the base reference code if we're not loading the collection root
-          //if ($result['parent'] != QubitInformationObject::ROOT_ID && !empty($result['identifier']))
-
-          // Append result identifier, if it exists, to the reference passed to the function
-          if (!empty($result['identifier']))
-          {
-            $result['referenceCode'] = $result['referenceCode'] . sfConfig::get('app_separator_character', '-') . render_value_inline($result['identifier']);
-          }
-        }
-
-        // Prepend reference code to text
-        $result['text'] = "{$result['referenceCode']} - {$result['text']}";
-      }
-
-      // Add level of description based on setting
-      if (sfConfig::get('app_treeview_show_level_of_description', 'yes') === 'yes' && strlen($result['lod']) > 0)
-      {
-        $lod = render_value_inline($result['lod']);
-        $result['text'] = "[{$lod}] {$result['text']}";
-      }
-
-      // Add dates based on setting
-      if (sfConfig::get('app_treeview_show_dates', 'no') === 'yes')
-      {
-        $sql = "SELECT
-          event.start_date, event.end_date,
-          current_i18n.date AS display_date,
-          source_i18n.date AS source_date
-          FROM
-            event
-            LEFT JOIN event_i18n current_i18n ON event.id = current_i18n.id AND current_i18n.culture = :culture
-            LEFT JOIN event_i18n source_i18n ON event.id = source_i18n.id AND source_i18n.culture = event.source_culture
-          WHERE
-            event.object_id = :id;";
-
-        $params = array(
-          ':culture' => $culture,
-          ':id' => $result['id']
-        );
-
-        $events = QubitPdo::fetchAll($sql, $params, array('fetchMode' => PDO::FETCH_ASSOC));
-
-        // As in the search results from ES, get the first event with any date
-        foreach ($events as $event)
-        {
-          if (empty($event['display_date']))
-          {
-            $event['display_date'] = $event['source_date'];
-          }
-
-          if (empty($event['display_date']) && empty($event['start_date']) && empty($event['end_date']))
-          {
-            continue;
-          }
-
-          $date = render_value_inline(Qubit::renderDateStartEnd($event['display_date'], $event['start_date'], $event['end_date']));
-          $result['text'] = "{$result['text']}, {$date}";
-
-          break;
-        }
-      }
-
-      if ($result['status_id'] == QubitTerm::PUBLICATION_STATUS_DRAFT_ID)
-      {
-        $status = render_value_inline($result['status']);
-        $result['text'] = "({$status}) {$result['text']}";
-      }
+      $result['baseReferenceCode'] = $baseReferenceCode;
+      $result['text'] = $this->getNodeText($result);
 
       // Some special flags on our current selected item
       if ($result['id'] == $this->resource->id)
@@ -224,7 +155,10 @@ class DefaultFullTreeViewAction extends sfAction
 
       // Add node link attributes
       $result['a_attr']['title'] = strip_tags($result['text']);
-      $result['a_attr']['href'] = $this->generateUrl('slug', array('slug' => $result['slug']));
+      $result['a_attr']['href'] = $this->generateUrl(
+        'slug',
+        ['slug' => $result['slug']]
+      );
 
       // If not a leaf node, indicate node has children
       if ($result['rgt'] - $result['lft'] > 1)
@@ -233,47 +167,312 @@ class DefaultFullTreeViewAction extends sfAction
         $result['children'] = true;
 
         // If loading an ancestor of the resource, fetch children
-        if ($result['lft'] <= $this->resource->lft && $result['rgt'] >= $this->resource->rgt)
+        if (
+          $result['lft'] <= $this->resource->lft
+          && $result['rgt'] >= $this->resource->rgt
+        )
         {
-          $refCode = '';
-          if (!empty($result['referenceCode']))
-          {
-            $refCode = $result['referenceCode'];
-          }
-
           // If we're not currently fetching children and paging options are set,
           // use paging options when fetching children
           $childOptions = array();
           if (!$children && (isset($options['skip']) || isset($options['limit'])))
           {
-            $childOptions = array('skip' => $options['skip'], 'limit' => $options['limit']);
+            $childOptions = array(
+              'skip' => $options['skip'], 'limit' => $options['limit']
+            );
           }
 
-          // Fetch children and note total number of children that exist (useful for paging through children)
-          $childData = $this->getNodeOrChildrenNodes($result['id'], $refCode, $children = true, $childOptions);
+          // Fetch children and note total number of children that exist
+          // (useful for paging through children)
+          $childData = $this->getNodeOrChildrenNodes(
+            $result['id'],
+            $this->getReferenceCode($result),
+            $children = true,
+            $childOptions
+          );
+
           $result['children'] = $childData['nodes'];
           $result['total'] = $childData['total'];
         }
       }
 
-      // Not used currently
-      $unset = array('lft', 'rgt', 'parent', 'lod', 'status', 'status_id', 'slug', 'source_culture', 'current_title', 'identifier');
+      // Unset unused array elements
+      $unset = array(
+        'baseReferenceCode',
+        'lft',
+        'rgt',
+        'parent',
+        'lod',
+        'status',
+        'status_id',
+        'slug',
+        'source_culture',
+        'current_title',
+        'identifier'
+      );
 
       $data[] = array_diff_key($result, array_flip($unset));
     }
 
-    // If not ordered in SQL, order in-memory by "text" attribute of each node
-    if (!empty($options['memorySort']))
-    {
-      $titles = array();
-      foreach ($data as $key => $node)
-      {
-        $titles[$key] = $node['text'];
-      }
+    return $data;
+  }
 
-      usort($data, function($el1, $el2) { return strnatcmp($el1['text'], $el2['text']); });
+  /**
+   * Get the SQL criteria to exclude draft descriptions for unauthenticated
+   * users
+   *
+   * @return string SQL criteria to remove drafts, or an empty string
+   */
+  protected function getDraftsCriteria()
+  {
+    return !$this->getUser()->user ?
+      ' AND status.status_id <> ' . QubitTerm::PUBLICATION_STATUS_DRAFT_ID : '';
+  }
+
+  /**
+   * Get appropriate SQL LIMIT clause for query parameters
+   *
+   * @param bool $children true if getting the children of an information object
+   * @param array $options optional query parameters
+   *
+   * @return string a SQL limit clause or an empty string if no limit is needed
+   */
+  protected function getLimitClause($children, $options)
+  {
+    // If we are not getting children, we are getting a single information
+    // object and there's no need for a limit
+    if (!$children)
+    {
+      return '';
     }
 
-    return array('nodes' => $data, 'total' => $totalCount);
+    $limitClause = '';
+
+    $skip = (isset($options['skip'])) ? $options['skip'] : null;
+    $limit = (isset($options['limit'])) ? $options['limit'] : null;
+
+    // If paging options are set, use paging options to assemble LIMIT clause
+    if (ctype_digit($skip) || ctype_digit($limit))
+    {
+      $limitClause = "LIMIT ";
+      $limitClause .= (ctype_digit($skip)) ? $skip : "0";
+      $limitClause .= (ctype_digit($limit)) ? ", ". $limit : "";
+    }
+
+    return $limitClause;
+  }
+
+  /**
+   * Get the display text for a treeview node
+   *
+   * In addition to the description title, the dispay text may include
+   * the description identifier, reference code, level of description, event
+   * dates, and a "Draft" indicator
+   *
+   * @param array $record archival description data
+   *
+   * @return string the display text for a treeview record
+   */
+  protected function getNodeText($record)
+  {
+    $text = $this->getTitle($record);
+
+    // Prepend identifier or reference code to text
+    $identifier = $this->getIdentifier($record);
+
+    if (!empty($identifier))
+    {
+      $text = "$identifier - $text";
+    }
+
+    // Prepend level of description based on setting
+    if (
+      'yes' === sfConfig::get('app_treeview_show_level_of_description', 'yes')
+      && !empty($record['lod'])
+    )
+    {
+      $text = sprintf('[%s] %s', render_value_inline($record['lod']), $text);
+    }
+
+    // Append dates based on setting
+    if ('yes' === sfConfig::get('app_treeview_show_dates', 'no'))
+    {
+      $dates = $this->getDates($record);
+
+      if (!empty($dates))
+      {
+        $text .= ", $dates";
+      }
+    }
+
+    // Prepend "(Draft)" to draft records
+    if ($record['status_id'] == QubitTerm::PUBLICATION_STATUS_DRAFT_ID)
+    {
+      $text = sprintf('(%s) %s', render_value_inline($record['status']), $text);
+    }
+
+    return $text;
+  }
+
+  /**
+   * Get the title of a description in the best available culture
+   *
+   * Return description title in the current culture if available, and if not
+   * then fall back to the source culture title.  If the description has *no*
+   * valid title, then return "<em>Untitled</em>"
+   *
+   * @param array $record archival description data
+   *
+   * @return string the best available archival description title
+   */
+  protected function getTitle($record)
+  {
+    // Use the current culture "title" value, if it is set
+    if (!empty($record['current_title']))
+    {
+      return render_value_inline($record['current_title']);
+    }
+
+    // If the current culture title is null, use the source culture title.
+    // render_title() will return "<em>Untitled</em>" if
+    // $record['source_culture'] is null
+    return render_title($record['source_title']);
+  }
+
+  /**
+   * Return an archival description identifier or reference code based on the
+   * application "full width treeview > show identifier" setting
+   *
+   * @param array $record archival description data
+   *
+   * @return string|null the appropriate identifier/reference code, or null
+   */
+  protected function getIdentifier($record)
+  {
+    // If show identifier setting is "no" return null
+    if ('no' === $this->showIdentifier)
+    {
+      return null;
+    }
+
+    // If show identifier setting is "identifier" return the simple identifier
+    if ('identifier' == $this->showIdentifier)
+    {
+      return render_value_inline($record['identifier']);
+    }
+
+    // Otherwise return the reference code
+    return $this->getReferenceCode($record);
+  }
+
+  /**
+   * Construct and return an archival description reference code
+   *
+   * @param array $record archival description data
+   *
+   * @return string|null a reference code, or null
+   */
+  protected function getReferenceCode($record)
+  {
+    // Return null if the show identifier setting is not "referenceCode" or if
+    // this result has no identifier
+    if (
+      'referenceCode' !== $this->showIdentifier
+      || empty($record['identifier']))
+    {
+      return null;
+    }
+
+    // If this is a top-level node return it's identifier
+    if ($record['parent'] == QubitInformationObject::ROOT_ID)
+    {
+      return render_value_inline($record['identifier']);
+    }
+
+    // Append this result's identifier to the base reference code passed from
+    // its parent
+    return $record['baseReferenceCode']
+      . sfConfig::get('app_separator_character', '-')
+      . render_value_inline($record['identifier']);
+  }
+
+  /**
+   * Get event dates related to an archival description
+   *
+   * If $record has multiple related events, the dates returned will be from the
+   * first related event that has date data
+   *
+   * @param array $record archival description data
+   *
+   * @return string a related event's dates, or an empty string
+   */
+  protected function getDates($record)
+  {
+    $dates = '';
+
+    $sql = <<<EOL
+SELECT
+  event.start_date, event.end_date,
+  current_i18n.date AS display_date,
+  source_i18n.date AS source_date
+  FROM
+    event
+    LEFT JOIN event_i18n current_i18n ON event.id = current_i18n.id
+      AND current_i18n.culture = :culture
+    LEFT JOIN event_i18n source_i18n ON event.id = source_i18n.id
+      AND source_i18n.culture = event.source_culture
+  WHERE
+    event.object_id = :id;
+EOL;
+
+    $events = QubitPdo::fetchAll(
+      $sql,
+      [':culture' => $this->getUser()->getCulture(), ':id' => $record['id']],
+      ['fetchMode' => PDO::FETCH_ASSOC]
+    );
+
+    // As in the search results from ES, get the first event with any date
+    foreach ($events as $event)
+    {
+      if (empty($event['display_date']))
+      {
+        $event['display_date'] = $event['source_date'];
+      }
+
+      if (
+        empty($event['display_date']) && empty($event['start_date'])
+        && empty($event['end_date'])
+      )
+      {
+        continue;
+      }
+
+      $dates = render_value_inline(Qubit::renderDateStartEnd(
+        $event['display_date'], $event['start_date'], $event['end_date']
+      ));
+
+      break;
+    }
+
+    return $dates;
+  }
+
+  /**
+   * Sort data in-memory by "text" attribute of each node
+   *
+   * @param array $data data to sort
+   */
+  protected function memorySort(&$data)
+  {
+    $titles = array();
+
+    foreach ($data as $key => $node)
+    {
+      $titles[$key] = $node['text'];
+    }
+
+    usort($data, function($el1, $el2) {
+      return strnatcmp($el1['text'], $el2['text']);
+    });
   }
 }

--- a/apps/qubit/modules/informationobject/actions/fullWidthTreeViewAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/fullWidthTreeViewAction.class.php
@@ -51,41 +51,24 @@ class InformationObjectFullWidthTreeViewAction extends DefaultFullTreeViewAction
       $request->nodeLimit = $maxItemsPerPage;
     }
 
-    $baseReferenceCode = '';
-
     // Allow the ability to page through children
     $options = array(
       'skip' => $request->skip,
       'limit' => $request->nodeLimit
     );
 
-    // On first load, retrieve the ancestors of the selected resource, the resource
-    // and its children, otherwise get only the resource's children
-    if (filter_var($request->getParameter('firstLoad', false), FILTER_VALIDATE_BOOLEAN)
-      && null !== $collectionRoot = $this->resource->getCollectionRoot())
+    // On first load, retrieve the ancestors of the selected resource, the
+    // resource and its siblings, otherwise get only the resource's siblings
+    if (filter_var(
+      $request->getParameter('firstLoad', false),
+      FILTER_VALIDATE_BOOLEAN
+    ))
     {
-      if ($this->showIdentifier === 'referenceCode')
-      {
-        // On first load, get the base reference code from the ORM
-        $baseReferenceCode = render_value_inline($collectionRoot->getInheritedReferenceCode());
-      }
-
-      $data = $this->getNodeOrChildrenNodes($collectionRoot->id, $baseReferenceCode, $children = false, $options);
+      $data = $this->getAncestorsAndSiblings($options);
     }
     else
     {
-      if ($this->showIdentifier === 'referenceCode')
-      {
-        // Try to get the resource's reference code from the request
-        $baseReferenceCode = $request->getParameter('referenceCode');
-        if (empty($baseReferenceCode))
-        {
-          // Or get it from the ORM
-          $baseReferenceCode = render_value_inline($this->resource->getInheritedReferenceCode());
-        }
-      }
-
-      $data = $this->getNodeOrChildrenNodes($this->resource->id, $baseReferenceCode, $children = true, $options);
+      $data = $this->getChildren($this->resource->id, $options);
     }
 
     return $this->renderText(json_encode($data));

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObjectPdo.class.php
@@ -809,6 +809,7 @@ class arElasticSearchInformationObjectPdo
     $serialized['referenceCode'] = $this->getReferenceCode();
     $serialized['referenceCodeWithoutCountryAndRepo'] = $this->getReferenceCode(false);
     $serialized['levelOfDescriptionId'] = $this->level_of_description_id;
+    $serialized['lft'] = $this->lft;
     $serialized['publicationStatusId'] = $this->publication_status_id;
 
     // Alternative identifiers


### PR DESCRIPTION
- Refactor full width treeview code
- Get information object data for the treeview from Elasticsearch 
   because it is already normalized, runs faster, and uses less memory
- Add information_object.lft column data to Elasticsearch index to
  allow sorting search results on the column
- Wrap long lines

