### PR TITLE
Consolidate DO auth logic, refs #13437

### DIFF
--- a/apps/qubit/modules/actor/actions/indexAction.class.php
+++ b/apps/qubit/modules/actor/actions/indexAction.class.php
@@ -43,6 +43,6 @@ class ActorIndexAction extends sfAction
 
     $this->functions = QubitFunctionObject::get($criteria);
 
-    $this->digitalObjectLink = $this->resource->getDigitalObjectLink();
+    $this->digitalObjectLink = $this->resource->getDigitalObjectUrl();
   }
 }

--- a/apps/qubit/modules/digitalobject/actions/imageflowComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/imageflowComponent.class.php
@@ -74,8 +74,7 @@ class DigitalObjectImageflowComponent extends sfComponent
       else
       {
         // Ensure the user has permissions to see a thumbnail
-        if (!QubitAcl::check($item->object, 'readThumbnail') ||
-            !QubitGrantedRight::checkPremis($item->object->id, 'readThumb'))
+        if (!QubitAcl::check($item->object, 'readThumbnail'))
         {
           $thumbnail = QubitDigitalObject::getGenericRepresentation(
             $item->mimeType, QubitTerm::THUMBNAIL_ID

--- a/apps/qubit/modules/digitalobject/actions/showDownloadComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/showDownloadComponent.class.php
@@ -58,9 +58,13 @@ class DigitalObjectShowDownloadComponent extends sfComponent
     }
 
     // Build a fully qualified URL to this digital object asset
-    if ((QubitTerm::IMAGE_ID != $this->resource->mediaTypeId || QubitTerm::REFERENCE_ID == $this->usageType)
-        && $this->resource->usageId != QubitTerm::OFFLINE_ID
-        && QubitAcl::check($this->resource->object, 'readMaster'))
+    if (
+      (
+        QubitTerm::IMAGE_ID != $this->resource->mediaTypeId
+        || QubitTerm::REFERENCE_ID == $this->usageType
+      )
+      && $this->resource->usageId != QubitTerm::OFFLINE_ID
+      && QubitAcl::check($this->resource->object, 'readMaster'))
     {
       $this->link = $this->resource->getPublicPath();
     }

--- a/apps/qubit/modules/digitalobject/actions/showGenericIconComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/showGenericIconComponent.class.php
@@ -18,7 +18,7 @@
  */
 
 /**
- * Display an 'image' digital asset
+ * Display a generic representation of a digital object
  *
  * @package    AccesstoMemory
  * @subpackage digital object
@@ -27,23 +27,18 @@
 class DigitalObjectShowGenericIconComponent extends sfComponent
 {
   /**
-   * Show a representation of a digital object image.
+   * Show a generic representation of a digital object image
    *
    * @param sfWebRequest $request
-   *
    */
   public function execute($request)
   {
-    $this->representation = QubitDigitalObject::getGenericRepresentation($this->resource->mimeType, $this->resource->usageId);
+    $this->representation = QubitDigitalObject::getGenericRepresentation(
+      $this->resource->mimeType, $this->resource->usageId
+    );
 
-    if ($this->resource->object instanceOf QubitInformationObject)
-    {
-      $this->canReadMaster = QubitAcl::check($this->resource->object, 'readMaster');
-    }
-    else if ($this->resource->object instanceOf QubitActor &&
-      $this->context->user->isAuthenticated())
-    {
-      $this->canReadMaster = QubitAcl::check($this->resource->object, 'read');;
-    }
+    $this->canReadMaster = QubitAcl::check(
+      $this->resource->object, 'readMaster'
+    );
   }
 }

--- a/apps/qubit/modules/digitalobject/actions/viewAction.class.php
+++ b/apps/qubit/modules/digitalobject/actions/viewAction.class.php
@@ -44,11 +44,8 @@ class DigitalObjectViewAction extends sfAction
 
     list($obj, $action) = $this->getObjAndAction();
 
-    // Do appropriate ACL check(s). Master copy of text objects are always allowed for reading
-    // QubitActor does not have a ACL check for readmaster.
-    if ((!QubitAcl::check($obj, $action) || !QubitGrantedRight::checkPremis($obj->id, $action))
-      && !($action == 'readMaster' && $this->resource->mediaTypeId == QubitTerm::TEXT_ID)
-      && $obj instanceOf QubitInformationObject)
+    // If access is denied, forward user to a 404 "Not found" page
+    if (!QubitAcl::check($obj, $action))
     {
       $this->forward404();
     }

--- a/apps/qubit/modules/digitalobject/templates/_metadata.php
+++ b/apps/qubit/modules/digitalobject/templates/_metadata.php
@@ -133,7 +133,7 @@
 
           <?php if ($showMasterFileName): ?>
             <?php if ($canAccessMasterFile): ?>
-              <?php echo render_show(__('Filename'), link_to(render_value_inline($resource->name), $resource->object->getDigitalObjectLink(), array('target' => '_blank')), array('fieldLabel' => 'filename')) ?>
+              <?php echo render_show(__('Filename'), link_to(render_value_inline($resource->name), $resource->object->getDigitalObjectUrl(), array('target' => '_blank')), array('fieldLabel' => 'filename')) ?>
             <?php else: ?>
               <?php echo render_show(__('Filename'), render_value($resource->name), array('fieldLabel' => 'filename')) ?>
             <?php endif; ?>

--- a/apps/qubit/modules/informationobject/actions/indexAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/indexAction.class.php
@@ -130,6 +130,6 @@ class InformationObjectIndexAction extends sfAction
       $this->response->addMeta('description', truncate_text(strip_markdown($scopeAndContent), 150));
     }
 
-    $this->digitalObjectLink = $this->resource->getDigitalObjectLink();
+    $this->digitalObjectLink = $this->resource->getDigitalObjectUrl();
   }
 }

--- a/apps/qubit/modules/informationobject/templates/_cardViewResults.php
+++ b/apps/qubit/modules/informationobject/templates/_cardViewResults.php
@@ -13,9 +13,11 @@
     <?php endif; ?>
 
       <a href="<?php echo url_for(array('module' => 'informationobject', 'slug' => $doc['slug'])) ?>">
-        <?php if (isset($doc['digitalObject']) && !empty($doc['digitalObject']['thumbnailPath'])
+        <?php if (
+          isset($doc['digitalObject'])
+          && !empty($doc['digitalObject']['thumbnailPath'])
           && QubitAcl::check(QubitInformationObject::getById($hit->getId()), 'readThumbnail')
-          && QubitGrantedRight::checkPremis($hit->getId(), 'readThumb')): ?>
+        ): ?>
 
           <?php echo link_to(image_tag($doc['digitalObject']['thumbnailPath'],
             array('alt' => isset($doc['digitalObject']['digitalObjectAltText']) ? $doc['digitalObject']['digitalObjectAltText'] : truncate_text(strip_markdown($title), 100))),

--- a/apps/qubit/modules/informationobject/templates/inventorySuccess.php
+++ b/apps/qubit/modules/informationobject/templates/inventorySuccess.php
@@ -55,7 +55,7 @@
             <td>
               <?php if ($doc['hasDigitalObject']): ?>
                 <?php if (null !== $io = QubitInformationObject::getById($hit->getId())): ?>
-                  <?php if (null !== $link = $io->getDigitalObjectLink()): ?>
+                  <?php if (null !== $link = $io->getDigitalObjectUrl()): ?>
                     <?php echo link_to(__('View'), $link) ?>
                   <?php endif; ?>
                 <?php endif; ?>

--- a/apps/qubit/modules/search/templates/_searchResult.php
+++ b/apps/qubit/modules/search/templates/_searchResult.php
@@ -11,9 +11,11 @@
     <div class="search-result-preview">
       <a href="<?php echo url_for(array('module' => 'informationobject', 'slug' => $doc['slug'])) ?>">
         <div class="preview-container">
-          <?php if (isset($doc['digitalObject']['thumbnailPath']) &&
-                    QubitAcl::check(QubitInformationObject::getById($hit->getId()), 'readThumbnail') &&
-                    QubitGrantedRight::checkPremis($hit->getId(), 'readThumb')): ?>
+          <?php if (
+              isset($doc['digitalObject']['thumbnailPath']) &&
+              QubitAcl::check(QubitInformationObject::getById($hit->getId()), 'readThumbnail')
+            ):
+          ?>
             <?php echo image_tag($doc['digitalObject']['thumbnailPath'],
               array('alt' => isset($doc['digitalObject']['digitalObjectAltText']) ? $doc['digitalObject']['digitalObjectAltText'] : truncate_text(strip_markdown(get_search_i18n($doc, 'title', array('allowEmpty' => false, 'culture' => $culture))), 100))) ?>
           <?php else: ?>

--- a/lib/job/arExportJob.class.php
+++ b/lib/job/arExportJob.class.php
@@ -314,28 +314,13 @@ class arExportJob extends arBaseJob
 
   protected function allowDigitalObjectExport($resource, $digitalObject)
   {
-    // If we need to add in check for images only, then use:
-    // $digitalObject->isImage() or
-    // $digitalObject->isWebCompatibleImageFormat()
-    // ----------
-    // Do appropriate ACL check(s). Master copy of text objects are always
-    // allowed for reading. QubitActor does not have a ACL check for
-    // readMaster - so only enable for authenticated users.
+    // Check that digital object has a URL, the current user is authorized to
+    // access it, and a conditional copyright statement doesn't need to be
+    // accepted
     if (
       $digitalObject->masterAccessibleViaUrl()
-      && (
-        QubitTerm::TEXT_ID == $digitalObject->mediaTypeId
-        || (
-          'actor' == $this->params['objectType']
-          && $this->user->isAuthenticated()
-          && QubitAcl::check($resource, 'read')
-        ) || (
-          'informationObject' == $this->params['objectType']
-          && QubitAcl::check($resource, 'readMaster')
-          && QubitGrantedRight::checkPremis($resource->id, 'readMaster')
-          && !$digitalObject->hasConditionalCopyright()
-        )
-      )
+      && QubitAcl::check($resource, 'readMaster')
+      && !$digitalObject->hasConditionalCopyright()
     )
     {
       // Export is allowed

--- a/lib/model/QubitActor.php
+++ b/lib/model/QubitActor.php
@@ -813,41 +813,4 @@ class QubitActor extends BaseActor
 
     $this->digitalObjectsRelatedByobjectId[] = $digitalObject;
   }
-
-  /**
-   * Return the absolute link to the digital object master unless the user has
-   * no permission (readMaster). Text objects are always allowed for reading.
-   *
-   * @return string Absolute link to the digital object master
-   */
-  public function getDigitalObjectLink()
-  {
-    if (count($this->digitalObjectsRelatedByobjectId) <= 0)
-    {
-      return;
-    }
-
-    $digitalObject = $this->digitalObjectsRelatedByobjectId[0];
-    if (!$digitalObject->masterAccessibleViaUrl())
-    {
-      return;
-    }
-
-    $isText = in_array($digitalObject->mediaTypeId, array(QubitTerm::TEXT_ID));
-
-    $hasReadMaster = sfContext::getInstance()->user->isAuthenticated();
-    if ($hasReadMaster || $isText)
-    {
-      if (QubitTerm::EXTERNAL_URI_ID == $digitalObject->usageId)
-      {
-        return $digitalObject->path;
-      }
-      else
-      {
-        $request = sfContext::getInstance()->getRequest();
-        return $request->getUriPrefix().$request->getRelativeUrlRoot().
-          $digitalObject->getFullPath();
-      }
-    }
-  }
 }

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -3055,43 +3055,6 @@ class QubitInformationObject extends BaseInformationObject
     return strip_tags($this->getExtentAndMedium($options));
   }
 
-  /**
-   * Return the absolute link to the digital object master unless the user has
-   * no permission (readMaster). Text objects are always allowed for reading.
-   *
-   * @return string Absolute link to the digital object master
-   */
-  public function getDigitalObjectLink()
-  {
-    if (count($this->digitalObjectsRelatedByobjectId) <= 0)
-    {
-      return;
-    }
-
-    $digitalObject = $this->digitalObjectsRelatedByobjectId[0];
-    if (!$digitalObject->masterAccessibleViaUrl())
-    {
-      return;
-    }
-
-    $isText = in_array($digitalObject->mediaTypeId, array(QubitTerm::TEXT_ID));
-    $hasReadMaster = QubitAcl::check($this, 'readMaster');
-
-    if (QubitGrantedRight::checkPremis($this->id, 'readMaster') && ($hasReadMaster || $isText))
-    {
-      if (QubitTerm::EXTERNAL_URI_ID == $digitalObject->usageId)
-      {
-        return $digitalObject->path;
-      }
-      else
-      {
-        $request = sfContext::getInstance()->getRequest();
-        return $request->getUriPrefix().$request->getRelativeUrlRoot().
-          $digitalObject->getFullPath();
-      }
-    }
-  }
-
   /*
    * Generate a slug for this information object. This might be based
    * on title, identifier (reference code), or other properties in the future.

--- a/plugins/qbAclPlugin/lib/QubitActorAcl.class.php
+++ b/plugins/qbAclPlugin/lib/QubitActorAcl.class.php
@@ -18,13 +18,13 @@
  */
 
 /**
- * Custom ACL rules for QubitInformationObject resources
+ * Custom ACL rules for QubitActor resources
  *
  * @package    qbAclPlugin
  * @subpackage acl
  * @author     David Juhasz <david@artefactual.com>
  */
-class QubitInformationObjectAcl extends QubitAcl
+class QubitActorAcl extends QubitAcl
 {
   // Add viewDraft and publish actions to list
   public static $ACTIONS = array(
@@ -40,17 +40,14 @@ class QubitInformationObjectAcl extends QubitAcl
     'readThumbnail' => 'Access thumbnail'
   );
 
-  // For information objects check parent authorization for create OR publish
-  // actions
   protected static
-    $_parentAuthActions = ['create', 'publish'],
     $_digitalObjectActions = ['readMaster', 'readReference', 'readThumbnail'];
 
   /**
-   * Do custom ACL checks for QubitInformationObject resources
+   * Do custom ACL checks for QubitActor resources
    *
    * @param myUser $user to authorize
-   * @param QubitInformationObject $resource target of the requested action
+   * @param QubitActor $resource target of the requested action
    * @param string $action requested for authorization (e.g. 'read')
    * @param array|null $options optional parameters
    *
@@ -58,11 +55,6 @@ class QubitInformationObjectAcl extends QubitAcl
    */
   public static function isAllowed($user, $resource, $action, $options = array())
   {
-    if ('read' == $action)
-    {
-      return self::isReadAllowed($user, $resource, $action, $options);
-    }
-
     // Do custom ACL checks for digital object actions
     if (in_array($action, self::$_digitalObjectActions))
     {
@@ -76,63 +68,32 @@ class QubitInformationObjectAcl extends QubitAcl
   }
 
   /**
-   * Custom QubitInformationObject "read" authorization rules
+   * Check if $user is authorized to do $action on the digital object linked to
+   * this actor
    *
-   * @param myUser $user to authorize
-   * @param mixed $resource target of the requested action
-   * @param string $action requested for authorization (e.g. 'read')
-   * @param array|null $options optional parameters
+   * @param QubitUser $user to authorize
+   * @param string $action being requested (e.g. "readReference")
    *
-   * @return bool true if the access request is authorized
+   * @return bool true if $user is authorized to perform $action
    */
-  private static function isReadAllowed($user, $resource, $action, $options = array())
-  {
-    if (null === $resource->getPublicationStatus())
-    {
-      throw new sfException(
-        'No publication status set for information object id: '.$resource->id
-      );
-    }
-
-    // If this is a draft information object, check "read" and "viewDraft"
-    // authorization
-    if (
-      QubitTerm::PUBLICATION_STATUS_DRAFT_ID
-      == $resource->getPublicationStatus()->statusId
-    )
-    {
-      $instance = self::getInstance()->buildAcl($resource, $options);
-
-      return
-        $instance->acl->isAllowed($user, $resource, 'read')
-        && $instance->acl->isAllowed($user, $resource, 'viewDraft');
-    }
-
-    // Otherwise, just do a "read" ACL check
-    return parent::isAllowed($user, $resource, $action, $options);
-  }
-
-  /**
-   * Do custom ACL checks for digital object actions
-   *
-   * @param myUser $user to authorize
-   * @param mixed $resource target of the requested action
-   * @param string $action requested for authorization (e.g. 'read')
-   * @param array|null $options optional parameters
-   */
-  private static function isDigitalObjectActionAllowed(
+  private function isDigitalObjectActionAllowed(
     $user, $resource, $action, $options = []
   )
   {
+    // All users can access actor reference representations and thumbnails
+    if (in_array($action, ['readReference', 'readThumbnail']))
+    {
+      return true;
+    }
+
     // All users are authorized to read text (PDF) masters
     if ($action == 'readMaster' && $resource->hasTextDigitalObject())
     {
       return true;
     }
 
-    // Do the standard QubitAcl authorization check AND a QubitGrantedRight
-    // check
-    return parent::isAllowed($user, $resource, $action, $options)
-      && QubitGrantedRight::checkPremis($resource->id, $action);
+    // All authenticated users are authorized to read actor master DOs
+    return $user->isAuthenticated();
   }
 }
+


### PR DESCRIPTION
- Move information object specific ACL logic to the QubitInformationObjectAcl
  subclass
- Consolidate information object digital object authorization logic
- Consolidate actor digital object authorization logic
- Update all digital object authorization checks to use the new consolidated
  auth code
- Merge duplicate code for getting a digital object URL from QubitActor and 
  QubitInformationObject classes to the QubitObject class