### PR TITLE
Fix CSV transformation encoding, refs #13538

### DIFF
--- a/lib/QubitCsvTransformFactory.class.php
+++ b/lib/QubitCsvTransformFactory.class.php
@@ -80,7 +80,7 @@ class QubitCsvTransformFactory
             ],
 
             'preserveOrder' => $this->preserveOrder,
-            'convertWindowsEncoding' => true,
+            'convertWindowsEncoding' => $this->convertWindowsEncoding,
 
             'setupLogic' => $this->setupLogic,
             'transformLogic' => $this->transformLogic,


### PR DESCRIPTION
Fixed problem with CSV transformations defaulting to being converted from using Windows character set.