### PR TITLE
Simplify debug mode in Docker, refs #13489

### DIFF
--- a/docker/etc/environment
+++ b/docker/etc/environment
@@ -18,4 +18,3 @@ ATOM_GEARMAND_HOST=gearmand
 ATOM_MYSQL_DSN=mysql:host=percona;port=3306;dbname=atom;charset=utf8mb4
 ATOM_MYSQL_USERNAME=atom
 ATOM_MYSQL_PASSWORD=atom_12345
-ATOM_DEBUG_IP=172.22.0.1


### PR DESCRIPTION
If ATOM_DEVELOPMENT_MODE is enabled, get the container's network gateway
and add it to the AtoM debug IPs automatically in the bootstrap process.