### PR TITLE
Fix D.O. load task indexing issue, refs #13484

### DIFF
--- a/lib/task/digitalobject/digitalObjectLoadTask.class.php
+++ b/lib/task/digitalobject/digitalObjectLoadTask.class.php
@@ -22,7 +22,7 @@
  *
  * @author     David Juhasz <david@artefactual.com>
  */
-class digitalObjectLoadTask extends sfBaseTask
+class digitalObjectLoadTask extends arBaseTask
 {
     protected static $count = 0;
 
@@ -39,7 +39,8 @@ class digitalObjectLoadTask extends sfBaseTask
      */
     public function execute($arguments = [], $options = [])
     {
-        sfContext::createInstance($this->configuration);
+        parent::execute($arguments, $options);
+
         $databaseManager = new sfDatabaseManager($this->configuration);
         $options['conn'] = $databaseManager->getDatabase('propel')->getConnection();
 


### PR DESCRIPTION
Fixed issue with the digital object load task not properly updating the search index. The issue was due to the sfConfig settings cache not being populated and, subsequently, the cached i18n_languages setting being empty during indexing and causing i18n data not to be indexed.