### PR TITLE
Protect reference copy link, refs #13388

### DIFF
--- a/apps/qubit/modules/digitalobject/templates/_metadata.php
+++ b/apps/qubit/modules/digitalobject/templates/_metadata.php
@@ -171,7 +171,7 @@
 
         <div class="digital-object-metadata-body">
           <?php if ($showReferenceCopyFileName): ?>
-            <?php if ($canAccessReferenceCopy): ?>
+            <?php if ($canAccessReferenceCopy && $sf_user->isAuthenticated()): ?>
               <?php echo render_show(__('Filename'), link_to(render_value_inline($referenceCopy->name), $referenceCopy->getFullPath(), array('target' => '_blank')), array('fieldLabel' => 'referenceCopyFileName')) ?>
             <?php else: ?>
               <?php echo render_show(__('Filename'), render_value($referenceCopy->name), array('fieldLabel' => 'referenceCopyFileName')) ?>


### PR DESCRIPTION
This updates the DO metadata template to show the link to the
reference copy only to authenticated users.

For more context on the change see https://projects.artefactual.com/issues/13388#note-16