### PR TITLE
Add unit tests GA workflow, refs #13460

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,48 @@
+name: Unit tests
+on:
+  pull_request:
+  push:
+    branches:
+    - qa/**
+    - stable/**
+jobs:
+  unit-tests:
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [7.2, 7.3, 7.4]
+    name: PHP ${{ matrix.php }}
+    env:
+      COMPOSE_FILE: ${{ github.workspace }}/docker/docker-compose.dev.yml
+    steps:
+    - name: Setup PHP ${{ matrix.php }}
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+        coverage: none
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/.composer/cache/files
+        key: php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+    - name: Install dependencies
+      run: composer update
+    - name: Copy config files
+      run: |
+        cp test/bootstrap/config.php config/config.php
+        cp test/bootstrap/search.yml config/search.yml
+        cp config/propel.ini.tmpl config/propel.ini
+        cp apps/qubit/config/settings.yml.tmpl apps/qubit/config/settings.yml
+    - name: Increase virtual memory max_map_count
+      run: sudo sysctl -w vm.max_map_count=262144
+    - name: Start services
+      run: docker-compose up -d percona elasticsearch
+    - name: Sleep for 15 seconds
+      run: sleep 15
+    - name: Initialize database and search index
+      run: php symfony tools:purge --demo
+    - name: Run tests
+      run: composer test

--- a/test/bootstrap/config.php
+++ b/test/bootstrap/config.php
@@ -1,0 +1,70 @@
+<?php
+
+return array (
+  'all' =>
+  array (
+    'propel' =>
+    array (
+      'class' => 'sfPropelDatabase',
+      'param' =>
+      array (
+        'encoding' => 'utf8mb4',
+        'persistent' => true,
+        'pooling' => true,
+        'dsn' => 'mysql:host=127.0.0.1;port=63003;dbname=atom;charset=utf8mb4',
+        'username' => 'atom',
+        'password' => 'atom_12345',
+      ),
+    ),
+  ),
+  'dev' =>
+  array (
+    'propel' =>
+    array (
+      'param' =>
+      array (
+        'classname' => 'DebugPDO',
+        'debug' =>
+        array (
+          'realmemoryusage' => true,
+          'details' =>
+          array (
+            'time' =>
+            array (
+              'enabled' => true,
+            ),
+            'slow' =>
+            array (
+              'enabled' => true,
+              'threshold' => 0.1,
+            ),
+            'mem' =>
+            array (
+              'enabled' => true,
+            ),
+            'mempeak' =>
+            array (
+              'enabled' => true,
+            ),
+            'memdelta' =>
+            array (
+              'enabled' => true,
+            ),
+          ),
+        ),
+      ),
+    ),
+  ),
+  'test' =>
+  array (
+    'propel' =>
+    array (
+      'param' =>
+      array (
+        'classname' => 'DebugPDO',
+      ),
+    ),
+  ),
+);
+
+?>

--- a/test/bootstrap/search.yml
+++ b/test/bootstrap/search.yml
@@ -1,0 +1,4 @@
+all:
+  server:
+    host: 127.0.0.1
+    port: 63002


### PR DESCRIPTION
Adds a Github Actions workflow to run the existing unit tests over
Ubuntu 18.04 and a matrix of PHP versions. These tests require access
to MySQL/Percona and Elasticsearch, which are setup using the Docker
Compose environment (only those two services). The workflow will be
triggered on all PRs and new commits on qa/* and stable/* branches.