### PR TITLE
Improve clipboard accessibility, refs #13535

### DIFF
--- a/apps/qubit/modules/clipboard/actions/loadAction.class.php
+++ b/apps/qubit/modules/clipboard/actions/loadAction.class.php
@@ -21,7 +21,7 @@ class ClipboardLoadAction extends DefaultEditAction
 {
     // Arrays not allowed in class constants
     public static $NAMES = [
-        'password',
+        'clipboardPassword',
         'mode',
     ];
 
@@ -98,9 +98,9 @@ class ClipboardLoadAction extends DefaultEditAction
     protected function addField($name)
     {
         switch ($name) {
-            case 'password':
-                $this->form->setValidator('password', new sfValidatorString(['required' => true]));
-                $this->form->setWidget('password', new sfWidgetFormInput());
+            case 'clipboardPassword':
+                $this->form->setValidator('clipboardPassword', new sfValidatorString(['required' => true]));
+                $this->form->setWidget('clipboardPassword', new sfWidgetFormInput());
 
                 break;
 
@@ -120,7 +120,7 @@ class ClipboardLoadAction extends DefaultEditAction
     protected function processField($field)
     {
         switch ($field->getName()) {
-            case 'password':
+            case 'clipboardPassword':
                 $this->password = $this->form->getValue($field->getName());
 
                 break;

--- a/apps/qubit/modules/clipboard/templates/exportSuccess.php
+++ b/apps/qubit/modules/clipboard/templates/exportSuccess.php
@@ -34,7 +34,7 @@
             <div class="panel-body">
               <?php if (!empty($helpMessages)) { ?>
                 <div class="generic-help-box">
-                  <a href="#" class="generic-help-icon" aria-expanded="false"><i class="fa fa-question-circle pull-right"></i></a>
+                  <a href="#" class="generic-help-icon" aria-expanded="false" aria-label="<?php echo __('Help'); ?>"><i class="fa fa-question-circle pull-right"></i></a>
                 </div>
               <?php } ?>
               <?php if (isset($form->includeDescendants)) { ?>

--- a/apps/qubit/modules/clipboard/templates/loadSuccess.php
+++ b/apps/qubit/modules/clipboard/templates/loadSuccess.php
@@ -21,8 +21,10 @@
 
       <fieldset class="collapsible">
 
+        <legend class="sr-only"><?php echo __('Load options'); ?></legend>
+
         <div class="fieldset-wrapper">
-          <?php echo $form->password->label(__('Clipboard ID'))->renderRow(); ?>
+          <?php echo $form->clipboardPassword->label(__('Clipboard ID'))->renderRow(); ?>
         </div>
 
         <div class="fieldset-wrapper">

--- a/apps/qubit/modules/repository/templates/_browseTableView.php
+++ b/apps/qubit/modules/repository/templates/_browseTableView.php
@@ -42,6 +42,7 @@
       </th>
 
       <th style="width 3%">
+        <span class="sr-only"><?php echo __('Clipboard'); ?></span>
       </th>
     </tr>
   </thead>


### PR DESCRIPTION
PR adds accessibility fixes and enhancements for screen readers to the clipboard module, as well as a small clipboard related improvement for table view in repository search. Improvements include:

- **Clipboard ID form no longer sharing label association with user password form.** Depending on the SR you use, this can cause behaviour such as multiple labels being heard for one form, or none at all.
- **Add legend to 'Load clipboard' fieldset.** I've opted for an 'sr-only' legend to avoid adding what could be seen as superfluous information for sighted users.
- **Add aria-label to help button.**
- **Add text to clipboard column header for table view in repository search.** Without header text this column label was either not identified or identified as 'column 5'. I've opted for 'sr-only' to keep the look of the table unchanged.

Testing utilised Orca and NVDA screen readers.