### PR TITLE
Update unit tests workflow, refs #13485 and #13486

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,42 +7,38 @@ on:
     - stable/**
 jobs:
   unit-tests:
-    runs-on: ubuntu-18.04
-    strategy:
-      fail-fast: false
-      matrix:
-        php: [7.2, 7.3, 7.4]
-    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-20.04
+    name: PHP 7.4
     env:
       COMPOSE_FILE: ${{ github.workspace }}/docker/docker-compose.dev.yml
     steps:
-    - name: Setup PHP ${{ matrix.php }}
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php }}
-        coverage: none
-        extensions: apcu
     - name: Checkout code
       uses: actions/checkout@v2
+    - name: Increase virtual memory max_map_count
+      run: sudo sysctl -w vm.max_map_count=262144
+    - name: Start services
+      run: docker-compose up -d percona elasticsearch
+    - name: Setup PHP 7.4
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: 7.4
+        coverage: none
+        extensions: apcu
     - name: Cache dependencies
       uses: actions/cache@v2
       with:
         path: ~/.composer/cache/files
-        key: php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+        key: 20.04-7.4-composer-${{ hashFiles('composer.lock') }}
     - name: Install dependencies
-      run: composer update
+      run: composer install
     - name: Copy config files
       run: |
         cp test/bootstrap/config.php config/config.php
         cp test/bootstrap/search.yml config/search.yml
         cp config/propel.ini.tmpl config/propel.ini
         cp apps/qubit/config/settings.yml.tmpl apps/qubit/config/settings.yml
-    - name: Increase virtual memory max_map_count
-      run: sudo sysctl -w vm.max_map_count=262144
-    - name: Start services
-      run: docker-compose up -d percona elasticsearch
-    - name: Sleep for 15 seconds
-      run: sleep 15
+    - name: Sleep for 10 seconds
+      run: sleep 10
     - name: Initialize database and search index
       run: php symfony tools:purge --demo
     - name: Run tests


### PR DESCRIPTION
- Test only over Ubuntu 20.04 and PHP 7.4 for now.
- Use `composer install` to install deps using the `composer.lock` file.
- Start services earlier in the process and reduce sleep time.