### PR TITLE
Add video/audio caption/subtitle/chapter file support, refs #13490

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/showVideoComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/showVideoComponent.class.php
@@ -61,7 +61,10 @@ class DigitalObjectShowVideoComponent extends sfComponent
       list($this->width, $this->height) = QubitDigitalObject::getImageMaxDimensions($this->usageType);
 
       // For javascript_tag()
-      $this->representationFullPath = public_path($this->representation->getFullPath());
+      if (QubitTerm::CHAPTERS_ID != $this->usageType && QubitTerm::SUBTITLES_ID != $this->usageType)
+      {
+        $this->representationFullPath = public_path($this->representation->getFullPath());
+      }
     }
     // If representation is not a valid digital object, return a generic icon
     else

--- a/apps/qubit/modules/digitalobject/actions/viewAction.class.php
+++ b/apps/qubit/modules/digitalobject/actions/viewAction.class.php
@@ -111,6 +111,8 @@ class DigitalObjectViewAction extends sfAction
         break;
 
       case QubitTerm::REFERENCE_ID:
+      case QubitTerm::CHAPTERS_ID:
+      case QubitTerm::SUBTITLES_ID:
         $action = 'readReference';
         $obj = $this->resource->parent->object;
         break;

--- a/apps/qubit/modules/digitalobject/templates/_editRepresentation.php
+++ b/apps/qubit/modules/digitalobject/templates/_editRepresentation.php
@@ -1,13 +1,18 @@
 <div>
 
-  <div style="float: right;">
+  <div class="digital-object-preview">
 
-    <?php echo get_component('digitalobject', 'show', array(
-      'iconOnly' => true,
-      'link' => public_path($representation->getFullPath()),
-      'resource' => $representation,
-      'usageType' => QubitTerm::THUMBNAIL_ID)) ?>
+    <?php if ($representation->usageId == QubitTerm::CHAPTERS_ID): ?>
+      <a href="<?php echo $representation->getFullPath() ?>"><?php echo __('View file') ?></a>
 
+    <?php else: ?>
+      <?php echo get_component('digitalobject', 'show', array(
+        'iconOnly' => true,
+        'link' => public_path($representation->getFullPath()),
+        'resource' => $representation,
+        'usageType' => QubitTerm::THUMBNAIL_ID)) ?>
+
+    <?php endif; ?>
   </div>
 
   <div>

--- a/apps/qubit/modules/digitalobject/templates/_editSubtitles.php
+++ b/apps/qubit/modules/digitalobject/templates/_editSubtitles.php
@@ -1,0 +1,42 @@
+<fieldset class="collapsible">
+<legend><?php echo __('%1%', array('%1%' => QubitTerm::getById($usageId))) ?></legend> 
+
+<?php foreach ($subtitles as $subtitle): ?>
+  <table class="table table-bordered">
+    <thead>
+      <tr><th><?php echo format_language($subtitle->language) ?></th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+        
+          <div class="digital-object-preview">
+            <a href="<?php echo $subtitle->getFullPath() ?>"><?php echo __('View file') ?></a>
+          </div>
+        
+          <div>
+            <?php echo render_show(__('Filename'), render_value($subtitle->name)) ?>
+            <?php echo render_show(__('Filesize'), hr_filesize($subtitle->byteSize)) ?>
+            <?php echo link_to(__('Delete'), array($subtitle, 'module' => 'digitalobject', 'action' => 'delete'), array('class' => 'delete')) ?>
+          </div>
+      
+        </td>
+      </tr>
+    </tbody>
+  </table>
+<?php endforeach ?>
+
+<table class="table table-bordered">
+  <tr>
+    <td>
+      <?php echo $form["trackFile_$usageId"]
+        ->label(__('Select a file to upload (.vtt|.srt)'))
+        ->renderRow() ?>
+              
+      <?php echo $form["lang_$usageId"]
+        ->label(__('Language'))
+        ->renderRow() ?>
+    </td>
+  </tr>
+</table>
+</fieldset>

--- a/apps/qubit/modules/digitalobject/templates/_show.php
+++ b/apps/qubit/modules/digitalobject/templates/_show.php
@@ -1,9 +1,20 @@
-<div class="digital-object-reference">
+<?php if ($usageType == QubitTerm::CHAPTERS_ID || $usageType == QubitTerm::SUBTITLES_ID): ?>
   <?php if (!empty($accessWarning)): ?>
-    <div class="access-warning">
-      <?php echo $accessWarning ?>
-    </div>
-  <?php else: ?>
-    <?php echo get_component('digitalobject', $showComponent, array('iconOnly' => $iconOnly, 'link' => $link, 'resource' => $resource, 'usageType' => $usageType)) ?>
+      <div class="access-warning">
+        <?php echo $accessWarning ?>
+      </div>
+    <?php else: ?>
+      <?php echo get_component('digitalobject', $showComponent, array('iconOnly' => $iconOnly, 'link' => $link, 'resource' => $resource, 'usageType' => $usageType)) ?>
   <?php endif; ?>
-</div>
+    
+<?php else: ?>
+  <div class="digital-object-reference">
+    <?php if (!empty($accessWarning)): ?>
+      <div class="access-warning">
+        <?php echo $accessWarning ?>
+      </div>
+    <?php else: ?>
+      <?php echo get_component('digitalobject', $showComponent, array('iconOnly' => $iconOnly, 'link' => $link, 'resource' => $resource, 'usageType' => $usageType)) ?>
+    <?php endif; ?>
+  </div>
+<?php endif; ?>

--- a/apps/qubit/modules/digitalobject/templates/_showAudio.php
+++ b/apps/qubit/modules/digitalobject/templates/_showAudio.php
@@ -1,9 +1,17 @@
 <?php use_helper('Text') ?>
 
-<?php if (QubitTerm::REFERENCE_ID == $usageType): ?>
+<?php if ($usageType == QubitTerm::CHAPTERS_ID): ?>
 
   <?php if ($showMediaPlayer): ?>
-    <audio class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>"></audio>
+    <track kind="chapters" src="<?php echo public_path($representation->getFullPath()) ?>" srclang="">
+  <?php endif; ?>
+
+<?php elseif (QubitTerm::REFERENCE_ID == $usageType): ?>
+
+  <?php if ($showMediaPlayer): ?>
+    <audio class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>">
+      <?php echo get_component('digitalobject', 'show', array('resource' => $resource, 'usageType' => QubitTerm::CHAPTERS_ID)) ?>
+    </audio>
   <?php else: ?>
     <div style="text-align: center">
       <?php echo image_tag($representation->getFullPath(), array('style' => 'border: #999 1px solid', 'alt' => '')) ?>

--- a/apps/qubit/modules/digitalobject/templates/_showVideo.php
+++ b/apps/qubit/modules/digitalobject/templates/_showVideo.php
@@ -8,10 +8,27 @@
     <?php echo link_to(image_tag($representation->getFullPath(), array('alt' => __($resource->getDigitalObjectAltText() ?: 'Open original %1%', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))), $link) ?>
   <?php endif; ?>
 
+<?php elseif ($usageType == QubitTerm::CHAPTERS_ID): ?>
+
+  <?php if ($showMediaPlayer): ?>
+    <track kind="chapters" src="<?php echo public_path($representation->getFullPath()) ?>" srclang="">
+  <?php endif; ?>
+
+<?php elseif ($usageType == QubitTerm::SUBTITLES_ID): ?>
+
+  <?php if ($showMediaPlayer): ?>
+    <?php foreach ($representation as $subtitle): ?>
+      <track kind="subtitles" src="<?php echo public_path($subtitle->getFullPath()) ?>" srclang="<?php echo $subtitle->language ?>" label="<?php echo format_language($subtitle->language) ?>">
+    <?php endforeach; ?>
+  <?php endif; ?>
+
 <?php elseif ($usageType == QubitTerm::REFERENCE_ID): ?>
 
   <?php if ($showMediaPlayer): ?>
-    <video preload="metadata" class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>"></video>
+    <video preload="metadata" class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>">
+      <?php echo get_component('digitalobject', 'show', array('resource' => $resource, 'usageType' => QubitTerm::CHAPTERS_ID)) ?>
+      <?php echo get_component('digitalobject', 'show', array('resource' => $resource, 'usageType' => QubitTerm::SUBTITLES_ID)) ?>
+    </video>
   <?php else: ?>
     <div style="text-align: center">
       <?php echo image_tag($representation->getFullPath(), array('style' => 'border: #999 1px solid', 'alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>

--- a/apps/qubit/modules/digitalobject/templates/deleteSuccess.php
+++ b/apps/qubit/modules/digitalobject/templates/deleteSuccess.php
@@ -2,7 +2,11 @@
 
 <?php slot('title') ?>
   <?php if (isset($resource->parent)): ?>
-    <h1><?php echo __('Are you sure you want to delete this reference/thumbnail representation?') ?></h1>
+    <?php if ($resource->usageId == QubitTerm::CHAPTERS_ID || $resource->usageId == QubitTerm::SUBTITLES_ID): ?>
+      <h1><?php echo __('Are you sure you want to delete these captions/subtitles/chapters?') ?></h1>
+    <?php else: ?>
+      <h1><?php echo __('Are you sure you want to delete this reference/thumbnail representation?') ?></h1>
+    <?php endif; ?>
   <?php else: ?>
     <h1><?php echo __('Are you sure you want to delete the %1% linked to %2%?', array('%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject')), '%2%' => render_title($object))) ?></h1>
   <?php endif; ?>

--- a/apps/qubit/modules/digitalobject/templates/editSuccess.php
+++ b/apps/qubit/modules/digitalobject/templates/editSuccess.php
@@ -80,6 +80,36 @@
 
       <?php endforeach; ?>
 
+      <?php if ($resource->mediaTypeId == QubitTerm::VIDEO_ID || $resource->mediaTypeId == QubitTerm::AUDIO_ID): ?>
+        
+        <?php foreach ($videoTracks as $usageId => $videoTrack): ?>
+
+          <?php if ($resource->mediaTypeId == QubitTerm::VIDEO_ID && $usageId == QubitTerm::SUBTITLES_ID): ?>
+            
+            <?php echo include_partial('editSubtitles', array('resource' => $resource, 'subtitles' => $videoTrack, 'form' => $form, 'usageId' => $usageId)) ?>
+
+          <?php elseif ($usageId != QubitTerm::SUBTITLES_ID): ?>                 
+          
+            <fieldset class="collapsible">
+
+              <legend><?php echo __('%1%', array('%1%' => QubitTerm::getById($usageId))) ?></legend>
+
+              <?php if (isset($videoTrack)): ?>
+              
+                <?php echo get_component('digitalobject', 'editRepresentation', array('resource' => $resource, 'representation' => $videoTrack)) ?>
+
+              <?php else: ?>
+
+                <?php echo $form["trackFile_$usageId"]
+                  ->label(__('Select a file to upload (.vtt|.srt)'))
+                  ->renderRow() ?>
+            
+              <?php endif; ?>
+            </fieldset> 
+          <?php endif; ?>
+        <?php endforeach; ?>
+      <?php endif; ?>
+
     </section>
 
     <section class="actions">

--- a/config/schema.yml
+++ b/config/schema.yml
@@ -98,6 +98,7 @@ propel:
     id: { type: integer, required: true, primaryKey: true, foreignTable: object, foreignReference: id, onDelete: cascade, inheritanceKey: true }
     object_id: { type: integer, foreignTable: object, foreignReference: id, onDelete: cascade }
     usage_id: { type: integer, foreignTable: term, foreignReference: id, onDelete: setnull }
+    language: varchar(50)
     mime_type: varchar(255)
     media_type_id: { type: integer, foreignTable: term, foreignReference: id, onDelete: setnull }
     name: { type: varchar(1024), required: true }

--- a/data/fixtures/taxonomyTerms.yml
+++ b/data/fixtures/taxonomyTerms.yml
@@ -2678,6 +2678,22 @@ QubitTerm:
       hr: 'Vanjska datoteka'
       pt: 'Ficheiro externo'
       pt_BR: 'Arquivo externo'
+  QubitTerm_chapters_id:
+    taxonomy_id: QubitTaxonomy_17
+    parent_id: QubitTerm_110
+    id: 195
+    source_culture: en
+    name:
+      en: 'Chapters'
+      fr: 'Chapitres'
+  QubitTerm_subtitles_id:
+    taxonomy_id: QubitTaxonomy_17
+    parent_id: QubitTerm_110
+    id: 196
+    source_culture: en
+    name:
+      en: 'Captions/Subtitles'
+      fr: 'Légendes/Sous-titres'
   QubitTerm_140:
     taxonomy_id: QubitTaxonomy_18
     parent_id: QubitTerm_110

--- a/data/sql/lib.model.schema.sql
+++ b/data/sql/lib.model.schema.sql
@@ -316,6 +316,7 @@ CREATE TABLE `digital_object`
 	`id` INTEGER  NOT NULL,
 	`object_id` INTEGER,
 	`usage_id` INTEGER,
+	`language` VARCHAR(50),
 	`mime_type` VARCHAR(255),
 	`media_type_id` INTEGER,
 	`name` VARCHAR(1024)  NOT NULL,

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -912,6 +912,7 @@ class QubitDigitalObject extends BaseDigitalObject
       'vss' => 'application/vnd.visio',
       'vst' => 'application/vnd.visio',
       'vsw' => 'application/vnd.visio',
+      'vtt' => 'text/vtt',
       'vtu' => 'model/vnd.vtu',
       'vxml' => 'application/voicexml+xml',
       'w3d' => 'application/x-director',
@@ -1768,7 +1769,14 @@ class QubitDigitalObject extends BaseDigitalObject
     $criteria->add(QubitDigitalObject::PARENT_ID, $this->id);
     $criteria->add(QubitDigitalObject::USAGE_ID, $usageId);
 
-    $result = QubitDigitalObject::getOne($criteria);
+    if ($usageId == QubitTerm::SUBTITLES_ID)
+    {
+      $result = QubitDigitalObject::get($criteria);
+    }
+    else
+    {
+      $result = QubitDigitalObject::getOne($criteria);
+    }
 
     return $result;
   }
@@ -2595,7 +2603,7 @@ class QubitDigitalObject extends BaseDigitalObject
   }
 
   /**
-   * Resize an image using the sfThubmnail Plugin.
+   * Resize an image using the sfThumbnail Plugin.
    *
    * @param string $originalImageName
    * @param integer $width
@@ -2772,7 +2780,7 @@ class QubitDigitalObject extends BaseDigitalObject
 
   /*
    * -----------------------------------------------------------------------
-   * VIDEO
+   * Audio
    * -----------------------------------------------------------------------
    */
   public function createAudioDerivative($usageId, $connection = null)

--- a/lib/model/QubitTerm.php
+++ b/lib/model/QubitTerm.php
@@ -184,7 +184,11 @@ class QubitTerm extends BaseTerm
     ACCESSION_EVENT_PHYSICAL_TRANSFER_ID = 193,
 
     // Accession event note
-    ACCESSION_EVENT_NOTE_ID = 194;
+    ACCESSION_EVENT_NOTE_ID = 194,
+
+    // Digital object usage taxonomy (addition)
+    CHAPTERS_ID = 195,
+    SUBTITLES_ID = 196;
 
   public static function isProtected($id)
   {
@@ -200,6 +204,7 @@ class QubitTerm extends BaseTerm
       QubitTerm::ARTEFACT_MATERIAL_ID,
       QubitTerm::ASSOCIATIVE_RELATION_ID,
       QubitTerm::AUDIO_ID,
+      QubitTerm::CHAPTERS_ID,
       QubitTerm::COLLECTION_ID,
       QubitTerm::COMPOUND_ID,
       QubitTerm::CONTAINER_ID,
@@ -245,6 +250,7 @@ class QubitTerm extends BaseTerm
       QubitTerm::SOURCE_NOTE_ID,
       QubitTerm::STANDARDIZED_FORM_OF_NAME_ID,
       QubitTerm::STATUS_TYPE_PUBLICATION_ID,
+      QubitTerm::SUBTITLES_ID,
       QubitTerm::TEMPORAL_RELATION_ID,
       QubitTerm::TERM_RELATION_ASSOCIATIVE_ID,
       QubitTerm::TEXT_ID,

--- a/lib/model/map/ActorTableMap.php
+++ b/lib/model/map/ActorTableMap.php
@@ -58,7 +58,6 @@ class ActorTableMap extends TableMap {
     $this->addRelation('termRelatedBydescriptionStatusId', 'term', RelationMap::MANY_TO_ONE, array('description_status_id' => 'id', ), 'SET NULL', null);
     $this->addRelation('termRelatedBydescriptionDetailId', 'term', RelationMap::MANY_TO_ONE, array('description_detail_id' => 'id', ), 'SET NULL', null);
     $this->addRelation('actorRelatedByparentId', 'actor', RelationMap::MANY_TO_ONE, array('parent_id' => 'id', ), 'CASCADE', null);
-    $this->addRelation('donor', 'donor', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('actorRelatedByparentId', 'actor', RelationMap::ONE_TO_MANY, array('id' => 'parent_id', ), 'CASCADE', null);
     $this->addRelation('actorI18n', 'actorI18n', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('contactInformation', 'contactInformation', RelationMap::ONE_TO_MANY, array('id' => 'actor_id', ), 'CASCADE', null);
@@ -67,6 +66,7 @@ class ActorTableMap extends TableMap {
     $this->addRelation('rights', 'rights', RelationMap::ONE_TO_MANY, array('id' => 'rights_holder_id', ), 'SET NULL', null);
     $this->addRelation('rightsHolder', 'rightsHolder', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('user', 'user', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
+    $this->addRelation('donor', 'donor', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
 	} // buildRelations()
 
 } // ActorTableMap

--- a/lib/model/map/DigitalObjectTableMap.php
+++ b/lib/model/map/DigitalObjectTableMap.php
@@ -39,6 +39,7 @@ class DigitalObjectTableMap extends TableMap {
 		$this->addForeignPrimaryKey('ID', 'id', 'INTEGER' , 'object', 'ID', true, null, null);
 		$this->addForeignKey('OBJECT_ID', 'objectId', 'INTEGER', 'object', 'ID', false, null, null);
 		$this->addForeignKey('USAGE_ID', 'usageId', 'INTEGER', 'term', 'ID', false, null, null);
+		$this->addColumn('LANGUAGE', 'language', 'VARCHAR', false, 50, null);
 		$this->addColumn('MIME_TYPE', 'mimeType', 'VARCHAR', false, 255, null);
 		$this->addForeignKey('MEDIA_TYPE_ID', 'mediaTypeId', 'INTEGER', 'term', 'ID', false, null, null);
 		$this->addColumn('NAME', 'name', 'VARCHAR', true, 1024, null);

--- a/lib/model/map/ObjectTableMap.php
+++ b/lib/model/map/ObjectTableMap.php
@@ -49,10 +49,6 @@ class ObjectTableMap extends TableMap {
 	 */
 	public function buildRelations()
 	{
-    $this->addRelation('accession', 'accession', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
-    $this->addRelation('accessionEvent', 'accessionEvent', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
-    $this->addRelation('deaccession', 'deaccession', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
-    $this->addRelation('aclPermission', 'aclPermission', RelationMap::ONE_TO_MANY, array('id' => 'object_id', ), 'CASCADE', null);
     $this->addRelation('accessLog', 'accessLog', RelationMap::ONE_TO_MANY, array('id' => 'object_id', ), 'CASCADE', null);
     $this->addRelation('actor', 'actor', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('aipRelatedByid', 'aip', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
@@ -82,6 +78,10 @@ class ObjectTableMap extends TableMap {
     $this->addRelation('status', 'status', RelationMap::ONE_TO_MANY, array('id' => 'object_id', ), 'CASCADE', null);
     $this->addRelation('taxonomy', 'taxonomy', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('term', 'term', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
+    $this->addRelation('aclPermission', 'aclPermission', RelationMap::ONE_TO_MANY, array('id' => 'object_id', ), 'CASCADE', null);
+    $this->addRelation('accession', 'accession', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
+    $this->addRelation('accessionEvent', 'accessionEvent', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
+    $this->addRelation('deaccession', 'deaccession', RelationMap::ONE_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
 	} // buildRelations()
 
 } // ObjectTableMap

--- a/lib/model/map/TermTableMap.php
+++ b/lib/model/map/TermTableMap.php
@@ -54,12 +54,6 @@ class TermTableMap extends TableMap {
     $this->addRelation('object', 'object', RelationMap::MANY_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
     $this->addRelation('taxonomy', 'taxonomy', RelationMap::MANY_TO_ONE, array('taxonomy_id' => 'id', ), 'CASCADE', null);
     $this->addRelation('termRelatedByparentId', 'term', RelationMap::MANY_TO_ONE, array('parent_id' => 'id', ), 'CASCADE', null);
-    $this->addRelation('accessionRelatedByacquisitionTypeId', 'accession', RelationMap::ONE_TO_MANY, array('id' => 'acquisition_type_id', ), 'SET NULL', null);
-    $this->addRelation('accessionRelatedByprocessingPriorityId', 'accession', RelationMap::ONE_TO_MANY, array('id' => 'processing_priority_id', ), 'SET NULL', null);
-    $this->addRelation('accessionRelatedByprocessingStatusId', 'accession', RelationMap::ONE_TO_MANY, array('id' => 'processing_status_id', ), 'SET NULL', null);
-    $this->addRelation('accessionRelatedByresourceTypeId', 'accession', RelationMap::ONE_TO_MANY, array('id' => 'resource_type_id', ), 'SET NULL', null);
-    $this->addRelation('accessionEvent', 'accessionEvent', RelationMap::ONE_TO_MANY, array('id' => 'type_id', ), 'SET NULL', null);
-    $this->addRelation('deaccession', 'deaccession', RelationMap::ONE_TO_MANY, array('id' => 'scope_id', ), 'SET NULL', null);
     $this->addRelation('actorRelatedByentityTypeId', 'actor', RelationMap::ONE_TO_MANY, array('id' => 'entity_type_id', ), 'SET NULL', null);
     $this->addRelation('actorRelatedBydescriptionStatusId', 'actor', RelationMap::ONE_TO_MANY, array('id' => 'description_status_id', ), 'SET NULL', null);
     $this->addRelation('actorRelatedBydescriptionDetailId', 'actor', RelationMap::ONE_TO_MANY, array('id' => 'description_detail_id', ), 'SET NULL', null);
@@ -92,6 +86,12 @@ class TermTableMap extends TableMap {
     $this->addRelation('statusRelatedBystatusId', 'status', RelationMap::ONE_TO_MANY, array('id' => 'status_id', ), 'CASCADE', null);
     $this->addRelation('termRelatedByparentId', 'term', RelationMap::ONE_TO_MANY, array('id' => 'parent_id', ), 'CASCADE', null);
     $this->addRelation('termI18n', 'termI18n', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null);
+    $this->addRelation('accessionRelatedByacquisitionTypeId', 'accession', RelationMap::ONE_TO_MANY, array('id' => 'acquisition_type_id', ), 'SET NULL', null);
+    $this->addRelation('accessionRelatedByprocessingPriorityId', 'accession', RelationMap::ONE_TO_MANY, array('id' => 'processing_priority_id', ), 'SET NULL', null);
+    $this->addRelation('accessionRelatedByprocessingStatusId', 'accession', RelationMap::ONE_TO_MANY, array('id' => 'processing_status_id', ), 'SET NULL', null);
+    $this->addRelation('accessionRelatedByresourceTypeId', 'accession', RelationMap::ONE_TO_MANY, array('id' => 'resource_type_id', ), 'SET NULL', null);
+    $this->addRelation('accessionEvent', 'accessionEvent', RelationMap::ONE_TO_MANY, array('id' => 'type_id', ), 'SET NULL', null);
+    $this->addRelation('deaccession', 'deaccession', RelationMap::ONE_TO_MANY, array('id' => 'scope_id', ), 'SET NULL', null);
 	} // buildRelations()
 
 } // TermTableMap

--- a/lib/model/map/UserTableMap.php
+++ b/lib/model/map/UserTableMap.php
@@ -51,12 +51,12 @@ class UserTableMap extends TableMap {
 	public function buildRelations()
 	{
     $this->addRelation('actor', 'actor', RelationMap::MANY_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
-    $this->addRelation('aclPermission', 'aclPermission', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'CASCADE', null);
-    $this->addRelation('aclUserGroup', 'aclUserGroup', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'CASCADE', null);
     $this->addRelation('auditLog', 'auditLog', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'SET NULL', null);
     $this->addRelation('job', 'job', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'SET NULL', null);
     $this->addRelation('clipboardSave', 'clipboardSave', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'SET NULL', null);
     $this->addRelation('note', 'note', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'SET NULL', null);
+    $this->addRelation('aclPermission', 'aclPermission', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'CASCADE', null);
+    $this->addRelation('aclUserGroup', 'aclUserGroup', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'CASCADE', null);
 	} // buildRelations()
 
 } // UserTableMap

--- a/lib/model/om/BaseDigitalObject.php
+++ b/lib/model/om/BaseDigitalObject.php
@@ -10,6 +10,7 @@ abstract class BaseDigitalObject extends QubitObject implements ArrayAccess
     ID = 'digital_object.ID',
     OBJECT_ID = 'digital_object.OBJECT_ID',
     USAGE_ID = 'digital_object.USAGE_ID',
+    LANGUAGE = 'digital_object.LANGUAGE',
     MIME_TYPE = 'digital_object.MIME_TYPE',
     MEDIA_TYPE_ID = 'digital_object.MEDIA_TYPE_ID',
     NAME = 'digital_object.NAME',
@@ -29,6 +30,7 @@ abstract class BaseDigitalObject extends QubitObject implements ArrayAccess
     $criteria->addSelectColumn(QubitDigitalObject::ID);
     $criteria->addSelectColumn(QubitDigitalObject::OBJECT_ID);
     $criteria->addSelectColumn(QubitDigitalObject::USAGE_ID);
+    $criteria->addSelectColumn(QubitDigitalObject::LANGUAGE);
     $criteria->addSelectColumn(QubitDigitalObject::MIME_TYPE);
     $criteria->addSelectColumn(QubitDigitalObject::MEDIA_TYPE_ID);
     $criteria->addSelectColumn(QubitDigitalObject::NAME);

--- a/lib/model/om/BaseObject.php
+++ b/lib/model/om/BaseObject.php
@@ -185,11 +185,6 @@ abstract class BaseObject implements ArrayAccess
       }
     }
 
-    if ('aclPermissions' == $name)
-    {
-      return true;
-    }
-
     if ('accessLogs' == $name)
     {
       return true;
@@ -260,6 +255,11 @@ abstract class BaseObject implements ArrayAccess
       return true;
     }
 
+    if ('aclPermissions' == $name)
+    {
+      return true;
+    }
+
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
@@ -299,23 +299,6 @@ abstract class BaseObject implements ArrayAccess
 
         $offset++;
       }
-    }
-
-    if ('aclPermissions' == $name)
-    {
-      if (!isset($this->refFkValues['aclPermissions']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['aclPermissions'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['aclPermissions'] = self::getaclPermissionsById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['aclPermissions'];
     }
 
     if ('accessLogs' == $name)
@@ -554,6 +537,23 @@ abstract class BaseObject implements ArrayAccess
       }
 
       return $this->refFkValues['statuss'];
+    }
+
+    if ('aclPermissions' == $name)
+    {
+      if (!isset($this->refFkValues['aclPermissions']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['aclPermissions'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['aclPermissions'] = self::getaclPermissionsById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['aclPermissions'];
     }
 
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
@@ -882,26 +882,6 @@ abstract class BaseObject implements ArrayAccess
 		$this->setid($key);
 	}
 
-  public static function addaclPermissionsCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitAclPermission::OBJECT_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getaclPermissionsById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::addaclPermissionsCriteriaById($criteria, $id);
-
-    return QubitAclPermission::get($criteria, $options);
-  }
-
-  public function addaclPermissionsCriteria(Criteria $criteria)
-  {
-    return self::addaclPermissionsCriteriaById($criteria, $this->id);
-  }
-
   public static function addaccessLogsCriteriaById(Criteria $criteria, $id)
   {
     $criteria->add(QubitAccessLog::OBJECT_ID, $id);
@@ -1180,6 +1160,26 @@ abstract class BaseObject implements ArrayAccess
   public function addstatussCriteria(Criteria $criteria)
   {
     return self::addstatussCriteriaById($criteria, $this->id);
+  }
+
+  public static function addaclPermissionsCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitAclPermission::OBJECT_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getaclPermissionsById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addaclPermissionsCriteriaById($criteria, $id);
+
+    return QubitAclPermission::get($criteria, $options);
+  }
+
+  public function addaclPermissionsCriteria(Criteria $criteria)
+  {
+    return self::addaclPermissionsCriteriaById($criteria, $this->id);
   }
 
   public function __call($name, $args)

--- a/lib/model/om/BaseTerm.php
+++ b/lib/model/om/BaseTerm.php
@@ -109,36 +109,6 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
     {
     }
 
-    if ('accessionsRelatedByacquisitionTypeId' == $name)
-    {
-      return true;
-    }
-
-    if ('accessionsRelatedByprocessingPriorityId' == $name)
-    {
-      return true;
-    }
-
-    if ('accessionsRelatedByprocessingStatusId' == $name)
-    {
-      return true;
-    }
-
-    if ('accessionsRelatedByresourceTypeId' == $name)
-    {
-      return true;
-    }
-
-    if ('accessionEvents' == $name)
-    {
-      return true;
-    }
-
-    if ('deaccessions' == $name)
-    {
-      return true;
-    }
-
     if ('actorsRelatedByentityTypeId' == $name)
     {
       return true;
@@ -299,6 +269,36 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
       return true;
     }
 
+    if ('accessionsRelatedByacquisitionTypeId' == $name)
+    {
+      return true;
+    }
+
+    if ('accessionsRelatedByprocessingPriorityId' == $name)
+    {
+      return true;
+    }
+
+    if ('accessionsRelatedByprocessingStatusId' == $name)
+    {
+      return true;
+    }
+
+    if ('accessionsRelatedByresourceTypeId' == $name)
+    {
+      return true;
+    }
+
+    if ('accessionEvents' == $name)
+    {
+      return true;
+    }
+
+    if ('deaccessions' == $name)
+    {
+      return true;
+    }
+
     try
     {
       if (!$value = call_user_func_array(array($this->getCurrenttermI18n($options), '__isset'), $args) && !empty($options['cultureFallback']))
@@ -341,108 +341,6 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
     }
     catch (sfException $e)
     {
-    }
-
-    if ('accessionsRelatedByacquisitionTypeId' == $name)
-    {
-      if (!isset($this->refFkValues['accessionsRelatedByacquisitionTypeId']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['accessionsRelatedByacquisitionTypeId'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['accessionsRelatedByacquisitionTypeId'] = self::getaccessionsRelatedByacquisitionTypeIdById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['accessionsRelatedByacquisitionTypeId'];
-    }
-
-    if ('accessionsRelatedByprocessingPriorityId' == $name)
-    {
-      if (!isset($this->refFkValues['accessionsRelatedByprocessingPriorityId']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['accessionsRelatedByprocessingPriorityId'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['accessionsRelatedByprocessingPriorityId'] = self::getaccessionsRelatedByprocessingPriorityIdById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['accessionsRelatedByprocessingPriorityId'];
-    }
-
-    if ('accessionsRelatedByprocessingStatusId' == $name)
-    {
-      if (!isset($this->refFkValues['accessionsRelatedByprocessingStatusId']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['accessionsRelatedByprocessingStatusId'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['accessionsRelatedByprocessingStatusId'] = self::getaccessionsRelatedByprocessingStatusIdById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['accessionsRelatedByprocessingStatusId'];
-    }
-
-    if ('accessionsRelatedByresourceTypeId' == $name)
-    {
-      if (!isset($this->refFkValues['accessionsRelatedByresourceTypeId']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['accessionsRelatedByresourceTypeId'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['accessionsRelatedByresourceTypeId'] = self::getaccessionsRelatedByresourceTypeIdById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['accessionsRelatedByresourceTypeId'];
-    }
-
-    if ('accessionEvents' == $name)
-    {
-      if (!isset($this->refFkValues['accessionEvents']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['accessionEvents'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['accessionEvents'] = self::getaccessionEventsById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['accessionEvents'];
-    }
-
-    if ('deaccessions' == $name)
-    {
-      if (!isset($this->refFkValues['deaccessions']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['deaccessions'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['deaccessions'] = self::getdeaccessionsById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['deaccessions'];
     }
 
     if ('actorsRelatedByentityTypeId' == $name)
@@ -989,6 +887,108 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
       return $this->refFkValues['termI18ns'];
     }
 
+    if ('accessionsRelatedByacquisitionTypeId' == $name)
+    {
+      if (!isset($this->refFkValues['accessionsRelatedByacquisitionTypeId']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['accessionsRelatedByacquisitionTypeId'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['accessionsRelatedByacquisitionTypeId'] = self::getaccessionsRelatedByacquisitionTypeIdById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['accessionsRelatedByacquisitionTypeId'];
+    }
+
+    if ('accessionsRelatedByprocessingPriorityId' == $name)
+    {
+      if (!isset($this->refFkValues['accessionsRelatedByprocessingPriorityId']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['accessionsRelatedByprocessingPriorityId'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['accessionsRelatedByprocessingPriorityId'] = self::getaccessionsRelatedByprocessingPriorityIdById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['accessionsRelatedByprocessingPriorityId'];
+    }
+
+    if ('accessionsRelatedByprocessingStatusId' == $name)
+    {
+      if (!isset($this->refFkValues['accessionsRelatedByprocessingStatusId']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['accessionsRelatedByprocessingStatusId'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['accessionsRelatedByprocessingStatusId'] = self::getaccessionsRelatedByprocessingStatusIdById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['accessionsRelatedByprocessingStatusId'];
+    }
+
+    if ('accessionsRelatedByresourceTypeId' == $name)
+    {
+      if (!isset($this->refFkValues['accessionsRelatedByresourceTypeId']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['accessionsRelatedByresourceTypeId'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['accessionsRelatedByresourceTypeId'] = self::getaccessionsRelatedByresourceTypeIdById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['accessionsRelatedByresourceTypeId'];
+    }
+
+    if ('accessionEvents' == $name)
+    {
+      if (!isset($this->refFkValues['accessionEvents']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['accessionEvents'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['accessionEvents'] = self::getaccessionEventsById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['accessionEvents'];
+    }
+
+    if ('deaccessions' == $name)
+    {
+      if (!isset($this->refFkValues['deaccessions']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['deaccessions'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['deaccessions'] = self::getdeaccessionsById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['deaccessions'];
+    }
+
     try
     {
       if (1 > strlen($value = call_user_func_array(array($this->getCurrenttermI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
@@ -1215,126 +1215,6 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
     $criteria->addJoin(QubitTerm::PARENT_ID, QubitTerm::ID);
 
     return $criteria;
-  }
-
-  public static function addaccessionsRelatedByacquisitionTypeIdCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitAccession::ACQUISITION_TYPE_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getaccessionsRelatedByacquisitionTypeIdById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::addaccessionsRelatedByacquisitionTypeIdCriteriaById($criteria, $id);
-
-    return QubitAccession::get($criteria, $options);
-  }
-
-  public function addaccessionsRelatedByacquisitionTypeIdCriteria(Criteria $criteria)
-  {
-    return self::addaccessionsRelatedByacquisitionTypeIdCriteriaById($criteria, $this->id);
-  }
-
-  public static function addaccessionsRelatedByprocessingPriorityIdCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitAccession::PROCESSING_PRIORITY_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getaccessionsRelatedByprocessingPriorityIdById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::addaccessionsRelatedByprocessingPriorityIdCriteriaById($criteria, $id);
-
-    return QubitAccession::get($criteria, $options);
-  }
-
-  public function addaccessionsRelatedByprocessingPriorityIdCriteria(Criteria $criteria)
-  {
-    return self::addaccessionsRelatedByprocessingPriorityIdCriteriaById($criteria, $this->id);
-  }
-
-  public static function addaccessionsRelatedByprocessingStatusIdCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitAccession::PROCESSING_STATUS_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getaccessionsRelatedByprocessingStatusIdById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::addaccessionsRelatedByprocessingStatusIdCriteriaById($criteria, $id);
-
-    return QubitAccession::get($criteria, $options);
-  }
-
-  public function addaccessionsRelatedByprocessingStatusIdCriteria(Criteria $criteria)
-  {
-    return self::addaccessionsRelatedByprocessingStatusIdCriteriaById($criteria, $this->id);
-  }
-
-  public static function addaccessionsRelatedByresourceTypeIdCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitAccession::RESOURCE_TYPE_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getaccessionsRelatedByresourceTypeIdById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::addaccessionsRelatedByresourceTypeIdCriteriaById($criteria, $id);
-
-    return QubitAccession::get($criteria, $options);
-  }
-
-  public function addaccessionsRelatedByresourceTypeIdCriteria(Criteria $criteria)
-  {
-    return self::addaccessionsRelatedByresourceTypeIdCriteriaById($criteria, $this->id);
-  }
-
-  public static function addaccessionEventsCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitAccessionEvent::TYPE_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getaccessionEventsById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::addaccessionEventsCriteriaById($criteria, $id);
-
-    return QubitAccessionEvent::get($criteria, $options);
-  }
-
-  public function addaccessionEventsCriteria(Criteria $criteria)
-  {
-    return self::addaccessionEventsCriteriaById($criteria, $this->id);
-  }
-
-  public static function adddeaccessionsCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitDeaccession::SCOPE_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getdeaccessionsById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::adddeaccessionsCriteriaById($criteria, $id);
-
-    return QubitDeaccession::get($criteria, $options);
-  }
-
-  public function adddeaccessionsCriteria(Criteria $criteria)
-  {
-    return self::adddeaccessionsCriteriaById($criteria, $this->id);
   }
 
   public static function addactorsRelatedByentityTypeIdCriteriaById(Criteria $criteria, $id)
@@ -1975,6 +1855,126 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
   public function addtermI18nsCriteria(Criteria $criteria)
   {
     return self::addtermI18nsCriteriaById($criteria, $this->id);
+  }
+
+  public static function addaccessionsRelatedByacquisitionTypeIdCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitAccession::ACQUISITION_TYPE_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getaccessionsRelatedByacquisitionTypeIdById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addaccessionsRelatedByacquisitionTypeIdCriteriaById($criteria, $id);
+
+    return QubitAccession::get($criteria, $options);
+  }
+
+  public function addaccessionsRelatedByacquisitionTypeIdCriteria(Criteria $criteria)
+  {
+    return self::addaccessionsRelatedByacquisitionTypeIdCriteriaById($criteria, $this->id);
+  }
+
+  public static function addaccessionsRelatedByprocessingPriorityIdCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitAccession::PROCESSING_PRIORITY_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getaccessionsRelatedByprocessingPriorityIdById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addaccessionsRelatedByprocessingPriorityIdCriteriaById($criteria, $id);
+
+    return QubitAccession::get($criteria, $options);
+  }
+
+  public function addaccessionsRelatedByprocessingPriorityIdCriteria(Criteria $criteria)
+  {
+    return self::addaccessionsRelatedByprocessingPriorityIdCriteriaById($criteria, $this->id);
+  }
+
+  public static function addaccessionsRelatedByprocessingStatusIdCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitAccession::PROCESSING_STATUS_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getaccessionsRelatedByprocessingStatusIdById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addaccessionsRelatedByprocessingStatusIdCriteriaById($criteria, $id);
+
+    return QubitAccession::get($criteria, $options);
+  }
+
+  public function addaccessionsRelatedByprocessingStatusIdCriteria(Criteria $criteria)
+  {
+    return self::addaccessionsRelatedByprocessingStatusIdCriteriaById($criteria, $this->id);
+  }
+
+  public static function addaccessionsRelatedByresourceTypeIdCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitAccession::RESOURCE_TYPE_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getaccessionsRelatedByresourceTypeIdById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addaccessionsRelatedByresourceTypeIdCriteriaById($criteria, $id);
+
+    return QubitAccession::get($criteria, $options);
+  }
+
+  public function addaccessionsRelatedByresourceTypeIdCriteria(Criteria $criteria)
+  {
+    return self::addaccessionsRelatedByresourceTypeIdCriteriaById($criteria, $this->id);
+  }
+
+  public static function addaccessionEventsCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitAccessionEvent::TYPE_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getaccessionEventsById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addaccessionEventsCriteriaById($criteria, $id);
+
+    return QubitAccessionEvent::get($criteria, $options);
+  }
+
+  public function addaccessionEventsCriteria(Criteria $criteria)
+  {
+    return self::addaccessionEventsCriteriaById($criteria, $this->id);
+  }
+
+  public static function adddeaccessionsCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitDeaccession::SCOPE_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getdeaccessionsById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::adddeaccessionsCriteriaById($criteria, $id);
+
+    return QubitDeaccession::get($criteria, $options);
+  }
+
+  public function adddeaccessionsCriteria(Criteria $criteria)
+  {
+    return self::adddeaccessionsCriteriaById($criteria, $this->id);
   }
 
   public function getCurrenttermI18n(array $options = array())

--- a/lib/model/om/BaseUser.php
+++ b/lib/model/om/BaseUser.php
@@ -84,16 +84,6 @@ abstract class BaseUser extends QubitActor implements ArrayAccess
     {
     }
 
-    if ('aclPermissions' == $name)
-    {
-      return true;
-    }
-
-    if ('aclUserGroups' == $name)
-    {
-      return true;
-    }
-
     if ('auditLogs' == $name)
     {
       return true;
@@ -110,6 +100,16 @@ abstract class BaseUser extends QubitActor implements ArrayAccess
     }
 
     if ('notes' == $name)
+    {
+      return true;
+    }
+
+    if ('aclPermissions' == $name)
+    {
+      return true;
+    }
+
+    if ('aclUserGroups' == $name)
     {
       return true;
     }
@@ -133,40 +133,6 @@ abstract class BaseUser extends QubitActor implements ArrayAccess
     }
     catch (sfException $e)
     {
-    }
-
-    if ('aclPermissions' == $name)
-    {
-      if (!isset($this->refFkValues['aclPermissions']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['aclPermissions'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['aclPermissions'] = self::getaclPermissionsById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['aclPermissions'];
-    }
-
-    if ('aclUserGroups' == $name)
-    {
-      if (!isset($this->refFkValues['aclUserGroups']))
-      {
-        if (!isset($this->id))
-        {
-          $this->refFkValues['aclUserGroups'] = QubitQuery::create();
-        }
-        else
-        {
-          $this->refFkValues['aclUserGroups'] = self::getaclUserGroupsById($this->id, array('self' => $this) + $options);
-        }
-      }
-
-      return $this->refFkValues['aclUserGroups'];
     }
 
     if ('auditLogs' == $name)
@@ -237,47 +203,41 @@ abstract class BaseUser extends QubitActor implements ArrayAccess
       return $this->refFkValues['notes'];
     }
 
+    if ('aclPermissions' == $name)
+    {
+      if (!isset($this->refFkValues['aclPermissions']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['aclPermissions'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['aclPermissions'] = self::getaclPermissionsById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['aclPermissions'];
+    }
+
+    if ('aclUserGroups' == $name)
+    {
+      if (!isset($this->refFkValues['aclUserGroups']))
+      {
+        if (!isset($this->id))
+        {
+          $this->refFkValues['aclUserGroups'] = QubitQuery::create();
+        }
+        else
+        {
+          $this->refFkValues['aclUserGroups'] = self::getaclUserGroupsById($this->id, array('self' => $this) + $options);
+        }
+      }
+
+      return $this->refFkValues['aclUserGroups'];
+    }
+
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
-  }
-
-  public static function addaclPermissionsCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitAclPermission::USER_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getaclPermissionsById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::addaclPermissionsCriteriaById($criteria, $id);
-
-    return QubitAclPermission::get($criteria, $options);
-  }
-
-  public function addaclPermissionsCriteria(Criteria $criteria)
-  {
-    return self::addaclPermissionsCriteriaById($criteria, $this->id);
-  }
-
-  public static function addaclUserGroupsCriteriaById(Criteria $criteria, $id)
-  {
-    $criteria->add(QubitAclUserGroup::USER_ID, $id);
-
-    return $criteria;
-  }
-
-  public static function getaclUserGroupsById($id, array $options = array())
-  {
-    $criteria = new Criteria;
-    self::addaclUserGroupsCriteriaById($criteria, $id);
-
-    return QubitAclUserGroup::get($criteria, $options);
-  }
-
-  public function addaclUserGroupsCriteria(Criteria $criteria)
-  {
-    return self::addaclUserGroupsCriteriaById($criteria, $this->id);
   }
 
   public static function addauditLogsCriteriaById(Criteria $criteria, $id)
@@ -358,5 +318,45 @@ abstract class BaseUser extends QubitActor implements ArrayAccess
   public function addnotesCriteria(Criteria $criteria)
   {
     return self::addnotesCriteriaById($criteria, $this->id);
+  }
+
+  public static function addaclPermissionsCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitAclPermission::USER_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getaclPermissionsById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addaclPermissionsCriteriaById($criteria, $id);
+
+    return QubitAclPermission::get($criteria, $options);
+  }
+
+  public function addaclPermissionsCriteria(Criteria $criteria)
+  {
+    return self::addaclPermissionsCriteriaById($criteria, $this->id);
+  }
+
+  public static function addaclUserGroupsCriteriaById(Criteria $criteria, $id)
+  {
+    $criteria->add(QubitAclUserGroup::USER_ID, $id);
+
+    return $criteria;
+  }
+
+  public static function getaclUserGroupsById($id, array $options = array())
+  {
+    $criteria = new Criteria;
+    self::addaclUserGroupsCriteriaById($criteria, $id);
+
+    return QubitAclUserGroup::get($criteria, $options);
+  }
+
+  public function addaclUserGroupsCriteria(Criteria $criteria)
+  {
+    return self::addaclUserGroupsCriteriaById($criteria, $this->id);
   }
 }

--- a/lib/task/migrate/migrations/arMigration0190.class.php
+++ b/lib/task/migrate/migrations/arMigration0190.class.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Modify database for caption/subtitle/chapter support.
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0190
+{
+  const
+    VERSION = 190, // The new database version
+    MIN_MILESTONE = 2; // The minimum milestone required
+
+  public function up($configuration)
+  {
+    // Add extra column, language
+    QubitMigrate::addColumn(
+      QubitDigitalObject::TABLE_NAME,
+      'language VARCHAR(50)',
+      ['after' => 'usage_id']
+    );
+  
+    // Add chapters term
+    QubitMigrate::bumpTerm(QubitTerm::CHAPTERS_ID, $configuration);
+    $term = new QubitTerm;
+    $term->id = QubitTerm::CHAPTERS_ID;
+    $term->parentId = QubitTerm::ROOT_ID;
+    $term->taxonomyId = QubitTaxonomy::DIGITAL_OBJECT_USAGE_ID;
+    $term->sourceCulture = 'en';
+    $term->setName('Chapters', ['culture' => 'en']);
+    $term->setName('Chapitres', ['culture' => 'fr']);
+    $term->save();
+
+    // Add subtitles term
+    QubitMigrate::bumpTerm(QubitTerm::SUBTITLES_ID, $configuration);
+    $term = new QubitTerm;
+    $term->id = QubitTerm::SUBTITLES_ID;
+    $term->parentId = QubitTerm::ROOT_ID;
+    $term->taxonomyId = QubitTaxonomy::DIGITAL_OBJECT_USAGE_ID;
+    $term->sourceCulture = 'en';
+    $term->setName('Captions/Subtitles', ['culture' => 'en']);
+    $term->setName('Légendes/Sous-titres', ['culture' => 'fr']);
+    $term->save();
+
+    return true;
+  }
+}

--- a/lib/validator/QubitValidatorMimeType.class.php
+++ b/lib/validator/QubitValidatorMimeType.class.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class QubitValidatorMimeType extends sfValidatorBase
+{
+  /**
+   * @param array $options   An array of options
+   * @param array $messages  An array of error messages
+   *
+   * @see sfValidatorBase
+   */
+  protected function configure($options = array(), $messages = array())
+  {
+    $this->addRequiredOption('mime_types');
+    $this->addMessage('mime_types', 'Invalid file type (%value%: %mime_type%)');
+  }
+  
+  /**
+   * @see sfValidatorBase
+   */
+
+  protected function doClean($value)
+  {        
+    $mimeType = QubitDigitalObject::deriveMimeType($value['name']);
+    $mimeTypes = $this->getOption('mime_types');
+    
+    if (!in_array($mimeType, $mimeTypes))
+    {
+      throw new sfValidatorError($this, 'mime_types', ['value' => $value['name'], 'mime_type' => $mimeType]);
+    }
+    
+    return $value;
+  }
+  
+  /**
+   * @see sfValidatorBase
+   */
+  protected function isEmpty($value)
+  {
+    // Empty if the value is not an array
+    // or if the value comes from PHP with an error of UPLOAD_ERR_NO_FILE.
+    return
+      !is_array($value) || (is_array($value) && isset($value['error']) && UPLOAD_ERR_NO_FILE === $value['error']);
+  }
+}

--- a/plugins/arDominionPlugin/css/less/forms.less
+++ b/plugins/arDominionPlugin/css/less/forms.less
@@ -160,6 +160,11 @@ fieldset {
     }
   }
 
+  // Thumbnails or 'View file' links for digital objects
+  .digital-object-preview {
+    float: right;
+  }
+
 }
 
 // For tables like aclGroup/editorActorAcl


### PR DESCRIPTION
### Administrative

~~PR needs an issue id.~~ -> 13490

### Description

PR adds the ability to add caption/subtitle/chapter files in SRT or VTT format for use with video reference files. This takes advantage of HTML5 `<track>` tags in `<video>` elements: 590a164, e87a47e. As many caption/subtitle files may be uploaded and included as needed b1c7f45, and a single chapter file. Only files with extensions .srt or .vtt are permitted. This restriction is handled by a new validator that works off of the `$qubitMimeTypes` array in `QubitDigitalObject.php`: ff6a95b, ce3649e. File uploading and deletion uses the existing 'Edit digital object' module: 081418f, e8e384b. These sections will only show when `media_type_id` corresponds to video.

This feature is largely achieved by adding two additional usage types [`usage_id`] for use with the `digital_object` table, one for captions/subtitles and one for chapters: 5bc3001. These new types are thus treated very similarly to other representation types. The only change in the database structure is the addition of a `language` column in the `digital_object` table: 787b0d7. Data type for this field has been set to varchar(50), despite currently only storing ISO-639 codes. The extra room is added to facilitate custom language values, should this be needed in the future.

I18n has been implemented for this feature. Symfony handles the translation of language names in all situations. I've added the new usage terms to the taxonomy for the section labeling and added French translations so you can see it working: 2c84abb.

Two minor digital object related changes are also included:
- ~~Restrict the maximum width of the video frame while stretching. 2ba823e~~ [removed]
  - ~~This was briefly discussed in PR #1238, but I threw it in at the end so it didn't get implemented.~~
  - ~~This is intended to make the size of the video frame in the 'Edit digital object' module less overbearing.~~
- Typos and mislabeling in comments. 8ac160a

### Limitations

- Can upload as many captions/subs as needed, but only 1 at a time
- Can't change language once uploaded
- Can't specify a custom language
  - Limited to symfony list, but the vast majority of ISO 639 languages are there.
  - Two captions/subs of the same language can't be labeled differently, which may cause some confusion between CC and standard subs in the selection menu [eg. English, English CC]. I have some ideas about how to add a little '[CC]' label when it's needed without requiring a whole section dedicated to captions, but I think this PR covers enough ground for now.
- Subtitle style hasn't been changed.
  - The background transparency of for subtitles may not be appropriate for accessibility reasons.
  - The text position in fullscreen seems quite high. This might be a personal preference, though.

### Review

Feel free to ask me any questions about any of the code here.

### Images

![subs_sample1](https://user-images.githubusercontent.com/76928773/109397066-d677c100-7902-11eb-87f4-ef5d5c08a5fd.png)
*Caption/subtitle display on record.*

![subs_sample2](https://user-images.githubusercontent.com/76928773/109397067-d677c100-7902-11eb-8d14-bd68f44977f6.png)
*Restricted video width in 'Edit digital object' module.  2ba823e*

![subs_sample3](https://user-images.githubusercontent.com/76928773/109397068-d7105780-7902-11eb-947a-7ea1ba865438.png)
*Caption/subtitle/chapter upload area in 'Edit digital object' module.*
 