### PR TITLE
Avoid routing exception in purge task, refs #13452

### DIFF
--- a/lib/task/tools/purgeTask.class.php
+++ b/lib/task/tools/purgeTask.class.php
@@ -87,6 +87,7 @@ class purgeTask extends installTask
         $validator = new sfValidatorUrl(['protocols' => ['http', 'https']]);
         $validator->clean($siteBaseUrl);
 
+        sfConfig::set('app_avoid_routing_propel_exceptions', true);
         $this->configuration = ProjectConfiguration::getApplicationConfiguration(
             'qubit',
             'cli',


### PR DESCRIPTION
Context creation causes route initialization, which hits the database.
As in the install task, this exception can be avoided with the
`app_avoid_routing_propel_exceptions` config setting.