### PR TITLE
Fix storage location display, refs #13314

### DIFF
--- a/lib/model/QubitTerm.php
+++ b/lib/model/QubitTerm.php
@@ -541,8 +541,7 @@ class QubitTerm extends BaseTerm
 
       if (isset($options['returnObjectInstances']) && true == $options['returnObjectInstances'])
       {
-        $node->name = $indentedName;
-        $tree[sfContext::getInstance()->routing->generate(null, array($node, 'module' => 'term'))] = $node;
+        $tree[sfContext::getInstance()->routing->generate(null, array($node, 'module' => 'term'))] = $indentedName;
       }
       else
       {


### PR DESCRIPTION
A function that was generating data for an HTML select form field was unnessarily modifying QubitTerm instances. The modifed instances were getting cached and this caching was leading to incorrect display of the names of the cached QubitTerm instances in logic following the generation of the HTML select form field data.

This was fixed by not modifying the QubitTerm instances.