### PR TITLE
Fix composer install on Docker, refs #13441

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git
 .gitignore
+vendor/composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,8 @@ WORKDIR /atom/src
 RUN set -xe \
     && make -C plugins/arDominionPlugin \
     && make -C plugins/arArchivesCanadaPlugin \
-    && mv /atom/build/vendor/composer vendor/composer
+    && mv /atom/build/vendor/composer vendor/ \
+    && rm -rf /atom/build
 
 ENTRYPOINT ["docker/entrypoint.sh"]
 


### PR DESCRIPTION
- Make sure an existing vendor/composer folder is not added
  to the container.
- Do not copy entire composer folder within vendor/composer.
- Remove build directory after moving composer contents.