### PR TITLE
Add logic to paginate I.O. indexing, refs #13464

### DIFF
--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
@@ -53,14 +53,10 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
 
     // Loop through hierarchy and add to search index
     $sql = "WITH RECURSIVE cte (id, parent_id) AS (
-              SELECT id, parent_id
-              FROM information_object
-              WHERE parent_id = ?
+              SELECT id, parent_id FROM information_object WHERE parent_id = ?
               UNION ALL
-              SELECT i.id, i.parent_id
-              FROM information_object i
-              INNER JOIN cte
-              ON i.parent_id = cte.id
+              SELECT i.id, i.parent_id FROM information_object i
+              INNER JOIN cte ON i.parent_id = cte.id
             )
             SELECT * FROM cte";
 

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
@@ -80,6 +80,7 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
 
       try
       {
+        // Discard cached parent-related data if parent has changed
         if ($lastParentId != $row['parent_id'])
         {
           unset($options['ancestors']);
@@ -94,7 +95,7 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
 
         $this->logEntry($data['i18n'][$data['sourceCulture']]['title'], self::$counter);
 
-        // If under a different parent then cache related data
+        // If parent has changed then cache this node's parent-related data
         if ($lastParentId != $row['parent_id'])
         {
           $options['ancestors'] = $node->getAncestors();
@@ -102,6 +103,7 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
           $option['inheritedCreators'] = $node->inheritedCreators;          
         }
 
+        // Take note of the last indexed node's parent ID
         $lastParentId = $row['parent_id'];
       }
       catch (sfException $e)

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
@@ -78,7 +78,6 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
     {
       self::$counter++;
 
-print 'ID:'. $row['id'] ."\n";
       try
       {
         if ($lastParentId != $row['parent_id'])

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
@@ -69,7 +69,6 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
     {
       self::$counter++;
 
-print "ID:". $row['id'] ."\n";
       try
       {
         // Discard cached parent-related data if parent has changed

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
@@ -52,13 +52,8 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
     $limit = isset($options['limit']) ? $options['limit'] : $this->count;
 
     // Loop through hierarchy and add to search index
-    $sql = "WITH RECURSIVE cte (id, parent_id) AS (
-              SELECT id, parent_id FROM information_object WHERE parent_id = ?
-              UNION ALL
-              SELECT i.id, i.parent_id FROM information_object i
-              INNER JOIN cte ON i.parent_id = cte.id
-            )
-            SELECT * FROM cte";
+    $sql = "SELECT id, parent_id FROM information_object
+              WHERE id != ? ORDER BY parent_id, id";
 
     $sql .= sprintf(" LIMIT %d, %d", $skip, $limit);
 
@@ -74,6 +69,7 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
     {
       self::$counter++;
 
+print "ID:". $row['id'] ."\n";
       try
       {
         // Discard cached parent-related data if parent has changed

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchModelBase.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchModelBase.class.php
@@ -45,6 +45,11 @@ abstract class arElasticSearchModelBase
     return $this->count;
   }
 
+  public function setCount($count)
+  {
+    $this->count = $count;
+  }
+
   public function setTimer($timer)
   {
     $this->timer = $timer;

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchModelBase.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchModelBase.class.php
@@ -45,11 +45,6 @@ abstract class arElasticSearchModelBase
     return $this->count;
   }
 
-  public function setCount($count)
-  {
-    $this->count = $count;
-  }
-
   public function setTimer($timer)
   {
     $this->timer = $timer;


### PR DESCRIPTION
Ran into a situation with a client where memory ran out during indexing. Paging indexing, via a custom script, worked around this.

Modified classes, related to Elastsearch indexing of information objects, to allow indexing to be paginated using custom scripts.