### PR TITLE
Make MediaElement work on B5 theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.3",
         "bootstrap": "^5.0.1",
-        "jquery": "^3.6.0"
+        "jquery": "^3.6.0",
+        "mediaelement": "^4.2.16"
       },
       "devDependencies": {
         "cypress": "^7.0.0",
@@ -815,6 +816,11 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1136,6 +1142,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
       }
     },
     "node_modules/global-dirs": {
@@ -1884,6 +1899,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/mediaelement": {
+      "version": "4.2.16",
+      "resolved": "https://registry.npmjs.org/mediaelement/-/mediaelement-4.2.16.tgz",
+      "integrity": "sha512-5GinxsRpVA36w6tAD6nTqVSiZ0LzIhqUrzD8wzOAtZPPM7NOwOBtz6Oa85VemS+3Jvoo38jM1RvNqwKYJBBxtQ==",
+      "dependencies": {
+        "global": "^4.3.1"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -1930,6 +1953,14 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dependencies": {
+        "dom-walk": "^0.1.0"
       }
     },
     "node_modules/minimatch": {
@@ -2114,6 +2145,14 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -3337,6 +3376,11 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -3604,6 +3648,15 @@
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
+      }
+    },
+    "global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "requires": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
       }
     },
     "global-dirs": {
@@ -4193,6 +4246,14 @@
         }
       }
     },
+    "mediaelement": {
+      "version": "4.2.16",
+      "resolved": "https://registry.npmjs.org/mediaelement/-/mediaelement-4.2.16.tgz",
+      "integrity": "sha512-5GinxsRpVA36w6tAD6nTqVSiZ0LzIhqUrzD8wzOAtZPPM7NOwOBtz6Oa85VemS+3Jvoo38jM1RvNqwKYJBBxtQ==",
+      "requires": {
+        "global": "^4.3.1"
+      }
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -4225,6 +4286,14 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "requires": {
+        "dom-walk": "^0.1.0"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
@@ -4364,6 +4433,11 @@
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
       "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
       "dev": true
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.3",
     "bootstrap": "^5.0.1",
-    "jquery": "^3.6.0"
+    "jquery": "^3.6.0",
+    "mediaelement": "^4.2.16"
   },
   "devDependencies": {
     "cypress": "^7.0.0",

--- a/plugins/arDominionB5Plugin/modules/digitalobject/actions/showAudioComponent.class.php
+++ b/plugins/arDominionB5Plugin/modules/digitalobject/actions/showAudioComponent.class.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Digital Object audio display component.
+ *
+ * @author     Jesús García Crespo <correo@sevein.com>
+ */
+class DigitalObjectShowAudioComponent extends sfComponent
+{
+    /**
+     * Show a representation of a digital object image.
+     *
+     * @param sfWebRequest $request
+     */
+    public function execute($request)
+    {
+        // Get representation by usage type
+        $this->representation = $this->resource->getRepresentationByUsage($this->usageType);
+
+        // If we can't find a representation for this object, try their parent
+        if (!$this->representation && ($parent = $this->resource->parent)) {
+            $this->representation = $parent->getRepresentationByUsage($this->usageType);
+        }
+
+        // Set up display of video in mediaelement
+        if ($this->representation) {
+            $this->showMediaPlayer = true;
+        } else {
+            $this->showMediaPlayer = false;
+
+            $this->representation = QubitDigitalObject::getGenericRepresentation($this->resource->mimeType, $this->usageType);
+        }
+    }
+}

--- a/plugins/arDominionB5Plugin/modules/digitalobject/actions/showVideoComponent.class.php
+++ b/plugins/arDominionB5Plugin/modules/digitalobject/actions/showVideoComponent.class.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Digital Object video display component.
+ *
+ * @author     David Juhasz <david@artefactual.com>
+ */
+class DigitalObjectShowVideoComponent extends sfComponent
+{
+    /**
+     * Show a representation of a digital object image.
+     *
+     * @param sfWebRequest $request
+     */
+    public function execute($request)
+    {
+        // Get representation by usage type
+        $this->representation = $this->resource->getRepresentationByUsage($this->usageType);
+
+        // If we can't find a representation for this object, try their parent
+        if (!$this->representation && ($parent = $this->resource->parent)) {
+            $this->representation = $parent->getRepresentationByUsage($this->usageType);
+        }
+
+        // Set up display of video in mediaelement
+        if ($this->representation) {
+            // If this is a reference movie, get the thumbnail representation for the
+            // place holder image
+            $this->showMediaPlayer = true;
+            if (QubitTerm::REFERENCE_ID == $this->usageType) {
+                $this->thumbnail = $this->resource->getRepresentationByUsage(QubitTerm::THUMBNAIL_ID);
+            }
+
+            list($this->width, $this->height) = QubitDigitalObject::getImageMaxDimensions($this->usageType);
+
+            // For javascript_tag()
+            if (QubitTerm::CHAPTERS_ID != $this->usageType && QubitTerm::SUBTITLES_ID != $this->usageType) {
+                $this->representationFullPath = public_path($this->representation->getFullPath());
+            }
+        }
+        // If representation is not a valid digital object, return a generic icon
+        else {
+            $this->showMediaPlayer = false;
+            $this->representation = QubitDigitalObject::getGenericRepresentation($this->resource->mimeType, $this->usageType);
+        }
+    }
+}

--- a/plugins/arDominionB5Plugin/modules/digitalobject/templates/_showAudio.php
+++ b/plugins/arDominionB5Plugin/modules/digitalobject/templates/_showAudio.php
@@ -1,0 +1,55 @@
+<?php use_helper('Text'); ?>
+
+<?php if (QubitTerm::CHAPTERS_ID == $usageType) { ?>
+
+  <?php if ($showMediaPlayer) { ?>
+    <track kind="chapters" src="<?php echo public_path($representation->getFullPath()); ?>" srclang="">
+  <?php } ?>
+
+<?php } elseif (QubitTerm::REFERENCE_ID == $usageType) { ?>
+
+  <?php if ($showMediaPlayer) { ?>
+    <audio class="mejs__player" data-mejsoptions='{"pluginPath": "node_modules/mediaelement/build/", "renderers": ["html5", "flash_video"], "alwaysShowControls": "true", "stretching": "responsive"}' src="<?php echo public_path($representation->getFullPath()); ?>">
+      <?php echo get_component('digitalobject', 'show', ['resource' => $resource, 'usageType' => QubitTerm::CHAPTERS_ID]); ?>
+    </audio>
+  <?php } else { ?>
+    <div style="text-align: center">
+      <?php echo image_tag($representation->getFullPath(), ['style' => 'border: #999 1px solid', 'alt' => '']); ?>
+    </div>
+  <?php }?>
+
+  <?php if (isset($link) && QubitAcl::check($resource->object, 'readMaster')) { ?>
+    <?php echo link_to(__('Download audio'), $link, ['class' => 'download']); ?>
+  <?php } ?>
+
+<?php } elseif (QubitTerm::THUMBNAIL_ID == $usageType && isset($link)) { ?>
+
+  <?php if ($iconOnly) { ?>
+
+    <?php echo link_to(image_tag('play', ['alt' => __($resource->getDigitalObjectAltText() ?: 'Open original %1%', ['%1%' => sfConfig::get('app_ui_label_digitalobject')])]), $link); ?>
+
+  <?php } else { ?>
+
+    <div class="resource">
+
+      <div class="resourceRep">
+        <?php echo link_to(image_tag('play', ['alt' => __($resource->getDigitalObjectAltText() ?: 'Open original %1%', ['%1%' => sfConfig::get('app_ui_label_digitalobject')])]), $link); ?>
+      </div>
+
+      <div class="resourceDesc">
+        <?php echo wrap_text($resource->name, 18); ?>
+      </div>
+
+    </div>
+
+  <?php } ?>
+
+<?php } else { ?>
+
+  <div class="resource">
+
+    <?php echo image_tag('play', ['alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', ['%1%' => sfConfig::get('app_ui_label_digitalobject')])]); ?>
+
+  </div>
+
+<?php } ?>

--- a/plugins/arDominionB5Plugin/modules/digitalobject/templates/_showVideo.php
+++ b/plugins/arDominionB5Plugin/modules/digitalobject/templates/_showVideo.php
@@ -1,0 +1,70 @@
+<?php use_helper('Text'); ?>
+
+<?php if (QubitTerm::MASTER_ID == $usageType) { ?>
+
+  <?php if (isset($link)) { ?>
+    <?php echo image_tag($representation->getFullPath(), ['alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', ['%1%' => sfConfig::get('app_ui_label_digitalobject')])]); ?>
+  <?php } else { ?>
+    <?php echo link_to(image_tag($representation->getFullPath(), ['alt' => __($resource->getDigitalObjectAltText() ?: 'Open original %1%', ['%1%' => sfConfig::get('app_ui_label_digitalobject')])]), $link); ?>
+  <?php } ?>
+
+<?php } elseif (QubitTerm::CHAPTERS_ID == $usageType) { ?>
+
+  <?php if ($showMediaPlayer) { ?>
+    <track kind="chapters" src="<?php echo public_path($representation->getFullPath()); ?>" srclang="">
+  <?php } ?>
+
+<?php } elseif (QubitTerm::SUBTITLES_ID == $usageType) { ?>
+
+  <?php if ($showMediaPlayer) { ?>
+    <?php foreach ($representation as $subtitle) { ?>
+      <track kind="subtitles" src="<?php echo public_path($subtitle->getFullPath()); ?>" srclang="<?php echo $subtitle->language; ?>" label="<?php echo format_language($subtitle->language); ?>">
+    <?php } ?>
+  <?php } ?>
+
+<?php } elseif (QubitTerm::REFERENCE_ID == $usageType) { ?>
+
+  <?php if ($showMediaPlayer) { ?>
+    <video preload="metadata" class="mejs__player" data-mejsoptions='{"pluginPath": "node_modules/mediaelement/build/", "renderers": ["html5", "flash_video"], "alwaysShowControls": "true", "stretching": "responsive"}' src="<?php echo public_path($representation->getFullPath()); ?>">
+      <?php echo get_component('digitalobject', 'show', ['resource' => $resource, 'usageType' => QubitTerm::CHAPTERS_ID]); ?>
+      <?php echo get_component('digitalobject', 'show', ['resource' => $resource, 'usageType' => QubitTerm::SUBTITLES_ID]); ?>
+    </video>
+  <?php } else { ?>
+    <div style="text-align: center">
+      <?php echo image_tag($representation->getFullPath(), ['style' => 'border: #999 1px solid', 'alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', ['%1%' => sfConfig::get('app_ui_label_digitalobject')])]); ?>
+    </div>
+  <?php }?>
+
+  <!-- link to download master -->
+  <?php if (isset($link)) { ?>
+    <?php echo link_to(__('Download movie'), $link, ['class' => 'download']); ?>
+  <?php } ?>
+
+<?php } elseif (QubitTerm::THUMBNAIL_ID == $usageType) { ?>
+
+  <?php if ($iconOnly) { ?>
+
+    <?php if (isset($link)) { ?>
+      <?php echo link_to(image_tag($representation->getFullPath(), ['alt' => __($resource->getDigitalObjectAltText() ?: 'Open original %1%', ['%1%' => sfConfig::get('app_ui_label_digitalobject')])]), $link); ?>
+    <?php } else { ?>
+      <?php echo image_tag($representation->getFullPath(), ['alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', ['%1%' => sfConfig::get('app_ui_label_digitalobject')])]); ?>
+    <?php } ?>
+
+  <?php } else { ?>
+
+    <div class="digitalObject">
+      <div class="digitalObjectRep">
+        <?php if (isset($link)) { ?>
+          <?php echo link_to(image_tag($representation->getFullPath(), ['alt' => __($resource->getDigitalObjectAltText() ?: 'Open original %1%', ['%1%' => sfConfig::get('app_ui_label_digitalobject')])]), $link); ?>
+        <?php } else { ?>
+          <?php echo image_tag($representation->getFullPath(), ['alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', ['%1%' => sfConfig::get('app_ui_label_digitalobject')])]); ?>
+        <?php } ?>
+      </div>
+      <div class="digitalObjectDesc">
+        <?php echo wrap_text($resource->name, 18); ?>
+      </div>
+    </div>
+
+  <?php } ?>
+
+<?php } ?>

--- a/plugins/arDominionB5Plugin/templates/_layout_end.php
+++ b/plugins/arDominionB5Plugin/templates/_layout_end.php
@@ -1,6 +1,7 @@
     <?php include_slot('post'); ?>
     <?php echo get_partial('footer'); ?>
     <script src="/node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/node_modules/mediaelement/build/mediaelement-and-player.min.js"></script>
     <script src="/vendor/uppy/uppy-bundle.js"></script>
     <script src="/plugins/arDominionB5Plugin/js/privacyMessage.js"></script>
     <script src="/plugins/arDominionB5Plugin/js/multiFileUpload.js"></script>

--- a/plugins/arDominionB5Plugin/templates/_layout_start.php
+++ b/plugins/arDominionB5Plugin/templates/_layout_start.php
@@ -8,6 +8,7 @@
     <link rel="shortcut icon" href="<?php echo public_path('favicon.ico'); ?>"/>
     <link rel="stylesheet" href="/plugins/arDominionB5Plugin/build/css/min.css">
     <link rel="stylesheet" href="/vendor/uppy/uppy-bundle.css">
+    <link rel="stylesheet" href="/node_modules/mediaelement/build/mediaelementplayer.min.css">
     <!-- TODO: Move jQuery after footer when all JS is also there -->
     <script src="/node_modules/jquery/dist/jquery.min.js"></script>
   </head>


### PR DESCRIPTION
- Added MediaElement to package.json to install via npm.
- Removed refs to MediaElement js and css from the show* actions.
- Added class 'mejs__player' to the show* templates on <video> and
<audio> elements.
- Load options using the <video> and <audio> element attribute
'data-mejsoptions'.
- Added reference to MediaElement minified js and css to B5 plugin start
and end templates.