### PR TITLE
Hide missing DO master file, refs #13388

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/metadataComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/metadataComponent.class.php
@@ -38,6 +38,7 @@ class DigitalObjectMetadataComponent extends sfComponent
       && arStorageServiceUtils::getAipDownloadEnabled()
     );
 
+    $this->masterCopy = $this->resource->getRepresentationByUsage(QubitTerm::MASTER_ID);
     $this->referenceCopy = $this->resource->getRepresentationByUsage(QubitTerm::REFERENCE_ID);
     $this->thumbnailCopy = $this->resource->getRepresentationByUsage(QubitTerm::THUMBNAIL_ID);
 
@@ -201,7 +202,7 @@ class DigitalObjectMetadataComponent extends sfComponent
       || $this->showMasterFileMimeType
       || $this->showMasterFileSize
       || $this->showMasterFileCreatedAt
-    );
+    ) && null !== $this->masterCopy;
   }
 
   protected function setReferenceCopyShowProperties()
@@ -237,7 +238,7 @@ class DigitalObjectMetadataComponent extends sfComponent
       || $this->showReferenceCopyMimeType
       || $this->showReferenceCopyFileSize
       || $this->showReferenceCopyCreatedAt
-    );
+    ) && null !== $this->referenceCopy;
   }
 
   protected function setThumbnailCopyShowProperties()
@@ -273,7 +274,7 @@ class DigitalObjectMetadataComponent extends sfComponent
       || $this->showThumbnailCopyMimeType
       || $this->showThumbnailCopyFileSize
       || $this->showThumbnailCopyCreatedAt
-    );
+    ) && null !== $this->thumbnailCopy;
   }
 
   protected function setOriginalFileShowProperties()

--- a/apps/qubit/modules/digitalobject/templates/_metadata.php
+++ b/apps/qubit/modules/digitalobject/templates/_metadata.php
@@ -163,7 +163,7 @@
 
       <?php endif; ?>
 
-      <?php if (null !== $referenceCopy && $showReferenceCopyMetadata): ?>
+      <?php if ($showReferenceCopyMetadata): ?>
 
         <div class="digital-object-metadata-header">
           <h3><?php echo __('Reference copy') ?> <i class="fa fa-file<?php if (!$canAccessReferenceCopy): ?> inactive<?php endif; ?>" aria-hidden="true"></i></h3>
@@ -202,7 +202,7 @@
 
       <?php endif; ?>
 
-      <?php if (null !== $thumbnailCopy && $showThumbnailCopyMetadata): ?>
+      <?php if ($showThumbnailCopyMetadata): ?>
 
         <div class="digital-object-metadata-header">
           <h3><?php echo __('Thumbnail copy') ?> <i class="fa fa-file<?php if (!$canAccessThumbnailCopy): ?> inactive<?php endif; ?>" aria-hidden="true"></i></h3>


### PR DESCRIPTION
Archivematica's metadata-only DIP upload generates a DO with no master
file. This updates the DO metadata component to hide the master file
section when the master file is missing.

The existing conditions for the reference and thumbnail copy areas
have been moved to the component class for uniformity.