### PR TITLE
Search accessibility improvements, refs #13535

### DIFF
--- a/apps/qubit/modules/actor/templates/_advancedSearch.php
+++ b/apps/qubit/modules/actor/templates/_advancedSearch.php
@@ -1,4 +1,4 @@
-<section class="advanced-search-section">
+<section class="advanced-search-section" role="search" aria-label="<?php echo __('Advanced %1%', ['%1%' => sfConfig::get('app_ui_label_actor')]); ?>">
 
   <a href="#" class="advanced-search-toggle <?php echo $show ? 'open' : ''; ?>" aria-expanded="<?php echo $show ? 'true' : 'false'; ?>"><?php echo __('Advanced search options'); ?></a>
 
@@ -26,7 +26,7 @@
                 <option value="not"<?php echo 'not' == $item['operator'] ? ' selected="selected"' : ''; ?>><?php echo __('not'); ?></option>
               </select>
 
-              <input class="query" type="text" placeholder="<?php echo __('Search'); ?>" name="sq<?php echo $key; ?>" value="<?php echo $item['query']; ?>"/>
+              <input class="query" type="text" aria-label="<?php echo __('Search'); ?>" placeholder="<?php echo __('Search'); ?>" name="sq<?php echo $key; ?>" value="<?php echo $item['query']; ?>"/>
 
               <span><?php echo __('in'); ?></span>
 
@@ -37,7 +37,7 @@
                 <?php } ?>
               </select>
 
-              <a href="#" class="delete-criterion"><i class="fa fa-times"></i></a>
+              <a href="#" class="delete-criterion" aria-label="<?php echo __('Delete criterion'); ?>"><i aria-hidden="true" class="fa fa-times"></i></a>
 
             </div>
 
@@ -55,7 +55,7 @@
             <option value="not"><?php echo __('not'); ?></option>
           </select>
 
-          <input class="query" type="text" placeholder="<?php echo __('Search'); ?>" name="sq<?php echo $count; ?>"/>
+          <input class="query" type="text" aria-label="<?php echo __('Search'); ?>" placeholder="<?php echo __('Search'); ?>" name="sq<?php echo $count; ?>"/>
 
           <span><?php echo __('in'); ?></span>
 
@@ -66,7 +66,7 @@
             <?php } ?>
           </select>
 
-          <a href="#" class="delete-criterion"><i class="fa fa-times"></i></a>
+          <a href="#" class="delete-criterion" aria-label="<?php echo __('Delete criterion'); ?>"><i aria-hidden="true" class="fa fa-times"></i></a>
 
         </div>
 

--- a/apps/qubit/modules/actor/templates/browseSuccess.php
+++ b/apps/qubit/modules/actor/templates/browseSuccess.php
@@ -102,7 +102,8 @@
     <div class="row">
       <div class="span5">
         <?php echo get_component('search', 'inlineSearch', [
-            'label' => __('Search %1%', ['%1%' => strtolower(sfConfig::get('app_ui_label_actor'))]), ]); ?>
+            'label' => __('Search %1%', ['%1%' => strtolower(sfConfig::get('app_ui_label_actor'))]),
+            'landmarkLabel' => __(sfConfig::get('app_ui_label_actor')), ]); ?>
       </div>
     </div>
 

--- a/apps/qubit/modules/default/templates/_viewPicker.php
+++ b/apps/qubit/modules/default/templates/_viewPicker.php
@@ -3,9 +3,9 @@
 <div class="btn-group">
   <?php echo link_to(' ', ['module' => $module, 'action' => 'browse', 'view' => $cardView] +
                       $sf_data->getRaw('sf_request')->getParameterHolder()->getAll(),
-                      ['class' => 'btn fa fa-th-large '.($view === $cardView ? 'active' : ''), 'title' => __('Card view')]); ?>
+                      ['class' => 'btn fa fa-th-large '.($view === $cardView ? 'active' : ''), 'aria-label' => __('Card view')]); ?>
 
   <?php echo link_to(' ', ['module' => $module, 'action' => 'browse', 'view' => $tableView] +
                       $sf_data->getRaw('sf_request')->getParameterHolder()->getAll(),
-                      ['class' => 'btn fa fa-list '.($view === $tableView ? 'active' : ''), 'title' => __('Table view')]); ?>
+                      ['class' => 'btn fa fa-list '.($view === $tableView ? 'active' : ''), 'aria-label' => __('Table view')]); ?>
 </div>

--- a/apps/qubit/modules/default/templates/moveSuccess.php
+++ b/apps/qubit/modules/default/templates/moveSuccess.php
@@ -7,20 +7,20 @@
 <?php slot('before-content'); ?>
 
   <div class="row">
-    <div class="inline-search span6">
+    <div class="inline-search span6" role="search" aria-label="<?php echo __(sfConfig::get('app_ui_label_informationobject')); ?>">
       <form action="<?php echo url_for([$resource, 'module' => 'default', 'action' => 'move']); ?>">
         <div class="input-append">
           <?php if (isset($sf_request->query)) { ?>
-            <input type="text" name="query" value="<?php echo $sf_request->query; ?>" />
-            <a class="btn" href="<?php echo url_for([$resource, 'module' => 'default', 'action' => 'move']); ?>">
-              <i class="fa fa-times"></i>
+            <input type="text" aria-label="<?php echo __('Search title or identifier'); ?>" name="query" value="<?php echo $sf_request->query; ?>" placeholder="<?php echo __('Search title or identifier'); ?>" />
+            <a class="btn" href="<?php echo url_for([$resource, 'module' => 'default', 'action' => 'move']); ?>" aria-label=<?php echo __('Reset search'); ?>>
+              <i aria-hidden="true" class="fa fa-undo"></i>
             </a>
           <?php } else { ?>
-            <input type="text" name="query" placeholder="<?php echo __('Search title or identifier'); ?>" />
+            <input type="text" name="query" aria-label="<?php echo __('Search title or identifier'); ?>" placeholder="<?php echo __('Search title or identifier'); ?>" />
           <?php } ?>
           <div class="btn-group">
-            <button class="btn" type="submit">
-              <i class="fa fa-search"></i>
+            <button class="btn" type="submit" aria-label=<?php echo __('Search'); ?>>
+              <i aria-hidden="true" class="fa fa-search"></i>
             </button>
           </div>
         </div>

--- a/apps/qubit/modules/function/templates/browseSuccess.php
+++ b/apps/qubit/modules/function/templates/browseSuccess.php
@@ -15,7 +15,8 @@
     <div class="row">
       <div class="span6">
         <?php echo get_component('search', 'inlineSearch', [
-            'label' => __('Search %1%', ['%1%' => strtolower(sfConfig::get('app_ui_label_function'))]), ]); ?>
+            'label' => __('Search %1%', ['%1%' => strtolower(sfConfig::get('app_ui_label_function'))]),
+            'landmarkLabel' => __(sfConfig::get('app_ui_label_function')), ]); ?>
       </div>
 
       <div class="pickers">

--- a/apps/qubit/modules/informationobject/templates/_treeView.php
+++ b/apps/qubit/modules/informationobject/templates/_treeView.php
@@ -111,12 +111,12 @@
 
 </div>
 
-<div id="treeview-search" <?php echo ('sidebar' != $treeviewType) ? 'class="force-show"' : ''; ?>>
+<div id="treeview-search" role="search" aria-label="<?php echo __('Hierarchy'); ?>" <?php echo ('sidebar' != $treeviewType) ? 'class="force-show"' : ''; ?>>
 
   <form method="get" action="<?php echo url_for(['module' => 'search', 'action' => 'index', 'collection' => $resource->getCollectionRoot()->id]); ?>" data-not-found="<?php echo __('No results found.'); ?>">
     <div class="search-box">
-      <input type="text" name="query" placeholder="<?php echo __('Search'); ?>" />
-      <button type="submit"><i class="fa fa-search"></i></button>
+      <input type="text" name="query" aria-label="<?php echo __('Search hierarchy'); ?>" placeholder="<?php echo __('Search hierarchy'); ?>" />
+      <button type="submit" aria-label="<?php echo __('Search'); ?>"><i aria-hidden="true" class="fa fa-search"></i></button>
     </div>
   </form>
 

--- a/apps/qubit/modules/informationobject/templates/browseSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/browseSuccess.php
@@ -132,7 +132,7 @@
         <?php echo __('Only top-level descriptions'); ?>
         <?php $params = $sf_data->getRaw('sf_request')->getGetParameters(); ?>
         <?php $params['topLod'] = 0; ?>
-        <a href="<?php echo url_for(['module' => 'informationobject', 'action' => 'browse'] + $params); ?>" class="remove-filter"><i class="fa fa-times"></i></a>
+        <a href="<?php echo url_for(['module' => 'informationobject', 'action' => 'browse'] + $params); ?>" class="remove-filter" aria-label="<?php echo __('Remove filter'); ?>"><i aria-hidden="true" class="fa fa-times"></i></a>
       </span>
     <?php } ?>
 

--- a/apps/qubit/modules/physicalobject/templates/browseSuccess.php
+++ b/apps/qubit/modules/physicalobject/templates/browseSuccess.php
@@ -10,7 +10,8 @@
     <div class="row">
       <div class="span6">
         <?php echo get_component('search', 'inlineSearch', [
-            'label' => __('Search physical objects'), ]); ?>
+            'label' => __('Search %1%', ['%1%' => strtolower(sfConfig::get('app_ui_label_physicalobject'))]),
+            'landmarkLabel' => __(sfConfig::get('app_ui_label_physicalobject')), ]); ?>
       </div>
     </div>
   </section>

--- a/apps/qubit/modules/repository/templates/_advancedFilters.php
+++ b/apps/qubit/modules/repository/templates/_advancedFilters.php
@@ -8,21 +8,8 @@
 
     <div class="row-fluid">
       <div class="span4">
-        <?php echo __('Thematic area:'); ?>
-      </div>
-
-      <div class="span4">
-        <?php echo __('Archive type:'); ?>
-      </div>
-
-      <div class="span4">
-        <?php echo __('Regions:'); ?>
-      </div>
-    </div>
-
-    <div class="row-fluid">
-      <div class="span4">
-        <select name="thematicAreas">
+        <label for="thematicAreas"><?php echo __('Thematic area:'); ?></label>
+        <select name="thematicAreas" id="thematicAreas">
           <option selected="selected"></option>
           <?php foreach ($thematicAreas as $r) { ?>
             <option value="<?php echo $r->getId(); ?>">
@@ -33,7 +20,8 @@
       </div>
 
       <div class="span4">
-        <select name="types">
+        <label for="types"><?php echo __('Archive type:'); ?></label>
+        <select name="types" id="types">
           <option selected="selected"></option>
           <?php foreach ($repositoryTypes as $r) { ?>
             <option value="<?php echo $r->getId(); ?>">
@@ -44,7 +32,8 @@
       </div>
 
       <div class="span4">
-        <select name="regions">
+        <label for="regions"><?php echo __('Region:'); ?></label>
+        <select name="regions" id="regions">
           <option selected="selected"></option>
           <?php $regions = []; ?>
           <?php foreach ($repositories as $r) { ?>

--- a/apps/qubit/modules/repository/templates/_holdings.php
+++ b/apps/qubit/modules/repository/templates/_holdings.php
@@ -2,12 +2,12 @@
   <?php echo sfConfig::get('app_ui_label_holdings'); ?>
   <?php echo image_tag('loading.small.gif', ['class' => 'hidden', 'id' => 'spinner', 'alt' => __('Loading ...')]); ?>
 </h3>
-<form class="sidebar-search" action="<?php echo url_for(['module' => 'informationobject', 'action' => 'browse']); ?>">
+<form class="sidebar-search" role="search" aria-label="<?php echo sfConfig::get('app_ui_label_holdings'); ?>" action="<?php echo url_for(['module' => 'informationobject', 'action' => 'browse']); ?>">
   <input type="hidden" name="repos" value="<?php echo $resource->id; ?>">
   <div class="input-prepend input-append">
-    <input type="text" name="query" placeholder="<?php echo __('Search holdings'); ?>">
-    <button class="btn" type="submit">
-      <i class="fa fa-search"></i>
+    <input type="text" name="query" aria-label="<?php echo __('Search %1%', ['%1%' => sfConfig::get('app_ui_label_holdings')]); ?>" placeholder="<?php echo __('Search %1%', ['%1%' => strtolower(sfConfig::get('app_ui_label_holdings'))]); ?>">
+    <button class="btn" type="submit" aria-label=<?php echo __('Search'); ?>>
+      <i aria-hidden="true" class="fa fa-search"></i>
     </button>
   </div>
 </form>

--- a/apps/qubit/modules/repository/templates/_holdingsInstitution.php
+++ b/apps/qubit/modules/repository/templates/_holdingsInstitution.php
@@ -24,12 +24,12 @@
         <?php echo image_tag('loading.small.gif', ['class' => 'hidden', 'id' => 'spinner', 'alt' => __('Loading ...')]); ?>
       </h3>
 
-      <form class="sidebar-search" action="<?php echo url_for(['module' => 'informationobject', 'action' => 'browse']); ?>">
+      <form class="sidebar-search" role="search" aria-label="<?php echo __(sfConfig::get('app_ui_label_informationobject')); ?>" action="<?php echo url_for(['module' => 'informationobject', 'action' => 'browse']); ?>">
         <input type="hidden" name="repos" value="<?php echo $resource->id; ?>">
         <div class="input-prepend input-append">
-          <input type="text" name="query" value="<?php echo $sf_request->query; ?>" placeholder="<?php echo __('Search'); ?>">
-          <button class="btn" type="submit">
-            <i class="fa fa-search"></i>
+          <input type="text" name="query" aria-label="<?php echo __('Search'); ?>" value="<?php echo $sf_request->query; ?>" placeholder="<?php echo __('Search'); ?>">
+          <button class="btn" type="submit" aria-label="<?php echo __('Search'); ?>">
+            <i aria-hidden="true" class="fa fa-search"></i>
           </button>
         </div>
       </form>

--- a/apps/qubit/modules/repository/templates/browseSuccess.php
+++ b/apps/qubit/modules/repository/templates/browseSuccess.php
@@ -78,7 +78,8 @@
     <div class="row">
       <div class="span4">
         <?php echo get_component('search', 'inlineSearch', [
-            'label' => __('Search %1%', ['%1%' => strtolower(sfConfig::get('app_ui_label_repository'))]), ]); ?>
+            'label' => __('Search %1%', ['%1%' => strtolower(sfConfig::get('app_ui_label_repository'))]),
+            'landmarkLabel' => __(sfConfig::get('app_ui_label_repository')), ]); ?>
       </div>
 
       <?php echo get_partial('default/viewPicker', ['view' => $view, 'cardView' => $cardView,
@@ -95,7 +96,7 @@
     </div>
   </section>
 
-  <section class="advanced-search-section">
+  <section class="advanced-search-section" role="search" aria-label="<?php echo __('Advanced %1%', ['%1%' => sfConfig::get('app_ui_label_repository')]); ?>">
     <a href="#" id="toggle-advanced-filters" class="advanced-search-toggle"><?php echo __('Advanced search options'); ?></a>
     <div id="advanced-repository-filters" class="advanced-search">
       <?php echo get_component('repository', 'advancedFilters', [

--- a/apps/qubit/modules/rightsholder/templates/browseSuccess.php
+++ b/apps/qubit/modules/rightsholder/templates/browseSuccess.php
@@ -4,7 +4,7 @@
 <?php slot('title'); ?>
   <div class="multiline-header">
     <h1 aria-describedby="results-label"><?php echo __('Showing %1% results', ['%1%' => $pager->getNbResults()]); ?></h1>
-    <span class="sub" id="results-label"><?php echo __('Rights holder'); ?></span>
+    <span class="sub" id="results-label"><?php echo __('Rights holders'); ?></span>
   </div>
 <?php end_slot(); ?>
 
@@ -14,7 +14,8 @@
     <div class="row">
       <div class="span6">
         <?php echo get_component('search', 'inlineSearch', [
-            'label' => __('Search rights holder'), ]); ?>
+            'label' => __('Search rights holders'),
+            'landmarkLabel' => __('Rights holder'), ]); ?>
       </div>
 
       <div class="pickers">

--- a/apps/qubit/modules/search/templates/_advancedSearch.php
+++ b/apps/qubit/modules/search/templates/_advancedSearch.php
@@ -1,4 +1,4 @@
-<section class="advanced-search-section">
+<section class="advanced-search-section" role="search" aria-label="<?php echo __('Advanced %1%', ['%1%' => sfConfig::get('app_ui_label_informationobject')]); ?>">
 
   <a href="#" class="advanced-search-toggle <?php echo $show ? 'open' : ''; ?>" aria-expanded="<?php echo $show ? 'true' : 'false'; ?>"><?php echo __('Advanced search options'); ?></a>
 
@@ -26,7 +26,7 @@
                 <option value="not"<?php echo 'not' == $item['operator'] ? ' selected="selected"' : ''; ?>><?php echo __('not'); ?></option>
               </select>
 
-              <input class="query" type="text" placeholder="<?php echo __('Search'); ?>" name="sq<?php echo $key; ?>" value="<?php echo $item['query']; ?>"/>
+              <input class="query" type="text" aria-label="<?php echo __('Search'); ?>" placeholder="<?php echo __('Search'); ?>" name="sq<?php echo $key; ?>" value="<?php echo $item['query']; ?>"/>
 
               <span><?php echo __('in'); ?></span>
 
@@ -52,7 +52,7 @@
                 <option value="allExceptFindingAidTranscript"<?php echo 'allExceptFindingAidTranscript' == $item['field'] ? ' selected="selected"' : ''; ?>><?php echo __('Any field except finding aid text'); ?></option>
               </select>
 
-              <a href="#" class="delete-criterion"><i class="fa fa-times"></i></a>
+              <a href="#" class="delete-criterion" aria-label="<?php echo __('Delete criterion'); ?>"><i aria-hidden="true" class="fa fa-times"></i></a>
 
             </div>
 
@@ -70,7 +70,7 @@
             <option value="not"><?php echo __('not'); ?></option>
           </select>
 
-          <input class="query" type="text" placeholder="<?php echo __('Search'); ?>" name="sq<?php echo $count; ?>"/>
+          <input class="query" aria-label="<?php echo __('Search'); ?>" type="text" placeholder="<?php echo __('Search'); ?>" name="sq<?php echo $count; ?>"/>
 
           <span><?php echo __('in'); ?></span>
 
@@ -96,7 +96,7 @@
             <option value="allExceptFindingAidTranscript"><?php echo __('Any field except finding aid text'); ?></option>
           </select>
 
-          <a href="#" class="delete-criterion"><i class="fa fa-times"></i></a>
+          <a href="#" class="delete-criterion" aria-label="<?php echo __('Delete criterion'); ?>"><i aria-hidden="true" class="fa fa-times"></i></a>
 
         </div>
 
@@ -238,7 +238,7 @@
             </label>
           </div>
 
-          <a href="#" class="date-range-help-icon" aria-expanded="false"><i class="fa fa-question-circle"></i></a>
+          <a href="#" class="date-range-help-icon" aria-expanded="false" aria-label="<?php echo __('Help'); ?>"><i aria-hidden="true" class="fa fa-question-circle"></i></a>
 
         </div>
 

--- a/apps/qubit/modules/search/templates/_box.php
+++ b/apps/qubit/modules/search/templates/_box.php
@@ -8,12 +8,12 @@
     <input type="hidden" name="sort" value="relevance"/>
 
     <?php if (isset($repository) && !sfConfig::get('app_enable_institutional_scoping')) { ?>
-      <input type="text" name="query"<?php echo isset($sf_request->query) ? ' class="focused"' : ''; ?> value="<?php echo $sf_request->query; ?>" placeholder="<?php echo __('Search %1%', ['%1%' => strip_markdown($repository)]); ?>"/>
+      <input type="text" name="query"<?php echo isset($sf_request->query) ? ' class="focused"' : ''; ?> aria-label="<?php echo __('Search %1%', ['%1%' => strip_markdown($repository)]); ?>" value="<?php echo $sf_request->query; ?>" placeholder="<?php echo __('Search %1%', ['%1%' => strip_markdown($repository)]); ?>"/>
     <?php } else { ?>
-      <input type="text" name="query"<?php echo isset($sf_request->query) ? ' class="focused"' : ''; ?> value="<?php echo !$sf_user->getAttribute('search-realm') || !sfConfig::get('app_enable_institutional_scoping') ? $sf_request->query : ''; ?>" placeholder="<?php echo __('%1%', ['%1%' => sfConfig::get('app_ui_label_globalSearch')]); ?>"/>
+      <input type="text" name="query"<?php echo isset($sf_request->query) ? ' class="focused"' : ''; ?> aria-label="<?php echo __('%1%', ['%1%' => sfConfig::get('app_ui_label_globalSearch')]); ?>" value="<?php echo !$sf_user->getAttribute('search-realm') || !sfConfig::get('app_enable_institutional_scoping') ? $sf_request->query : ''; ?>" placeholder="<?php echo __('%1%', ['%1%' => sfConfig::get('app_ui_label_globalSearch')]); ?>"/>
     <?php } ?>
 
-    <button><span><?php echo __('Search'); ?></span></button>
+    <button aria-label="<?php echo __('Search'); ?>"></button>
 
     <div id="search-realm" class="search-popover">
 

--- a/apps/qubit/modules/search/templates/_filterTag.php
+++ b/apps/qubit/modules/search/templates/_filterTag.php
@@ -4,5 +4,5 @@
   <?php } else { ?>
     <?php echo render_title($object); ?>
   <?php } ?>
-  <a href="<?php echo url_for(['module' => $module, 'action' => $action] + $sf_data->getRaw('getParams')); ?>" class="remove-filter"><i class="fa fa-times"></i></a>
+  <a href="<?php echo url_for(['module' => $module, 'action' => $action] + $sf_data->getRaw('getParams')); ?>" class="remove-filter" aria-label="<?php echo __('Remove filter'); ?>"><i aria-hidden="true" class="fa fa-times"></i></a>
 </span>

--- a/apps/qubit/modules/search/templates/_inlineSearch.php
+++ b/apps/qubit/modules/search/templates/_inlineSearch.php
@@ -1,4 +1,4 @@
-<div class="inline-search">
+<div class="inline-search" role="search" aria-label="<?php echo $landmarkLabel; ?>">
 
   <form method="get" action="<?php echo $route; ?>">
 
@@ -33,17 +33,17 @@
       <?php } ?>
 
       <?php if (isset($sf_request->subquery)) { ?>
-        <input type="text" name="subquery" value="<?php echo $sf_request->subquery; ?>" />
-        <a class="btn" href="<?php echo $cleanRoute; ?>">
-          <i class="fa fa-times"></i>
+        <input type="text" name="subquery" aria-label="<?php echo $label; ?>" value="<?php echo $sf_request->subquery; ?>" placeholder="<?php echo $label; ?>" />
+        <a class="btn" href="<?php echo $cleanRoute; ?>" aria-label="<?php echo __('Reset search'); ?>">
+          <i aria-hidden="true" class="fa fa-undo"></i>
         </a>
       <?php } else { ?>
-        <input type="text" name="subquery" placeholder="<?php echo $label; ?>" />
+        <input type="text" name="subquery" aria-label="<?php echo $label; ?>" placeholder="<?php echo $label; ?>" />
       <?php } ?>
 
       <div class="btn-group">
-        <button class="btn" type="submit">
-          <i class="fa fa-search"></i>
+        <button class="btn" type="submit" aria-label="<?php echo __('Search'); ?>">
+          <i aria-hidden="true" class="fa fa-search"></i>
         </button>
       </div>
 

--- a/apps/qubit/modules/taxonomy/templates/indexSuccess.php
+++ b/apps/qubit/modules/taxonomy/templates/indexSuccess.php
@@ -26,7 +26,8 @@
     <div class="row">
       <div class="span5">
         <?php echo get_component('search', 'inlineSearch', [
-            'label' => __('Search %1%', ['%1%' => render_title($resource)]),
+            'label' => __('Search %1%', ['%1%' => strtolower(render_title($resource))]),
+            'landmarkLabel' => __(render_title($resource)),
             'route' => url_for(['module' => 'taxonomy', 'action' => 'index', 'slug' => $resource->slug]),
             'fields' => [
                 'allLabels' => __('All labels'),

--- a/apps/qubit/modules/term/templates/_treeView.php
+++ b/apps/qubit/modules/term/templates/_treeView.php
@@ -163,13 +163,13 @@
 
     </div>
 
-    <div id="treeview-search">
+    <div id="treeview-search" role="search" aria-label="<?php echo strip_markdown($resource->taxonomy); ?>">
 
       <form method="get" action="<?php echo url_for([$resource->taxonomy, 'module' => 'taxonomy']); ?>" data-not-found="<?php echo __('No results found.'); ?>">
         <div class="search-box">
-          <input type="text" name="query" placeholder="<?php echo __('Search %1%', ['%1%' => strip_markdown($resource->taxonomy)]); ?>" />
-          <button type="submit"><i class="fa fa-search"></i></button>
-          <button id="treeview-search-settings" href="#"><i class="fa fa-cog"></i></button>
+          <input type="text" name="query" aria-label="<?php echo __('Search %1%', ['%1%' => strip_markdown($resource->taxonomy)]); ?>" placeholder="<?php echo __('Search %1%', ['%1%' => strtolower(strip_markdown($resource->taxonomy))]); ?>" />
+          <button type="submit" aria-label="<?php echo __('Search'); ?>"><i aria-hidden="true" class="fa fa-search"></i></button>
+          <button id="treeview-search-settings" aria-label="<?php echo __('Settings'); ?>" href="#"><i aria-hidden="true" class="fa fa-cog"></i></button>
         </div>
 
         <div class="animateNicely" id="field-options" style="display: none;">

--- a/apps/qubit/modules/term/templates/indexSuccess.php
+++ b/apps/qubit/modules/term/templates/indexSuccess.php
@@ -60,7 +60,7 @@
           <?php $params = $sf_data->getRaw('sf_request')->getGetParameters(); ?>
           <?php unset($params['onlyDirect']); ?>
           <?php unset($params['page']); ?>
-          <a href="<?php echo url_for([$resource, 'module' => 'term'] + $params); ?>" class="remove-filter"><i class="fa fa-times"></i></a>
+          <a href="<?php echo url_for([$resource, 'module' => 'term'] + $params); ?>" class="remove-filter" aria-label="<?php echo __('Remove filter'); ?>"><i aria-hidden="true" class="fa fa-times"></i></a>
         </span>
       <?php } ?>
 

--- a/apps/qubit/modules/term/templates/relatedAuthoritiesSuccess.php
+++ b/apps/qubit/modules/term/templates/relatedAuthoritiesSuccess.php
@@ -60,7 +60,7 @@
         <?php $params = $sf_data->getRaw('sf_request')->getGetParameters(); ?>
         <?php unset($params['onlyDirect']); ?>
         <?php unset($params['page']); ?>
-        <a href="<?php echo url_for([$resource, 'module' => 'term'] + $params); ?>" class="remove-filter"><i class="fa fa-times"></i></a>
+        <a href="<?php echo url_for([$resource, 'module' => 'term'] + $params); ?>" class="remove-filter" aria-label="<?php echo __('Remove filter'); ?>"><i aria-hidden="true" class="fa fa-times"></i></a>
       </span>
     <?php } ?>
 

--- a/apps/qubit/modules/user/templates/listSuccess.php
+++ b/apps/qubit/modules/user/templates/listSuccess.php
@@ -5,6 +5,7 @@
     <div class="span6">
       <?php echo get_component('search', 'inlineSearch', [
           'label' => __('Search users'),
+          'landmarkLabel' => __('User'),
           'route' => url_for(['module' => 'user', 'action' => 'list']), ]); ?>
     </div>
   </div>

--- a/plugins/arCasPlugin/modules/user/templates/listSuccess.php
+++ b/plugins/arCasPlugin/modules/user/templates/listSuccess.php
@@ -5,6 +5,7 @@
     <div class="span6">
       <?php echo get_component('search', 'inlineSearch', [
           'label' => __('Search users'),
+          'landmarkLabel' => __('User'),
           'route' => url_for(['module' => 'user', 'action' => 'list']), ]); ?>
     </div>
   </div>

--- a/plugins/qtAccessionPlugin/modules/accession/templates/browseSuccess.php
+++ b/plugins/qtAccessionPlugin/modules/accession/templates/browseSuccess.php
@@ -2,7 +2,7 @@
 <?php use_helper('Date'); ?>
 
 <?php slot('title'); ?>
-  <h1><?php echo __('Browse accession'); ?></h1>
+  <h1><?php echo __('Browse accessions'); ?></h1>
 <?php end_slot(); ?>
 
 <?php slot('before-content'); ?>
@@ -11,7 +11,8 @@
     <div class="row">
       <div class="span6">
         <?php echo get_component('search', 'inlineSearch', [
-            'label' => __('Search %1%', ['%1%' => strtolower(sfConfig::get('app_ui_label_accession'))]), ]); ?>
+            'label' => __('Search accessions'),
+            'landmarkLabel' => __('Accession'), ]); ?>
       </div>
 
       <div class="pickers">

--- a/plugins/qtAccessionPlugin/modules/donor/templates/browseSuccess.php
+++ b/plugins/qtAccessionPlugin/modules/donor/templates/browseSuccess.php
@@ -2,7 +2,7 @@
 <?php use_helper('Date'); ?>
 
 <?php slot('title'); ?>
-  <h1><?php echo __('Browse donor'); ?></h1>
+  <h1><?php echo __('Browse donors'); ?></h1>
 <?php end_slot(); ?>
 
 <?php slot('before-content'); ?>
@@ -11,7 +11,8 @@
     <div class="row">
       <div class="span6">
         <?php echo get_component('search', 'inlineSearch', [
-            'label' => __('Search %1%', ['%1%' => strtolower(sfConfig::get('app_ui_label_donor'))]), ]); ?>
+            'label' => __('Search donors'),
+            'landmarkLabel' => __('Donor'), ]); ?>
       </div>
 
       <div class="pickers">


### PR DESCRIPTION
### Description
PR seeks to improve search and advanced search form accessibility and compatibility with screen readers, as well as general clarity of function. This is achieved through the following:

- **Add aria-labels to search forms currently relying on placeholder text.** Not all screen reader use placeholder text.
- **Add ~~titles~~ aria-labels to search buttons.** This adds text for screen readers ~~and hover text for general clarity~~.
- **Associate form labels with existing forms.**
- **Change reset icon in advanced search to 'undo' for general clarity of function**. The 'x' has the same functionality as the reset action button at the bottom of advanced search. I felt that the 'undo' icon was a better representation for reset. 

For a fuller breakdown of the changes, see the commit descriptions.

Testing utilised Orca and NVDA screen readers.

### Images
Reset button icon changed from 'x' to 'undo'
![times_button](https://user-images.githubusercontent.com/76928773/121615426-d8d3d600-ca2e-11eb-9701-26788305bf09.png)
![undo_button](https://user-images.githubusercontent.com/76928773/121615429-da9d9980-ca2e-11eb-8a7f-0b43654a4f97.png)
