### PR TITLE
Inherit from arBaseTask, refs #13434

### DIFF
--- a/lib/task/tools/updatePublicationStatusTask.class.php
+++ b/lib/task/tools/updatePublicationStatusTask.class.php
@@ -17,7 +17,7 @@
  * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
  */
 
-class updatePublicationStatusTask extends sfBaseTask
+class updatePublicationStatusTask extends arBaseTask
 {
   protected function configure()
   {
@@ -46,9 +46,7 @@ EOF;
 
   protected function execute($arguments = array(), $options = array())
   {
-    sfContext::createInstance($this->configuration);
-    $databaseManager = new sfDatabaseManager($this->configuration);
-    $conn = $databaseManager->getDatabase('propel')->getConnection();
+    parent::execute($arguments, $options);
 
     $criteria = new Criteria;
     $criteria->add(QubitSlug::SLUG, $arguments['slug']);


### PR DESCRIPTION
Ensure that the symfony task required to update publication status
inherits from arBaseTask so that it is initialized correctly. This
commit makes sure that the search index can now be properly updated
when the task is run.

Cherry-picked from https://github.com/artefactual/atom/pull/1212 as a candidate for `2.6.2`. (I believe a PR is needed because of branch protection) 