### PR TITLE
Schema version bump, refs #13490

### DIFF
--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 189
+    value: 190
   milestone:
     name: milestone
     editable: 0


### PR DESCRIPTION
A migration was created in an earlier commit but the schema wasn't accordingly bumped.