### PR TITLE
Add parent ID checking to CSV check, refs #13474

### DIFF
--- a/lib/task/import/csvCheckImportTask.class.php
+++ b/lib/task/import/csvCheckImportTask.class.php
@@ -131,14 +131,15 @@ EOF;
             }
             else
             {
-              // Note that the legacy ID is a duplicate
+              // Note that the legacy ID is used more than once
               $self->status['duplicateLegacyIds'][$self->columnValue('legacyId')] = true;
             }
           }
 
-          // Count parent ID uses
+          // Count uses of parent IDs and note premature use of an ID
           if ($self->columnExists('parentId') && !empty($self->columnValue('parentId')))
           {
+            // Count parent ID uses
             $parentId = $self->columnValue('parentId');
 
             if (empty($self->status['parentIds'][$parentId]))

--- a/lib/task/import/csvCheckImportTask.class.php
+++ b/lib/task/import/csvCheckImportTask.class.php
@@ -131,7 +131,7 @@ EOF;
             }
             else
             {
-              // Note that the legacy ID is used more than once
+              // Note that the legacy ID has been used more than once
               $self->status['duplicateLegacyIds'][$self->columnValue('legacyId')] = true;
             }
           }

--- a/lib/task/import/csvCheckImportTask.class.php
+++ b/lib/task/import/csvCheckImportTask.class.php
@@ -76,7 +76,7 @@ EOF;
           'legacyIds'                   => $legacyIds,
           'parentIds'                   => $parentIds,
           'duplicateLegacyIds'          => $duplicateLegacyIds,
-          'prematureParentIds'         => $prematureParentIds,
+          'prematureParentIds'          => $prematureParentIds,
         ),
 
         'saveLogic' => function(&$self)
@@ -162,7 +162,7 @@ EOF;
 
       $legacyIds = $import->status['legacyIds'];
       $parentIds = $import->status['parentIds'];
-      $duplicateLegacyIds  = $import->status['duplicateLegacyIds'];
+      $duplicateLegacyIds = $import->status['duplicateLegacyIds'];
       $prematureParentIds = $import->status['prematureParentIds'];
 
       $nonEmptyColumns = array_merge(

--- a/lib/task/import/csvCheckImportTask.class.php
+++ b/lib/task/import/csvCheckImportTask.class.php
@@ -259,7 +259,7 @@ EOF;
 
       if (!count($legacyIds))
       {
-        print "No legacyId values were found: all parent IDs may be invalid.\n";
+        print "No legacyId values were found in CSV data: all parent IDs may be invalid.\n";
       }
       else
       {

--- a/lib/task/import/csvCheckImportTask.class.php
+++ b/lib/task/import/csvCheckImportTask.class.php
@@ -311,25 +311,6 @@ EOF;
       }
     }
 
-    /*
-    if (count($prematureParentIds))
-    {
-      print "\n\nParent IDs referenced prematurely:\n";
-      print "----------------------------------\n\n";
-
-      print "These parent IDs referenced legacy ID values that don't exist in data.\n\n";
-
-      foreach (array_keys($prematureParentIds) as $parentId)
-      {
-        // If parent is missing entirely it will be reported separately as missing
-        if (empty($missingParentIds[$parentId]))
-        {
-          print sprintf("* parentId: %d\n", $parentId);
-        }
-      }
-    }
-    */
-
     if ($import->status['numberOfSampleValues'] > 0)
     {
       print "\n\nSample Values:\n";

--- a/lib/task/import/csvCheckImportTask.class.php
+++ b/lib/task/import/csvCheckImportTask.class.php
@@ -215,40 +215,47 @@ EOF;
       }
     }
 
-    // Check that parent IDs actually exist if legacy and parent IDs were found
-    if (count($legacyIds) && count($parentIds))
+    // Check that parent IDs actually exist if parent IDs were found
+    if (count($parentIds))
     {
-      $missingParentIds = array();
-
-      foreach ($parentIds as $parentId => $occurrences)
-      {
-        // If a legacy ID doesn't exist for a parent ID, then add to missing count
-        if (empty($legacyIds[$parentId]))
-        {
-          $missingParentIds[$parentId] = $occurrences;
-        }
-      }
-
       print "\n\nMissing parent IDs:\n";
       print "-------------------\n\n";
 
-      print sprintf("Total unique parent IDs: %d\n\n", count($parentIds));
-
-      print sprintf("Number of unique missing parent IDs: %d\n", count($missingParentIds));
-
-      // Display details about each missing parent and total number of rows affected
-      if (count($missingParentIds))
+      if (!count($legacyIds))
       {
-        $orphans = 0;
+        print "No legacyId values were found.\n";
+      }
+      else
+      {
+        $missingParentIds = array();
 
-        foreach ($missingParentIds as $parentId => $numberOfChildren)
+        foreach ($parentIds as $parentId => $occurrences)
         {
-          print sprintf("* %d (%d children)\n", $parentId, $numberOfChildren);
-
-          $orphans += $numberOfChildren;
+          // If a legacy ID doesn't exist for a parent ID, then add to missing count
+          if (empty($legacyIds[$parentId]))
+          {
+            $missingParentIds[$parentId] = $occurrences;
+          }
         }
 
-        print sprintf("\nTotal number of rows with missing parents: %d\n", $orphans);
+        print sprintf("Total unique parent IDs: %d\n\n", count($parentIds));
+
+        print sprintf("Number of unique missing parent IDs: %d\n", count($missingParentIds));
+
+        // Display details about each missing parent and total number of rows affected
+        if (count($missingParentIds))
+        {
+          $orphans = 0;
+
+          foreach ($missingParentIds as $parentId => $numberOfChildren)
+          {
+            print sprintf("* parentId: %d (%d children)\n", $parentId, $numberOfChildren);
+
+            $orphans += $numberOfChildren;
+          }
+
+          print sprintf("\nTotal number of rows with missing parents: %d\n", $orphans);
+        }
       }
     }
 


### PR DESCRIPTION
Added, to the csv:check CLI task, logic to check parent IDs to make sure they correspond to legacy IDs in the CSV file(s) being checked.