### PR TITLE
Avoid removal of qtAclPlugin, refs #13518

### DIFF
--- a/plugins/arArchivesCanadaPlugin/config/arArchivesCanadaPluginConfiguration.class.php
+++ b/plugins/arArchivesCanadaPlugin/config/arArchivesCanadaPluginConfiguration.class.php
@@ -51,7 +51,9 @@ class arArchivesCanadaPluginConfiguration extends sfPluginConfiguration
         // Move this plugin to the top to allow overwriting
         // controllers and views from other plugin modules.
         $plugins = $this->configuration->getPlugins();
-        unset($plugins[array_search($this->name, $plugins)]);
-        $this->configuration->setPlugins(array_values([$this->name] + $plugins));
+        if (false !== $key = array_search($this->name, $plugins)) {
+            unset($plugins[$key]);
+        }
+        $this->configuration->setPlugins(array_merge([$this->name], $plugins));
     }
 }

--- a/plugins/arDominionPlugin/config/arDominionPluginConfiguration.class.php
+++ b/plugins/arDominionPlugin/config/arDominionPluginConfiguration.class.php
@@ -51,7 +51,9 @@ class arDominionPluginConfiguration extends sfPluginConfiguration
         // Move this plugin to the top to allow overwriting
         // controllers and views from other plugin modules.
         $plugins = $this->configuration->getPlugins();
-        unset($plugins[array_search($this->name, $plugins)]);
-        $this->configuration->setPlugins(array_values([$this->name] + $plugins));
+        if (false !== $key = array_search($this->name, $plugins)) {
+            unset($plugins[$key]);
+        }
+        $this->configuration->setPlugins(array_merge([$this->name], $plugins));
     }
 }


### PR DESCRIPTION
If the theme plugin was not yet included in the enabled plugins list,
when it was moved to the top to allow plugin customizations it was
replacing the qtAclPlugin. Only unset when the plugin is found and
use `array_merge` to add it on top.