### PR TITLE
CAS: make service URL configurable, refs #13524

### DIFF
--- a/plugins/arCasPlugin/config/app.yml
+++ b/plugins/arCasPlugin/config/app.yml
@@ -37,3 +37,9 @@ all:
         translator:
             attribute_value: 'atom-translators'
             group_id: 103
+
+    # Override default service URL.
+    # Needed when hostname does not match the host part of the AtoM
+    # instance URL
+    # e.g. https://atom.somedomain.org/cas/login
+    service_url:

--- a/plugins/arCasPlugin/lib/arCAS.class.php
+++ b/plugins/arCasPlugin/lib/arCAS.class.php
@@ -58,6 +58,12 @@ class arCAS
         // interaction of phpCAS with Symfony's session management.
         phpCAS::setNoClearTicketsFromUrl();
 
+        // Override default service URL if required
+        $serviceUrl = sfConfig::get('app_cas_service_url', '');
+        if (!empty($serviceUrl)) {
+            phpCAS::setFixedServiceURL($serviceUrl);
+        }
+
         // Validate the server SSL certificate according to configuration.
         $certPath = sfConfig::get('app_cas_server_cert', false);
         if (0 === !strpos($certPath, '/')) {


### PR DESCRIPTION
Make it possible to override the CAS service string (service URL).
This is needed when the hostname does not match the host part of the
AtoM instance URL (as phpCAS seems to set the service URL based on the
hostname by default).