### PR TITLE
Fix test for unreadable filename, refs #13492

### DIFF
--- a/test/phpunit/PhysicalobjectCsvImporterTest.php
+++ b/test/phpunit/PhysicalobjectCsvImporterTest.php
@@ -59,7 +59,7 @@ class PhysicalObjectCsvImporterTest extends \PHPUnit\Framework\TestCase
                 "\n",
                 $this->csvData + $this->csvData
             ),
-            'root.csv' => $this->csvData[0],
+            'unreadable.csv' => $this->csvData[0],
             'error.log' => '',
         ];
 
@@ -67,9 +67,9 @@ class PhysicalObjectCsvImporterTest extends \PHPUnit\Framework\TestCase
         $this->vfs = vfsStream::setup('root', null, $directory);
 
         // Make 'root.csv' owned and readable only by root user
-        $file = $this->vfs->getChild('root/root.csv');
+        $file = $this->vfs->getChild('root/unreadable.csv');
         $file->chmod('0400');
-        $file->chown(vfsStream::OWNER_ROOT);
+        $file->chown(vfsStream::OWNER_USER_1);
     }
 
     public function getCsvRowAsAssocArray($row = 0)
@@ -259,7 +259,7 @@ class PhysicalObjectCsvImporterTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(sfException::class);
         $importer = new PhysicalObjectCsvImporter($this->context, $this->vdbcon);
-        $importer->setFilename($this->vfs->url().'/root.csv');
+        $importer->setFilename($this->vfs->url().'/unreadable.csv');
     }
 
     public function testSetFilenameSuccess()


### PR DESCRIPTION
On Windows phpunit runs as the root user, so the virtual "root.csv" file
was readable, causing the test to fail. I've changed the name of the
virtual file to "unreadable.csv" and set the file owner to
vfsStream::OWNER_USER_1 to trigger the unreadable file exception in the
test.