### PR TITLE
Highlight errors on job detail page, refs #13504

### DIFF
--- a/apps/qubit/modules/jobs/actions/reportAction.class.php
+++ b/apps/qubit/modules/jobs/actions/reportAction.class.php
@@ -33,6 +33,18 @@ class JobsReportAction extends DefaultBrowseAction
 
         $this->job = QubitJob::getById($request->id);
 
+        // Fetch error notes
+        $criteria = new Criteria();
+        $criteria->add(QubitNote::OBJECT_ID, $request->id);
+        $criteria->add(QubitNote::TYPE_ID, QubitTerm::JOB_ERROR_NOTE_ID);
+
+        $this->errorOutput = '';
+        foreach (QubitNote::get($criteria) as $note) {
+            // Job complete time indicates error time because jobs are stopped after error
+            $this->errorOutput .= sprintf("%s %s\n", $this->job->completedAt, $note->getContent());
+        }
+        $this->errorOutput = trim($this->errorOutput);
+
         if (!$this->job) {
             $this->forward404();
         }

--- a/apps/qubit/modules/jobs/templates/reportSuccess.php
+++ b/apps/qubit/modules/jobs/templates/reportSuccess.php
@@ -62,6 +62,13 @@
 </section>
 
 <section id="log-area">
+  <?php if (!empty($errorOutput)) { ?>
+    <h2><?php echo __('Error(s)'); ?></h2>
+    <div>
+      <pre id="job-log-error-output"><?php echo render_value($errorOutput); ?></pre>
+    </div>
+  <?php } ?>
+
   <h2><?php echo __('Log'); ?></h2>
   <div>
     <?php $output = trim($job->output); ?>

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 190
+    value: 191
   milestone:
     name: milestone
     editable: 0

--- a/data/fixtures/taxonomyTerms.yml
+++ b/data/fixtures/taxonomyTerms.yml
@@ -2694,6 +2694,13 @@ QubitTerm:
     name:
       en: 'Captions/Subtitles'
       fr: 'Légendes/Sous-titres'
+  QubitTerm_error_note:
+    taxonomy_id: QubitTaxonomy_7
+    parent_id: QubitTerm_110
+    id: 197
+    source_culture: en
+    name:
+      en: 'Job error note'
   QubitTerm_140:
     taxonomy_id: QubitTaxonomy_18
     parent_id: QubitTerm_110

--- a/lib/model/QubitJob.php
+++ b/lib/model/QubitJob.php
@@ -69,7 +69,7 @@ class QubitJob extends BaseJob
     public function setStatusError($errorNote = null)
     {
         if (null !== $errorNote) {
-            $this->addNoteText($errorNote);
+            $this->addNoteText($errorNote, QubitTerm::JOB_ERROR_NOTE_ID);
         }
 
         $this->statusId = QubitTerm::JOB_STATUS_ERROR_ID;
@@ -169,11 +169,13 @@ class QubitJob extends BaseJob
      * Add a basic note to this job. This function creates/saves a new note.
      *
      * @param string $contents The text for the note
+     * @param mixed  $noteType The type of the note (or null)
      */
-    public function addNoteText($contents)
+    public function addNoteText($contents, $noteType = null)
     {
         $note = new QubitNote();
         $note->content = $contents;
+        $note->typeId = $noteType;
 
         if (!isset($this->id)) {
             throw new sfException('Tried to add a note to a job that is not saved yet');

--- a/lib/model/QubitTerm.php
+++ b/lib/model/QubitTerm.php
@@ -147,6 +147,8 @@ class QubitTerm extends BaseTerm
     // Digital object usage taxonomy (addition)
     public const CHAPTERS_ID = 195;
     public const SUBTITLES_ID = 196;
+    // Job error note
+    public const JOB_ERROR_NOTE_ID = 197;
 
     public $disableNestedSetUpdating = false;
 

--- a/lib/task/migrate/migrations/arMigration0191.class.php
+++ b/lib/task/migrate/migrations/arMigration0191.class.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Adds note type term for job error notes
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0191
+{
+    public const VERSION = 191;
+    public const MIN_MILESTONE = 2;
+
+    /**
+     * Upgrade.
+     *
+     * @param mixed $configuration
+     *
+     * @return bool True if the upgrade succeeded, False otherwise
+     */
+    public function up($configuration)
+    {
+        QubitMigrate::bumpTerm(QubitTerm::JOB_ERROR_NOTE_ID, $configuration);
+        $term = new QubitTerm();
+        $term->id = QubitTerm::JOB_ERROR_NOTE_ID;
+        $term->parentId = QubitTerm::ROOT_ID;
+        $term->taxonomyId = QubitTaxonomy::NOTE_TYPE_ID;
+        $term->sourceCulture = 'en';
+        $term->setName('Job error note', ['culture' => 'en']);
+        $term->save();
+
+        return true;
+    }
+}

--- a/plugins/arDominionPlugin/css/less/jobs.less
+++ b/plugins/arDominionPlugin/css/less/jobs.less
@@ -44,7 +44,7 @@
   margin-top: 20px;
 }
 
-#job-log-output {
+#job-log-output, #job-log-error-output {
   margin: 5px 5px 5px 5px;
   padding: 5px;
   color: @white;
@@ -52,6 +52,10 @@
   border-radius: 4px;
   max-height: 400px;
   overflow-y: auto;
+}
+
+#job-log-error-output {
+  background-color: #880015;
 }
 
 #job-log-output-empty {


### PR DESCRIPTION
On the job detail page show error details, highlighted in red, in the
area above the full job output.