### PR TITLE
Fix ES' query string queries, refs #12186

### DIFF
--- a/apps/qubit/modules/default/actions/moveAction.class.php
+++ b/apps/qubit/modules/default/actions/moveAction.class.php
@@ -139,13 +139,13 @@ class DefaultMoveAction extends sfAction
 
     if (isset($request->query))
     {
-      $query = new \Elastica\Query\QueryString(arElasticSearchPluginUtil::escapeTerm($request->query));
-      $query->setDefaultOperator('AND');
-      $query->setFields(array(
-        'identifier',
-        'referenceCode',
-        sprintf('i18n.%s.title', sfContext::getInstance()->user->getCulture())));
-      $this->queryBool->addMust($query);
+      $fields = array(
+        'identifier' => 1,
+        'referenceCode' => 1,
+        sprintf('i18n.%s.title', sfContext::getInstance()->user->getCulture()) => 1);
+      $this->queryBool->addMust(
+        arElasticSearchPluginUtil::generateBoolQueryString($request->query, $fields)
+      );
     }
     else
     {

--- a/apps/qubit/modules/informationobject/actions/autocompleteAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/autocompleteAction.class.php
@@ -51,13 +51,12 @@ class InformationObjectAutocompleteAction extends sfAction
     }
     else
     {
-      $queryString = new \Elastica\Query\QueryString(arElasticSearchPluginUtil::escapeTerm($request->query));
-      $queryString->setDefaultOperator('AND');
+      $fields = array('i18n.'.$culture.'.title.autocomplete' => 1);
 
       // Search for referenceCode or identifier, and title
       if (1 == sfConfig::get('app_inherit_code_informationobject', 1))
       {
-        $queryString->setFields(array('i18n.'.$culture.'.title.autocomplete', 'referenceCode.autocomplete'));
+        $fields['referenceCode.autocomplete'] = 1;
 
         // Change sort order
         $this->query->setSort(array(
@@ -67,10 +66,12 @@ class InformationObjectAutocompleteAction extends sfAction
       }
       else
       {
-        $queryString->setFields(array('i18n.'.$culture.'.title.autocomplete', 'identifier'));
+        $fields['identifier'] = 1;
       }
 
-      $this->queryBool->addMust($queryString);
+      $this->queryBool->addMust(
+        arElasticSearchPluginUtil::generateBoolQueryString($request->query, $fields)
+      );
     }
 
     // Filter results by parent

--- a/apps/qubit/modules/repository/actions/browseAction.class.php
+++ b/apps/qubit/modules/repository/actions/browseAction.class.php
@@ -122,11 +122,11 @@ class RepositoryBrowseAction extends DefaultBrowseAction
     }
     else
     {
-      $queryText = new \Elastica\Query\QueryString(arElasticSearchPluginUtil::escapeTerm($request->subquery));
-      $queryText->setDefaultOperator('OR');
-      arElasticSearchPluginUtil::setFields($queryText, 'repository');
-
-      $this->search->queryBool->addMust($queryText);
+      $this->search->queryBool->addMust(
+        arElasticSearchPluginUtil::generateBoolQueryString(
+          $request->subquery, arElasticSearchPluginUtil::getAllFields('repository')
+        )
+      );
     }
 
     $i18n = sprintf('i18n.%s.', $this->selectedCulture);

--- a/apps/qubit/modules/search/actions/indexAction.class.php
+++ b/apps/qubit/modules/search/actions/indexAction.class.php
@@ -28,11 +28,11 @@ class SearchIndexAction extends DefaultBrowseAction
   {
     parent::execute($request);
 
-    $queryText = new \Elastica\Query\QueryString(arElasticSearchPluginUtil::escapeTerm($request->query));
-    $queryText->setDefaultOperator('AND');
-    arElasticSearchPluginUtil::setFields($queryText, 'informationObject');
-
-    $this->search->queryBool->addMust($queryText);
+    $this->search->queryBool->addMust(
+      arElasticSearchPluginUtil::generateBoolQueryString(
+        $request->query, arElasticSearchPluginUtil::getAllFields('informationObject')
+      )
+    );
 
     // Realm filter
     if (isset($request->repos) && ctype_digit($request->repos))

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPlugin.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPlugin.class.php
@@ -520,22 +520,6 @@ class arElasticSearchPlugin extends QubitSearchEngine
     }
   }
 
-  /**
-   * Function helper to parse query strings
-   */
-  public function parse(string $query)
-  {
-    if (empty($query))
-    {
-      throw new Exception('No search terms specified.');
-    }
-
-    $query = new \Elastica\Query\QueryString(arElasticSearchPluginUtil::escapeTerm($query));
-    $query->setDefaultOperator('AND');
-
-    return $query;
-  }
-
   // ---------------------------------------------------------------------------
 
   public function delete($object)

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginQuery.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginQuery.class.php
@@ -261,35 +261,27 @@ class arElasticSearchPluginQuery
 
   protected function queryField($field, $query, $archivalStandard)
   {
-    $query = arElasticSearchPluginUtil::escapeTerm($query);
-
     switch ($field)
     {
       case 'identifier':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setDefaultField('identifier');
-        $queryField->setDefaultOperator('AND');
-
-        break;
-
       case 'referenceCode':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setDefaultField('referenceCode');
-        $queryField->setDefaultOperator('AND');
+      case 'descriptionIdentifier':
+        $fields = array($field => 1);
 
         break;
 
       case 'title':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.title'));
-        $queryField->setDefaultOperator('AND');
-
-        break;
-
       case 'scopeAndContent':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.scopeAndContent'));
-        $queryField->setDefaultOperator('AND');
+      case 'extentAndMedium':
+      case 'authorizedFormOfName':
+      case 'datesOfExistence':
+      case 'history':
+      case 'legalStatus':
+      case 'generalContext':
+      case 'institutionResponsibleIdentifier':
+      case 'sources':
+      case 'places':
+        $fields = array('i18n.%s.'.$field => 1);
 
         break;
 
@@ -297,204 +289,90 @@ class arElasticSearchPluginQuery
         ProjectConfiguration::getActive()->loadHelpers(array('Asset', 'Qubit'));
 
         // Check archival history visibility
-        if (($archivalStandard == 'rad' && check_field_visibility('app_element_visibility_rad_archival_history'))
-          || ($archivalStandard == 'isad' && check_field_visibility('app_element_visibility_isad_archival_history'))
-          || ($archivalStandard != 'isad' && $archivalStandard != 'rad'))
+        if (($archivalStandard == 'rad' && !check_field_visibility('app_element_visibility_rad_archival_history'))
+          || ($archivalStandard == 'isad' && !check_field_visibility('app_element_visibility_isad_archival_history')))
         {
-          $queryField = new \Elastica\Query\QueryString($query);
-          $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.archivalHistory'));
-          $queryField->setDefaultOperator('AND');
+          return;
         }
 
-        break;
-
-      case 'extentAndMedium':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.extentAndMedium'));
-        $queryField->setDefaultOperator('AND');
+        $fields = array('i18n.%s.archivalHistory' => 1);
 
         break;
 
       case 'genre':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('genres.i18n.%s.name'));
-        $queryField->setDefaultOperator('AND');
+        $fields = array('genres.i18n.%s.name' => 1);
 
         break;
 
       case 'subject':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('subjects.i18n.%s.name'));
-        $queryField->setDefaultOperator('AND');
+        $fields = array('subjects.i18n.%s.name' => 1);
 
         break;
 
       case 'name':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('names.i18n.%s.authorizedFormOfName'));
-        $queryField->setDefaultOperator('AND');
+        $fields = array('names.i18n.%s.authorizedFormOfName' => 1);
 
         break;
 
       case 'creator':
-        $queryField = new \Elastica\Query\BoolQuery;
-
-        $queryCreatorTerm = new \Elastica\Query\QueryString($query);
-        $queryCreatorTerm->setFields(arElasticSearchPluginUtil::getI18nFieldNames('creators.i18n.%s.authorizedFormOfName'));
-        $queryField->addShould($queryCreatorTerm);
-
-        $queryInheritedCreatorTerm = new \Elastica\Query\QueryString($query);
-        $queryInheritedCreatorTerm->setFields(arElasticSearchPluginUtil::getI18nFieldNames('inheritedCreators.i18n.%s.authorizedFormOfName'));
-        $queryField->addShould($queryInheritedCreatorTerm);
+        $fields = array(
+          'creators.i18n.%s.authorizedFormOfName' => 1,
+          'inheritedCreators.i18n.%s.authorizedFormOfName' => 1
+        );
 
         break;
 
       case 'place':
-        $queryField = new \Elastica\Query\BoolQuery;
-
-        $queryPlaceTermName = new \Elastica\Query\QueryString($query);
-        $queryPlaceTermName->setFields(arElasticSearchPluginUtil::getI18nFieldNames('places.i18n.%s.name'));
-        $queryPlaceTermName->setDefaultOperator('AND');
-        $queryField->addShould($queryPlaceTermName);
-
-        $queryPlaceTermUseFor = new \Elastica\Query\QueryString($query);
-        $queryPlaceTermUseFor->setFields(arElasticSearchPluginUtil::getI18nFieldNames('places.useFor.i18n.%s.name'));
-        $queryPlaceTermUseFor->setDefaultOperator('AND');
-        $queryField->addShould($queryPlaceTermUseFor);
+        $fields = array(
+          'places.i18n.%s.name' => 1,
+          'places.useFor.i18n.%s.name' => 1
+        );
 
         break;
 
       case 'findingAidTranscript':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setDefaultField('findingAid.transcript');
-        $queryField->setDefaultOperator('AND');
+        $fields = array('findingAid.transcript' => 1);
 
         break;
 
       case 'digitalObjectTranscript':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setDefaultField('transcript');
-        $queryField->setDefaultOperator('AND');
+        $fields = array('transcript' => 1);
 
         break;
 
       case 'allExceptFindingAidTranscript':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setDefaultOperator('AND');
-        $except = array('findingAid.transcript');
-        arElasticSearchPluginUtil::setFields($queryField, 'informationObject', $except);
-
-        break;
-
-      case 'authorizedFormOfName':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.authorizedFormOfName'));
-        $queryField->setDefaultOperator('AND');
-
-        break;
-
-      case 'datesOfExistence':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.datesOfExistence'));
-        $queryField->setDefaultOperator('AND');
-
-        break;
-
-      case 'history':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.history'));
-        $queryField->setDefaultOperator('AND');
-
-        break;
-
-      case 'legalStatus':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.legalStatus'));
-        $queryField->setDefaultOperator('AND');
-
-        break;
-
-      case 'generalContext':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.generalContext'));
-        $queryField->setDefaultOperator('AND');
-
-        break;
-
-      case 'institutionResponsibleIdentifier':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.institutionResponsibleIdentifier'));
-        $queryField->setDefaultOperator('AND');
-
-        break;
-
-      case 'sources':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.sources'));
-        $queryField->setDefaultOperator('AND');
+        $fields = arElasticSearchPluginUtil::getAllFields(
+          'informationObject', array('findingAid.transcript')
+        );
 
         break;
 
       case 'parallelNames':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('parallelNames.i18n.%s.name'));
-        $queryField->setDefaultOperator('AND');
-
-        break;
-
       case 'otherNames':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('otherNames.i18n.%s.name'));
-        $queryField->setDefaultOperator('AND');
-
-        break;
-
       case 'occupations':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('occupations.i18n.%s.name'));
-        $queryField->setDefaultOperator('AND');
+        $fields = array($field.'.i18n.%s.name' => 1);
 
         break;
 
       case 'occupationNotes':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('occupations.i18n.%s.content'));
-        $queryField->setDefaultOperator('AND');
+        $fields = array('occupations.i18n.%s.content' => 1);
 
         break;
 
       case 'maintenanceNotes':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('maintenanceNotes.i18n.%s.content'));
-        $queryField->setDefaultOperator('AND');
-
-        break;
-
-      case 'places':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setFields(arElasticSearchPluginUtil::getI18nFieldNames('i18n.%s.places'));
-        $queryField->setDefaultOperator('AND');
-
-        break;
-
-      case 'descriptionIdentifier':
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setDefaultField('descriptionIdentifier');
-        $queryField->setDefaultOperator('AND');
+        $fields = array('maintenanceNotes.i18n.%s.content' => 1);
 
         break;
 
       case '_all':
       default:
-        $queryField = new \Elastica\Query\QueryString($query);
-        $queryField->setDefaultOperator('AND');
         $documentType = ($archivalStandard == 'isaar') ? 'actor' : 'informationObject';
-        arElasticSearchPluginUtil::setFields($queryField, $documentType);
+        $fields = arElasticSearchPluginUtil::getAllFields($documentType);
 
         break;
     }
 
-    return $queryField;
+    return arElasticSearchPluginUtil::generateBoolQueryString($query, $fields);
   }
 
   protected function addToQueryBool(&$queryBool, $operator, $queryField)

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchInformationObject.class.php
@@ -174,28 +174,4 @@ class arElasticSearchInformationObject extends arElasticSearchModelBase
 
     return $children;
   }
-
-  /**
-   * Set boost values for various information object fields.
-   *
-   * @param array &$fields  A reference to our array of fields we're adding boost values to.
-   * @param array $cultures  An array specifying which cultures the i18n fields cover.
-   */
-  public static function setBoostValues(&$fields, $cultures)
-  {
-    $i18nBoostFields = array(
-      'i18n.%s.title' => 10,
-      'subjects.i18n.%s.name' => 5,
-      'creators.i18n.%s.authorizedFormOfName' => 6,
-      'names.i18n.%s.authorizedFormOfName' => 3,
-      'places.i18n.%s.name' => 3,
-      'i18n.%s.scopeAndContent' => 5,
-    );
-
-    $nonI18nBoostFields = array(
-      'identifier' => 5,
-    );
-
-    self::addBoostValuesToFields($fields, $i18nBoostFields, $nonI18nBoostFields);
-  }
 }

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchModelBase.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchModelBase.class.php
@@ -138,48 +138,6 @@ abstract class arElasticSearchModelBase
     return true;
   }
 
-  /**
-   * Add boost values to various fields.
-   *
-   * @param array &$fields  An array of the fields to be modified with their boost values added.
-   * @param array $i18nfields  Specifies which i18n fields to boost, and which boost value to use.
-   *                           The array is in the form of 'fieldName' => (int)boostNumber
-   *
-   * @param array $nonI18nFields  Same as above, except for non-i18n string fields.
-   */
-  protected static function addBoostValuesToFields(&$fields, $i18nFields, $nonI18nFields)
-  {
-    // Expand all the i18n fields into their various cultures, add boost values
-    $i18nBoostFields = arElasticSearchPluginUtil::getI18nFieldNames(
-      array_keys($i18nFields),
-      null,
-      $i18nFields
-    );
-
-    foreach ($fields as &$field)
-    {
-      foreach ($i18nBoostFields as $i18nBoostField)
-      {
-        // Match boost field against current field, add boost if match found.
-        // i.e.: i18n.en.title will turn into i18n.en.title^10
-        if (0 === strpos($i18nBoostField, $field))
-        {
-          $field = $i18nBoostField;
-        }
-      }
-
-      foreach ($nonI18nFields as $nonI18nBoostField => $boost)
-      {
-        $nonI18nBoostField = $nonI18nBoostField.'^'.$boost;
-
-        if (0 === strpos($nonI18nBoostField, $field))
-        {
-          $field = $nonI18nBoostField;
-        }
-      }
-    }
-  }
-
   public static function getRelatedTerms($objectId, $taxonomyIds)
   {
     // We can't reuse this statement as there is no way to bind

--- a/plugins/qtAccessionPlugin/modules/accession/actions/browseAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/browseAction.class.php
@@ -100,49 +100,32 @@ class AccessionBrowseAction extends sfAction
     }
     else
     {
-      $queryString = new \Elastica\Query\QueryString(arElasticSearchPluginUtil::escapeTerm($request->subquery));
-      $queryString->setDefaultOperator('AND');
-
-      $boost = array(
+      $fields = array(
+        'identifier' => 10,
         'donors.i18n.%s.authorizedFormOfName' => 10,
         'i18n.%s.title' => 10,
         'i18n.%s.scopeAndContent' => 10,
         'i18n.%s.locationInformation' => 5,
         'i18n.%s.processingNotes' => 5,
         'i18n.%s.sourceOfAcquisition' => 5,
-        'i18n.%s.archivalHistory' => 5);
-
-      $fields = arElasticSearchPluginUtil::getI18nFieldNames(
-        array(
-          'donors.i18n.%s.authorizedFormOfName',
-          'i18n.%s.title',
-          'i18n.%s.scopeAndContent',
-          'i18n.%s.locationInformation',
-          'i18n.%s.processingNotes',
-          'i18n.%s.sourceOfAcquisition',
-          'i18n.%s.archivalHistory',
-          'i18n.%s.appraisal',
-          'i18n.%s.physicalCharacteristics',
-          'i18n.%s.receivedExtentUnits',
-          'alternativeIdentifiers.i18n.%s.name',
-          'creators.i18n.%s.authorizedFormOfName',
-          'alternativeIdentifiers.i18n.%s.note',
-          'alternativeIdentifiers.type.i18n.%s.name',
-          'accessionEvents.i18n.%s.agent',
-          'accessionEvents.type.i18n.%s.name',
-          'accessionEvents.notes.i18n.%s.content'
-        ),
-        null,
-        $boost
+        'i18n.%s.archivalHistory' => 5,
+        'i18n.%s.appraisal' => 1,
+        'i18n.%s.physicalCharacteristics' => 1,
+        'i18n.%s.receivedExtentUnits' => 1,
+        'alternativeIdentifiers.i18n.%s.name' => 1,
+        'creators.i18n.%s.authorizedFormOfName' => 1,
+        'alternativeIdentifiers.i18n.%s.note' => 1,
+        'alternativeIdentifiers.type.i18n.%s.name' => 1,
+        'accessionEvents.i18n.%s.agent' => 1,
+        'accessionEvents.type.i18n.%s.name' => 1,
+        'accessionEvents.notes.i18n.%s.content' => 1,
+        'donors.contactInformations.contactPerson' => 1,
+        'accessionEvents.dateString' => 1
       );
 
-      $fields[] = 'identifier^10';
-      $fields[] = 'donors.contactInformations.contactPerson';
-      $fields[] = 'accessionEvents.dateString';
-
-      $queryString->setFields($fields);
-
-      $this->queryBool->addMust($queryString);
+      $this->queryBool->addMust(
+        arElasticSearchPluginUtil::generateBoolQueryString($request->subquery, $fields)
+      );
 
       $this->sortOptions['relevance'] = $this->context->i18n->__('Relevance');
     }


### PR DESCRIPTION
Splits multi-field string queries into boolean queries with a string query
clause per field. This allows ES to use the field's analyzer on each clause
instead of the default analyzer and therefore it generates better results,
specially working with stop-words in a multi-culture index.

Additionally:

- Simplify retrieval of all fields by not processing the enabled
  languages until the query generation.
- Modify and simplify boosting process, now required as part of the
  boolean query clauses and not appended to the fields.
- Remove unused parse function from arElasticSearchPlugin class.

More info in https://projects.artefactual.com/issues/12186.