### PR TITLE
CSV export duplicate cols, refs #13430

### DIFF
--- a/lib/flatfile/QubitFlatfileExport.class.php
+++ b/lib/flatfile/QubitFlatfileExport.class.php
@@ -193,6 +193,16 @@ class QubitFlatfileExport
       }
       else
       {
+        // If config array being overridden is a sequential array,
+        // replace all elements in the array (e.g. isad 'columnNames').
+        // If config array being overridden is an associative array,
+        // override elements are merged so do not use this logic
+        // (e.g. rad 'map').
+        if ($config[$key] === array_values($config[$key]))
+        {
+          $config[$key] = array();
+        }
+
         $this->overrideConfigData($config[$key], $mixin[$key]);
       }
     }


### PR DESCRIPTION
This commit fixes an issue where duplicated columns were being included
in the information object csv export files.

The cause of the issue was that when overriding the standard columnNames,
there were fewer columns specified in QubitInformationObject-isad.yml
than the default file: QubitInformationObject.yml. The duplicated columns
are elements from the default array that were not overwritten because
the override array had fewer elements.

This fix checks if the array is a sequential array vs an associative
one. If the array is sequential the default array will be emptied
so the contents (e.g. 'columnNames' sequential array) are replaced by
the contents from the isad or rad standards file. The behaviour for
associative array data in the isad or rad yml file stays the same - it
is merged into the default settings file.