### PR TITLE
Respect 'no_script_name' for EAD URLs, refs #13456

### DIFF
--- a/apps/qubit/config/qubitConfiguration.class.php
+++ b/apps/qubit/config/qubitConfiguration.class.php
@@ -118,4 +118,45 @@ class qubitConfiguration extends sfApplicationConfiguration
 
     $this->setWebDir($path);
   }
+
+  /**
+   * Get a config variable from an application config file (YAML) for a specific
+   * environment (e.g. "prod", "dev", "cli")
+   *
+   * N.B. to get a config variable for the current context/environment, use
+   * sfConfing::get() instead!
+   *
+   * @param string $varname config variable name
+   * @param string $env Environment name (e.g. 'prod', 'cli')
+   * @param string $configFile config file to check (e.g. 'config/settings.yml')
+   *
+   * @return string|null config value or null if variable is not set
+   */
+  public static function getConfigForEnvironment($varname, $env, $configFile)
+  {
+    // Parse the YAML data to an array
+    $config = sfSimpleYamlConfigHandler::getConfiguration(
+      sfContext::getInstance()
+        ->getConfiguration()
+        ->getConfigPaths($configFile)
+    );
+
+    // The settings.yml file requires an intermediate '.settings' key for
+    // some reason :-/
+    if (
+      'config/settings.yml' == $configFile &&
+      isset($config[$env]['.settings'][$varname]))
+    {
+      return $config[$env]['.settings'][$varname];
+    }
+
+    // Get a value from non "settings.yml" config files
+    if (isset($config[$env][$varname]))
+    {
+      return $config[$env][$varname];
+    }
+
+    // Return null if the variable is not set in the specified config file
+    return null;
+  }
 }


### PR DESCRIPTION
- Use symfony web routing to generate resource URL when in web request
  context
- In cli and worker contexts, build resource URL using siteBaseUrl
  setting
- Include "index.php" script name when generating the <eadid @url> only
  when production environment "no_script_name" value is not true
- Create qubitConfiguration::getConfigForEnvironment() method to get
  qubit configuration values outside current context
- Use new method to get "no_script_name" setting for prod environment
  when generating a resource URL in cli or worker context