### PR TITLE
Fix term sidebar list paging, refs #13491

### DIFF
--- a/apps/qubit/modules/term/actions/indexAction.class.php
+++ b/apps/qubit/modules/term/actions/indexAction.class.php
@@ -116,7 +116,7 @@ class TermIndexAction extends DefaultBrowseAction
                     return;
                 }
 
-                sfContext::getInstance()->getConfiguration()->loadHelpers('Url', 'Qubit');
+                sfContext::getInstance()->getConfiguration()->loadHelpers(['Url', 'Qubit']);
 
                 $response = ['results' => []];
                 foreach ($this->listResultSet->getResults() as $item) {


### PR DESCRIPTION
Fixed issue in helper loading, on term index page, that was causing term sidebar list pagination not to work.