### PR TITLE
Add CLI task to generate finding aids, refs #13500

### DIFF
--- a/apps/qubit/modules/informationobject/actions/deleteFindingAidAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/deleteFindingAidAction.class.php
@@ -34,9 +34,10 @@ class InformationObjectDeleteFindingAidAction extends sfAction
         }
 
         $this->form = new sfForm();
-        $this->path = arFindingAidJob::getFindingAidPathForDownload($this->resource->id);
-        $parts = explode(DIRECTORY_SEPARATOR, $this->path);
-        $this->filename = array_pop($parts);
+        $findingAid = new QubitFindingAid($this->resource);
+
+        $this->path = $findingAid->getPath();
+        $this->filename = basename($this->path);
 
         if ($request->isMethod('delete')) {
             $this->form->bind($request->getPostParameters());
@@ -46,13 +47,22 @@ class InformationObjectDeleteFindingAidAction extends sfAction
 
                 $params = [
                     'objectId' => $this->resource->id,
-                    'description' => $i18n->__('Deleting finding aid for: %1%', ['%1%' => $this->resource->getTitle(['cultureFallback' => true])]),
+                    'description' => $i18n->__(
+                        'Deleting finding aid for: %1%',
+                        [
+                            '%1%' => $this->resource->getTitle(
+                                ['cultureFallback' => true]
+                            ),
+                        ]
+                    ),
                     'delete' => true,
                 ];
 
                 QubitJob::runJob('arFindingAidJob', $params);
 
-                $this->redirect([$this->resource, 'module' => 'informationobject']);
+                $this->redirect(
+                    [$this->resource, 'module' => 'informationobject']
+                );
             }
         }
     }

--- a/apps/qubit/modules/informationobject/actions/findingAidLinkComponent.class.php
+++ b/apps/qubit/modules/informationobject/actions/findingAidLinkComponent.class.php
@@ -26,29 +26,32 @@ class InformationObjectFindingAidLinkComponent extends sfComponent
             $this->resource = $this->resource->getCollectionRoot();
         }
 
-        $this->path = arFindingAidJob::getFindingAidPathForDownload($this->resource->id);
+        $findingAid = new QubitFindingAid($this->resource);
+        $this->path = $findingAid->getPath();
+
         if (!isset($this->path)) {
-            return sfView::NONE;
+            return;
         }
 
-        $parts = explode(DIRECTORY_SEPARATOR, $this->path);
-        $this->filename = array_pop($parts);
+        $this->filename = basename($this->path);
 
-        $i18n = $this->context->i18n;
+        switch ((int) $findingAid->getStatus()) {
+            case QubitFindingAid::GENERATED_STATUS:
+                $this->label = $this->context->i18n->__(
+                    'Generated finding aid'
+                );
 
-        switch ((int) $this->resource->getFindingAidStatus()) {
-            case arFindingAidJob::GENERATED_STATUS:
-                $this->label = $i18n->__('Generated finding aid');
+                break;
 
-            break;
+            case QubitFindingAid::UPLOADED_STATUS:
+                $this->label = $this->context->i18n->__('Uploaded finding aid');
 
-            case arFindingAidJob::UPLOADED_STATUS:
-                $this->label = $i18n->__('Uploaded finding aid');
+                break;
 
-            break;
-            // It should never get here if we don't add more finding aid statuses
             default:
-                $this->label = $i18n->__('Finding aid');
+                // It should never get here if we don't add more finding aid
+                // statuses
+                $this->label = $this->context->i18n->__('Finding aid');
         }
     }
 }

--- a/apps/qubit/modules/informationobject/actions/generateFindingAidAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/generateFindingAidAction.class.php
@@ -28,21 +28,23 @@ class InformationObjectGenerateFindingAidAction extends sfAction
             $this->forward404();
         }
 
-        // Check user authorization
-        if (!QubitAcl::check($this->resource, 'update')) {
-            QubitAcl::forwardUnauthorized();
-        }
-
         // Check if a finding aid file already exists
-        if (null !== arFindingAidJob::getFindingAidPathForDownload($this->resource->id)) {
+        $findingAid = new QubitFindingAid($this->resource);
+
+        if (!empty($findingAid->getPath())) {
             $this->redirect([$this->resource, 'module' => 'informationobject']);
         }
 
-        $i18n = $this->context->i18n;
-
         $params = [
             'objectId' => $this->resource->id,
-            'description' => $i18n->__('Generating finding aid for: %1%', ['%1%' => $this->resource->getTitle(['cultureFallback' => true])]),
+            'description' => $this->context->i18n->__(
+                'Generating finding aid for: %1%',
+                [
+                    '%1%' => $this->resource->getTitle(
+                        ['cultureFallback' => true]
+                    ),
+                ]
+            ),
         ];
 
         QubitJob::runJob('arFindingAidJob', $params);

--- a/lib/QubitFindingAid.class.php
+++ b/lib/QubitFindingAid.class.php
@@ -1,0 +1,441 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Manage Finding Aid documents.
+ *
+ * @author David Juhasz <djjuhasz@gmail.com>
+ */
+class QubitFindingAid
+{
+    public const GENERATED_STATUS = 1;
+    public const UPLOADED_STATUS = 2;
+
+    private $format;
+    private $homeDir;
+    private $logger;
+    private $resource;
+    private $options;
+    private $path;
+
+    // Default options
+    private $defaults = [
+        'logger' => null,
+    ];
+
+    public function __construct(
+        QubitInformationObject $resource,
+        array $options = []
+    ) {
+        $this->setResource($resource);
+
+        // Fill options array with default values if explicit $options not
+        // passed
+        $options = array_merge($this->defaults, $options);
+
+        // Set logger (use default symfony logger if $option['logger'] is not
+        // set)
+        $this->setLogger($options['logger']);
+
+        // Set Finding Aid home directory
+        $this->setHomeDir($options['homeDir']);
+    }
+
+    /**
+     * Set the finding aid's primary (top-level) information object.
+     */
+    public function setResource(QubitInformationObject $resource): void
+    {
+        // Make sure $resource is not the QubitInformationObject root
+        if (QubitInformationObject::ROOT_ID === $resource->id) {
+            throw new UnexpectedValueException(
+                sprintf(
+                    'Invalid QubitInformationObject id: %s',
+                    QubitInformationObject::ROOT_ID
+                )
+            );
+        }
+
+        $this->resource = $resource;
+    }
+
+    /**
+     * Get the finding aid's primary information object.
+     */
+    public function getResource(): QubitInformationObject
+    {
+        return $this->resource;
+    }
+
+    /**
+     * Set a logger, or use the default symfony logger.
+     */
+    public function setLogger(?sfLogger $logger): void
+    {
+        // Use the passed logger
+        if (!empty($logger)) {
+            $this->logger = $logger;
+
+            return;
+        }
+
+        // Or default to the configured symfony logger
+        $this->logger = sfContext::getInstance()->getLogger();
+    }
+
+    /**
+     * Get the current logger.
+     */
+    public function getLogger(): ?sfLogger
+    {
+        return $this->logger;
+    }
+
+    /**
+     * Set the home directory for finding aid files.
+     */
+    public function setHomeDir(?string $dir): void
+    {
+        if (isset($dir)) {
+            $this->homeDir = $dir;
+
+            return;
+        }
+
+        // Default finding aid home directory
+        $this->homeDir = sfConfig::get('sf_web_dir').'/downloads/';
+    }
+
+    /**
+     * Get the home directory for finding aid files.
+     *
+     * @param bool $absolute return absolute path if true (default), relative
+     *                       path if false
+     */
+    public function getHomeDir(?bool $absolute = true): string
+    {
+        // Return absolute (filesystem) path
+        if (true === $absolute) {
+            return $this->homeDir;
+        }
+
+        // Return relative path to file
+        return str_replace(sfConfig::get('sf_web_dir').'/', '', $this->homeDir);
+    }
+
+    /**
+     * Get possible file names for the finding aid.
+     *
+     * @return array of possible filenames
+     */
+    public function getPossibleFilenames(): array
+    {
+        $filenames = [
+            $this->resource->id.'.pdf',
+            $this->resource->id.'.rtf',
+        ];
+
+        if (null !== $this->resource->slug) {
+            $filenames[] = $this->resource->slug.'.pdf';
+            $filenames[] = $this->resource->slug.'.rtf';
+        }
+
+        return $filenames;
+    }
+
+    /**
+     * Set the path for the finding aid file.
+     *
+     * @param mixed $path
+     */
+    public function setPath($path)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * Get the relative path for the finding aid file.
+     *
+     * If $this->path has no value, check the list of possible finding aid file
+     * names for a matching file name on the filesystem.
+     *
+     * @return null|string path to finding aid file
+     */
+    public function getPath()
+    {
+        if (!isset($this->path)) {
+            foreach (self::getPossibleFilenames() as $filename) {
+                if (file_exists($this->getHomeDir().$filename)) {
+                    // Set relative path to file
+                    $this->path = $this->getHomeDir(false).$filename;
+                }
+            }
+        }
+
+        return $this->path;
+    }
+
+    /**
+     * Get the Finding Aid file format.
+     *
+     * @return string file extension (e.g. "pdf", "rtf")
+     */
+    public function getFormat(): string
+    {
+        // If not set, try and determine the format from the file extension
+        if (!isset($this->format) && !empty($this->getPath())) {
+            $this->format = strtolower(
+                pathinfo($this->getPath(), PATHINFO_EXTENSION)
+            );
+        }
+
+        return $this->format;
+    }
+
+    /**
+     * Set the Finding Aid status.
+     *
+     * @param $status either self::GENERATED_STATUS or self::UPLOADED_STATUS
+     */
+    public function setStatus(int $status): void
+    {
+        // Search for an existing 'findingAidStatus' property
+        $criteria = new Criteria();
+        $criteria->add(QubitProperty::OBJECT_ID, $this->resource->id);
+        $criteria->add(QubitProperty::NAME, 'findingAidStatus');
+
+        // Create a related 'findingAidStatus' QubitProperty if this resource
+        // doesn't already have one
+        if (null === $property = QubitProperty::getOne($criteria)) {
+            $property = new QubitProperty();
+            $property->objectId = $this->resource->id;
+            $property->name = 'findingAidStatus';
+        }
+
+        // Set the status
+        $property->setValue($status, ['sourceCulture' => true]);
+        $property->indexOnSave = false;
+        $property->save();
+
+        // Update ES document with finding aid status
+        $partialData = [
+            'findingAid' => [
+                'status' => $status,
+            ],
+        ];
+
+        QubitSearch::getInstance()->partialUpdate(
+            $this->resource, $partialData
+        );
+    }
+
+    /**
+     * Set the Finding Aid status.
+     */
+    public function getStatus(): ?int
+    {
+        $criteria = new Criteria();
+        $criteria->add(QubitProperty::OBJECT_ID, $this->resource->id);
+        $criteria->add(QubitProperty::NAME, 'findingAidStatus');
+        $property = QubitProperty::getOne($criteria);
+
+        if (!isset($property)) {
+            return null;
+        }
+
+        return $property->getValue(['sourceCulture' => true]);
+    }
+
+    /**
+     * Delete the finding aid file and data.
+     *
+     * @return true on success
+     */
+    public function delete(): ?bool
+    {
+        $this->logger->info(
+            sprintf('Deleting finding aid (%s)...', $this->resource->slug)
+        );
+
+        if (!empty($this->getPath()) && file_exists($this->getPath())) {
+            unlink($this->getPath());
+        }
+
+        // Delete 'findingAidTranscript' property if it exists
+        $criteria = new Criteria();
+        $criteria->add(QubitProperty::OBJECT_ID, $this->resource->id);
+        $criteria->add(QubitProperty::NAME, 'findingAidTranscript');
+        $criteria->add(
+            QubitProperty::SCOPE,
+            'Text extracted from finding aid PDF file text layer using'.
+            ' pdftotext'
+        );
+
+        if (null !== $property = QubitProperty::getOne($criteria)) {
+            $this->logger->info('Deleting finding aid transcript...');
+
+            $property->indexOnDelete = false;
+            $property->delete();
+        }
+
+        // Delete 'findingAidStatus' property if it exists
+        $criteria = new Criteria();
+        $criteria->add(QubitProperty::OBJECT_ID, $this->resource->id);
+        $criteria->add(QubitProperty::NAME, 'findingAidStatus');
+
+        if (null !== $property = QubitProperty::getOne($criteria)) {
+            $property->indexOnDelete = false;
+            $property->delete();
+        }
+
+        // Update ES document removing finding aid status and transcript
+        $partialData = [
+            'findingAid' => [
+                'transcript' => null,
+                'status' => null,
+            ],
+        ];
+
+        QubitSearch::getInstance()->partialUpdate(
+            $this->resource, $partialData
+        );
+
+        $this->logger->info('Finding aid deleted successfully.');
+
+        return true;
+    }
+
+    /**
+     * Add finding aid data for an uploaded finding aid.
+     *
+     * @param $path to the uploaded finding aid file (the file should already be
+     *              named correctly and be in the "downloads/" directory)
+     *
+     * @return true on success
+     */
+    public function upload(string $path): ?bool
+    {
+        $this->logger->info(
+            sprintf('Uploading finding aid (%s)...', $this->resource->slug)
+        );
+
+        // Ensure 'downloads' directory exists
+        Qubit::createDownloadsDirIfNeeded();
+
+        // Set status
+        $this->setStatus(self::UPLOADED_STATUS);
+
+        $this->logger->info(
+            sprintf('Finding aid uploaded successfully: %s', $path)
+        );
+
+        // Extract finding aid transcript
+        $transcript = $this->extractTranscript();
+
+        if (!empty($transcript)) {
+            // Write transcript to database
+            $this->saveTranscript($transcript);
+
+            // Update partial data with transcript
+            $partialData['findingAid']['transcript'] = $transcript;
+        }
+
+        // Update ES document with finding aid status and transcript
+        QubitSearch::getInstance()->partialUpdate(
+            $this->resource, $partialData
+        );
+
+        return true;
+    }
+
+    /**
+     * Extract PDF text.
+     */
+    public function extractTranscript(): ?string
+    {
+        $mimeType = 'application/'.$this->getFormat();
+
+        if (!QubitDigitalObject::canExtractText($mimeType)) {
+            $this->logger->info(
+                sprintf(
+                    'Can not extract finding aid text for mime type "%s"',
+                    $mimeType
+                )
+            );
+
+            return null;
+        }
+
+        $this->logger->info('Extracting finding aid text...');
+
+        $command = sprintf('pdftotext %s - 2> /dev/null', $path);
+        exec($command, $output, $status);
+
+        if (0 !== $status) {
+            $this->logger->warning(
+                'WARNING(PDFTOTEXT) Extracting finding aid text has failed'
+            );
+
+            return null;
+        }
+
+        if (0 === count($output)) {
+            $this->logger->info(
+                'No finding aid text found in document'
+            );
+
+            return null;
+        }
+
+        $text = implode(PHP_EOL, $output);
+
+        // Truncate PDF text to <64KB to fit in `property.value` column
+        return mb_strcut($text, 0, 65535);
+    }
+
+    /**
+     * Save transcript text to `property` table.
+     *
+     * @param $text the transcript text
+     */
+    public function saveTranscript(string $text): void
+    {
+        // Update or create 'findingAidTranscript' property
+        $criteria = new Criteria();
+        $criteria->add(QubitProperty::OBJECT_ID, $this->resource->id);
+        $criteria->add(QubitProperty::NAME, 'findingAidTranscript');
+        $criteria->add(
+            QubitProperty::SCOPE,
+            'Text extracted from finding aid PDF file text layer using'.
+            ' pdftotext'
+        );
+
+        if (null === $property = QubitProperty::getOne($criteria)) {
+            $property = new QubitProperty();
+            $property->objectId = $this->resource->id;
+            $property->name = 'findingAidTranscript';
+            $property->scope = 'Text extracted from finding aid PDF file text'.
+                ' layer using pdftotext';
+        }
+
+        $property->setValue($text, ['sourceCulture' => true]);
+        $property->indexOnSave = false;
+        $property->save();
+    }
+}

--- a/lib/QubitFindingAidGenerator.class.php
+++ b/lib/QubitFindingAidGenerator.class.php
@@ -1,0 +1,564 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Generate a Finding Aid.
+ *
+ * @author David Juhasz <djjuhasz@gmail.com>
+ */
+class QubitFindingAidGenerator
+{
+    public const XML_STANDARD = 'ead';
+    public const SAXON_PATH = 'lib/task/pdf/saxon9he.jar';
+
+    private $appRoot;
+    private $format;
+    private $logger;
+    private $resource;
+    private $options;
+    private $path;
+
+    // Valid finding aid file formats
+    private static $formats = [
+        'pdf',
+        'rtf',
+    ];
+
+    // Valid finding aid "models"
+    private $models = [
+        'inventory-summary',
+        'full-details',
+    ];
+
+    // Default options
+    private $defaults = [
+        'appRoot' => null,
+        'logger' => null,
+        'format' => 'pdf',
+        'model' => 'inventory-summary',
+    ];
+
+    public function __construct(
+        QubitInformationObject $resource,
+        ?array $options = []
+    ) {
+        $this->setResource($resource);
+
+        // Fill options array with default values if explicit $options not
+        // passed
+        $options = array_merge($this->defaults, $options);
+
+        $this->setAppRoot($options['appRoot']);
+        $this->setFormat($options['format']);
+        $this->setLogger($options['logger']);
+        $this->setModel($options['model']);
+    }
+
+    /**
+     * Set the finding aid's primary (top-level) information object.
+     */
+    public function setResource(QubitInformationObject $resource): void
+    {
+        // Make sure $resource is not the QubitInformationObject root
+        if (QubitInformationObject::ROOT_ID === $resource->id) {
+            throw new UnexpectedValueException(
+                sprintf(
+                    'Invalid QubitInformationObject id: %s',
+                    QubitInformationObject::ROOT_ID
+                )
+            );
+        }
+
+        $this->resource = $resource;
+    }
+
+    /**
+     * Get the finding aid's primary information object.
+     */
+    public function getResource(): QubitInformationObject
+    {
+        return $this->resource;
+    }
+
+    /**
+     * Set a logger, or use the default symfony logger.
+     */
+    public function setLogger(?sfLogger $logger): void
+    {
+        // Use the passed logger
+        if (!empty($logger)) {
+            $this->logger = $logger;
+
+            return;
+        }
+
+        // Or default to the configured symfony logger
+        $this->logger = sfContext::getInstance()->getLogger();
+    }
+
+    /**
+     * Get the current logger.
+     */
+    public function getLogger(): ?sfLogger
+    {
+        return $this->logger;
+    }
+
+    /**
+     * Set the application root directory, or use symfony's sf_root_dir value.
+     */
+    public function setAppRoot(?string $appRoot): void
+    {
+        // If $appRoot is set, use the passed value
+        if (!empty($appRoot)) {
+            $this->appRoot = $appRoot;
+
+            return;
+        }
+
+        // Default to the symfony sf_root_dir config setting, if not explicitly set
+        $this->appRoot = rtrim(sfConfig::get('sf_root_dir'), '/');
+    }
+
+    /**
+     * Get the application root directory.
+     */
+    public function getAppRoot(): string
+    {
+        return $this->appRoot;
+    }
+
+    /**
+     * Set the finding aid format (rtf, pdf).
+     */
+    public function setFormat(string $format): void
+    {
+        if (!in_array($format, self::$formats)) {
+            throw new UnexpectedValueException(
+                sprintf(
+                    'Invalid format "%s", must be one of (%s)',
+                    $format,
+                    implode(', ', self::$formats)
+                )
+            );
+        }
+
+        $this->format = $format;
+    }
+
+    /**
+     * Get the finding aid format.
+     */
+    public function getFormat(): string
+    {
+        return $this->format;
+    }
+
+    /**
+     * Set the finding aid model.
+     */
+    public function setModel(string $model): void
+    {
+        if (!in_array($model, $this->models)) {
+            throw new UnexpectedValueException(
+                sprintf(
+                    'Invalid model "%s", must be one of (%s)',
+                    $model,
+                    implode(', ', $this->models)
+                )
+            );
+        }
+
+        $this->model = $model;
+    }
+
+    /**
+     * Get the finding aid model.
+     */
+    public function getModel(): string
+    {
+        return $this->model;
+    }
+
+    /**
+     * Check if XML caching is enabled.
+     */
+    public function isXmlCachingEnabled(): bool
+    {
+        return sfConfig::get('app_cache_xml_on_save', false);
+    }
+
+    /**
+     * Generate the finding aid document.
+     */
+    public function generate()
+    {
+        // Delete existing finding aid linked to this resource
+        $findingAid = new QubitFindingAid($this->resource);
+
+        if (null !== $findingAid->getPath()) {
+            $this->logger->info(
+                sprintf(
+                    'Deleting existing finding aid (%s)',
+                    $findingAid->getPath()
+                )
+            );
+
+            $findingAid->delete();
+        }
+
+        $this->logger->info(
+            sprintf('Generating finding aid (%s)...', $this->resource->slug)
+        );
+
+        // Ensure 'downloads' directory exists
+        Qubit::createDownloadsDirIfNeeded();
+
+        // Get the path to this resource's cached EAD file, if caching is enabled
+        $eadFilePath = $this->getEadCacheFilePath();
+
+        // Generate an EAD file, if there is no cached EAD file
+        if (empty($eadFilePath)) {
+            $eadFilePath = $this->generateEadFile();
+        }
+
+        $foFilePath = $this->generateXslFoFile($eadFilePath);
+        $this->path = $this->generateFindingAid($foFilePath);
+
+        $findingAid = new QubitFindingAid($this->resource);
+        $findingAid->setPath($this->path);
+        $findingAid->setStatus(QubitFindingAid::GENERATED_STATUS);
+
+        $this->logger->info(
+            sprintf('Finding aid generated successfully: %s', $this->path)
+        );
+
+        // Delete temporary files
+        unlink($foFilePath);
+
+        // Only delete the EAD file if XML caching is disabled, so we don't delete
+        // the cache file
+        if (!$this->isXmlCachingEnabled()) {
+            unlink($eadFilePath);
+        }
+
+        return $findingAid;
+    }
+
+    /**
+     * Generate and cache an XML representation of $this->resource.
+     */
+    public function generateEadCacheFile(): string
+    {
+        $cacher = new QubitInformationObjectXmlCache(
+            ['logger' => $this->logger]
+        );
+
+        $cacher->export($this->resource, self::XML_STANDARD);
+
+        // Return cached file path
+        return $cacher::resourceExportFilePath(
+            $this->resource, self::XML_STANDARD
+        );
+    }
+
+    /**
+     * Get the path to the cached XML file for this resource.
+     *
+     * @return null|string path to cache file, null if there is none
+     */
+    public function getEadCacheFilePath(): ?string
+    {
+        // If XML caching is disabled, then don't look for a cache file
+        if (!$this->isXmlCachingEnabled()) {
+            return null;
+        }
+
+        $filepath = QubitInformationObjectXmlCache::resourceExportFilePath(
+            $this->resource, self::XML_STANDARD
+        );
+
+        if (!empty($filepath) && file_exists($filepath)) {
+            return $filepath;
+        }
+
+        // If a cached file doesn't exist already, attempt to generate one and
+        // return the file path
+        return $this->generateEadCacheFile();
+    }
+
+    /**
+     * Get the correct XLST file path for the current Finding Aid model.
+     */
+    public function getXslFilePath(): string
+    {
+        return $this->getAppRoot().
+            sprintf('/lib/task/pdf/ead-pdf-%s.xsl', $this->getModel());
+    }
+
+    /**
+     * Get the absolute path of the saxon9he.jar.
+     */
+    public function getSaxonPath(): string
+    {
+        return $this->getAppRoot().'/'.self::SAXON_PATH;
+    }
+
+    /**
+     * Generate an EAD XML file and return the file path.
+     *
+     * @return string Generated EAD XML file path
+     */
+    public function generateEadFile(): string
+    {
+        exportBulkBaseTask::includeXmlExportClassesAndHelpers();
+
+        try {
+            // Print warnings/notices here too, as they are often important.
+            $errLevel = error_reporting(E_ALL);
+
+            $rawXml = exportBulkBaseTask::captureResourceExportTemplateOutput(
+                $this->resource, 'ead'
+            );
+            $xml = Qubit::tidyXml($rawXml);
+
+            error_reporting($errLevel);
+        } catch (Exception $e) {
+            throw new sfException($this->i18n->__(
+                "Error generating EAD XML for '%1%.'",
+                ['%1%' => $this->resource->slug]
+            ));
+        }
+
+        $filename = exportBulkBaseTask::generateSortableFilename(
+            $this->resource, 'xml', 'ead'
+        );
+
+        $filepath = sys_get_temp_dir().DIRECTORY_SEPARATOR.$filename;
+
+        if (false === file_put_contents($filepath, $xml)) {
+            throw new sfException(
+                sprintf(
+                    'ERROR (EAD-EXPORT): Couldn\'t write file: "%s"',
+                    $filepath
+                )
+            );
+        }
+
+        // Log successful EAD generation
+        $this->logger->info(sprintf('Generated EAD file "%s"', $filepath));
+
+        return $filepath;
+    }
+
+    /**
+     * Apache FOP requires certain namespaces to be included in the XML in order
+     * to process it.
+     */
+    public function addEadNamespaces(string $filename, string $url = null): void
+    {
+        $content = file_get_contents($filename);
+
+        $eadHeader = <<<'EOL'
+<ead xmlns:ns2="http://www.w3.org/1999/xlink" xmlns="urn:isbn:1-931666-22-9"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+EOL;
+
+        $content = preg_replace('(<ead .*?>|<ead>)', $eadHeader, $content, 1);
+
+        file_put_contents($filename, $content);
+    }
+
+    /**
+     * Generate an XSL-FO file and return the file path.
+     *
+     * @return string path to the generated file
+     */
+    public function generateXslFoFile(string $eadFilePath): string
+    {
+        // Replace {{ app_root }} placeholder var with the appRoot value, and
+        // return the temp XSL file path for Saxon processing
+        $xslTmpPath = $this->renderXsl(
+            $this->getXslFilePath(),
+            ['app_root' => $this->getAppRoot()]
+        );
+
+        // Add required namespaces to EAD header
+        $this->addEadNamespaces($eadFilePath);
+
+        // Get a temporary file path for the FO file
+        $foFilePath = tempnam(sys_get_temp_dir(), 'ATM');
+
+        $cmd = sprintf(
+            "java -jar '%s' -s:'%s' -xsl:'%s' -o:'%s' 2>&1",
+            $this->getSaxonPath(), $eadFilePath, $xslTmpPath, $foFilePath
+        );
+
+        $this->logger->info(sprintf('Running: %s', $cmd));
+
+        exec($cmd, $output, $exitCode);
+
+        if ($exitCode > 0) {
+            $this->logger->err(
+                'ERROR(SAXON): Transforming the EAD with Saxon has failed.'
+            );
+
+            throw new Exception('ERROR(SAXON): '.implode("\n", $output));
+        }
+
+        return $foFilePath;
+    }
+
+    /**
+     * Replace XSL template variables at run time.
+     *
+     * @param string $filename path to XSL template file
+     * @param array  $vars     template variables to replace
+     *
+     * @return string path to rendered XSL file
+     */
+    public function renderXsl(string $filename, array $vars): string
+    {
+        // Get XSL file contents
+        $content = file_get_contents($filename);
+
+        // Replace placeholder vars (e.g. "{{ app_root }}")
+        foreach ($vars as $key => $val) {
+            $content = str_replace("{{ {$key} }}", $val, $content);
+        }
+
+        // Write contents to temp file for processing with Saxon
+        $tmpFilePath = tempnam(sys_get_temp_dir(), 'ATM');
+
+        $this->logger->info(
+            sprintf(
+                "Rendering XSL template '%s' to '%s'",
+                $filename,
+                $tmpFilePath
+            )
+        );
+
+        file_put_contents($tmpFilePath, $content);
+
+        return $tmpFilePath;
+    }
+
+    /**
+     * Generate the finding aid document with Apache FOP.
+     *
+     * @param string $foFilePath FO file path
+     *
+     * @return string Finding Aid path
+     */
+    public function generateFindingAid(string $foFilePath): string
+    {
+        $findingAidPath = sfConfig::get('sf_web_dir').DIRECTORY_SEPARATOR.
+            self::generatePath($this->resource, $this->getFormat());
+
+        // Use FO file generated in previous step to generate finding aid
+        $cmd = sprintf(
+            "fop -r -q -fo '%s' -%s '%s' 2>&1",
+            $foFilePath, $this->getFormat(),
+            $findingAidPath
+        );
+
+        $this->logger->info(sprintf('Running: %s', $cmd));
+
+        $output = [];
+
+        exec($cmd, $output, $exitCode);
+
+        if (0 != $exitCode) {
+            $this->logger->err(
+                sprintf(
+                    'Converting the XSL-FO document to a %s file has failed.',
+                    $this->getFormat()
+                )
+            );
+
+            throw new Exception('ERROR(FOP): '.implode("\n", $output));
+        }
+
+        return $findingAidPath;
+    }
+
+    /**
+     * Generate a path and file name for a finding aid for $resource.
+     *
+     * @return string file path for finding aid
+     */
+    public static function generatePath(
+        QubitInformationObject $resource,
+        ?string $format = null
+    ): string {
+        if (null === $format) {
+            $format = self::getFormatSetting();
+        }
+
+        if (!in_array($format, self::$formats)) {
+            throw sfException(
+                sprintf(
+                    "Invalid format '%s', must be one of (%s).",
+                    $format,
+                    self::$formats
+                )
+            );
+        }
+
+        $filename = $resource->slug;
+
+        if (empty($filename)) {
+            $filename = $resource->id;
+        }
+
+        return sprintf(
+            'downloads'.DIRECTORY_SEPARATOR.'%s.%s',
+            $filename,
+            $format
+        );
+    }
+
+    /**
+     * Get the system setting for the format used to generate finding aids.
+     *
+     * @return string pdf (default) or rtf file format
+     */
+    public static function getFormatSetting(): string
+    {
+        if (null !== $setting = QubitSetting::getByName('findingAidFormat')) {
+            $value = $setting->getValue(['sourceCulture' => true]);
+        }
+
+        return isset($value) ? $value : 'pdf';
+    }
+
+    /**
+     * Get the system setting for the model used to generate finding aids.
+     *
+     * @return string "inventory-summary" (default) or "full-details"
+     */
+    public static function getModelSetting(): string
+    {
+        if (null !== $setting = QubitSetting::getByName('findingAidModel')) {
+            $value = $setting->getValue(['sourceCulture' => true]);
+        }
+
+        return isset($value) ? $value : 'inventory-summary';
+    }
+}

--- a/lib/job/arFindingAidJob.class.php
+++ b/lib/job/arFindingAidJob.class.php
@@ -18,13 +18,12 @@
  */
 
 /**
+ * Finding aid job manager.
+ *
  * @author     Mike G <mikeg@artefactual.com>
  */
 class arFindingAidJob extends arBaseJob
 {
-    public const GENERATED_STATUS = 1;
-    public const UPLOADED_STATUS = 2;
-
     /**
      * @see arBaseJob::$requiredParameters
      */
@@ -44,14 +43,20 @@ class arFindingAidJob extends arBaseJob
             return false;
         }
 
-        Qubit::createDownloadsDirIfNeeded();
-
         if (isset($parameters['delete']) && $parameters['delete']) {
-            $result = $this->delete();
+            $findingAid = new QubitFindingAid($this->resource);
+            $findingAid->setLogger($this->logger);
+            $result = $findingAid->delete();
         } elseif (isset($parameters['uploadPath'])) {
-            $result = $this->upload($parameters['uploadPath']);
+            $findingAid = new QubitFindingAid($this->resource);
+            $findingAid->setLogger($this->logger);
+            $result = $findingAid->upload($parameters['uploadPath']);
         } else {
-            $result = $this->generate();
+            $generator = new QubitFindingAidGenerator($this->resource);
+            $generator->setLogger($this->logger);
+            $generator->setFormat(QubitFindingAidGenerator::getFormatSetting());
+            $generator->setModel(QubitFindingAidGenerator::getModelSetting());
+            $result = $generator->generate();
         }
 
         if (!$result) {
@@ -66,371 +71,13 @@ class arFindingAidJob extends arBaseJob
 
     public static function getStatus($id)
     {
-        $sql = 'SELECT j.status_id as statusId FROM
-            job j JOIN object o ON j.id = o.id
+        $sql = 'SELECT j.status_id as statusId
+            FROM job j JOIN object o ON j.id = o.id
             WHERE j.name = ? AND j.object_id = ?
             ORDER BY o.created_at DESC';
 
         $ret = QubitPdo::fetchOne($sql, [get_class(), $id]);
 
         return $ret ? (int) $ret->statusId : null;
-    }
-
-    public static function getPossibleFilenames($id)
-    {
-        $filenames = [
-            $id.'.pdf',
-            $id.'.rtf',
-        ];
-
-        if (null !== $slug = QubitSlug::getByObjectId($id)) {
-            $filenames[] = $slug->slug.'.pdf';
-            $filenames[] = $slug->slug.'.rtf';
-        }
-
-        return $filenames;
-    }
-
-    public static function getFindingAidPathForDownload($id)
-    {
-        foreach (self::getPossibleFilenames($id) as $filename) {
-            $path = 'downloads'.DIRECTORY_SEPARATOR.$filename;
-
-            if (file_exists(sfConfig::get('sf_web_dir').DIRECTORY_SEPARATOR.$path)) {
-                return $path;
-            }
-        }
-
-        return null;
-    }
-
-    public static function getFindingAidPath($id)
-    {
-        if (null !== $slug = QubitSlug::getByObjectId($id)) {
-            $filename = $slug->slug;
-        }
-
-        if (!isset($filename)) {
-            $filename = $id;
-        }
-
-        return 'downloads'.DIRECTORY_SEPARATOR.$filename.'.'.self::getFindingAidFormat();
-    }
-
-    public static function getFindingAidFormat()
-    {
-        if (null !== $setting = QubitSetting::getByName('findingAidFormat')) {
-            $format = $setting->getValue(['sourceCulture' => true]);
-        }
-
-        return isset($format) ? $format : 'pdf';
-    }
-
-    private function generate()
-    {
-        $this->info($this->i18n->__('Generating finding aid (%1)...', ['%1' => $this->resource->slug]));
-
-        $this->appRoot = rtrim(sfConfig::get('sf_root_dir'), '/');
-
-        $eadFileHandle = tmpfile();
-        $foFileHandle = tmpfile();
-
-        if (!$eadFileHandle || !$foFileHandle) {
-            $this->error($this->i18n->__('Failed to create temporary file.'));
-
-            return false;
-        }
-
-        $eadFilePath = $this->getTmpFilePath($eadFileHandle);
-        $foFilePath = $this->getTmpFilePath($foFileHandle);
-
-        unlink($eadFilePath);
-
-        $public = '';
-        if (
-            (null !== $setting = QubitSetting::getByName('publicFindingAid'))
-            && $setting->getValue(['sourceCulture' => true])
-        ) {
-            $public = '--public';
-        }
-
-        // Call generate EAD task
-        $slug = $this->resource->slug;
-        $output = [];
-        exec(PHP_BINARY." {$this->appRoot}/symfony export:bulk --single-slug=\"{$slug}\" {$public} {$eadFilePath} 2>&1", $output, $exitCode);
-
-        if ($exitCode > 0) {
-            $this->error($this->i18n->__('Exporting EAD has failed.'));
-            $this->logCmdOutput($output, 'ERROR(EAD-EXPORT)');
-
-            return false;
-        }
-
-        // Use XSL file selected in Finding Aid model setting
-        $findingAidModel = 'inventory-summary';
-        if (null !== $setting = QubitSetting::getByName('findingAidModel')) {
-            $findingAidModel = $setting->getValue(['sourceCulture' => true]);
-        }
-
-        $eadXslFilePath = $this->appRoot.'/lib/task/pdf/ead-pdf-'.$findingAidModel.'.xsl';
-        $saxonPath = $this->appRoot.'/lib/task/pdf/saxon9he.jar';
-
-        // Crank the XML through XSL stylesheet and fix header / fonds URL
-        $eadFileString = file_get_contents($eadFilePath);
-        $eadFileString = $this->fixHeader($eadFileString, sfConfig::get('app_site_base_url', null));
-        file_put_contents($eadFilePath, $eadFileString);
-
-        // Replace {{ app_root }} placeholder var with the $this->appRoot value, and
-        // return the temp XSL file path for Saxon processing
-        $xslTmpPath = $this->renderXsl(
-            $eadXslFilePath,
-            ['app_root' => $this->appRoot]
-        );
-
-        // Transform EAD file with Saxon
-        $pdfPath = sfConfig::get('sf_web_dir').DIRECTORY_SEPARATOR.self::getFindingAidPath($this->resource->id);
-        $cmd = sprintf("java -jar '%s' -s:'%s' -xsl:'%s' -o:'%s' 2>&1", $saxonPath, $eadFilePath, $xslTmpPath, $foFilePath);
-        $this->info(sprintf('Running: %s', $cmd));
-        $output = [];
-        exec($cmd, $output, $exitCode);
-
-        if ($exitCode > 0) {
-            $this->error($this->i18n->__('Transforming the EAD with Saxon has failed.'));
-            $this->logCmdOutput($output, 'ERROR(SAXON)');
-
-            return false;
-        }
-
-        // Use FOP generated in previous step to generate PDF
-        $cmd = sprintf("fop -r -q -fo '%s' -%s '%s' 2>&1", $foFilePath, self::getFindingAidFormat(), $pdfPath);
-        $this->info(sprintf('Running: %s', $cmd));
-        $output = [];
-        exec($cmd, $output, $exitCode);
-
-        if (0 != $exitCode) {
-            $this->error($this->i18n->__('Converting the EAD FO to PDF has failed.'));
-            $this->logCmdOutput($output, 'ERROR(FOP)');
-
-            return false;
-        }
-
-        // Update or create 'findingAidStatus' property
-        $criteria = new Criteria();
-        $criteria->add(QubitProperty::OBJECT_ID, $this->resource->id);
-        $criteria->add(QubitProperty::NAME, 'findingAidStatus');
-
-        if (null === $property = QubitProperty::getOne($criteria)) {
-            $property = new QubitProperty();
-            $property->objectId = $this->resource->id;
-            $property->name = 'findingAidStatus';
-        }
-
-        $property->setValue(self::GENERATED_STATUS, ['sourceCulture' => true]);
-        $property->indexOnSave = false;
-        $property->save();
-
-        // Update ES document with finding aid status
-        $partialData = [
-            'findingAid' => [
-                'status' => self::GENERATED_STATUS,
-            ],
-        ];
-
-        QubitSearch::getInstance()->partialUpdate($this->resource, $partialData);
-
-        $this->info($this->i18n->__('Finding aid generated successfully: %1', ['%1' => $pdfPath]));
-
-        fclose($eadFileHandle); // Will delete the tmp file
-        fclose($foFileHandle);
-
-        return true;
-    }
-
-    private function renderXsl($filename, $vars)
-    {
-        // Get XSL file contents
-        $content = file_get_contents($filename);
-
-        // Replace placeholder vars (e.g. "{{ app_root }}")
-        foreach ($vars as $key => $val) {
-            $content = str_replace("{{ {$key} }}", $val, $content);
-        }
-
-        // Write contents to temp file for processing with Saxon
-        $tmpFilePath = tempnam(sys_get_temp_dir(), 'ATM');
-        file_put_contents($tmpFilePath, $content);
-
-        return $tmpFilePath;
-    }
-
-    private function upload($path)
-    {
-        $this->info($this->i18n->__('Uploading finding aid (%1)...', ['%1' => $this->resource->slug]));
-
-        // Update or create 'findingAidStatus' property
-        $criteria = new Criteria();
-        $criteria->add(QubitProperty::OBJECT_ID, $this->resource->id);
-        $criteria->add(QubitProperty::NAME, 'findingAidStatus');
-
-        if (null === $property = QubitProperty::getOne($criteria)) {
-            $property = new QubitProperty();
-            $property->objectId = $this->resource->id;
-            $property->name = 'findingAidStatus';
-        }
-
-        $property->setValue(self::UPLOADED_STATUS, ['sourceCulture' => true]);
-        $property->indexOnSave = false;
-        $property->save();
-
-        $partialData = [
-            'findingAid' => [
-                'transcript' => null,
-                'status' => self::UPLOADED_STATUS,
-            ],
-        ];
-
-        $this->info($this->i18n->__('Finding aid uploaded successfully: %1', ['%1' => $path]));
-
-        // Extract finding aid transcript
-        $mimeType = 'application/'.self::getFindingAidFormat();
-
-        if (!QubitDigitalObject::canExtractText($mimeType)) {
-            $message = $this->i18n->__('Could not obtain finding aid text.');
-            $this->job->addNoteText($message);
-            $this->info($message);
-        } else {
-            $this->info($this->i18n->__('Obtaining finding aid text...'));
-
-            $command = sprintf('pdftotext %s - 2> /dev/null', $path);
-            exec($command, $output, $status);
-
-            if (0 != $status) {
-                $message = $this->i18n->__('Obtaining the text has failed.');
-                $this->job->addNoteText($message);
-                $this->info($message);
-                $this->logCmdOutput($output, 'WARNING(PDFTOTEXT)');
-            } elseif (0 < count($output)) {
-                $text = implode(PHP_EOL, $output);
-
-                // Truncate PDF text to <64KB to fit in `property.value` column
-                $text = mb_strcut($text, 0, 65535);
-
-                // Update or create 'findingAidTranscript' property
-                $criteria = new Criteria();
-                $criteria->add(QubitProperty::OBJECT_ID, $this->resource->id);
-                $criteria->add(QubitProperty::NAME, 'findingAidTranscript');
-                $criteria->add(QubitProperty::SCOPE, 'Text extracted from finding aid PDF file text layer using pdftotext');
-
-                if (null === $property = QubitProperty::getOne($criteria)) {
-                    $property = new QubitProperty();
-                    $property->objectId = $this->resource->id;
-                    $property->name = 'findingAidTranscript';
-                    $property->scope = 'Text extracted from finding aid PDF file text layer using pdftotext';
-                }
-
-                $property->setValue($text, ['sourceCulture' => true]);
-                $property->indexOnSave = false;
-                $property->save();
-
-                // Update partial data with transcript
-                $partialData['findingAid']['transcript'] = $text;
-            }
-        }
-
-        // Update ES document with finding aid status and transcript
-        QubitSearch::getInstance()->partialUpdate($this->resource, $partialData);
-
-        return true;
-    }
-
-    private function delete()
-    {
-        $this->info($this->i18n->__('Deleting finding aid (%1)...', ['%1' => $this->resource->slug]));
-
-        foreach (self::getPossibleFilenames($this->resource->id) as $filename) {
-            $path = sfConfig::get('sf_web_dir').DIRECTORY_SEPARATOR.'downloads'.DIRECTORY_SEPARATOR.$filename;
-
-            if (file_exists($path)) {
-                unlink($path);
-            }
-        }
-
-        // Delete 'findingAidTranscript' property if it exists
-        $criteria = new Criteria();
-        $criteria->add(QubitProperty::OBJECT_ID, $this->resource->id);
-        $criteria->add(QubitProperty::NAME, 'findingAidTranscript');
-        $criteria->add(QubitProperty::SCOPE, 'Text extracted from finding aid PDF file text layer using pdftotext');
-
-        if (null !== $property = QubitProperty::getOne($criteria)) {
-            $this->info($this->i18n->__('Deleting finding aid transcript...'));
-
-            $property->indexOnDelete = false;
-            $property->delete();
-        }
-
-        // Delete 'findingAidStatus' property if it exists
-        $criteria = new Criteria();
-        $criteria->add(QubitProperty::OBJECT_ID, $this->resource->id);
-        $criteria->add(QubitProperty::NAME, 'findingAidStatus');
-
-        if (null !== $property = QubitProperty::getOne($criteria)) {
-            $property->indexOnDelete = false;
-            $property->delete();
-        }
-
-        // Update ES document removing finding aid status and transcript
-        $partialData = [
-            'findingAid' => [
-                'transcript' => null,
-                'status' => null,
-            ],
-        ];
-
-        QubitSearch::getInstance()->partialUpdate($this->resource, $partialData);
-
-        $this->info($this->i18n->__('Finding aid deleted successfully.'));
-
-        return true;
-    }
-
-    private function logCmdOutput(array $output, $prefix = null)
-    {
-        if (empty($prefix)) {
-            $prefix = 'ERROR: ';
-        } else {
-            $prefix = $prefix.': ';
-        }
-
-        foreach ($output as $line) {
-            $this->error($prefix.$line);
-        }
-    }
-
-    private function fixHeader($xmlString, $url = null)
-    {
-        // Apache FOP requires certain namespaces to be included in the XML in order to process it.
-        $xmlString = preg_replace(
-            '(<ead .*?>|<ead>)', '<ead xmlns:ns2="http://www.w3.org/1999/xlink" '
-            .'xmlns="urn:isbn:1-931666-22-9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">',
-            $xmlString,
-            1
-        );
-
-        // TODO: Use new base url functionality in AtoM instead of doing this kludge
-        if (null !== $url) {
-            // Since we call the EAD generation from inside Symfony and not as part as a web request,
-            // the url was returning symfony://weirdurlhere. We can get around this by passing the referring url into
-            // the job as an option when the user clicks 'generate' and replace the url in the EAD manually.
-            $xmlString = preg_replace('/<eadid(.*?)url=\".*?\"(.*?)>/', '<eadid$1url="'.$url.'"$2>', $xmlString, 1);
-        }
-
-        return $xmlString;
-    }
-
-    private function getTmpFilePath($handle)
-    {
-        $meta_data = stream_get_meta_data($handle);
-
-        return $meta_data['uri'];
     }
 }

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -362,9 +362,11 @@ class QubitInformationObject extends BaseInformationObject
         // Delete any keymap entries
         $this->removeKeymapEntries();
 
-        // Delete finding aid
-        if (null !== $path = arFindingAidJob::getFindingAidPathForDownload($this->id)) {
-            unlink($path);
+        // Delete finding aid document
+        $findingAid = new QubitFindingAid($this);
+
+        if (!empty($findingAid->getPath())) {
+            unlink($findingAid->getPath());
         }
 
         QubitSearch::getInstance()->delete($this);
@@ -728,20 +730,6 @@ class QubitInformationObject extends BaseInformationObject
     public function getCollectionRoot()
     {
         return $this->ancestors->andSelf()->orderBy('lft')->__get(1);
-    }
-
-    public function getFindingAidStatus()
-    {
-        $criteria = new Criteria();
-        $criteria->add(QubitProperty::OBJECT_ID, $this->id);
-        $criteria->add(QubitProperty::NAME, 'findingAidStatus');
-        $property = QubitProperty::getOne($criteria);
-
-        if (!isset($property)) {
-            return;
-        }
-
-        return $property->getValue(['sourceCulture' => true]);
     }
 
     public function setRoot()

--- a/lib/task/findingAid/findingAidGenerateTask.class.php
+++ b/lib/task/findingAid/findingAidGenerateTask.class.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Generate a finding aid.
+ *
+ * @author David Juhasz <djjuhasz@gmail.com>
+ */
+class findingAidGenerateTask extends arBaseTask
+{
+    protected $namespace = 'finding-aid';
+    protected $name = 'generate';
+    protected $briefDescription = 'Generate a Finding Aid document';
+
+    protected $detailedDescription = <<<'EOL'
+Generate and attach a Finding Aid document, in PDF or RTF format, for the
+top-level archival description selected by SLUG.
+EOL;
+
+    public function execute($args = [], $options = [])
+    {
+        // @see arBaseTask
+        parent::execute($args, $options);
+
+        $resource = QubitInformationObject::getBySlug($args['slug']);
+
+        if (null === $resource) {
+            $this->log(sprintf('Invalid slug "%s"', $args['slug']));
+
+            exit(1);
+        }
+
+        $options['logger'] = $this->getLogger($options);
+
+        $generator = new QubitFindingAidGenerator($resource, $options);
+        $generator->generate();
+    }
+
+    /**
+     * @see sfBaseTask
+     */
+    protected function configure()
+    {
+        $this->addArguments([
+            new sfCommandArgument(
+              'slug',
+              sfCommandArgument::REQUIRED,
+              'The top-level archival description slug'),
+        ]);
+
+        $this->addOptions([
+            new sfCommandOption(
+                'application',
+                null,
+                sfCommandOption::PARAMETER_OPTIONAL,
+                'The application name',
+                true
+            ),
+            new sfCommandOption(
+                'env',
+                null,
+                sfCommandOption::PARAMETER_REQUIRED,
+                'The environment',
+                'cli'
+            ),
+            new sfCommandOption(
+                'connection',
+                null,
+                sfCommandOption::PARAMETER_REQUIRED,
+                'The connection name',
+                'propel'
+            ),
+            new sfCommandOption(
+                'format',
+                null,
+                sfCommandOption::PARAMETER_REQUIRED,
+                'Finding aid format ("pdf" or "rtf")',
+                'pdf'
+            ),
+            new sfCommandOption(
+                'model',
+                null,
+                sfCommandOption::PARAMETER_REQUIRED,
+                'Finding aid model ("inventory-summary" or "full-details")',
+                'inventory-summary'
+            ),
+            new sfCommandOption(
+                'verbose',
+                'v',
+                sfCommandOption::PARAMETER_NONE,
+                'Output extra debugging information',
+                null
+            ),
+        ]);
+    }
+
+    private function getLogger($options)
+    {
+        $logger = new sfConsoleLogger($this->dispatcher);
+
+        if (!empty($options['verbose'])) {
+            $logger->setLogLevel(sfLogger::DEBUG);
+        }
+
+        return $logger;
+    }
+}

--- a/test/phpunit/QubitFindingAidGeneratorTest.php
+++ b/test/phpunit/QubitFindingAidGeneratorTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * @covers \QubitFindingAidGenerator
+ *
+ * @internal
+ */
+class QubitFindingAidGeneratorTest extends \PHPUnit\Framework\TestCase
+{
+    public function testSetResourceFromConstructor()
+    {
+        $resource = new QubitInformationObject();
+        $generator = new QubitFindingAidGenerator($resource);
+
+        $this->assertSame($resource, $generator->getResource());
+    }
+
+    public function testSetResource()
+    {
+        $resource1 = new QubitInformationObject();
+        $resource2 = new QubitInformationObject();
+        $resource2->id = '11111';
+
+        $generator = new QubitFindingAidGenerator($resource1);
+        $generator->setResource($resource2);
+
+        $this->assertSame($resource2, $generator->getResource());
+    }
+
+    public function testSetResourceTypeError()
+    {
+        $generator = new QubitFindingAidGenerator(new QubitInformationObject());
+        $this->expectException(TypeError::class);
+        $generator->setResource('foo');
+    }
+
+    public function testSetLogger()
+    {
+        $logger = new sfNoLogger(new sfEventDispatcher());
+        $generator = new QubitFindingAidGenerator(new QubitInformationObject());
+        $generator->setLogger($logger);
+
+        $this->assertSame($logger, $generator->getLogger());
+    }
+
+    public function testSetLoggerFromConstructorOption()
+    {
+        $logger = new sfNoLogger(new sfEventDispatcher());
+        $generator = new QubitFindingAidGenerator(
+            new QubitInformationObject(),
+            ['logger' => $logger]
+        );
+
+        $this->assertSame($logger, $generator->getLogger());
+    }
+
+    public function testSetAppRoot()
+    {
+        $generator = new QubitFindingAidGenerator(new QubitInformationObject());
+        $generator->setAppRoot('/tmp/foo');
+
+        $this->assertSame('/tmp/foo', $generator->getAppRoot());
+    }
+
+    public function testSetAppRootFromConstructorOptions()
+    {
+        $generator = new QubitFindingAidGenerator(
+            new QubitInformationObject(),
+            ['appRoot' => '/tmp/foo']
+        );
+
+        $this->assertSame('/tmp/foo', $generator->getAppRoot());
+    }
+
+    public function testSetFormat()
+    {
+        $generator = new QubitFindingAidGenerator(new QubitInformationObject());
+        $generator->setFormat('rtf');
+
+        $this->assertSame('rtf', $generator->getFormat());
+    }
+
+    public function testSetFormatInvalidValue()
+    {
+        $generator = new QubitFindingAidGenerator(new QubitInformationObject());
+
+        $this->expectException(UnexpectedValueException::class);
+        $generator->setFormat('foo');
+    }
+
+    public function testGetModelDefaultValue()
+    {
+        $generator = new QubitFindingAidGenerator(new QubitInformationObject());
+
+        $this->assertSame('inventory-summary', $generator->getModel());
+    }
+
+    public function testSetModel()
+    {
+        $generator = new QubitFindingAidGenerator(new QubitInformationObject());
+        $generator->setModel('full-details');
+
+        $this->assertSame('full-details', $generator->getModel());
+    }
+
+    public function testSetInvalidModel()
+    {
+        $generator = new QubitFindingAidGenerator(new QubitInformationObject());
+
+        $this->expectException(UnexpectedValueException::class);
+        $generator->setModel('foo');
+    }
+
+    public function testGetXslFilePath()
+    {
+        $generator = new QubitFindingAidGenerator(new QubitInformationObject());
+        $generator->setAppRoot('/tmp');
+
+        $this->assertSame(
+            '/tmp/lib/task/pdf/ead-pdf-inventory-summary.xsl',
+            $generator->getXslFilePath()
+        );
+    }
+
+    public function testGetSaxonPath()
+    {
+        $generator = new QubitFindingAidGenerator(new QubitInformationObject());
+        $generator->setAppRoot('/tmp');
+
+        $this->assertSame(
+            '/tmp/'.QubitFindingAidGenerator::SAXON_PATH,
+            $generator->getSaxonPath()
+        );
+    }
+}

--- a/test/phpunit/QubitFindingAidTest.php
+++ b/test/phpunit/QubitFindingAidTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use org\bovigo\vfs\vfsStream;
+
+/**
+ * @covers \QubitFindingAid
+ *
+ * @internal
+ */
+class QubitFindingAidTest extends \PHPUnit\Framework\TestCase
+{
+    public function setUp(): void
+    {
+        // define virtual file system
+        $directory = [
+            'foobar.pdf' => 'foobar',
+        ];
+
+        // setup and cache the virtual file system
+        $this->vfs = vfsStream::setup('root', null, $directory);
+    }
+
+    public function testSetResourceFromConstructor()
+    {
+        $resource = new QubitInformationObject();
+        $findingAid = new QubitFindingAid($resource);
+
+        $this->assertSame($resource, $findingAid->getResource());
+    }
+
+    public function testSetResource()
+    {
+        $resource1 = new QubitInformationObject();
+        $resource2 = new QubitInformationObject();
+        $resource2->id = '11111';
+
+        $findingAid = new QubitFindingAid($resource1);
+
+        $findingAid->setResource($resource2);
+
+        $this->assertSame($resource2, $findingAid->getResource());
+    }
+
+    public function testSetResourceTypeError()
+    {
+        $findingAid = new QubitFindingAid(new QubitInformationObject());
+
+        $this->expectException(TypeError::class);
+        $findingAid->setResource('foo');
+    }
+
+    public function testSetLogger()
+    {
+        $logger = new sfNoLogger(new sfEventDispatcher());
+        $findingAid = new QubitFindingAid(new QubitInformationObject());
+
+        $findingAid->setLogger($logger);
+
+        $this->assertSame($logger, $findingAid->getLogger());
+    }
+
+    public function testSetLoggerFromConstructorOption()
+    {
+        $logger = new sfNoLogger(new sfEventDispatcher());
+        $findingAid = new QubitFindingAid(
+            new QubitInformationObject(),
+            ['logger' => $logger]
+        );
+
+        $this->assertSame($logger, $findingAid->getLogger());
+    }
+
+    public function testSetHomeDir()
+    {
+        $findingAid = new QubitFindingAid(new QubitInformationObject());
+        $findingAid->setHomeDir('/foo/');
+
+        $this->assertSame('/foo/', $findingAid->getHomeDir());
+    }
+
+    public function testGetHomeDirDefault()
+    {
+        $findingAid = new QubitFindingAid(new QubitInformationObject());
+
+        $this->assertSame(
+            sfConfig::get('sf_web_dir').'/downloads/',
+            $findingAid->getHomeDir()
+        );
+    }
+
+    public function testGetPossibleFilenames()
+    {
+        $resource = new QubitInformationObject();
+        $resource->id = '12345';
+        $resource->slug = 'foobar';
+        $findingAid = new QubitFindingAid($resource);
+
+        $this->assertSame(
+            ['12345.pdf', '12345.rtf', 'foobar.pdf', 'foobar.rtf'],
+            $findingAid->getPossibleFilenames()
+        );
+    }
+
+    public function testSetPath()
+    {
+        $path = '/path/to/foo.pdf';
+        $findingAid = new QubitFindingAid(new QubitInformationObject());
+        $findingAid->setPath($path);
+
+        $this->assertSame($path, $findingAid->getPath());
+    }
+
+    public function testGetPathByInference()
+    {
+        $resource = new QubitInformationObject();
+        $resource->id = '12345';
+        $resource->slug = 'foobar';
+
+        $findingAid = new QubitFindingAid($resource);
+        $findingAid->setHomeDir($this->vfs->url().'/');
+
+        $this->assertSame(
+            $this->vfs->url().'/foobar.pdf',
+            $findingAid->getPath()
+        );
+    }
+
+    public function testGetFormat()
+    {
+        $findingAid = new QubitFindingAid(new QubitInformationObject());
+        $findingAid->setPath($this->vfs->url().'/foobar.pdf');
+
+        $this->assertSame(
+            'pdf',
+            $findingAid->getFormat()
+        );
+    }
+}


### PR DESCRIPTION
- Add `finding-aid:generate SLUG` CLI task with options for format (PDF or RTF) and "model" ("inventory-summary" or "full-details")
- Refactor general finding aid code into QubitFindingAid class
- Refactor finding aid generation code into QubitFindingAidGenerator
  class
- Use QubitFindingAid and QubitFindingAidGenerator libraries in
  arFindingAidJob
- Add a finding-aid:generate task to generate a new finding aid from
  the CLI using the new libraries
- When generating a new finding aid, delete the old finding aid first
  to avoid having two finding aid files for the same resource (e.g.
  foo.pdf and foo.rtf)
- Add unit tests