### PR TITLE
Fix permission denied adding child, refs #13435

### DIFF
--- a/apps/qubit/modules/informationobject/actions/editAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/editAction.class.php
@@ -125,12 +125,12 @@ class InformationObjectEditAction extends DefaultEditAction
       $this->form->setValidator('parent', new sfValidatorString);
       $this->form->setWidget('parent', new sfWidgetFormInputHidden);
 
-      $getParams = $this->request->getGetParameters();
-      if (isset($getParams['parent']))
+      $params = $this->request->getParameters();
+      if (isset($params['parent']))
       {
-        $params = $this->context->routing->parse(Qubit::pathInfo($getParams['parent']));
-        $this->parent = $params['_sf_route']->resource;
-        $this->form->setDefault('parent', $getParams['parent']);
+        $route = $this->context->routing->parse(Qubit::pathInfo($params['parent']));
+        $this->parent = $route['_sf_route']->resource;
+        $this->form->setDefault('parent', $params['parent']);
       }
       else
       {
@@ -139,7 +139,7 @@ class InformationObjectEditAction extends DefaultEditAction
         $this->form->setDefault('parent', $this->context->routing->generate(null, array($this->parent, 'module' => 'informationobject')));
       }
 
-      if (isset($getParams['repository']))
+      if (isset($params['repository']))
       {
         $this->resource->repository = QubitRepository::getById($this->request->repository);
         $this->form->setDefault('repository', $this->context->routing->generate(null, array($this->resource->repository, 'module' => 'repository')));

--- a/apps/qubit/modules/informationobject/templates/_actions.php
+++ b/apps/qubit/modules/informationobject/templates/_actions.php
@@ -10,7 +10,7 @@
       <?php endif; ?>
 
       <?php if (QubitAcl::check($resource, 'create')): ?>
-        <li><?php echo link_to(__('Add new'), array('module' => 'informationobject', 'action' => 'add', 'parent' => url_for(array($resource, 'module' => 'informationobject'))), array('class' => 'c-btn')) ?></li>
+        <li><?php echo link_to(__('Add new'), array('module' => 'informationobject', 'action' => 'add', 'parent' => $resource->slug), array('class' => 'c-btn')) ?></li>
         <li><?php echo link_to(__('Duplicate'), array('module' => 'informationobject', 'action' => 'copy', 'source' => $resource->id), array('class' => 'c-btn')) ?></li>
       <?php endif; ?>
 


### PR DESCRIPTION
- Use the parent resource slug (e.g. 'my-slug') not the relative path
  (e.g. '/my-slug') for the "parent" parameter when creating a new
  information object
- Check POST as well as GET parameters for a "parent" param when
  creating a new informtion object, to allow authenticating the
  "create" action against the parent IO on form submit.