### PR TITLE
PHP 7.4 array ref curly braces, refs #13433

### DIFF
--- a/vendor/symfony/lib/helper/UrlHelper.php
+++ b/vendor/symfony/lib/helper/UrlHelper.php
@@ -634,7 +634,7 @@ function _encodeText($text)
 
   for ($i = 0; $i < strlen($text); $i++)
   {
-    $char = $text{$i};
+    $char = $text[$i];
     $r = rand(0, 100);
 
     # roughly 10% raw, 45% hex, 45% dec

--- a/vendor/symfony/lib/i18n/sfDateFormat.class.php
+++ b/vendor/symfony/lib/i18n/sfDateFormat.class.php
@@ -229,7 +229,7 @@ class sfDateFormat
     for ($i = 0, $max = count($tokens); $i < $max; $i++)
     {
       $pattern = $tokens[$i];
-      if ($pattern{0} == "'" && $pattern{strlen($pattern) - 1} == "'")
+      if ($pattern[0] == "'" && $pattern[strlen($pattern) - 1] == "'")
       {
         $tokens[$i] = str_replace('``````', '\'', preg_replace('/(^\')|(\'$)/', '', $pattern));
       }
@@ -266,9 +266,9 @@ class sfDateFormat
    */
   protected function getFunctionName($token)
   {
-    if (isset($this->tokens[$token{0}]))
+    if (isset($this->tokens[$token[0]]))
     {
-      return $this->tokens[$token{0}];
+      return $this->tokens[$token[0]];
     }
   }
 
@@ -397,30 +397,30 @@ class sfDateFormat
 
     for ($i = 0, $max = strlen($pattern); $i < $max; $i++)
     {
-      if ($char == null || $pattern{$i} == $char || $text)
+      if ($char == null || $pattern[$i] == $char || $text)
       {
-        $token .= $pattern{$i};
+        $token .= $pattern[$i];
       }
       else
       {
         $tokens[] = str_replace("''", "'", $token);
-        $token = $pattern{$i};
+        $token = $pattern[$i];
       }
 
-      if ($pattern{$i} == "'" && $text == false)
+      if ($pattern[$i] == "'" && $text == false)
       {
         $text = true;
       }
-      else if ($text && $pattern{$i} == "'" && $char == "'")
+      else if ($text && $pattern[$i] == "'" && $char == "'")
       {
         $text = true;
       }
-      else if ($text && $char != "'" && $pattern{$i} == "'")
+      else if ($text && $char != "'" && $pattern[$i] == "'")
       {
         $text = false;
       }
 
-      $char = $pattern{$i};
+      $char = $pattern[$i];
 
     }
     $tokens[] = $token;

--- a/vendor/symfony/lib/i18n/sfNumberFormat.class.php
+++ b/vendor/symfony/lib/i18n/sfNumberFormat.class.php
@@ -193,7 +193,7 @@ class sfNumberFormat
       // now for the integer groupings
       for ($i = 0; $i < $len; $i++)
       {
-        $char = $string{$len - $i - 1};
+        $char = $string[$len - $i - 1];
 
         if ($multiGroup && $count == 0)
         {

--- a/vendor/symfony/lib/i18n/sfNumberFormatInfo.class.php
+++ b/vendor/symfony/lib/i18n/sfNumberFormatInfo.class.php
@@ -316,7 +316,7 @@ class sfNumberFormatInfo
         // to find the groupsize 1.
         for ($i = strlen($pattern) - 1; $i >= 0; $i--)
         {
-          if ($pattern{$i} == $digit || $pattern{$i} == $hash)
+          if ($pattern[$i] == $digit || $pattern[$i] == $hash)
           {
             $groupSize1 = $i - $groupPos1;
             break;
@@ -335,11 +335,11 @@ class sfNumberFormatInfo
     {
       for ($i = strlen($pattern) - 1; $i >= 0; $i--)
       {
-        if ($pattern{$i} == $dot)
+        if ($pattern[$i] == $dot)
         {
           break;
         }
-        if ($pattern{$i} == $digit)
+        if ($pattern[$i] == $digit)
         {
           $decimalPoints = $i - $decimalPos;
           break;

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/Phing.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/Phing.php
@@ -1049,7 +1049,7 @@ class Phing {
 		// This is a bit of a hack, but works better than previous solution of assuming
 		// data_dir is on the include_path.
 		$dataDir = '@DATA-DIR@';
-		if ($dataDir{0} != '@') { // if we're using PEAR then the @ DATA-DIR @ token will have been substituted.
+		if ($dataDir[0] != '@') { // if we're using PEAR then the @ DATA-DIR @ token will have been substituted.
 			$testPath = $dataDir . DIRECTORY_SEPARATOR . $path;
 			if (file_exists($testPath)) {
 				return $testPath;

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/lib/Capsule.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/lib/Capsule.php
@@ -183,9 +183,9 @@ class Capsule {
      * @return string "Best guess" path for this file.
      */
     protected function resolvePath($file, $basepath) {
-        if ( !($file{0} == DIRECTORY_SEPARATOR || $file{0} == '/') 
+        if ( !($file[0] == DIRECTORY_SEPARATOR || $file[0] == '/') 
             // also account for C:\ style path
-                && !($file{1} == ':' && ($file{2} ==  DIRECTORY_SEPARATOR || $file{2} == '/'))) { 
+                && !($file[1] == ':' && ($file[2] ==  DIRECTORY_SEPARATOR || $file[2] == '/'))) { 
             if ($basepath != null) {
                 $file = $basepath . DIRECTORY_SEPARATOR . $file;
             }

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/system/io/BufferedReader.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/system/io/BufferedReader.php
@@ -141,7 +141,7 @@ class BufferedReader extends Reader {
             // Get next buffered char ...
             // handle case where buffer is read-in, but is empty.  The next readChar() will return -1 EOF,
             // so we just return empty string (char) at this point.  (Probably could also return -1 ...?)
-            $ch = ($this->buffer !== "") ? $this->buffer{$this->bufferPos} : '';
+            $ch = ($this->buffer !== "") ? $this->buffer[$this->bufferPos] : '';
             $this->bufferPos++;
             if ( $this->bufferPos >= strlen($this->buffer) ) {
                 $this->buffer = null;

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/system/io/UnixFileSystem.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/system/io/UnixFileSystem.php
@@ -75,8 +75,8 @@ class UnixFileSystem extends FileSystem {
         // Resolve home directories. We assume /home is where all home
         // directories reside, b/c there is no other way to do this with
         // PHP AFAIK.
-        if ($strPathname{0} === "~") {
-            if ($strPathname{1} === "/") { // like ~/foo => /home/user/foo
+        if ($strPathname[0] === "~") {
+            if ($strPathname[1] === "/") { // like ~/foo => /home/user/foo
                 $strPathname = "/home/" . get_current_user() . substr($strPathname, 1);
             } else { // like ~foo => /home/foo
                 $pos = strpos($strPathname, "/");
@@ -88,7 +88,7 @@ class UnixFileSystem extends FileSystem {
         $n = strlen($strPathname);
         $prevChar = 0;
         for ($i=0; $i < $n; $i++) {
-            $c = $strPathname{$i};
+            $c = $strPathname[$i];
             if (($prevChar === '/') && ($c === '/')) {
                 return self::normalizer($strPathname, $n, $i - 1);
             }
@@ -109,7 +109,7 @@ class UnixFileSystem extends FileSystem {
             return $pathname;
         }
         $n = (int) $len;
-        while (($n > 0) && ($pathname{$n-1} === '/')) {
+        while (($n > 0) && ($pathname[$n-1] === '/')) {
             $n--;
         }
         if ($n === 0) {
@@ -122,7 +122,7 @@ class UnixFileSystem extends FileSystem {
         }
         $prevChar = 0;
         for ($i = $offset; $i < $n; $i++) {
-            $c = $pathname{$i};
+            $c = $pathname[$i];
             if (($prevChar === '/') && ($c === '/')) {
                 continue;
             }
@@ -140,7 +140,7 @@ class UnixFileSystem extends FileSystem {
         if (strlen($pathname === 0)) {
             return 0;
         }
-        return (($pathname{0} === '/') ? 1 : 0);
+        return (($pathname[0] === '/') ? 1 : 0);
     }
 
     /**
@@ -154,7 +154,7 @@ class UnixFileSystem extends FileSystem {
             return $parent;
         }
 
-        if ($child{0} === '/') {
+        if ($child[0] === '/') {
             if ($parent === '/') {
                 return $child;
             }
@@ -194,7 +194,7 @@ class UnixFileSystem extends FileSystem {
     function getBooleanAttributes($f) {
         //$rv = getBooleanAttributes0($f);
         $name = $f->getName();
-        $hidden = (strlen($name) > 0) && ($name{0} == '.');
+        $hidden = (strlen($name) > 0) && ($name[0] == '.');
         return ($hidden ? $this->BA_HIDDEN : 0);
     }
 

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/system/io/Win32FileSystem.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/system/io/Win32FileSystem.php
@@ -48,7 +48,7 @@ class Win32FileSystem extends FileSystem {
     }
 
     function slashify($p) {
-        if ((strlen($p) > 0) && ($p{0} != $this->slash)) {
+        if ((strlen($p) > 0) && ($p[0] != $this->slash)) {
             return $this->slash.$p;
         }
         else {
@@ -81,13 +81,13 @@ class Win32FileSystem extends FileSystem {
      */
     function normalizePrefix($strPath, $len, &$sb) {
         $src = 0;
-        while (($src < $len) && $this->isSlash($strPath{$src})) {
+        while (($src < $len) && $this->isSlash($strPath[$src])) {
             $src++;
         }
         $c = "";
         if (($len - $src >= 2)
-                && $this->isLetter($c = $strPath{$src})
-                && $strPath{$src + 1} === ':') {
+                && $this->isLetter($c = $strPath[$src])
+                && $strPath[$src + 1] === ':') {
             /* Remove leading slashes if followed by drive specifier.
              * This hack is necessary to support file URLs containing drive
              * specifiers (e.g., "file://c:/path").  As a side effect,
@@ -99,8 +99,8 @@ class Win32FileSystem extends FileSystem {
         else {
             $src = 0;
             if (($len >= 2)
-                    && $this->isSlash($strPath{0})
-                    && $this->isSlash($strPath{1})) {
+                    && $this->isSlash($strPath[0])
+                    && $this->isSlash($strPath[1])) {
                 /* UNC pathname: Retain first slash; leave src pointed at
                  * second slash so that further slashes will be collapsed
                  * into the second slash.  The result will be a pathname
@@ -138,15 +138,15 @@ class Win32FileSystem extends FileSystem {
         // Remove redundant slashes from the remainder of the path, forcing all
         // slashes into the preferred slash
         while ($src < $len) {
-            $c = $strPath{$src++};
+            $c = $strPath[$src++];
             if ($this->isSlash($c)) {
-                while (($src < $len) && $this->isSlash($strPath{$src})) {
+                while (($src < $len) && $this->isSlash($strPath[$src])) {
                     $src++;
                 }
                 if ($src === $len) {
                     /* Check for trailing separator */
                     $sn = (int) strlen($sb);
-                    if (($sn == 2) && ($sb{1} === ':')) {
+                    if (($sn == 2) && ($sb[1] === ':')) {
                         // "z:\\"
                         $sb .= $slash;
                         break;
@@ -156,7 +156,7 @@ class Win32FileSystem extends FileSystem {
                         $sb .= $slash;
                         break;
                     }
-                    if (($sn === 1) && ($this->isSlash($sb{0}))) {
+                    if (($sn === 1) && ($this->isSlash($sb[0]))) {
                         /* "\\\\" is not collapsed to "\\" because "\\\\" marks
                         the beginning of a UNC pathname.  Even though it is
                         not, by itself, a valid UNC pathname, we leave it as
@@ -194,7 +194,7 @@ class Win32FileSystem extends FileSystem {
         $altSlash = $this->altSlash;
         $prev = 0;
         for ($i = 0; $i < $n; $i++) {
-            $c = $strPath{$i};
+            $c = $strPath[$i];
             if ($c === $altSlash) {
                 return $this->normalizer($strPath, $n, ($prev === $slash) ? $i - 1 : $i);
             }
@@ -219,8 +219,8 @@ class Win32FileSystem extends FileSystem {
         if ($n === 0) {
             return 0;
         }
-        $c0 = $path{0};
-        $c1 = ($n > 1) ? $path{1} :
+        $c0 = $path[0];
+        $c1 = ($n > 1) ? $path[1] :
               0;
         if ($c0 === $slash) {
             if ($c1 === $slash) {
@@ -230,7 +230,7 @@ class Win32FileSystem extends FileSystem {
         }
 
         if ($this->isLetter($c0) && ($c1 === ':')) {
-            if (($n > 2) && ($path{2}) === $slash) {
+            if (($n > 2) && ($path[2]) === $slash) {
                 return 3;            // Absolute local pathname "z:\\foo" */
             }
             return 2;                // Directory-relative "z:foo"
@@ -253,8 +253,8 @@ class Win32FileSystem extends FileSystem {
         }
 
         $c = $child;
-        if (($cn > 1) && ($c{0} === $slash)) {
-            if ($c{1} === $slash) {
+        if (($cn > 1) && ($c[0] === $slash)) {
+            if ($c[1] === $slash) {
                 // drop prefix when child is a UNC pathname
                 $c = substr($c, 2);
             }
@@ -265,7 +265,7 @@ class Win32FileSystem extends FileSystem {
         }
 
         $p = $parent;
-        if ($p{$pn - 1} === $slash) {
+        if ($p[$pn - 1] === $slash) {
             $p = substr($p, 0, $pn - 1);
         }
         return $p.$this->slashify($c);
@@ -277,7 +277,7 @@ class Win32FileSystem extends FileSystem {
 
     function fromURIPath($strPath) {
         $p = (string) $strPath;
-        if ((strlen($p) > 2) && ($p{2} === ':')) {
+        if ((strlen($p) > 2) && ($p[2] === ':')) {
 
             // "/c:/foo" --> "c:/foo"
             $p = substr($p,1);
@@ -299,12 +299,12 @@ class Win32FileSystem extends FileSystem {
     function isAbsolute(PhingFile $f) {
         $pl = (int) $f->getPrefixLength();
         $p  = (string) $f->getPath();
-        return ((($pl === 2) && ($p{0} === $this->slash)) || ($pl === 3) || ($pl === 1 && $p{0} === $this->slash));
+        return ((($pl === 2) && ($p[0] === $this->slash)) || ($pl === 3) || ($pl === 1 && $p[0] === $this->slash));
     }
 
     /** private */
     function _driveIndex($d) {
-        $d = (string) $d{0};
+        $d = (string) $d[0];
         if ((ord($d) >= ord('a')) && (ord($d) <= ord('z'))) {
             return ord($d) - ord('a');
         }
@@ -316,7 +316,7 @@ class Win32FileSystem extends FileSystem {
 
     /** private */
     function _getDriveDirectory($drive) {
-        $drive = (string) $drive{0};
+        $drive = (string) $drive[0];
         $i = (int) $this->_driveIndex($drive);
         if ($i < 0) {
             return null;
@@ -348,7 +348,7 @@ class Win32FileSystem extends FileSystem {
         $path = $f->getPath();
         $pl   = (int) $f->getPrefixLength();
 
-        if (($pl === 2) && ($path{0} === $this->slash)) {
+        if (($pl === 2) && ($path[0] === $this->slash)) {
             return $path;            // UNC
         }
 
@@ -375,7 +375,7 @@ class Win32FileSystem extends FileSystem {
             if (($ud !== null) && StringHelper::startsWith($ud, $path)) {
                 return (string) ($up . $this->slashify(substr($path,2)));
             }
-            $drive = (string) $path{0};
+            $drive = (string) $path[0];
             $dir   = (string) $this->_getDriveDirectory($drive);
 
             $np = (string) "";

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/system/util/Properties.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/system/util/Properties.php
@@ -81,7 +81,7 @@ class Properties {
             if($line == "")
                 continue;
                     
-            if ($line{0} == '#' or $line{0} == ';') {
+            if ($line[0] == '#' or $line[0] == ';') {
                 // it's a comment, so continue to next line
                 continue;
             } else {

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/tasks/system/CvsPassTask.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/tasks/system/CvsPassTask.php
@@ -141,7 +141,7 @@ class CVSPassTask extends Task {
     private final function mangle($password){
         $buf = "";
         for ($i = 0, $plen = strlen($password); $i < $plen; $i++) {
-            $buf .= chr(self::$shifts[ord($password{$i})]);
+            $buf .= chr(self::$shifts[ord($password[$i])]);
         }
         return $buf;
     }

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/tasks/system/PropertyTask.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/tasks/system/PropertyTask.php
@@ -412,7 +412,7 @@ class PropertyTask extends Task {
             if ($pos === (strlen($value) - 1)) {
                 array_push($fragments, '$');
                 $prev = $pos + 1;
-            } elseif ($value{$pos+1} !== '{' ) {
+            } elseif ($value[$pos+1] !== '{' ) {
 
                 // the string positions were changed to value-1 to correct
                 // a fatal error coming from function substring()

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/types/Path.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/types/Path.php
@@ -350,8 +350,8 @@ class Path extends DataType {
      * replacements.
      */
     protected static function translateFileSep(&$buffer, $pos) {
-        if ($buffer{$pos} == '/' || $buffer{$pos} == '\\') {
-            $buffer{$pos} = DIRECTORY_SEPARATOR;
+        if ($buffer[$pos] == '/' || $buffer[$pos] == '\\') {
+            $buffer[$pos] = DIRECTORY_SEPARATOR;
             return true;
         }
         return false;

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/util/FileUtils.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/util/FileUtils.php
@@ -131,11 +131,11 @@ class FileUtils {
 
         // deal with absolute files
         if (StringHelper::startsWith($fs->getSeparator(), $filename) ||
-                (strlen($filename) >= 2 && Character::isLetter($filename{0}) && $filename{1} === ':')) {
+                (strlen($filename) >= 2 && Character::isLetter($filename[0]) && $filename[1] === ':')) {
             return new PhingFile($this->normalize($filename));
         }
 
-        if (strlen($filename) >= 2 && Character::isLetter($filename{0}) && $filename{1} === ':') {
+        if (strlen($filename) >= 2 && Character::isLetter($filename[0]) && $filename[1] === ':') {
             return new PhingFile($this->normalize($filename));
         }
 
@@ -182,7 +182,7 @@ class FileUtils {
 
         // make sure we are dealing with an absolute path
         if (!StringHelper::startsWith(DIRECTORY_SEPARATOR, $path)
-                && !(strlen($path) >= 2 && Character::isLetter($path{0}) && $path{1} === ':')) {
+                && !(strlen($path) >= 2 && Character::isLetter($path[0]) && $path[1] === ':')) {
             throw new IOException("$path is not an absolute path");
         }
 
@@ -191,7 +191,7 @@ class FileUtils {
 
         // Eliminate consecutive slashes after the drive spec
 
-        if (strlen($path) >= 2 && Character::isLetter($path{0}) && $path{1} === ':') {
+        if (strlen($path) >= 2 && Character::isLetter($path[0]) && $path[1] === ':') {
             $dosWithDrive = true;
 
             $ca = str_replace('/', '\\', $path);
@@ -221,7 +221,7 @@ class FileUtils {
             if (strlen($path) == 1) {
                 $root = DIRECTORY_SEPARATOR;
                 $path = "";
-            } else if ($path{1} == DIRECTORY_SEPARATOR) {
+            } else if ($path[1] == DIRECTORY_SEPARATOR) {
                 // UNC drive
                 $root = DIRECTORY_SEPARATOR.DIRECTORY_SEPARATOR;
                 $path = substr($path, 2);

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/util/PathTokenizer.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/util/PathTokenizer.php
@@ -179,7 +179,7 @@ class PathTokenizer {
 
 
 
-        if (strlen($token) === 1 && Character::isLetter($token{0})
+        if (strlen($token) === 1 && Character::isLetter($token[0])
 
                                 && $this->dosStyleFilesystem
 

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/util/StringHelper.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/phing/util/StringHelper.php
@@ -60,7 +60,7 @@ class StringHelper {
         $ret=array();
         $len=strlen($str);
         for ($i=0; $i < $len; $i++) {
-            $ret[] = $str{$i};
+            $ret[] = $str[$i];
         }
         return $ret;
     }
@@ -177,7 +177,7 @@ class StringHelper {
             trigger_error("substring(), Endindex out of bounds must be $startpos<n<".($len-1), E_USER_ERROR);
         }
         if ($startpos === $endpos) {
-            return (string) $string{$startpos};
+            return (string) $string[$startpos];
         } else {
             $len = $endpos-$startpos;
         }

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/GeneratorConfig.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/GeneratorConfig.php
@@ -119,7 +119,7 @@ class GeneratorConfig {
     // Basically, we want to turn ?.?.?.sqliteDDLBuilder into ?.?.?.SqliteDDLBuilder
     $lastdotpos = strrpos($classpath, '.');
     if ($lastdotpos !== null) {
-      $classpath{$lastdotpos+1} = strtoupper($classpath{$lastdotpos+1});
+      $classpath[$lastdotpos+1] = strtoupper($classpath[$lastdotpos+1]);
     } else {
       $classpath = ucfirst($classpath);
     }

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/database/transform/XmlToAppData.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/database/transform/XmlToAppData.php
@@ -181,7 +181,7 @@ class XmlToAppData extends AbstractHandler {
 							$this->isForReferenceOnly = ($isForRefOnly !== null ? (strtolower($isForRefOnly) === "true") : true); // defaults to TRUE
 						}
 
-						if ($xmlFile{0} != '/') {
+						if ($xmlFile[0] != '/') {
 							$f = new PhingFile($this->currentXmlFile);
 							$xf = new PhingFile($f->getParent(), $xmlFile);
 							$xmlFile = $xf->getPath();

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel/util/BasePeer.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel/util/BasePeer.php
@@ -373,10 +373,10 @@ class BasePeer
 								$rawcvt = '';
 								// parse the $params['raw'] for ? chars
 								for($r=0,$len=strlen($raw); $r < $len; $r++) {
-									if ($raw{$r} == '?') {
+									if ($raw[$r] == '?') {
 										$rawcvt .= ':p'.$p++;
 									} else {
-										$rawcvt .= $raw{$r};
+										$rawcvt .= $raw[$r];
 									}
 								}
 								$sql .= $rawcvt . ', ';

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel/validator/MatchValidator.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel/validator/MatchValidator.php
@@ -59,7 +59,7 @@ class MatchValidator implements BasicValidator
 	private function prepareRegexp($exp)
 	{
 		// remove surrounding '/' marks so that they don't get escaped in next step
-		if ($exp{0} !== '/' || $exp{strlen($exp)-1} !== '/' ) {
+		if ($exp[0] !== '/' || $exp[strlen($exp)-1] !== '/' ) {
 			$exp = '/' . $exp . '/';
 		}
 

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel/validator/NotMatchValidator.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel/validator/NotMatchValidator.php
@@ -57,7 +57,7 @@ class NotMatchValidator implements BasicValidator
 	private function prepareRegexp($exp)
 	{
 		// remove surrounding '/' marks so that they don't get escaped in next step
-		if ($exp{0} !== '/' || $exp{strlen($exp)-1} !== '/' ) {
+		if ($exp[0] !== '/' || $exp[strlen($exp)-1] !== '/' ) {
 			$exp = '/' . $exp . '/';
 		}
 

--- a/vendor/symfony/lib/util/sfFinder.class.php
+++ b/vendor/symfony/lib/util/sfFinder.class.php
@@ -580,10 +580,10 @@ class sfFinder
 
   public static function isPathAbsolute($path)
   {
-    if ($path{0} === '/' || $path{0} === '\\' ||
-        (strlen($path) > 3 && ctype_alpha($path{0}) &&
-         $path{1} === ':' &&
-         ($path{2} === '\\' || $path{2} === '/')
+    if ($path[0] === '/' || $path[0] === '\\' ||
+        (strlen($path) > 3 && ctype_alpha($path[0]) &&
+         $path[1] === ':' &&
+         ($path[2] === '\\' || $path[2] === '/')
         )
        )
     {

--- a/vendor/symfony/lib/vendor/swiftmailer/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/vendor/symfony/lib/vendor/swiftmailer/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -396,7 +396,7 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
             do {
                 $line = $this->_buffer->readLine($seq);
                 $response .= $line;
-            } while (null !== $line && false !== $line && ' ' != $line{3});
+            } while (null !== $line && false !== $line && ' ' != $line[3]);
         } catch (Swift_TransportException $e) {
             $this->_throwException($e);
         } catch (Swift_IoException $e) {


### PR DESCRIPTION
In PHP 7.4 array references using curly braces have been deprecated.
This commit updates all instances in Symfony where this occurs. The
fix is a direct replacement with square brackets.

e.g. $somearray{0}
Becomes:  $somearray[0]

https://wiki.php.net/rfc/deprecate_curly_braces_array_access