### PR TITLE
Various relation dialog fixes and improvements, refs #10682 #13218 #13425 #13499

### DIFF
--- a/apps/qubit/modules/contactinformation/templates/_edit.php
+++ b/apps/qubit/modules/contactinformation/templates/_edit.php
@@ -135,7 +135,7 @@ content
         <div id="contactInformationRelation_Tab1">
 
           <?php echo $form->primaryContact
-              ->label(__('Primary contract'))
+              ->label(__('Primary contact'))
               ->renderRow(); ?>
 
           <?php echo $form->contactPerson

--- a/apps/qubit/modules/relation/actions/editComponent.class.php
+++ b/apps/qubit/modules/relation/actions/editComponent.class.php
@@ -113,9 +113,10 @@ class RelationEditComponent extends sfComponent
                 break;
 
             case 'resource':
-                $this->form->setValidator('resource', new QubitValidatorForbiddenValues([
-                    'forbidden_values' => [$this->context->routing->generate(null, $this->resource)],
-                ]));
+                $this->form->setValidator('resource', new sfValidatorAnd([
+                    new sfValidatorString(),
+                    new QubitValidatorForbiddenValues(['forbidden_values' => [$this->context->routing->generate(null, $this->resource)]]),
+                ], ['required' => true]));
                 $this->form->setWidget('resource', new sfWidgetFormSelect(['choices' => []]));
 
                 break;

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -5,7 +5,7 @@
         // Share <form/> with nested scopes
         var $form = $(this);
 
-        // Keep a list of new releated resource forms that must be submitted
+        // Keep a list of new related resource forms that must be submitted
         // before $form so we can get the URIs after they are created
         var relatedResourceForms = [];
 
@@ -613,7 +613,11 @@
                 if (!$select.attr('multiple')) {
                   // Create iframe which will be submitted to create a new
                   // related resource from the "unmatched" value
-                  $relatedResourceForm = getRelatedResourceForm($input, $hidden, uri, rrFormInputId);
+
+                  // Exclude new additions to be handled by dialog.js
+                  if ($input.parents('div.yui-dialog').length == 0) {
+                    $relatedResourceForm = getRelatedResourceForm($input, $hidden, uri, rrFormInputId);
+                  }
                 } else {
                   // Cancel default action of saved DOM event so as
                   // not to loose focus when selecting multiple items

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -108,8 +108,6 @@
         // Submit dialog data
         var handleYuiSubmit = function ()
           {
-            this.hide(); // Hide dialog
-
             var data = this.getData();
 
             // The validator must return false to cancel the operation
@@ -119,11 +117,18 @@
               return false;
             };
 
+            this.hide(); // Hide dialog
+
             thisDialog.submit(data); // Save dialog data
           }
 
         var handleYuiCancel = function ()
           {
+            // Optionally execute logic upon canceling dialog
+            if ('undefined' !== typeof thisDialog.options.afterCancelLogic) {
+              thisDialog.options.afterCancelLogic.call(this);
+            }
+
             this.cancel(); // Cancel YUI submit
             thisDialog.clear(); // Clear dialog fields
           }
@@ -345,6 +350,7 @@
             {
               if (null == thisData[fieldname])
               {
+                thisData[fieldname] = '';
                 continue;
               }
 
@@ -382,7 +388,17 @@
                   dataSource.responseType = YAHOO.util.DataSourceBase.TYPE_TEXT;
                   dataSource.parseTextData = function (request, response)
                     {
-                      return { 'results' : [ $(response).find('.label, #main-column h1').text().trim() ] };
+                      var $response = $(response);
+
+                      // For pages decorated with 'layout_2col' or 'layout_3col'
+                      var $result = $response.find('#main-column h1');
+
+                      // Fallback for pages decorated with 'layout_1col'
+                      if (0 == $result.length) {
+                        $result = $response.find("#resource-name");
+                      }
+
+                      return {'results': [$result.first().text().trim()]};
                     };
 
                   // Set visible input field of yui-autocomplete

--- a/plugins/qtAccessionPlugin/modules/accession/templates/_relatedDonor.php
+++ b/plugins/qtAccessionPlugin/modules/accession/templates/_relatedDonor.php
@@ -48,13 +48,35 @@ value
 );
 
 echo javascript_tag(<<<content
-Drupal.behaviors.relatedAuthorityRecord = {
+Drupal.behaviors.relatedDonor = {
   attach: function (context)
     {
+      // Add validator to ensure a related donor is selected/created
+      var validator = function() {
+          var relation = jQuery('#relatedDonor_resource').val();
+
+          if (!relation.length) {
+            // Display error message
+            jQuery('#relatedDonorError').css('display', 'block');
+
+            return false;
+          } else {
+            // Hide error message until required again
+            jQuery('#relatedDonorError').css('display', 'none');
+          }
+      }
+
+      // Hide error on cancel
+      var afterCancelLogic = function () {
+          jQuery('#relatedDonorError').css('display', 'none');
+      }
+
       // Define dialog
       var dialog = new QubitDialog('relatedDonor', {
         'displayTable': 'relatedDonorDisplay',
         'newRowTemplate': {$rowTemplate},
+        'validator': validator,
+        'afterCancelLogic': afterCancelLogic,
         'relationTableMap': function (response)
           {
             response.resource = response.object;
@@ -110,6 +132,12 @@ content
     <h3><?php echo __('Related donor record'); ?></h3>
 
     <div>
+
+      <div class="messages error" id="relatedDonorError" style="display: none">
+        <ul>
+          <li><?php echo __('Please complete all required fields.'); ?></li>
+        </ul>
+      </div>
 
       <?php echo $form->renderHiddenFields(); ?>
 

--- a/plugins/sfDrupalPlugin/lib/sfDrupalWidgetFormSchemaFormatter.class.php
+++ b/plugins/sfDrupalPlugin/lib/sfDrupalWidgetFormSchemaFormatter.class.php
@@ -44,7 +44,7 @@ return;
 
         $validatorSchema = $this->form->getValidatorSchema();
         if (isset($validatorSchema[$name]) && $validatorSchema[$name]->getOption('required')) {
-            $label .= ' <span class="form-required" title="This field is required.">*</span>';
+            $label .= ' <span class="form-required" title="'.__('This field is required.').'">*</span>';
         }
 
         return $label;

--- a/plugins/sfIsaarPlugin/js/actorEvents.js
+++ b/plugins/sfIsaarPlugin/js/actorEvents.js
@@ -27,17 +27,30 @@
       // Add validator to make sure that an information object is selected
       var validator = function(data) {
         var informationObject = data["editEvent[informationObject]"];
+
         if (!informationObject.length) {
+          // Display error message
+          jQuery('#resourceRelationError').css('display', 'block');
+
           return false;
+        } else {
+          // Hide error message until required again
+          jQuery('#resourceRelationError').css('display', 'none');
         }
-      };
+      }
+
+      // Hide error on cancel
+      var afterCancelLogic = function () {
+          jQuery('#resourceRelationError').css('display', 'none');
+      }
 
       // Define dialog
       dialog = new QubitDialog("resourceRelation", {
         displayTable: "relatedEvents",
         handleFieldRender: handleFieldRender,
         newRowTemplate: $("#dialogNewRowTemplate").html(),
-        validator: validator
+        validator: validator,
+        afterCancelLogic: afterCancelLogic
       });
     }
   };

--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/actions/relatedAuthorityRecordComponent.class.php
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/actions/relatedAuthorityRecordComponent.class.php
@@ -93,7 +93,7 @@ class sfIsaarPluginRelatedAuthorityRecordComponent extends RelationEditComponent
                 $value = $this->form->getValue('resource');
                 if (isset($value)) {
                     $params = $this->context->routing->parse(Qubit::pathInfo($value));
-                    if ($this->resource->id != $this->relation->objectId) {
+                    if (!isset($this->resource->id) || $this->resource->id != $this->relation->objectId) {
                         $this->relation->object = $params['_sf_route']->resource;
                     } else {
                         $this->relation->subject = $params['_sf_route']->resource;

--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/_event.php
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/_event.php
@@ -55,6 +55,12 @@
   <!-- NOTE dialog.js wraps this *entire* table in a YUI dialog -->
   <div class="date section" id="resourceRelation">
 
+    <div class="messages error" id="resourceRelationError" style="display: none">
+      <ul>
+        <li><?php echo __('Please complete all required fields.'); ?></li>
+      </ul>
+    </div>
+
     <div class="form-item">
       <?php echo $form->informationObject
           ->label(__('Title of related resource'))

--- a/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/_relatedAuthorityRecord.php
+++ b/plugins/sfIsaarPlugin/modules/sfIsaarPlugin/templates/_relatedAuthorityRecord.php
@@ -53,7 +53,7 @@
             <?php echo render_value_inline(Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate)); ?>
           </td><td>
             <?php echo render_value_inline($item->description); ?>
-          </td><td style="text-align: center">
+          </td><td style="text-align: right">
             <input class="multiDelete" name="deleteRelations[]" type="checkbox" value="<?php echo url_for([$item, 'module' => 'relation']); ?>"/>
           </td>
         </tr>
@@ -107,11 +107,34 @@ Drupal.behaviors.relatedAuthorityRecord = {
           return this.renderField(fname);
         }
 
+        // Add validator to ensure a related record is selected
+        var validator = function(data) {
+            var relation = data["relatedAuthorityRecord[resource]"];
+            var category = data["relatedAuthorityRecord[type]"];
+
+            if (!relation.length || !category[0].length) {
+              // Display error message
+              jQuery('#actorRelationError').css('display', 'block');
+
+              return false;
+            } else {
+              // Hide error message until required again
+              jQuery('#actorRelationError').css('display', 'none');
+            }
+        }
+
+        // Hide error on cancel
+        var afterCancelLogic = function () {
+            jQuery('#actorRelationError').css('display', 'none');
+        }
+
       // Define dialog
       var dialog = new QubitDialog('actorRelation', {
         'displayTable': 'relatedEntities',
         'handleFieldRender': handleFieldRender,
         'newRowTemplate': {$rowTemplate},
+        'validator': validator,
+        'afterCancelLogic': afterCancelLogic,
         'relationTableMap': function (response)
           {
             response.resource = response.object;
@@ -145,6 +168,12 @@ content
     <h3><?php echo __('Related corporate body, person or family'); ?></h3>
 
     <div>
+
+      <div class="messages error" id="actorRelationError" style="display: none">
+        <ul>
+          <li><?php echo __('Please complete all required fields.'); ?></li>
+        </ul>
+      </div>
 
       <div class="form-item">
         <?php echo $form->resource

--- a/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/actions/relatedFunctionComponent.class.php
+++ b/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/actions/relatedFunctionComponent.class.php
@@ -72,7 +72,7 @@ class sfIsdfPluginRelatedFunctionComponent extends RelationEditComponent
                 $value = $this->form->getValue('resource');
                 if (isset($value)) {
                     $params = $this->context->routing->parse(Qubit::pathInfo($value));
-                    if ($this->resource->id != $this->relation->objectId) {
+                    if (!isset($this->resource->id) || $this->resource->id != $this->relation->objectId) {
                         $this->relation->object = $params['_sf_route']->resource;
                     } else {
                         $this->relation->subject = $params['_sf_route']->resource;

--- a/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/templates/_relatedAuthorityRecord.php
+++ b/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/templates/_relatedAuthorityRecord.php
@@ -31,7 +31,7 @@
             <?php echo render_value_inline($item->description); ?>
           </td><td>
             <?php echo render_value_inline(Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate)); ?>
-          </td><td style="text-align: center">
+          </td><td style="text-align: right">
             <input class="multiDelete" name="deleteRelations[]" type="checkbox" value="<?php echo url_for([$item, 'module' => 'relation']); ?>"/>
           </td>
         </tr>
@@ -64,11 +64,33 @@ echo javascript_tag(<<<content
 Drupal.behaviors.relatedAuthorityRecord = {
   attach: function (context)
     {
+      // Add validator to ensure a related record is selected
+      var validator = function(data) {
+          var relation = data["relatedAuthorityRecord[resource]"];
+
+          if (!relation.length) {
+            // Display error message
+            jQuery('#relatedEntityError').css('display', 'block');
+            
+            return false;
+          } else {
+            // Hide error message until required again
+            jQuery('#relatedEntityError').css('display', 'none');
+          }
+      }
+
+      // Hide error on cancel
+      var afterCancelLogic = function () {
+          jQuery('#relatedEntityError').css('display', 'none');
+      }
+
       // Define dialog
       var dialog = new QubitDialog('relatedEntity', {
         'displayTable': 'relatedEntityDisplay',
         'handleFieldRender': handleFieldRender,
         'newRowTemplate': {$rowTemplate},
+        'validator': validator,
+        'afterCancelLogic': afterCancelLogic,
         'relationTableMap': function (response)
           {
             response.resource = response.object;
@@ -95,6 +117,12 @@ content
     <h3><?php echo __('Related authority record'); ?></h3>
 
     <div>
+
+      <div class="messages error" id="relatedEntityError" style="display: none">
+        <ul>
+          <li><?php echo __('Please complete all required fields.'); ?></li>
+        </ul>
+      </div>
 
       <div class="form-item">
         <?php echo $form->resource

--- a/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/templates/_relatedFunction.php
+++ b/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/templates/_relatedFunction.php
@@ -39,7 +39,7 @@
             <?php echo render_value_inline($item->description); ?>
           </td><td>
             <?php echo render_value_inline(Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate)); ?>
-          </td><td style="text-align: center">
+          </td><td style="text-align: right">
             <input class="multiDelete" name="deleteRelations[]" type="checkbox" value="<?php echo url_for([$item, 'module' => 'relation']); ?>"/>
           </td>
         </tr>
@@ -91,11 +91,33 @@ var handleFieldRender = function (fname)
 Drupal.behaviors.relatedFunction = {
   attach: function (context)
     {
+      // Add validator to ensure a related function is selected
+      var validator = function(data) {
+          var relation = data["relatedFunction[resource]"];
+
+          if (!relation.length) {
+            // Display error message
+            jQuery('#relatedFunctionError').css('display', 'block');
+
+            return false;
+          } else {
+            // Hide error message until required again
+            jQuery('#relatedFunctionError').css('display', 'none');
+          }
+      }
+
+      // Hide error on cancel
+      var afterCancelLogic = function () {
+          jQuery('#relatedFunctionError').css('display', 'none');
+      }
+
       // Define dialog
       var dialog = new QubitDialog('functionRelation', {
         'displayTable': 'relatedFunctions',
         'newRowTemplate': {$rowTemplate},
         'handleFieldRender': handleFieldRender,
+        'validator': validator,
+        'afterCancelLogic': afterCancelLogic,
         'relationTableMap': function (response)
           {
             response.resource = response.object;
@@ -126,6 +148,12 @@ content
     <h3><?php echo __('Related function'); ?></h3>
 
     <div>
+
+      <div class="messages error" id="relatedFunctionError" style="display: none">
+        <ul>
+          <li><?php echo __('Please complete all required fields.'); ?></li>
+        </ul>
+      </div>
 
       <div class="form-item">
         <?php echo $form->resource

--- a/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/templates/_relatedResource.php
+++ b/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/templates/_relatedResource.php
@@ -31,7 +31,7 @@
             <?php echo render_value_inline($item->description); ?>
           </td><td>
             <?php echo render_value_inline(Qubit::renderDateStartEnd($item->date, $item->startDate, $item->endDate)); ?>
-          </td><td style="text-align: center">
+          </td><td style="text-align: right">
             <input class="multiDelete" name="deleteRelations[]" type="checkbox" value="<?php echo url_for([$item, 'module' => 'relation']); ?>"/>
           </td>
         </tr>
@@ -64,11 +64,33 @@ echo javascript_tag(<<<content
 Drupal.behaviors.relatedResource = {
   attach: function (context)
     {
+      // Add validator to ensure a related record is selected
+      var validator = function(data) {
+          var relation = data["relatedResource[resource]"];
+
+          if (!relation.length) {
+            // Display error message
+            jQuery('#relatedResourceError').css('display', 'block');
+
+            return false;
+          } else {
+            // Hide error message until required again
+            jQuery('#relatedResourceError').css('display', 'none');
+          }
+      }
+
+      // Hide error on cancel
+      var afterCancelLogic = function () {
+          jQuery('#relatedResourceError').css('display', 'none');
+      }
+
       // Define dialog
       var dialog = new QubitDialog('relatedResource', {
         'displayTable': 'relatedResourceDisplay',
         'handleFieldRender': handleFieldRender,
         'newRowTemplate': {$rowTemplate},
+        'validator': validator,
+        'afterCancelLogic': afterCancelLogic,
         'relationTableMap': function (response)
           {
             response.resource = response.object;
@@ -95,6 +117,12 @@ content
     <h3><?php echo __('Related resource'); ?></h3>
 
     <div>
+
+      <div class="messages error" id="relatedResourceError" style="display: none">
+        <ul>
+          <li><?php echo __('Please complete all required fields.'); ?></li>
+        </ul>
+      </div>
 
       <div class="form-item">
         <?php echo $form->resource

--- a/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsdfPlugin/modules/sfIsdfPlugin/templates/indexSuccess.php
@@ -1,13 +1,10 @@
 <?php decorate_with('layout_1col'); ?>
 
 <?php slot('title'); ?>
-  <h1 class="multiline">
-    <?php echo __('View ISDF function'); ?>
-    <span class="sub"><?php echo render_title($resource); ?></span>
-  </h1>
-<?php end_slot(); ?>
 
-<?php slot('before-content'); ?>
+  <h1 id="resource-name">
+    <?php echo render_title($resource); ?>
+  </h1>
 
   <?php if (isset($errorSchema)) { ?>
     <div class="messages error">
@@ -19,6 +16,17 @@
       </ul>
     </div>
   <?php } ?>
+
+  <section class="breadcrumb">
+    <ul>
+      <li><?php echo link_to(esc_specialchars(sfConfig::get('app_ui_label_function')), ['module' => 'function', 'action' => 'browse']); ?></li>
+      <li><span><?php echo render_title($resource); ?></span></li>
+    </ul>
+  </section>
+
+<?php end_slot(); ?>
+
+<?php slot('before-content'); ?>
 
   <?php echo get_component('default', 'translationLinks', ['resource' => $resource]); ?>
 


### PR DESCRIPTION
This is a small bug fix addressing 500 errors being thrown after attempting to save various types of records (eg. ISAAR, ISDF, Accession, etc.) containing incomplete relationships. For example, the related entity is unspecified so the relationship is incomplete:

![emptyRelatedEntity](https://user-images.githubusercontent.com/76928773/112741336-d8a95b80-8f52-11eb-803f-773c90d3ebc2.png)

To address this, an additional string validator has been added requiring that the relevant value be set. The incomplete relationship can still be staged as part of the form, like in the image above, but this relationship entry will now be ignored when saving. No error is thrown and all other form values and relationships will save as expected.