### PR TITLE
Reintroduce responsive video/audio, refs #13459

### DIFF
--- a/apps/qubit/modules/digitalobject/templates/_showAudio.php
+++ b/apps/qubit/modules/digitalobject/templates/_showAudio.php
@@ -3,7 +3,7 @@
 <?php if (QubitTerm::REFERENCE_ID == $usageType): ?>
 
   <?php if ($showFlashPlayer): ?>
-    <audio class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>"></audio>
+    <audio style="max-width:100%;" class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>"></audio>
   <?php else: ?>
     <div style="text-align: center">
       <?php echo image_tag($representation->getFullPath(), array('style' => 'border: #999 1px solid', 'alt' => '')) ?>

--- a/apps/qubit/modules/digitalobject/templates/_showVideo.php
+++ b/apps/qubit/modules/digitalobject/templates/_showVideo.php
@@ -11,7 +11,9 @@
 <?php elseif ($usageType == QubitTerm::REFERENCE_ID): ?>
 
   <?php if ($showFlashPlayer): ?>
-    <video style="max-width:100%;" preload="metadata" class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>"></video>
+    <div style="max-width:640px;margin:auto;">
+      <video style="max-width:100%;" preload="metadata" class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>"></video>
+    </div>
   <?php else: ?>
     <div style="text-align: center">
       <?php echo image_tag($representation->getFullPath(), array('style' => 'border: #999 1px solid', 'alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>

--- a/apps/qubit/modules/digitalobject/templates/_showVideo.php
+++ b/apps/qubit/modules/digitalobject/templates/_showVideo.php
@@ -11,7 +11,7 @@
 <?php elseif ($usageType == QubitTerm::REFERENCE_ID): ?>
 
   <?php if ($showFlashPlayer): ?>
-    <video width="320" height="240" preload="metadata" class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>"></video>
+    <video style="max-width:100%;" preload="metadata" class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>"></video>
   <?php else: ?>
     <div style="text-align: center">
       <?php echo image_tag($representation->getFullPath(), array('style' => 'border: #999 1px solid', 'alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>


### PR DESCRIPTION
- Reintroduces responsive video removed in #904 using alternative inline style method
- Tested successfully using chrome/edge/firefox/safari with 1920x1080/1920x800/720x480/320x240 h264 files
- Reference: https://github.com/mediaelement/mediaelement/blob/master/docs/usage.md#use-stretching-modes