### PR TITLE
CSV import matching issue, refs #13439

### DIFF
--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -502,6 +502,7 @@ mapping:
           slug: { type: keyword }
       repository:
         _i18nFields: [authorizedFormOfName]
+        _rawFields: [authorizedFormOfName]
         dynamic: strict
         properties:
           id: { type: integer }

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchMapping.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchMapping.class.php
@@ -376,10 +376,10 @@ class arElasticSearchMapping
         $languages = sfConfig::get('app_i18n_languages');
         if (1 > count($languages))
         {
-          throw new sfException('The database settings don\'t content any language.');
+          throw new sfException('The database settings do not contain any languages.');
         }
 
-        // Add source culture propertie
+        // Add source culture property
         $this->setIfNotSet($mapping['properties'], 'sourceCulture', array('type' => 'keyword', 'include_in_all' => false));
 
         $nestedI18nFields = array();
@@ -389,6 +389,16 @@ class arElasticSearchMapping
 
           // Create mapping for i18n field
           $nestedI18nFields[$i18nFieldNameCamelized] = $this->getI18nFieldMapping($i18nFieldNameCamelized);
+        }
+
+        // Add 'untouched' when _rawFields specified in _partial_foreign_types section
+        if (isset($mapping['_rawFields']))
+        {
+          foreach ($mapping['_rawFields'] as $item)
+          {
+            $nestedI18nFields[$item]['fields']['untouched'] = array('type' => 'keyword');
+          }
+          unset($mapping['_rawFields']);
         }
 
         // i18n documents (one per culture)


### PR DESCRIPTION
This commit addresses an issue in Descriptions CSV import where the
secondary matching logic based on the description's title, identifier,
and repo was failing. The way the repository logic was being indexed
with a description was recently changed so that only specific fields
are being included instead of the entire QubitRepository object.

This commit allows an 'untouched' keyword field to be added for
translatable fields included in a '_partial_foreign_types' mapping.yml
section.

To fix the CSV import secondary matching, the information object's
repository partial_foreign_type section now specifies
'_rawFields: [authorizedFormOfName]' to allow keyword matching on repo
name. This feature can be used in any _partial_foreign_type.