### PR TITLE
CSV Checker WebUI integration, refs #13508

### DIFF
--- a/apps/qubit/modules/jobs/templates/reportSuccess.php
+++ b/apps/qubit/modules/jobs/templates/reportSuccess.php
@@ -73,7 +73,7 @@
   <div>
     <?php $output = trim($job->output); ?>
     <?php if (0 < strlen($output)) { ?>
-      <pre id="job-log-output"><?php echo render_value($output); ?></pre>
+      <pre id="job-log-output"><?php echo $output; ?></pre>
     <?php } else { ?>
       <p id="job-log-output-empty"><?php echo __('Empty'); ?></p>
     <?php } ?>

--- a/apps/qubit/modules/object/actions/validateCsvAction.class.php
+++ b/apps/qubit/modules/object/actions/validateCsvAction.class.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class ObjectValidateCsvAction extends DefaultEditAction
+{
+    // Arrays not allowed in class constants
+    public static $NAMES = [];
+
+    public function execute($request)
+    {
+        parent::execute($request);
+
+        if ($request->isMethod('post')) {
+            $this->form->bind($request->getPostParameters());
+
+            if ($this->form->isValid()) {
+                $this->processForm();
+
+                $this->doBackgroundValidate($request);
+
+                $this->setTemplate('validateCsv');
+            }
+        } else {
+            $this->title = $this->context->i18n->__('Validate CSV');
+        }
+    }
+
+    protected function earlyExecute()
+    {
+        $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
+    }
+
+    protected function addField($name)
+    {
+        return parent::addField($name);
+    }
+
+    protected function processField($field)
+    {
+    }
+
+    /**
+     * Launch the file import background job and return.
+     *
+     * @param  $request data
+     */
+    protected function doBackgroundValidate($request)
+    {
+        $file = $request->getFiles('file');
+
+        $validateCsvRoute = ['module' => 'object', 'action' => 'validateCsv'];
+
+        // Move uploaded file to new location to pass off to background arFileImportJob.
+        try {
+            $file = Qubit::moveUploadFile($file);
+        } catch (sfException $e) {
+            $this->getUser()->setFlash('error', $e->getMessage());
+            $this->redirect($validateCsvRoute);
+        }
+
+        // if we got here without a file upload, go to file selection
+        if (0 == count($file) || empty($file['tmp_name'])) {
+            $this->redirect($validateCsvRoute);
+        }
+
+        $options = [
+            'objectType' => $request->getParameter('objectType'),
+            // Choose import type based on importType parameter
+            // This decision used to be based in the file extension but some users
+            // experienced problems when the extension was omitted
+            'importType' => $importType,
+            'file' => $file,
+        ];
+
+        try {
+            $job = QubitJob::runJob('arValidateCsvJob', $options);
+
+            $this->getUser()->setFlash('notice', $this->context->i18n->__('CSV validation initiated. Check %1%job %2%%3% to view the results of the validation.', [
+                '%1%' => sprintf('<a href="%s">', $this->context->routing->generate(null, ['module' => 'jobs', 'action' => 'report', 'id' => $job->id])),
+                '%2%' => $job->id,
+                '%3%' => '</a>',
+            ]), ['persist' => false]);
+        } catch (sfException $e) {
+            $this->context->user->setFlash('error', $e->getMessage());
+            $this->redirect($validateCsvRoute);
+        }
+    }
+}

--- a/apps/qubit/modules/object/config/security.yml
+++ b/apps/qubit/modules/object/config/security.yml
@@ -4,5 +4,8 @@ import:
 importSelect:
   credentials: administrator
 
+validateCsv:
+  credentials: administrator
+
 all:
   is_secure: true

--- a/apps/qubit/modules/object/config/view.yml
+++ b/apps/qubit/modules/object/config/view.yml
@@ -12,6 +12,12 @@ importSelectSuccess:
     multiRow:
     select:
 
+validateCsvSuccess:
+  javascripts:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/collapse:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/form:
+    /plugins/sfDrupalPlugin/vendor/drupal/misc/textarea:
+
 addDigitalObjectSuccess:
   javascripts:
     /plugins/sfDrupalPlugin/vendor/drupal/misc/collapse:

--- a/apps/qubit/modules/object/templates/validateCsvSuccess.php
+++ b/apps/qubit/modules/object/templates/validateCsvSuccess.php
@@ -1,0 +1,53 @@
+<?php decorate_with('layout_1col.php'); ?>
+
+<?php slot('title'); ?>
+    <h1><?php echo $title; ?></h1>
+<?php end_slot(); ?>
+
+<?php slot('content'); ?>
+
+  <?php echo $form->renderGlobalErrors(); ?>
+
+    <?php echo $form->renderFormTag(url_for(['module' => 'object', 'action' => 'validateCsv']), ['enctype' => 'multipart/form-data']); ?>
+
+    <?php echo $form->renderHiddenFields(); ?>
+
+    <section id="content">
+
+      <fieldset class="collapsible">
+
+        <legend><?php echo __('CSV Validation options'); ?></legend>
+
+          <div class="form-item">
+            <label><?php echo __('Type'); ?></label>
+            <select name="objectType">
+              <option value="informationObject"><?php echo sfConfig::get('app_ui_label_informationobject'); ?></option>
+              <option value="accession"><?php echo sfConfig::get('app_ui_label_accession', __('Accession')); ?></option>
+              <option value="authorityRecord"><?php echo sfConfig::get('app_ui_label_actor'); ?></option>
+              <option value="authorityRecordRelationship"><?php echo sfConfig::get('app_ui_label_authority_record_relationships'); ?></option>
+              <option value="event"><?php echo sfConfig::get('app_ui_label_event', __('Event')); ?></option>
+              <option value="repository"><?php echo sfConfig::get('app_ui_label_repository', __('Repository')); ?></option>
+            </select>
+          </div>
+      </fieldset>
+
+      <fieldset class="collapsible">
+        <legend><?php echo __('Select file'); ?></legend>
+
+        <div class="form-item">
+          <label><?php echo __('Select a CSV file to validate'); ?></label>
+          <input name="file" type="file"/>
+        </div>
+      </fieldset>
+
+    </section>
+
+    <section class="actions">
+      <ul>
+        <li><input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Validate'); ?>"/></li>
+      </ul>
+    </section>
+
+  </form>
+
+<?php end_slot(); ?>

--- a/apps/qubit/modules/settings/actions/csvValidatorAction.class.php
+++ b/apps/qubit/modules/settings/actions/csvValidatorAction.class.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class SettingsCsvValidatorAction extends SettingsEditAction
+{
+    const VALIDATOR_OFF = 0;
+    const VALIDATOR_PERMISSIVE = 1;
+    const VALIDATOR_STRICT = 2;
+
+    public static $NAMES = [
+        'csv_validator_default_import_behaviour',
+    ];
+
+    public function earlyExecute()
+    {
+        parent::earlyExecute();
+
+        $this->updateMessage = $this->i18n->__('CSV Validator settings saved.');
+
+        $this->settingDefaults = [
+            'csv_validator_default_import_behaviour' => 0,
+        ];
+    }
+
+    protected function addField($name)
+    {
+        switch ($name) {
+            case 'csv_validator_default_import_behaviour':
+                $this->form->setValidator($name, new sfValidatorString(['required' => false]));
+                $this->form->setWidget($name, new sfWidgetFormSelectRadio(
+                    ['choices' => [
+                        self::VALIDATOR_OFF => $this->i18n->__('Off - validation is not run before CSV imports'),
+                        self::VALIDATOR_PERMISSIVE => $this->i18n->__('Permissive - validation is run; warnings are ignored'),
+                        self::VALIDATOR_STRICT => $this->i18n->__('Strict - validation is run; warnings will halt import from running'),
+                    ]],
+                    ['class' => 'radio']
+                ));
+
+                break;
+        }
+    }
+}

--- a/apps/qubit/modules/settings/actions/menuComponent.class.php
+++ b/apps/qubit/modules/settings/actions/menuComponent.class.php
@@ -28,6 +28,10 @@ class SettingsMenuComponent extends sfComponent
                 'action' => 'clipboard',
             ],
             [
+                'label' => $i18n->__('CSV Validator'),
+                'action' => 'csvValidator',
+            ],
+            [
                 'label' => $i18n->__('Default page elements'),
                 'action' => 'pageElements',
             ],

--- a/apps/qubit/modules/settings/templates/csvValidatorSuccess.php
+++ b/apps/qubit/modules/settings/templates/csvValidatorSuccess.php
@@ -1,0 +1,45 @@
+<?php decorate_with('layout_2col.php'); ?>
+
+<?php slot('sidebar'); ?>
+
+  <?php echo get_component('settings', 'menu'); ?>
+
+<?php end_slot(); ?>
+
+<?php slot('title'); ?>
+
+  <h1><?php echo __('CSV Validator'); ?></h1>
+
+<?php end_slot(); ?>
+
+<?php slot('content'); ?>
+
+  <?php echo $form->renderGlobalErrors(); ?>
+
+  <?php echo $form->renderFormTag(url_for(['module' => 'settings', 'action' => 'csvValidator'])); ?>
+
+    <?php echo $form->renderHiddenFields(); ?>
+
+    <div id="content">
+
+      <fieldset class="collapsible">
+
+        <legend><?php echo __('CSV Validator settings'); ?></legend>
+
+        <?php echo $form->csv_validator_default_import_behaviour
+            ->label(__('CSV Validator default behaviour when CSV Import is run'))
+            ->renderRow(); ?>
+
+      </fieldset>
+
+    </div>
+
+    <section class="actions">
+      <ul>
+        <li><input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Save'); ?>"/></li>
+      </ul>
+    </section>
+
+  </form>
+
+<?php end_slot(); ?>

--- a/config/gearman.yml
+++ b/config/gearman.yml
@@ -37,3 +37,5 @@ all:
       - arUpdateEsIoDocumentsJob
     holdings_report:
       - arPhysicalObjectCsvHoldingsReportJob
+    csv_validation:
+      - arValidateCsvJob

--- a/data/fixtures/menus.yml
+++ b/data/fixtures/menus.yml
@@ -746,6 +746,13 @@ QubitMenu:
       vi: CSV
       zh: 逗号分隔值文件(CSV)
     path: 'object/importSelect?type=csv'
+  QubitMenu_mainmenu_validate_csv:
+    parent_id: QubitMenu_mainmenu_import
+    source_culture: en
+    name: validateCsv
+    label:
+      en: Validate CSV
+    path: 'object/validateCsv'
   QubitMenu_mainmenu_import_skos:
     parent_id: QubitMenu_mainmenu_import
     source_culture: en

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 191
+    value: 192
   milestone:
     name: milestone
     editable: 0
@@ -1496,3 +1496,6 @@ QubitSetting:
     source_culture: en
     value:
       en: 1
+  Qubit_Settings_csvValidatorDefaultImportBehaviour:
+    name: csv_validator_default_import_behaviour
+    value: 0

--- a/lib/CsvImportValidator.class.php
+++ b/lib/CsvImportValidator.class.php
@@ -38,6 +38,7 @@ class CsvImportValidator
         'QubitAccession',
         'QubitRepository',
         'QubitEvent',
+        'QubitRelation-actor',
     ];
 
     public static $bomTypeMap = [
@@ -138,7 +139,7 @@ class CsvImportValidator
             $this->validatorCollection = CsvValidatorCollection::getValidatorCollection($this->getClassName(), $this->getOptions());
         }
 
-        foreach ($this->filenames as $filename) {
+        foreach ($this->filenames as $displayFilename => $filename) {
             if (false === $fh = fopen($filename, 'rb')) {
                 throw new sfException('You must specify a valid filename');
             }
@@ -147,7 +148,7 @@ class CsvImportValidator
 
             // Set specifics for this csv file
             $this->validatorCollection->setOrmClasses($this->ormClasses);
-            $this->validatorCollection->setFilename($filename);
+            $this->validatorCollection->setFilename($filename, $displayFilename);
             $this->validatorCollection->setColumnCount($this->getLongestRow());
 
             // Iterate csv rows, calling each test/row.
@@ -159,8 +160,7 @@ class CsvImportValidator
                 $this->validatorCollection->testRow($this->header, $row);
             }
 
-            // Gather results for this CSV file.
-            $this->resultCollection = $this->validatorCollection->getResultCollection($this->header, $row);
+            $this->resultCollection = $this->validatorCollection->getResultCollection($this->resultCollection);
 
             // Reset test if more than one input CSV passed.
             if ((1 < count($this->filenames)) ? true : false) {
@@ -336,7 +336,7 @@ class CsvImportValidator
 
     public function setFilenames(array $filenames)
     {
-        foreach ($filenames as $filename) {
+        foreach ($filenames as $displayName => $filename) {
             self::validateFileName($filename);
         }
 

--- a/lib/job/arExportJob.class.php
+++ b/lib/job/arExportJob.class.php
@@ -29,7 +29,7 @@ class arExportJob extends arBaseJob
 
     // Child class should set this if creating user downloads
     protected $downloadFileExtension;
-
+    protected $zipFileDownload;
     protected $filenames = [];
     protected $itemsExported = 0;
 
@@ -37,7 +37,9 @@ class arExportJob extends arBaseJob
     {
         $this->params = $parameters;
 
-        $tempPath = $this->createJobTempDir();
+        $this->zipFileDownload = new arZipFileDownload($this->job->id, $this->downloadFileExtension);
+
+        $tempPath = $this->zipFileDownload->createJobTempDir();
 
         // Export CSV to temp directory
         $this->info(
@@ -57,11 +59,11 @@ class arExportJob extends arBaseJob
 
             $this->info($this->i18n->__(
                 'Creating ZIP file %1.',
-                ['%1' => $this->getDownloadFilePath()]
+                ['%1' => $this->zipFileDownload->getDownloadFilePath()]
             ));
 
             // Create ZIP file and add metadata file(s) and digital objects
-            $errors = $this->createZipForDownload($tempPath);
+            $errors = $this->zipFileDownload->createZipForDownload($tempPath, $this->user->isAdministrator());
 
             if (!empty($errors)) {
                 $this->error(
@@ -72,7 +74,7 @@ class arExportJob extends arBaseJob
                 return;
             }
 
-            $this->job->downloadPath = $this->getDownloadRelativeFilePath();
+            $this->job->downloadPath = $this->zipFileDownload->getDownloadRelativeFilePath();
             $this->info($this->i18n->__('Export and archiving complete.'));
         } else {
             $this->info($this->i18n->__('No relevant records were found to export.'));
@@ -84,149 +86,6 @@ class arExportJob extends arBaseJob
         // Delete temp directory contents and directory
         sfToolkit::clearDirectory($tempPath);
         rmdir($tempPath);
-    }
-
-    /**
-     * Return the job's download file path (or null if job doesn't create
-     * a download).
-     *
-     * @return string file path
-     */
-    public function getDownloadFilePath()
-    {
-        $downloadFilePath = null;
-
-        if (!is_null($this->downloadFileExtension)) {
-            $downloadFilePath = $this->getJobsDownloadDirectory()
-                .DIRECTORY_SEPARATOR
-                .$this->getJobDownloadFilename();
-        }
-
-        return $downloadFilePath;
-    }
-
-    /**
-     * Return the job's download file's relative path (or null if job doesn't
-     * create a download).
-     *
-     * @return string file path
-     */
-    public function getDownloadRelativeFilePath()
-    {
-        $downloadRelativeFilePath = null;
-
-        if (!is_null($this->downloadFileExtension)) {
-            $relativeBaseDir = 'downloads'.DIRECTORY_SEPARATOR.'jobs';
-            $downloadRelativeFilePath = $relativeBaseDir.DIRECTORY_SEPARATOR
-                .$this->getJobDownloadFilename();
-        }
-
-        return $downloadRelativeFilePath;
-    }
-
-    /**
-     * Get the jobs download directory, a subdirectory of main AtoM downloads
-     * directory.
-     *
-     * @return string directory path
-     */
-    public function getJobsDownloadDirectory()
-    {
-        $path = sfConfig::get('sf_web_dir').DIRECTORY_SEPARATOR.'downloads'
-            .DIRECTORY_SEPARATOR.'jobs';
-
-        // Create the "downloads/jobs" directory if it doesn't exist already
-        if (!is_dir($path)) {
-            mkdir($path, 0755, true);
-        }
-
-        return $path;
-    }
-
-    /**
-     * Create job temporary directory where the files will be added before
-     * they are compressed and added to the downloads folder. Use a MD5 hash
-     * created from instance info, job id and the current Epoch time to avoid
-     * collisions when multiple AtoM instances are available on the same machine
-     * and in instances where the database is regenerated from another dump (like
-     * it's done in sites with public and private instances), where the job id
-     * could be repeated, adding the export results to an existing export folder.
-     *
-     * @return string Temporary directory path
-     */
-    protected function createJobTempDir()
-    {
-        $name = md5(
-            sfConfig::get('sf_root_dir')
-            .sfConfig::get('app_workers_key', '')
-            .$this->job->id
-            .date_timestamp_get()
-        );
-        $path = sys_get_temp_dir().DIRECTORY_SEPARATOR.$name;
-        mkdir($path);
-
-        return $path;
-    }
-
-    /**
-     * Create ZIP file from exported files.
-     *
-     * @param string   Path of file to write CSV data to
-     * @param bool  Optional: Whether to include digital objects
-     * @param mixed $tempDir
-     *
-     * @return array Error messages
-     */
-    protected function createZipForDownload($tempDir)
-    {
-        $errors = [];
-
-        if (!is_writable($this->getJobsDownloadDirectory())) {
-            return [$this->i18n->__('Cannot write to directory')];
-        }
-
-        $zip = new ZipArchive();
-
-        if (
-            !$zip->open(
-                $this->getDownloadFilePath(),
-                ZipArchive::CREATE | ZipArchive::OVERWRITE
-            )
-        ) {
-            return [$this->i18n->__('Cannot create zip file')];
-        }
-
-        // Add exported files
-        $this->addFilesToZip($tempDir, $zip, $errors);
-
-        $zip->close();
-
-        return $errors;
-    }
-
-    protected function addFilesToZip($path, &$zip, &$errors)
-    {
-        foreach (scandir($path) as $file) {
-            if (is_dir($file)) {
-                continue;
-            }
-
-            try {
-                $zip->addFile($path.DIRECTORY_SEPARATOR.$file, $file);
-            } catch (Exception $e) {
-                if ($this->user->isAdministrator()) {
-                    $errors[] = 'Exception: '.$e->getMessage();
-                } else {
-                    $errors[] = $this->i18n->__(
-                        'Sorry, but there was an error retrieving'
-                        .' a data file. This has stopped the export process.'
-                        .' Please contact an administrator.'
-                    );
-                }
-
-                break;
-            }
-        }
     }
 
     /**
@@ -277,7 +136,7 @@ class arExportJob extends arBaseJob
             return false;
         }
 
-        $filename = $this->getUniqueFilename($filepath);
+        $filename = $this->zipFileDownload->getUniqueFilename($filepath);
         $dest = $tempDir.DIRECTORY_SEPARATOR.$filename;
 
         if (!copy($filepath, $dest)) {
@@ -309,28 +168,6 @@ class arExportJob extends arBaseJob
         return false;
     }
 
-    protected function getUniqueFilename($filepath)
-    {
-        $filename = basename($filepath);
-
-        if (!isset($this->filenames[$filename])) {
-            // Filename not used yet - add to tracker
-            $this->filenames[$filename] = 0;
-
-            return $filename;
-        }
-
-        // Filename has been used - increment counter and append value to filename
-        $pathinfo = pathinfo($filename);
-
-        return sprintf(
-            '%s_%s.%s',
-            $pathinfo['filename'],
-            $this->filenames[$filename]++,
-            $pathinfo['extension']
-        );
-    }
-
     /**
      * Log export progress every LOG_INTERVAL rows and clear Qubit class caches.
      */
@@ -346,10 +183,5 @@ class arExportJob extends arBaseJob
 
             Qubit::clearClassCaches();
         }
-    }
-
-    private function getJobDownloadFilename()
-    {
-        return md5($this->job->id).'.'.$this->downloadFileExtension;
     }
 }

--- a/lib/job/arValidateCsvJob.class.php
+++ b/lib/job/arValidateCsvJob.class.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Job worker for CSV Validation requests initiated from the WebUI.
+ */
+class arValidateCsvJob extends arBaseJob
+{
+    protected $zipFileDownload;
+    protected $downloadFileExtension = 'zip';
+    protected $verboseReportContents;
+
+    /**
+     * @see arBaseJob::$requiredParameters
+     *
+     * @param mixed $parameters
+     */
+    public function runJob($parameters)
+    {
+        if (!isset($parameters['file'])) {
+            $this->job->setStatusError($this->i18n->__('Validation file name not set.'));
+            $this->job->save();
+
+            return false;
+        }
+
+        $this->info($this->i18n->__('Validating file: %1.', ['%1' => $parameters['file']['name']]));
+
+        // Run CsvValidator and output short report to log panel.
+        $validationResultString = $this->runCsvValidator($this->context, $parameters);
+        $this->info($validationResultString);
+
+        // Attempt export of verbose report.
+        $this->zipFileDownload = new arZipFileDownload($this->job->id, $this->downloadFileExtension);
+        $tempPath = $this->zipFileDownload->createJobTempDir();
+
+        // Write verbose report contents to tempPath.
+        $exportFile = $tempPath.DIRECTORY_SEPARATOR.'validation_results.txt';
+        file_put_contents($exportFile, $this->verboseReportContents);
+
+        // Compress CSV export files as a ZIP archive.
+        $this->info($this->i18n->__(
+            'Creating ZIP file %1.',
+            ['%1' => $this->zipFileDownload->getDownloadFilePath()]
+        ));
+
+        // Create ZIP file.
+        $errors = $this->zipFileDownload->createZipForDownload($tempPath, $this->user->isAdministrator());
+
+        if (!empty($errors)) {
+            $this->error(
+                $this->i18n->__('Failed to create ZIP file.')
+                .' : '.implode(' : ', $errors)
+            );
+
+            return;
+        }
+
+        $this->job->downloadPath = $this->zipFileDownload->getDownloadRelativeFilePath();
+        $this->job->setStatusCompleted();
+        $this->job->save();
+
+        return true;
+    }
+
+    public function runCsvValidator($context, array $options = [])
+    {
+        $file = $options['file'];
+
+        $validatorOptions = self::mapImportTypeToClassName(self::setOptions($options));
+
+        $validator = new CsvImportValidator($context, null, $validatorOptions);
+        $validator->setFilenames([$file['name'] => $file['tmp_name']]);
+        $results = $validator->validate();
+
+        $this->verboseReportContents = CsvValidatorResultCollection::renderResultsAsText($results, true);
+
+        // Return short report.
+        return CsvValidatorResultCollection::renderResultsAsText($results, false);
+    }
+
+    public static function setOptions($options = [])
+    {
+        $opts = [];
+
+        $keymap = [
+            'source' => 'source',
+            'objectType' => 'className',
+            'specific-tests' => 'specificTests',
+            'path-to-digital-objects' => 'pathToDigitalObjects',
+        ];
+
+        foreach ($keymap as $oldkey => $newkey) {
+            if (empty($options[$oldkey])) {
+                continue;
+            }
+
+            $opts[$newkey] = $options[$oldkey];
+        }
+
+        return $opts;
+    }
+
+    public static function mapImportTypeToClassName($options)
+    {
+        $importOjectClassNames = [
+            'informationObject' => 'QubitInformationObject',
+            'accession' => 'QubitAccession',
+            'authorityRecord' => 'QubitActor',
+            'event' => 'QubitEvent',
+            'repository' => 'QubitRepository',
+            'authorityRecordRelationship' => 'QubitRelation-actor',
+        ];
+
+        $options['className'] = $importOjectClassNames[$options['className']];
+
+        return $options;
+    }
+}

--- a/lib/job/arZipFileDownload.class.php
+++ b/lib/job/arZipFileDownload.class.php
@@ -1,0 +1,211 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Class containing functions needed for creating a downloadable zip file.
+ *
+ * @author     Steve Breker <sbreker@artefactual.com>
+ */
+class arZipFileDownload
+{
+    protected $jobId;
+    protected $downloadFileExtension;
+    protected $i18n;
+
+    public function __construct($jobId, $downloadFileExtension)
+    {
+        $context = sfContext::getInstance();
+        $this->i18n = $context->i18n;
+
+        $this->jobId = $jobId;
+
+        $this->downloadFileExtension = $downloadFileExtension;
+    }
+
+    /**
+     * Create job temporary directory where the files will be added before
+     * they are compressed and added to the downloads folder. Use a MD5 hash
+     * created from instance info, job id and the current Epoch time to avoid
+     * collisions when multiple AtoM instances are available on the same machine
+     * and in instances where the database is regenerated from another dump (like
+     * it's done in sites with public and private instances), where the job id
+     * could be repeated, adding the export results to an existing export folder.
+     *
+     * @return string Temporary directory path
+     */
+    public function createJobTempDir()
+    {
+        $name = md5(
+            sfConfig::get('sf_root_dir')
+            .sfConfig::get('app_workers_key', '')
+            .$this->jobId
+            .date_timestamp_get()
+        );
+        $path = sys_get_temp_dir().DIRECTORY_SEPARATOR.$name;
+        mkdir($path);
+
+        return $path;
+    }
+
+    /**
+     * Return the job's download file path (or null if job doesn't create
+     * a download).
+     *
+     * @return string file path
+     */
+    public function getDownloadFilePath()
+    {
+        $downloadFilePath = null;
+
+        if (!is_null($this->downloadFileExtension)) {
+            $downloadFilePath = $this->getJobsDownloadDirectory()
+                .DIRECTORY_SEPARATOR
+                .$this->getJobDownloadFilename();
+        }
+
+        return $downloadFilePath;
+    }
+
+    /**
+     * Get the jobs download directory, a subdirectory of main AtoM downloads
+     * directory.
+     *
+     * @return string directory path
+     */
+    public function getJobsDownloadDirectory()
+    {
+        $path = sfConfig::get('sf_web_dir').DIRECTORY_SEPARATOR.'downloads'
+            .DIRECTORY_SEPARATOR.'jobs';
+
+        // Create the "downloads/jobs" directory if it doesn't exist already
+        if (!is_dir($path)) {
+            mkdir($path, 0755, true);
+        }
+
+        return $path;
+    }
+
+    /**
+     * Create ZIP file from exported files.
+     *
+     * @param string   Path of file to write CSV data to
+     * @param bool  Optional: Whether to include digital objects
+     * @param mixed $tempDir
+     * @param mixed $userIsAdministrator
+     *
+     * @return array Error messages
+     */
+    public function createZipForDownload($tempDir, $userIsAdministrator)
+    {
+        $errors = [];
+
+        if (!is_writable($this->getJobsDownloadDirectory())) {
+            return [$this->i18n->__('Cannot write to directory')];
+        }
+
+        $zip = new ZipArchive();
+
+        if (
+            !$zip->open(
+                $this->getDownloadFilePath(),
+                ZipArchive::CREATE | ZipArchive::OVERWRITE
+            )
+        ) {
+            return [$this->i18n->__('Cannot create zip file')];
+        }
+
+        // Add exported files
+        $this->addFilesToZip($tempDir, $zip, $errors, $userIsAdministrator);
+
+        $zip->close();
+
+        return $errors;
+    }
+
+    /**
+     * Return the job's download file's relative path (or null if job doesn't
+     * create a download).
+     *
+     * @return string file path
+     */
+    public function getDownloadRelativeFilePath()
+    {
+        $downloadRelativeFilePath = null;
+
+        if (!is_null($this->downloadFileExtension)) {
+            $relativeBaseDir = 'downloads'.DIRECTORY_SEPARATOR.'jobs';
+            $downloadRelativeFilePath = $relativeBaseDir.DIRECTORY_SEPARATOR
+                .$this->getJobDownloadFilename();
+        }
+
+        return $downloadRelativeFilePath;
+    }
+
+    public function getUniqueFilename($filepath)
+    {
+        $filename = basename($filepath);
+
+        if (!isset($this->filenames[$filename])) {
+            // Filename not used yet - add to tracker
+            $this->filenames[$filename] = 0;
+
+            return $filename;
+        }
+
+        // Filename has been used - increment counter and append value to filename
+        $pathinfo = pathinfo($filename);
+
+        return sprintf(
+            '%s_%s.%s',
+            $pathinfo['filename'],
+            $this->filenames[$filename]++,
+            $pathinfo['extension']
+        );
+    }
+
+    protected function addFilesToZip($path, &$zip, &$errors, $userIsAdministrator)
+    {
+        foreach (scandir($path) as $file) {
+            if (is_dir($file)) {
+                continue;
+            }
+
+            try {
+                $zip->addFile($path.DIRECTORY_SEPARATOR.$file, $file);
+            } catch (Exception $e) {
+                if ($userIsAdministrator) {
+                    $errors[] = 'Exception: '.$e->getMessage();
+                } else {
+                    $errors[] = $this->i18n->__(
+                        'Sorry, but there was an error retrieving'
+                        .' a data file. This has stopped the export process.'
+                        .' Please contact an administrator.'
+                    );
+                }
+
+                break;
+            }
+        }
+    }
+
+    private function getJobDownloadFilename()
+    {
+        return md5($this->jobId).'.'.$this->downloadFileExtension;
+    }
+}

--- a/lib/task/import/csvCheckImportTask.class.php
+++ b/lib/task/import/csvCheckImportTask.class.php
@@ -139,10 +139,11 @@ EOF;
     protected function setCsvValidatorFilenames($filenameString)
     {
         // Could be a comma separated list of filenames or just one.
-        $filenames = explode(',', $filenameString);
-
-        foreach ($filenames as $filename) {
+        foreach (explode(',', $filenameString) as $filename) {
             CsvImportValidator::validateFileName($filename);
+            // The validator expects an associative array of files
+            // where displayname => filename
+            $filenames[$filename] = $filename;
         }
 
         return $filenames;

--- a/lib/task/import/validate/csvBaseValidator.class.php
+++ b/lib/task/import/validate/csvBaseValidator.class.php
@@ -35,6 +35,7 @@ abstract class CsvBaseValidator
     const LIMIT_TO = [];
 
     protected $filename = '';
+    protected $displayFilename = '';
     protected $columnCount = 0;
     protected $rowNumber = 1;
     protected $title = '';
@@ -48,7 +49,7 @@ abstract class CsvBaseValidator
             $this->setOptions($options);
         }
 
-        $this->testData = new CsvValidatorResult($this->title, $this->filename, $this->getClassName());
+        $this->testData = new CsvValidatorResult($this->title, $this->filename, $this->displayFilename, $this->getClassName());
     }
 
     public function testRow(array $header, array $row)
@@ -59,7 +60,8 @@ abstract class CsvBaseValidator
     public function reset()
     {
         $this->filename = '';
-        $this->testData = new CsvValidatorResult($this->title, $this->filename, $this->getClassName());
+        $this->displayFilename = '';
+        $this->testData = new CsvValidatorResult($this->title, $this->filename, $this->displayFilename, $this->getClassName());
     }
 
     public function setOrmClasses(array $classes)
@@ -78,9 +80,20 @@ abstract class CsvBaseValidator
         $this->testData->setFilename($filename);
     }
 
+    public function setDisplayFilename(string $displayFilename)
+    {
+        $this->displayFilename = $displayFilename;
+        $this->testData->setDisplayFilename($displayFilename);
+    }
+
     public function getFilename()
     {
         return $this->filename;
+    }
+
+    public function getDisplayFilename()
+    {
+        return $this->displayFilename;
     }
 
     public function setTitle(string $title)

--- a/lib/task/import/validate/csvValidatorCollection.php
+++ b/lib/task/import/validate/csvValidatorCollection.php
@@ -61,10 +61,18 @@ class CsvValidatorCollection
         }
     }
 
-    public function setFilename(string $filename)
+    public function reset()
+    {
+        foreach ($this->validators as $validator) {
+            $validator->reset();
+        }
+    }
+
+    public function setFilename(string $filename, string $displayFilename)
     {
         foreach ($this->validators as $validator) {
             $validator->setFilename($filename);
+            $validator->setDisplayFilename($displayFilename);
         }
     }
 
@@ -82,9 +90,11 @@ class CsvValidatorCollection
         }
     }
 
-    public function getResultCollection(): CsvValidatorResultCollection
+    public function getResultCollection(?CsvValidatorResultCollection $resultCollection = null): CsvValidatorResultCollection
     {
-        $resultCollection = new CsvValidatorResultCollection();
+        if (!isset($resultCollection)) {
+            $resultCollection = new CsvValidatorResultCollection();
+        }
 
         foreach ($this->validators as $validator) {
             $resultCollection->appendResult($validator->getTestResult());

--- a/lib/task/import/validate/csvValidatorResult.class.php
+++ b/lib/task/import/validate/csvValidatorResult.class.php
@@ -36,11 +36,13 @@ class CsvValidatorResult
 
     protected $testData = [];
     protected $filename;
+    protected $displayFilename;
     protected $classname;
 
-    public function __construct(string $title = '', string $filename = '', string $classname = '')
+    public function __construct(string $title = '', string $filename = '', string $displayFilename = '', string $classname = '')
     {
         $this->filename = $filename;
+        $this->displayFilename = $displayFilename;
         $this->classname = $classname;
 
         $this->testData = [
@@ -118,6 +120,16 @@ class CsvValidatorResult
     public function setFilename(string $filename)
     {
         $this->filename = $filename;
+    }
+
+    public function setDisplayFilename(string $displayFilename)
+    {
+        $this->displayFilename = $displayFilename;
+    }
+
+    public function getDisplayFilename(): string
+    {
+        return $this->displayFilename;
     }
 
     public function getClassname(): string

--- a/lib/task/migrate/migrations/arMigration0192.class.php
+++ b/lib/task/migrate/migrations/arMigration0192.class.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Modify database for caption/subtitle/chapter support.
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0192
+{
+    const VERSION = 192;
+    const MIN_MILESTONE = 2;
+
+    public function up($configuration)
+    {
+        // Add CSV Validator settings.
+        if (null === QubitSetting::getByName('csv_validator_default_import_behaviour')) {
+            $setting = new QubitSetting();
+            $setting->name = 'csv_validator_default_import_behaviour';
+            $setting->value = SettingsCsvValidatorAction::VALIDATOR_OFF;
+            $setting->editable = 1;
+            $setting->source_culture = 'en';
+            $setting->save();
+        }
+
+        // Add 'Validate CSV' menu item.
+        if (null === $menuItem = QubitMenu::getByName('validateCsv')) {
+            $menu = new QubitMenu();
+            $menu->parentId = QubitMenu::IMPORT_ID;
+            $menu->sourceCulture = 'en';
+            $menu->name = 'validateCsv';
+            $menu->label = 'Validate CSV';
+            $menu->path = 'object/validateCsv';
+            $menu->save();
+        }
+
+        return true;
+    }
+}

--- a/test/phpunit/csvImportValidator/CsvValidatorResultCollectionTest.php
+++ b/test/phpunit/csvImportValidator/CsvValidatorResultCollectionTest.php
@@ -16,13 +16,13 @@ class CsvValidatorResultCollectionTest extends \PHPUnit\Framework\TestCase
 
     public function testToArray()
     {
-        $result = new CsvValidatorResult('Title', 'Filename', 'Classname', true);
+        $result = new CsvValidatorResult('Title', 'Filename', 'DisplayFilename', 'Classname');
         $resultCollection = new CsvValidatorResultCollection();
         $resultCollection->appendResult($result);
 
         $this->assertSame(
             [
-                'Filename' => [
+                'DisplayFilename' => [
                     'Classname' => [
                         'title' => 'Title',
                         'status' => 0,
@@ -37,41 +37,41 @@ class CsvValidatorResultCollectionTest extends \PHPUnit\Framework\TestCase
 
     public function testToJson()
     {
-        $result = new CsvValidatorResult('Title', 'Filename', 'Classname', true);
+        $result = new CsvValidatorResult('Title', 'Filename', 'DisplayFilename', 'Classname');
         $resultCollection = new CsvValidatorResultCollection();
         $resultCollection->appendResult($result);
 
         $this->assertSame(
-            '{"Filename":{"Classname":{"title":"Title","status":0,"results":[],"details":[]}}}',
+            '{"DisplayFilename":{"Classname":{"title":"Title","status":0,"results":[],"details":[]}}}',
             $resultCollection->toJson()
         );
     }
 
     public function testGetErrorCount()
     {
-        $result = new CsvValidatorResult('Title', 'Filename', 'Classname', true);
+        $result = new CsvValidatorResult('Title', 'Filename', 'DisplayFilename', 'Classname');
         $result->setStatusError();
         $resultCollection = new CsvValidatorResultCollection();
         $resultCollection->appendResult($result);
 
-        $this->assertSame(1, $resultCollection->getErrorCount());
-        $this->assertSame(0, $resultCollection->getWarnCount());
+        $this->assertSame(1, $resultCollection->getErrorCount('Filename'));
+        $this->assertSame(0, $resultCollection->getWarnCount('Filename'));
     }
 
     public function testGetWarnCount()
     {
-        $result = new CsvValidatorResult('Title', 'Filename', 'Classname', true);
+        $result = new CsvValidatorResult('Title', 'Filename', 'DisplayFilename', 'Classname');
         $result->setStatusWarn();
         $resultCollection = new CsvValidatorResultCollection();
         $resultCollection->appendResult($result);
 
-        $this->assertSame(1, $resultCollection->getWarnCount());
-        $this->assertSame(0, $resultCollection->getErrorCount());
+        $this->assertSame(1, $resultCollection->getWarnCount('Filename'));
+        $this->assertSame(0, $resultCollection->getErrorCount('Filename'));
     }
 
     public function testRenderResultsAsText()
     {
-        $result = new CsvValidatorResult('Title', 'Filename', 'Classname', true);
+        $result = new CsvValidatorResult('Title', 'Filename', 'DisplayFilename', 'Classname');
         $result->setStatusWarn();
         $resultCollection = new CsvValidatorResultCollection();
         $resultCollection->appendResult($result);

--- a/test/phpunit/csvImportValidator/CsvValidatorResultTest.php
+++ b/test/phpunit/csvImportValidator/CsvValidatorResultTest.php
@@ -46,7 +46,7 @@ class CsvValidatorResultTest extends \PHPUnit\Framework\TestCase
         $csvValidator->setClassname('Classname');
         $this->assertSame('Classname', $csvValidator->getClassname());
 
-        $csvValidator = new CsvValidatorResult('Title', 'Filename', 'Classname');
+        $csvValidator = new CsvValidatorResult('Title', 'Filename', 'DisplayFilename', 'Classname');
         $this->assertSame('Classname', $csvValidator->getClassname());
     }
 


### PR DESCRIPTION
Add logic to CSV import background job to run the validator prior to import if configured. Also adds a dedicated 'Validate CSV' task that can be run from the WebUI. Depending on 'permissive' or 'strict' setting, the validator results will prevent the import from proceeding. The verbose validator report will be zipped and linked as a download from the import and validate job results.