### PR TITLE
AIP Download metadata only DIPs, refs 13454

### DIFF
--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -74,6 +74,7 @@ class QubitInformationObject extends BaseInformationObject
       case 'formatRegistryName':
       case 'objectUUID':
       case 'aipUUID':
+      case 'aipName':
       case 'relativePathWithinAip':
       case 'originalFileName':
       case 'originalFileSize':

--- a/plugins/arRestApiPlugin/modules/api/actions/digitalobjectsCreateAction.class.php
+++ b/plugins/arRestApiPlugin/modules/api/actions/digitalobjectsCreateAction.class.php
@@ -54,7 +54,9 @@ class ApiDigitalObjectsCreateAction extends QubitApiAction
         'format_name' => 'formatName',
         'format_version' => 'formatVersion',
         'format_registry_key' => 'formatRegistryKey',
-        'format_registry_name' => 'formatRegistryName'
+        'format_registry_name' => 'formatRegistryName',
+        'relative_path_within_aip' => 'relativePathWithinAip',
+        'aip_name' => 'aipName'
       );
 
       foreach ($props as $pkey => $pval)

--- a/plugins/arStorageServicePlugin/modules/arStorageService/actions/downloadAction.class.php
+++ b/plugins/arStorageServicePlugin/modules/arStorageService/actions/downloadAction.class.php
@@ -96,6 +96,7 @@ class arStorageServiceDownloadAction extends sfAction
     // Check return status from Storage Service
     if (200 !== $status = arStorageServiceUtils::getFileFromStorageService($url))
     {
+      sfContext::getInstance()->getLogger()->err(sprintf('Storage Service download returned status: %s; %s', $status, $url));
       $ex = arStorageServiceUtils::getStorageServiceException($status);
       throw $ex;
     }

--- a/plugins/qtSwordPlugin/lib/qtPackageExtractorMETSArchivematicaDIP.class.php
+++ b/plugins/qtSwordPlugin/lib/qtPackageExtractorMETSArchivematicaDIP.class.php
@@ -151,12 +151,9 @@ class qtPackageExtractorMETSArchivematicaDIP extends qtPackageExtractorBase
     }
 
     // Create AIP
-    $parts = pathinfo($this->filename);
-    $aipName = substr($parts['basename'], 0, -37);
-
     $this->aip = new QubitAip;
     $this->aip->uuid = $aipUUID;
-    $this->aip->filename = $aipName;
+    $this->aip->filename = $this->extractAipNameFromFileName($this->filename);
     $this->aip->digitalObjectCount = $this->metsParser->getOriginalFileCount();
     $this->aip->partOf = $this->resource->id;
     $this->aip->sizeOnDisk = $this->metsParser->getAipSizeOnDisk();
@@ -167,6 +164,18 @@ class qtPackageExtractorMETSArchivematicaDIP extends qtPackageExtractorBase
     sfContext::getInstance()->getLogger()->info(
       'METSArchivematicaDIP - aipUUID: ' . $aipUUID
     );
+  }
+
+  /**
+   * Parse AIP name to extract filename
+   *
+   * @return string $filename
+   */
+  protected function extractAipNameFromFileName($filename)
+  {
+    $parts = pathinfo($filename);
+
+    return substr($parts['basename'], 0, -37);
   }
 
   /**
@@ -199,6 +208,14 @@ class qtPackageExtractorMETSArchivematicaDIP extends qtPackageExtractorBase
     $io->addProperty(
       'relativePathWithinAip',
       $this->metsParser->getOriginalPathInAip($fileId),
+      $options
+    );
+
+    // Metadata-only DIP Upload stores the AIP name in the 'aipName' property.
+    // Adding here for consistency.
+    $io->addProperty(
+      'aipName',
+      $this->extractAipNameFromFileName($this->filename),
       $options
     );
 


### PR DESCRIPTION
This commit fixes an issue where the 'Download file' link on the digital
object page was not working if the source of the digital object was a
metadata only DIP upload.

Now when a metadata only DIP upload is performed, the
relative_path_within_aip and aip_name will be saved as properties of the
object in AtoM's create digital object REST API endpoint. This
information is necessary when calling the AM Storage Service
'extract_file' API endpoint.