### PR TITLE
Clarify menu label/description for reference_image_maxwidth setting to better reflect behaviour

### DIFF
--- a/apps/qubit/i18n/ar/messages.xml
+++ b/apps/qubit/i18n/ar/messages.xml
@@ -2821,7 +2821,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>&#x627;&#x644;&#x62D;&#x62F; &#x627;&#x644;&#x623;&#x642;&#x635;&#x649; &#x644;&#x639;&#x631;&#x636; &#x627;&#x644;&#x635;&#x648;&#x631;&#x629; (&#x628;&#x643;&#x633;&#x644;)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4531,7 +4531,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target>&#x627;&#x644;&#x62D;&#x62F; &#x627;&#x644;&#x623;&#x642;&#x635;&#x649; &#x644;&#x639;&#x631;&#x636; &#x627;&#x644;&#x635;&#x648;&#x631; &#x627;&#x644;&#x645;&#x631;&#x62C;&#x639;&#x64A;&#x629; &#x627;&#x644;&#x645;&#x634;&#x62A;&#x642;&#x629;.</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ca/messages.xml
+++ b/apps/qubit/i18n/ca/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Amplada m&#xE0;xima de la imatge (p&#xED;xels) </target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ca@valencia/messages.xml
+++ b/apps/qubit/i18n/ca@valencia/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Ample m&#xE0;xim d'imatge (p&#xED;xels) </target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/cs/messages.xml
+++ b/apps/qubit/i18n/cs/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/cy/messages.xml
+++ b/apps/qubit/i18n/cy/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Uchafswm lled delwedd  (picseli)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target>Y lled mwyaf ar gyfer delweddau cyfeirio deilliedig.</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/de/messages.xml
+++ b/apps/qubit/i18n/de/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Maximale Bildbreite (Pixel)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/de_AT/messages.xml
+++ b/apps/qubit/i18n/de_AT/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Maximale Bildbreite (Pixel)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/de_CH/messages.xml
+++ b/apps/qubit/i18n/de_CH/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Maximale Bildbreite (Pixel)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/el/messages.xml
+++ b/apps/qubit/i18n/el/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>&#x39C;&#x3AD;&#x3B3;&#x3B9;&#x3C3;&#x3C4;&#x3BF; &#x3C0;&#x3BB;&#x3AC;&#x3C4;&#x3BF;&#x3C2; &#x3B5;&#x3B9;&#x3BA;&#x3CC;&#x3BD;&#x3B1;&#x3C2; (pixels)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4532,7 +4532,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/es/messages.xml
+++ b/apps/qubit/i18n/es/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Ancho m&#xE1;ximo de imagen (pixeles)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/et/messages.xml
+++ b/apps/qubit/i18n/et/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/eu/messages.xml
+++ b/apps/qubit/i18n/eu/messages.xml
@@ -2821,7 +2821,7 @@ oai:foo.org:repositorycode_10001</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Irudiaren gehienezko zabalera (pixeletan)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4531,7 +4531,7 @@ oai:foo.org:repositorycode_10001</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/fa/messages.xml
+++ b/apps/qubit/i18n/fa/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/fil/messages.xml
+++ b/apps/qubit/i18n/fil/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/fr/messages.xml
+++ b/apps/qubit/i18n/fr/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Largeur maximale de l'image (en pixels)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target>Taille maximum d'affichage pour les images de r&#xE9;f&#xE9;rence d&#xE9;riv&#xE9;es.</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/gl/messages.xml
+++ b/apps/qubit/i18n/gl/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Ancho m&#xE1;ximo de imaxe (pixels)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/he/messages.xml
+++ b/apps/qubit/i18n/he/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/hr/messages.xml
+++ b/apps/qubit/i18n/hr/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Maksimalna dozvoljena &#x161;irina slike (u pikselima)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target>Maksimalna &#x161;irina za izvedene izvorne slike.</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/hu/messages.xml
+++ b/apps/qubit/i18n/hu/messages.xml
@@ -2829,7 +2829,7 @@ YYYYMMDD, YYYY-MM-DD, YYYY-MM, YYYY.</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Maximum k&#xE9;p sz&#xE9;less&#xE9;g (pixelek)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4539,7 +4539,7 @@ YYYYMMDD, YYYY-MM-DD, YYYY-MM, YYYY.</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target>A sz&#xE1;rmaztatott referencia k&#xE9;pek maxim&#xE1;lis sz&#xE9;less&#xE9;ge</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/id/messages.xml
+++ b/apps/qubit/i18n/id/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Maksimum lebar gambar (pixels)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target>Lebar maksimal untuk ukuran gambar referensi turunan.</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/is/messages.xml
+++ b/apps/qubit/i18n/is/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>H&#xE1;marks st&#xE6;r&#xF0; myndar (pixlar)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/it/messages.xml
+++ b/apps/qubit/i18n/it/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Profondit&#xE0; massima dell'immagine (in pixel)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target>La larghezza massima per le immagini di riferimento derivate.</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ja/messages.xml
+++ b/apps/qubit/i18n/ja/messages.xml
@@ -2822,7 +2822,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>&#x753B;&#x50CF;&#x306E;&#x6700;&#x5927;&#x5024;(pixels)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4532,7 +4532,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ka/messages.xml
+++ b/apps/qubit/i18n/ka/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>&#x10E1;&#x10E3;&#x10E0;&#x10D0;&#x10D7;&#x10D8;&#x10E1; &#x10DB;&#x10D0;&#x10E5;&#x10E1;&#x10D8;&#x10DB;&#x10D0;&#x10DA;&#x10E3;&#x10E0;&#x10D8; &#x10E1;&#x10D8;&#x10D2;&#x10D0;&#x10DC;&#x10D4; (&#x10DE;&#x10D8;&#x10E5;&#x10E1;&#x10D4;&#x10DA;&#x10D4;&#x10D1;&#x10D8;)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ko/messages.xml
+++ b/apps/qubit/i18n/ko/messages.xml
@@ -2822,7 +2822,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>&#xCD5C;&#xB300; &#xC774;&#xBBF8;&#xC9C0; &#xB108;&#xBE44;(&#xD53D;&#xC140;)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4535,7 +4535,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/nb/messages.xml
+++ b/apps/qubit/i18n/nb/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/nl/messages.xml
+++ b/apps/qubit/i18n/nl/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/pl/messages.xml
+++ b/apps/qubit/i18n/pl/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Maksymalna szeroko&#x15B;&#x107; obrazku (piksele)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/pt/messages.xml
+++ b/apps/qubit/i18n/pt/messages.xml
@@ -2823,7 +2823,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Largura m&#xE1;xima da imagem (pixels)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4539,7 +4539,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target>A largura m&#xE1;xima para imagens de refer&#xEA;ncia derivadas.</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/pt_BR/messages.xml
+++ b/apps/qubit/i18n/pt_BR/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Dimens&#xE3;o m&#xE1;xima da imagem (pixels)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4531,7 +4531,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target>A largura m&#xE1;xima para imagens de refer&#xEA;ncia derivadas.</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ro/messages.xml
+++ b/apps/qubit/i18n/ro/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4531,7 +4531,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ru/messages.xml
+++ b/apps/qubit/i18n/ru/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>&#x41C;&#x430;&#x43A;&#x441;&#x438;&#x43C;&#x430;&#x43B;&#x44C;&#x43D;&#x430;&#x44F; &#x448;&#x438;&#x440;&#x438;&#x43D;&#x430; &#x438;&#x437;&#x43E;&#x431;&#x440;&#x430;&#x436;&#x435;&#x43D;&#x438;&#x44F; (&#x432; &#x43F;&#x438;&#x43A;&#x441;&#x435;&#x43B;&#x44F;&#x445;)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ru_RU/messages.xml
+++ b/apps/qubit/i18n/ru_RU/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>&#x41C;&#x430;&#x43A;&#x441;&#x438;&#x43C;&#x430;&#x43B;&#x44C;&#x43D;&#x430;&#x44F; &#x448;&#x438;&#x440;&#x438;&#x43D;&#x430; &#x438;&#x437;&#x43E;&#x431;&#x440;&#x430;&#x436;&#x435;&#x43D;&#x438;&#x44F; (&#x432; &#x43F;&#x438;&#x43A;&#x441;&#x435;&#x43B;&#x44F;&#x445;)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/sk/messages.xml
+++ b/apps/qubit/i18n/sk/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/sl/messages.xml
+++ b/apps/qubit/i18n/sl/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Najve&#x10D;ja dovoljena &#x161;irina slike (v slikovnih to&#x10D;kah)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/sq/messages.xml
+++ b/apps/qubit/i18n/sq/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/sr/messages.xml
+++ b/apps/qubit/i18n/sr/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>&#x41D;&#x430;&#x458;&#x432;&#x435;&#x45B;&#x430; &#x434;&#x43E;&#x437;&#x432;&#x43E;&#x459;&#x435;&#x43D;&#x430; &#x448;&#x438;&#x440;&#x438;&#x43D;&#x430; &#x441;&#x43B;&#x438;&#x43A;&#x435; (&#x443; &#x43F;&#x438;&#x43A;&#x441;&#x435;&#x43B;&#x438;&#x43C;&#x430;)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target>&#x41C;&#x430;&#x43A;&#x441;&#x438;&#x43C;&#x430;&#x43B;&#x43D;&#x430; &#x448;&#x438;&#x440;&#x438;&#x43D;&#x430; &#x437;&#x430; &#x438;&#x437;&#x432;&#x435;&#x434;&#x435;&#x43D;&#x435; &#x440;&#x435;&#x444;&#x435;&#x440;&#x435;&#x43D;&#x442;&#x43D;&#x435; &#x441;&#x43B;&#x438;&#x43A;&#x435;.</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/sv/messages.xml
+++ b/apps/qubit/i18n/sv/messages.xml
@@ -2821,7 +2821,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Maximal bildbredd (pixlar)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4531,7 +4531,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target>Maximal bredd f&#xF6;r bearbetade referensbilder.</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ta/messages.xml
+++ b/apps/qubit/i18n/ta/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/th/messages.xml
+++ b/apps/qubit/i18n/th/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>&#xE04;&#xE27;&#xE32;&#xE21;&#xE01;&#xE27;&#xE49;&#xE32;&#xE07;&#xE2A;&#xE39;&#xE07;&#xE2A;&#xE38;&#xE14;&#xE02;&#xE2D;&#xE07;&#xE20;&#xE32;&#xE1E;(pixels)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/tn/messages.xml
+++ b/apps/qubit/i18n/tn/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/tr/messages.xml
+++ b/apps/qubit/i18n/tr/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/uk/messages.xml
+++ b/apps/qubit/i18n/uk/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ur/messages.xml
+++ b/apps/qubit/i18n/ur/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/uz/messages.xml
+++ b/apps/qubit/i18n/uz/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Rasmning max.  eni (piksel)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/vi/messages.xml
+++ b/apps/qubit/i18n/vi/messages.xml
@@ -2822,7 +2822,7 @@ B&#x1EA1;n c&#xF3; ch&#x1EAF;c ch&#x1EAF;n b&#x1EA1;n mu&#x1ED1;n thay th&#x1EBF
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>Chi&#x1EC1;u r&#x1ED9;ng h&#xEC;nh &#x1EA3;nh t&#x1ED1;i &#x111;a (pixels)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4545,7 +4545,7 @@ Y&#xEA;u c&#x1EA7;u m&#x1EAD;t kh&#x1EA9;u m&#x1EA1;nh</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/zh/messages.xml
+++ b/apps/qubit/i18n/zh/messages.xml
@@ -2820,7 +2820,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/actions/editAction.class.php</note>
       </trans-unit>
       <trans-unit id="9917379c2d4f57eb0424e346a3a86a01f46d0d49">
-        <source>Maximum image width (pixels)</source>
+        <source>Maximum length on longest edge (pixels)</source>
         <target>&#x56FE;&#x7247;&#x6700;&#x5927;&#x5BBD;&#x5EA6;(&#x50CF;&#x7D20;)</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>
@@ -4530,7 +4530,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/templates/multiFileUploadSuccess.php</note>
       </trans-unit>
       <trans-unit id="1868000288b22c58b9cef7ca738317a8b8025970">
-        <source>The maximum width for derived reference images.</source>
+        <source>The maximum number of pixels on the longest edge for derived reference images.</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php</note>
       </trans-unit>

--- a/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php
+++ b/apps/qubit/modules/settings/templates/digitalObjectDerivativesSuccess.php
@@ -38,8 +38,8 @@
         <?php endif; ?><br />
 
         <?php echo $form->reference_image_maxwidth
-          ->label(__('Maximum image width (pixels)'))
-          ->help(__('The maximum width for derived reference images.'))
+          ->label(__('Maximum length on longest edge (pixels)'))
+          ->help(__('The maximum number of pixels on the longest edge for derived reference images.'))
           ->renderRow() ?>
 
       </fieldset>


### PR DESCRIPTION
The labels in the 'Digital object derivatives' menu for the `reference_image_maxwidth` setting don't accurately reflect its behaviour. The `reference_image_maxwidth` value is actually being used to determine the maximum number of pixels on the longest edge for the derived image. This can be either its height or width depending on whichever is larger.

While this wording may be a bit awkward, thinking in terms of the number of pixels on the longest edge is pretty standard for those working with image assets. For example, this is commonly used to determine the DPI when digitising photographs.

This pull request does introduce some inaccuracies in the translations but the values in the`<source>` tags have been updated to still facilitate the switch to the existing translations.

This is a pretty minor pull request, but since the original description caused me a bit of confusion, I thought it might help clarify things for others (or at least those who have AtoM set to English).