### PR TITLE
Restore access info to inventory list, refs #13480

### DIFF
--- a/lib/task/pdf/ead-pdf-inventory-summary.xsl
+++ b/lib/task/pdf/ead-pdf-inventory-summary.xsl
@@ -1484,7 +1484,12 @@
                 <fo:table-row padding-left="2pt" margin-left="2pt">
                     <fo:table-cell/>
                     <fo:table-cell number-columns-spanned="3">
-                        <fo:block><xsl:apply-templates select="ead:did" mode="itemDsc"/></fo:block>
+                        <fo:block margin-top="6pt">
+                            <xsl:apply-templates select="ead:did" mode="itemDsc"/>
+                            <xsl:apply-templates select="ead:scopecontent"/>
+                            <xsl:apply-templates select="ead:accessrestrict"/>
+                            <xsl:apply-templates select="ead:userestrict"/>
+                        </fo:block>
                     </fo:table-cell>
                 </fo:table-row>
             </xsl:otherwise>
@@ -1597,14 +1602,10 @@
     </xsl:template>
 
     <xsl:template match="ead:did" mode="itemDsc">
-        <fo:block margin-top="6pt">
-            <xsl:apply-templates select="ead:materialspec" mode="itemDsc"/>
-            <xsl:apply-templates select="ead:origination" mode="itemDsc"/>
-            <xsl:apply-templates select="../ead:scopecontent" mode="itemDsc"/>
-            <xsl:apply-templates select="../ead:userestrict" mode="itemDsc"/>
-            <xsl:apply-templates select="ead:note" mode="itemDsc"/>
-            <xsl:apply-templates select="ead:physloc" mode="itemDsc"/>
-        </fo:block>
+        <xsl:apply-templates select="ead:materialspec" mode="itemDsc"/>
+        <xsl:apply-templates select="ead:origination" mode="itemDsc"/>
+        <xsl:apply-templates select="ead:note" mode="itemDsc"/>
+        <xsl:apply-templates select="ead:physloc" mode="itemDsc"/>
     </xsl:template>
 
     <!-- Formats unitdates -->
@@ -1664,7 +1665,7 @@
 
     <!-- Special formatting for file/item table elements -->
     <xsl:template match="ead:origination | ead:scopecontent | ead:materialspec
-        | ead:physloc | ead:note | ead:userestrict" mode="itemDsc">
+        | ead:physloc | ead:note | ead:accessrestrict | ead:userestrict" mode="itemDsc">
         <fo:block>
             <fo:inline font-style="italic">
                 <xsl:choose>


### PR DESCRIPTION
Add the access restriction information back to the PDF Finding Aid
"inventory summary" table in the file and item level table row "body".

- Move non DID elements out of "ead:did" template
- Add ead:accessrestrict to "body" of file/item table row