### PR TITLE
Fix full treeview limit setting, refs #13451

### DIFF
--- a/apps/qubit/modules/informationobject/actions/fullWidthTreeViewAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/fullWidthTreeViewAction.class.php
@@ -46,7 +46,7 @@ class InformationObjectFullWidthTreeViewAction extends DefaultFullTreeViewAction
 
     // Impose limit to what nodeLimit parameter can be set to
     $maxItemsPerPage = sfConfig::get('app_treeview_items_per_page_max', 10000);
-    if (!ctype_digit($request->nodeLimit) || $request->nodeLimit > $maxItemsPerPage)
+    if (!intval($request->nodeLimit) || $request->nodeLimit < 1 || $request->nodeLimit > $maxItemsPerPage)
     {
       $request->nodeLimit = $maxItemsPerPage;
     }


### PR DESCRIPTION
Fixed an issue with the endpoint for providing full treeview node data.

Changed so if an integer hasn't been provided, as a GET parameter, to specify a treeview item per page limit then the default is used.

The existing logic was incorrectly allowing the limit to be set to "0".