### PR TITLE
Initiate config/propel.ini on Docker, refs #13487

### DIFF
--- a/docker/bootstrap.php
+++ b/docker/bootstrap.php
@@ -76,7 +76,7 @@ if (!file_exists(_ATOM_DIR.'/apps/qubit/config/settings.yml'))
 #
 
 @unlink(_ATOM_DIR.'/config/propel.ini');
-touch(_ATOM_DIR.'/config/propel.ini');
+copy(_ATOM_DIR.'/config/propel.ini.tmpl', _ATOM_DIR.'/config/propel.ini');
 
 
 #


### PR DESCRIPTION
Copy the contents from config/propel.ini.tmpl on the bootstrap process
of the Docker Compose environment to avoid errors in the Propel tasks.