### PR TITLE
Adjust Dockerfile to take advantage of docker caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ ENV FOP_HOME=/usr/share/fop-2.1 \
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-COPY . /atom/src
-
 RUN set -xe \
 		&& apk add --no-cache --virtual .phpext-builddeps \
 			gettext-dev \
@@ -48,12 +46,18 @@ RUN set -xe \
 			make \
 			bash \
 			gnu-libiconv \
+			fcgi \
 		&& npm install -g "less@<2.0.0" \
 		&& curl -Ls https://archive.apache.org/dist/xmlgraphics/fop/binaries/fop-2.1-bin.tar.gz | tar xz -C /usr/share \
-		&& ln -sf /usr/share/fop-2.1/fop /usr/local/bin/fop \
+		&& ln -sf /usr/share/fop-2.1/fop /usr/local/bin/fop
+
+COPY . /atom/src
+
+RUN set -xe \
 		&& make -C /atom/src/plugins/arDominionPlugin \
 		&& make -C /atom/src/plugins/arArchivesCanadaPlugin \
 		&& composer install -d /atom/src
+
 
 WORKDIR /atom/src
 


### PR DESCRIPTION
I've upgraded archives.mhsc.ca to AtoM 2.6 - it's now hosted using docker.  Kudos to you for your work on AtoM and your work to dockerize it!

I've worked with your Dockerfile a bit in updating our customizations and theming. One pain point I hit was that lessc (from make -C /atom/src/plugins/arDominionPlugin) failed due to a theming customization on our end.  Fixing and re-running meant re-building the entire container.  That meant several very slow iterations while I fixed that up.

I am submitting this PR which re-organizes your Dockerfile a bit.  The local source tree almost always has changes from the previous build, so docker can't usually use any cached steps below `COPY . /atom/src`.  The main idea in the PR is to move the COPY lower down in the file to allow docker's cache to work.  Building PHP doesn't depend on the codebase, so it's not necessary to have COPY above the PHP build.  

I also added the fcgi package - this allows a docker healthcheck to be defined in the atom container which tests that PHP-FPM is running and producing expected result (I can share the healthcheck code if you are interested).

