### PR TITLE
Change initial letter of languages to uppercase in menu, refs #13515

### DIFF
--- a/apps/qubit/modules/menu/templates/_changeLanguageMenu.php
+++ b/apps/qubit/modules/menu/templates/_changeLanguageMenu.php
@@ -16,7 +16,7 @@
       <ul>
         <?php foreach ($langCodes as $value) { ?>
           <li<?php if ($sf_user->getCulture() == $value) { ?> class="active"<?php } ?>>
-            <?php echo link_to(format_language($value, $value), ['sf_culture' => $value] + $sf_data->getRaw('sf_request')->getParameterHolder()->getAll()); ?>
+            <?php echo link_to(ucfirst(format_language($value, $value)), ['sf_culture' => $value] + $sf_data->getRaw('sf_request')->getParameterHolder()->getAll()); ?>
           </li>
         <?php } ?>
       </ul>


### PR DESCRIPTION
PR is in response to open issue #1128 regarding inconsistency in upper/lower casing of initial letter for languages in the language menu ~~and the language settings menu~~. Based on the assumption that language names written as a single word in a menu should *probably* start uppercased, it is now consistently uppercase.

If this is still an issue open for a bit of debate, that's cool, but this PR should at least provide an easy solution for those wishing for the consistency without modifying vendor files.