### PR TITLE
Varnish cache bypass support, refs #13519

### DIFF
--- a/apps/qubit/modules/user/actions/loginAction.class.php
+++ b/apps/qubit/modules/user/actions/loginAction.class.php
@@ -68,6 +68,9 @@ class UserLoginAction extends sfAction
                         $this->getUser()->setFlash('notice', $this->getDraftNotificationText($draftCount));
                     }
 
+                    // Can be read by reverse proxies to allow users to bypass caching
+                    setcookie('atom_authenticated', '1', ['path' => '/']);
+
                     if (null !== $next = $this->form->getValue('next')) {
                         $this->redirect($next);
                     }

--- a/docker/etc/varnish/default.vcl
+++ b/docker/etc/varnish/default.vcl
@@ -11,9 +11,25 @@ sub vcl_recv {
     return (pass);
   }
 
-  # Set HTTP header to culture cookie value
+  # Do not cache login or logout requests
+  if (req.url ~ "/user/login" || req.url ~ "/user/logout") {
+    return (pass);
+  }
+
+  # Parse cookies so we can read their values
   cookie.parse(req.http.cookie);
+
+  # Set HTTP header to culture cookie value
   set req.http.X-Atom-Culture = cookie.get("atom_culture");
+
+  # If user was athenticated by AtoM then bypass cache
+  if (cookie.get("atom_authenticated") ~ "1") {
+    # Set fake header so vcl_backend_response can read
+    # (see https://varnish-cache.org/docs/trunk/reference/vmod_cookie.html)
+    set req.http.X-Atom-Authenticated = "1";
+
+    return (pass);
+  }
 
   # Do not cache clipboard POST request
   if (req.method == "POST" && req.url ~ "/clipboard/") {
@@ -31,9 +47,22 @@ sub vcl_hash {
 
 sub vcl_backend_response {
   # Allow cookie setting in culture change request
-  if (bereq.url !~ "sf_culture")  {
-    unset beresp.http.Set-Cookie;
+  if (bereq.url ~ "sf_culture")  {
+    return (deliver);
   }
+
+  # Allow cookie setting in login and logout actions
+  if (bereq.url ~ "/user/login" || bereq.url ~ "/user/logout")  {
+    return (deliver);
+  }
+
+  # Allow cookie setting if authenticated so AtoM can, if the user logs out,
+  # reset the "atom_authenticated" cookie
+  if (bereq.http.X-Atom-Authenticated ~ "1") {
+    return (deliver);
+  }
+
+  unset beresp.http.Set-Cookie;
 
   return (deliver);
 }

--- a/lib/myUser.class.php
+++ b/lib/myUser.class.php
@@ -48,7 +48,7 @@ class myUser extends sfBasicSecurityUser implements Zend_Acl_Role_Interface
             return;
         }
 
-        if ($this->isAuthenticated()) {
+        if ($isAuthenticated = $this->isAuthenticated()) {
             try {
                 $this->user = QubitUser::getById($this->getUserID());
             } catch (Exception $e) {
@@ -61,6 +61,12 @@ class myUser extends sfBasicSecurityUser implements Zend_Acl_Role_Interface
             if (null === $this->user || !$this->user->active) {
                 $this->signOut();
             }
+        }
+
+        // Allow reverse proxies to know, via the "atom_authenticated" cookie, if a user
+        // is authenticated and should be able to bypass the cache
+        if (!isset($_COOKIE['atom_authenticated']) || $_COOKIE['atom_authenticated'] != $isAuthenticated) {
+            setcookie('atom_authenticated', $isAuthenticated, ['path' => '/']);
         }
 
         // Allow reverse proxies to pass a header to change culture


### PR DESCRIPTION
Added setting of a cookie, when a user is logged in, to let a reverse proxy know to let the user bypass the cache. Updated Varnish VCL, for use with AtoM running via Docker, to allow cache bypassing.