### PR TITLE
Use render_value_html in alerts, refs #13495

### DIFF
--- a/apps/qubit/templates/_alerts.php
+++ b/apps/qubit/templates/_alerts.php
@@ -2,7 +2,7 @@
   <?php if ($sf_user->hasFlash($alertType)) { ?>
     <div class="alert alert-<?php echo $alertType; ?>">
       <button type="button" class="close" data-dismiss="alert">&times;</button>
-      <?php echo $sf_user->getFlash($alertType, ESC_RAW); ?>
+      <?php echo render_value_html($sf_user->getFlash($alertType)); ?>
     </div>
   <?php } ?>
 <?php } ?>

--- a/plugins/arDominionPlugin/css/less/scaffolding.less
+++ b/plugins/arDominionPlugin/css/less/scaffolding.less
@@ -2016,3 +2016,9 @@ body.login #content {
 blockquote p {
   font-size: inherit;
 }
+
+// Remove last paragraph margin in alerts
+
+div.alert > p:last-child {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
User input should not be used in flash alerts but that's hard to control.
By using `render_value_html` when Markdown support is enabled, even
with Parsedown's safeMode disabled, the content is sligthly sanitized.
This does not fully escape malicious code, specially with Markdown
disabled, but it mnay prevent XSS attacks in some cases.