### PR TITLE
Remove redundant anchors from cards with images, refs #13535 

### DIFF
--- a/apps/qubit/modules/informationobject/templates/_cardViewResults.php
+++ b/apps/qubit/modules/informationobject/templates/_cardViewResults.php
@@ -7,12 +7,9 @@
     <?php $title = get_search_i18n($doc, 'title', ['allowEmpty' => false, 'culture' => $selectedCulture]); ?>
 
     <?php if (!empty($doc['hasDigitalObject'])) { ?>
-      <div class="brick">
-    <?php } else { ?>
-      <div class="brick brick-only-text">
-    <?php } ?>
 
-      <a href="<?php echo url_for(['module' => 'informationobject', 'slug' => $doc['slug']]); ?>">
+      <div class="brick">
+
         <?php if (
             isset($doc['digitalObject'])
             && !empty($doc['digitalObject']['thumbnailPath'])
@@ -28,18 +25,22 @@
           <?php echo link_to(image_tag(QubitDigitalObject::getGenericIconPathByMediaTypeId($doc['digitalObject']['mediaTypeId']),
             ['alt' => isset($doc['digitalObject']['digitalObjectAltText']) ? $doc['digitalObject']['digitalObjectAltText'] : truncate_text(strip_markdown($title), 100)]),
             ['module' => 'informationobject', 'slug' => $doc['slug']]); ?>
-
-        <?php } else { ?>
-
-          <h5><?php echo render_title($title); ?></h5>
-
         <?php } ?>
-      </a>
 
-      <div class="bottom">
-        <?php echo get_component('clipboard', 'button', ['slug' => $doc['slug'], 'wide' => false, 'repositoryOrDigitalObjBrowse' => true, 'type' => 'informationObject']); ?><?php echo render_title($title); ?>
+    <?php } else { ?>
+
+      <div class="brick brick-only-text">
+
+        <a href="<?php echo url_for(['module' => 'informationobject', 'slug' => $doc['slug']]); ?>">
+          <h5><?php echo render_title($title); ?></h5>
+        </a>
+    <?php } ?>
+
+        <div class="bottom">
+          <?php echo get_component('clipboard', 'button', ['slug' => $doc['slug'], 'wide' => false, 'repositoryOrDigitalObjBrowse' => true, 'type' => 'informationObject']); ?><?php echo render_title($title); ?>
+        </div>
+
       </div>
-    </div>
   <?php } ?>
 
 </section>


### PR DESCRIPTION
PR removes unnecessary anchors included in card view bricks with images. These anchors are intended to provide a text link to the relevant record for text-only bricks, therefore they serve no purpose for bricks with images as these bricks already have an appropriate link.

This PR is motivated by an accessibility concern for the following reasons:

- The redundant anchors introduce unnecessary focus elements when tabbing through card view
- The redundant anchors lack text, so are problematic for screen readers
- The previous point results in these elements being flagged by accessibility audit software (eg. WAVE evaluation tool)

I also cleaned up the logic quite a bit to better separate out image vs. text-only bricks.