### PR TITLE
Improve accessibility of expander links, refs #13535

### DIFF
--- a/apps/qubit/templates/_footer.php
+++ b/apps/qubit/templates/_footer.php
@@ -10,6 +10,13 @@
     <?php echo __('Printed: %d%', ['%d%' => date('Y-m-d')]); ?>
   </div>
 
+  <div id="js-i18n">
+    <div id="read-more-less-links"
+      data-read-more-text="<?php echo __('Read more'); ?>" 
+      data-read-less-text="<?php echo __('Read less'); ?>">
+    </div>
+  </div>
+
 </footer>
 
 <?php $gaKey = sfConfig::get('app_google_analytics_api_key', ''); ?>

--- a/js/qubit.js
+++ b/js/qubit.js
@@ -29,6 +29,26 @@ Drupal.behaviors.expander = {
             widow: 4,
             expandEffect: 'show'
           });
+
+          (function ($) {
+            'use strict';
+            // Get i18n text for read more/less links from footer
+            var $i18n = $('#js-i18n #read-more-less-links');
+
+            // Get read more/less link elements
+            var $readMoreLink = $element.find('.read-more a');
+            var $readLessLink = $element.find('.read-less a');
+
+            $(function() {
+              // Add accessibility label to read more link
+              $readMoreLink.attr('aria-label', $i18n.data('read-more-text'));
+
+              // Add accessibility label to read less link
+              $readLessLink.attr('aria-label', $i18n.data('read-less-text'));
+            });
+
+          })(jQuery);
+
         }
       });
     }


### PR DESCRIPTION
PR adds aria-labels ~~and titles~~ to expander more/less links. ~~Titles add hover text to the "»" and "«" icons for general clarity~~. The aria-label redirects screen readers to ignore the link text, which currently reads as "right-pointing double arrow link" or some variation of this.

Testing utilised Orca and NVDA screen readers.

The only caveat with the added title is that it doesn't work with Symfony's i18n dictionary. However, browser-based translation picks up the slack.