### PR TITLE
Fix CSRF validation, refs #13450

### DIFF
--- a/apps/qubit/modules/right/actions/manageAction.class.php
+++ b/apps/qubit/modules/right/actions/manageAction.class.php
@@ -92,9 +92,14 @@ class RightManageAction extends sfAction
             'default' => 'overwrite',
         ]));
 
-        $this->form->setValidators([
-            'all_or_digital_only' => new sfValidatorChoice(['choices' => ['all', 'digital_only'], 'required' => true]),
-            'overwrite_or_combine' => new sfValidatorChoice(['choices' => ['overwrite', 'combine'], 'required' => true]),
-        ]);
+        $this->form->setValidator('all_or_digital_only', new sfValidatorChoice([
+            'choices' => ['all', 'digital_only'],
+            'required' => true,
+        ]));
+
+        $this->form->setValidator('overwrite_or_combine', new sfValidatorChoice([
+            'choices' => ['overwrite', 'combine'],
+            'required' => true,
+        ]));
     }
 }

--- a/plugins/sfPluginAdminPlugin/modules/sfPluginAdminPlugin/actions/pluginsAction.class.php
+++ b/plugins/sfPluginAdminPlugin/modules/sfPluginAdminPlugin/actions/pluginsAction.class.php
@@ -59,15 +59,13 @@ class sfPluginAdminPluginPluginsAction extends sfAction
             }
         }
 
-        if ($request->isMethod('post')) {
-            $this->form->setValidators([
-                'enabled' => new sfValidatorChoice([
-                    'choices' => array_keys($this->plugins),
-                    'empty_value' => [],
-                    'multiple' => true,
-                ]),
-            ]);
+        $this->form->setValidator('enabled', new sfValidatorChoice([
+            'choices' => array_keys($this->plugins),
+            'empty_value' => [],
+            'multiple' => true,
+        ]));
 
+        if ($request->isMethod('post')) {
             $this->form->bind($request->getPostParameters());
 
             if ($this->form->isValid()) {

--- a/plugins/sfPluginAdminPlugin/modules/sfPluginAdminPlugin/actions/themesAction.class.php
+++ b/plugins/sfPluginAdminPlugin/modules/sfPluginAdminPlugin/actions/themesAction.class.php
@@ -58,15 +58,13 @@ class sfPluginAdminPluginThemesAction extends sfAction
             }
         }
 
-        if ($request->isMethod('post')) {
-            $this->form->setValidators([
-                'enabled' => new sfValidatorChoice([
-                    'choices' => array_keys($this->plugins),
-                    'empty_value' => [],
-                    'multiple' => true,
-                ]),
-            ]);
+        $this->form->setValidator('enabled', new sfValidatorChoice([
+            'choices' => array_keys($this->plugins),
+            'empty_value' => [],
+            'multiple' => true,
+        ]));
 
+        if ($request->isMethod('post')) {
             $this->form->bind($request->getPostParameters());
 
             if ($this->form->isValid()) {


### PR DESCRIPTION
Avoid `setValidators` outside of form's `configure` method as it may
overwrite other validators.