### PR TITLE
Fix cherry pick to stable/2.6.x, refs #8096

### DIFF
--- a/js/dominion.js
+++ b/js/dominion.js
@@ -250,7 +250,7 @@
           .on('blur', $.proxy(this.blur, this))
           .on('keydown', $.proxy(this.keydown, this));
 
-        this.$menu.on('click', 'li', $.proxy(this.click, this));
+        this.$form.on('click', '.search-popover li', $.proxy(this.click, this));
 
         this.$menu.on('mouseenter', 'li', $.proxy(this.mouseenter, this));
         this.$menu.on('mouseleave', 'li', $.proxy(this.mouseleave, this));


### PR DESCRIPTION
These commits revert the original cherry pick of 8096 in the 2.6.3 release and reapply it on stable/2.6.x. There was an issue with the conflict resolution when this cherry-pick was originally completed.