### PR TITLE
Clipboard IO export template, refs #13483

### DIFF
--- a/lib/job/arInformationObjectExportJob.class.php
+++ b/lib/job/arInformationObjectExportJob.class.php
@@ -100,7 +100,7 @@ class arInformationObjectExportJob extends arExportJob
    */
   static public function getCurrentArchivalStandard()
   {
-    if ('rad' === QubitSetting::getByNameAndScope('informationobject', 'default_template'))
+    if ('rad' == QubitSetting::getByNameAndScope('informationobject', 'default_template'))
     {
       return 'rad';
     }


### PR DESCRIPTION
Fix setting comparison so the correct template will be used for
description CSV export from AtoM's clipboard.