### PR TITLE
D.O. download API draft access check, ref #13436

### DIFF
--- a/plugins/arRestApiPlugin/modules/api/actions/informationobjectsDownloadDigitalObjectAction.class.php
+++ b/plugins/arRestApiPlugin/modules/api/actions/informationobjectsDownloadDigitalObjectAction.class.php
@@ -39,6 +39,17 @@ class ApiInformationObjectsDownloadDigitalObjectAction extends QubitApiAction
       throw new QubitApiNotAuthorizedException;
     }
 
+    // Check, if I.O. isn't published, that user is authorized to access drafts
+    $publicationStatusId = $this->resource->getPublicationStatus()->statusId;
+
+    if (
+      $publicationStatusId != QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID
+      && !QubitAcl::check($this->resource, 'viewDraft')
+    )
+    {
+      throw new QubitApiNotAuthorizedException;
+    }
+
     // Check that a master or external digital object exists
     $digitalObjectTypes = array(QubitTerm::MASTER_ID, QubitTerm::EXTERNAL_URI_ID);
     $criteria = new Criteria;


### PR DESCRIPTION
Added check, to API endpoint for downloading master digital objects, to make sure user has draft access if the digital object's information object isn't published.