### PR TITLE
Fix job error display, refs #13523

### DIFF
--- a/lib/job/arBaseJob.class.php
+++ b/lib/job/arBaseJob.class.php
@@ -150,7 +150,7 @@ class arBaseJob extends Net_Gearman_Job_Common
             throw new Net_Gearman_Job_Exception('Called arBaseJob::error() before QubitJob fetched.');
         }
 
-        $this->logger->info($message);
+        $this->logger->err($message);
         $this->job->setStatusError($message);
         $this->job->save();
     }


### PR DESCRIPTION
Fixed, on the job detail page, a minor issue with error display. In the black section of the page, showing all the job's logging output, errors were being shown with the category "[info]". This has been changed so they show as an error category.