### PR TITLE
Initialize settings array, refs #13434

### DIFF
--- a/lib/task/tools/updatePublicationStatusTask.class.php
+++ b/lib/task/tools/updatePublicationStatusTask.class.php
@@ -17,7 +17,7 @@
  * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
  */
 
-class updatePublicationStatusTask extends sfBaseTask
+class updatePublicationStatusTask extends arBaseTask
 {
   protected function configure()
   {
@@ -46,9 +46,7 @@ EOF;
 
   protected function execute($arguments = array(), $options = array())
   {
-    sfContext::createInstance($this->configuration);
-    $databaseManager = new sfDatabaseManager($this->configuration);
-    $conn = $databaseManager->getDatabase('propel')->getConnection();
+    parent::execute($arguments, $options);
 
     $criteria = new Criteria;
     $criteria->add(QubitSlug::SLUG, $arguments['slug']);


### PR DESCRIPTION
Ensure that the classes required for the update-publication-status
task are properly initialized. This commit makes sure that the
search index can be properly updated when the task is run, i.e. by
populating the allowed languages array to be properly used when
updating the index.

**NB.** _This is just an initial commit to fix this issue, but also looking for guidance on what else will be needed for it to be a complete PR._ 

Connected to https://github.com/artefactual/atom/issues/1211