### PR TITLE
Varnish culture support for Docker, refs #13405

### DIFF
--- a/apps/qubit/config/qubitConfiguration.class.php
+++ b/apps/qubit/config/qubitConfiguration.class.php
@@ -31,7 +31,7 @@ class qubitConfiguration extends sfApplicationConfiguration
 
     public function listenToChangeCultureEvent(sfEvent $event)
     {
-        setcookie('atom_culture', $event['culture']);
+        setcookie('atom_culture', $event['culture'], ['path' => '/']);
     }
 
     /**

--- a/docker/docker-compose.pmm.yml
+++ b/docker/docker-compose.pmm.yml
@@ -1,5 +1,5 @@
 ---
-version: "2"
+version: "2.1"
 
 volumes:
   pmm_prometheus_data:

--- a/docker/docker-compose.varnish.yml
+++ b/docker/docker-compose.varnish.yml
@@ -1,10 +1,10 @@
 ---
-version: "2"
+version: "2.1"
 
 services:
 
   varnish:
-    image: varnish:6.0
+    image: varnish:6.5.1
     volumes:
       - ./etc/varnish/default.vcl:/etc/varnish/default.vcl:ro
     ports:

--- a/docker/etc/varnish/default.vcl
+++ b/docker/etc/varnish/default.vcl
@@ -1,20 +1,40 @@
 vcl 4.1;
+import cookie;
 
 backend default {
   .host = "nginx";
 }
 
 sub vcl_recv {
+  # Do not cache culture change request
+  if (req.url ~ "sf_culture") {
+    return (pass);
+  }
+
+  # Set HTTP header to culture cookie value
+  cookie.parse(req.http.cookie);
+  set req.http.X-Atom-Culture = cookie.get("atom_culture");
+
   # Do not cache clipboard POST request
   if (req.method == "POST" && req.url ~ "/clipboard/") {
     return (pass);
   }
+
   unset req.http.Cookie;
   return (hash);
 }
 
+sub vcl_hash {
+  # Factor culture into hash
+  hash_data(req.http.X-Atom-Culture);
+}
+
 sub vcl_backend_response {
-  unset beresp.http.Set-Cookie;
+  # Allow cookie setting in culture change request
+  if (bereq.url !~ "sf_culture")  {
+    unset beresp.http.Set-Cookie;
+  }
+
   return (deliver);
 }
 


### PR DESCRIPTION
Updated Varnish VCL, for use with AtoM running via Docker, to allow the content of non-default cultures to be cached.