### PR TITLE
User Active setting fix, Refs #13393

### DIFF
--- a/apps/qubit/modules/user/actions/editAction.class.php
+++ b/apps/qubit/modules/user/actions/editAction.class.php
@@ -229,7 +229,15 @@ class UserEditAction extends DefaultEditAction
         break;
 
       case 'active':
-        $this->resource->active = $this->form->getValue('active') ? true : false;
+        if ($this->form->getValue('active')
+          || $this->context->user->user === $this->resource)
+        {
+          $this->resource->active = true;
+        }
+        else
+        {
+          $this->resource->active = false;
+        }
 
         break;
 


### PR DESCRIPTION
This commit fixes an issue where editing your own user account sets the
account to inactive on save. The 'active' checkbox is not displayed when
editing one's own user resulting in the field being assigned 'false' on
save.