### PR TITLE
Add CSV validator for repo, refs #13475

### DIFF
--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -867,11 +867,12 @@ class QubitFlatfileImport
     /**
      * Create a Qubit repository or, if one already exists, fetch it.
      *
-     * @param string $name name of repository
+     * @param string $name      name of repository
+     * @param mixed  $fetchOnly prevent create
      *
      * @return QubitRepository created or fetched repository
      */
-    public static function createOrFetchRepository($name)
+    public static function createOrFetchRepository($name, $fetchOnly = false)
     {
         $query = "SELECT r.id FROM actor_i18n a \r
             INNER JOIN repository r ON a.id=r.id \r
@@ -884,7 +885,9 @@ class QubitFlatfileImport
             return QubitRepository::getById($result->id);
         }
 
-        return QubitFlatfileImport::createRepository($name);
+        if (!$fetchOnly) {
+            return QubitFlatfileImport::createRepository($name);
+        }
     }
 
     /**

--- a/lib/task/import/validate/csvRepoValidator.class.php
+++ b/lib/task/import/validate/csvRepoValidator.class.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * CSV Repository Validator. Check if repo exists or not in the AtoM DB.
+ * Issue a warning if the CSV will result in the creation of a new Repo.
+ *
+ * @author     Steve Breker <sbreker@artefactual.com>
+ */
+class CsvRepoValidator extends CsvBaseValidator
+{
+    const TITLE = 'Repository Check';
+    const LIMIT_TO = ['QubitInformationObject'];
+
+    protected $existingRepositories = [];
+    protected $newRepositories = [];
+    protected $repositoryColumnPresent;
+
+    public function __construct(?array $options = null)
+    {
+        $this->setTitle(self::TITLE);
+
+        parent::__construct($options);
+    }
+
+    public function reset()
+    {
+        $this->repositoryColumnPresent = null;
+        $this->newRepositories = [];
+
+        parent::reset();
+    }
+
+    public function testRow(array $header, array $row)
+    {
+        parent::testRow($header, $row);
+        $row = $this->combineRow($header, $row);
+
+        // Set if repository column is present.
+        if (!isset($this->repositoryColumnPresent)) {
+            $this->repositoryColumnPresent = isset($row['repository']);
+        }
+
+        if (!$this->repositoryColumnPresent || empty($row['repository'])) {
+            return;
+        }
+
+        if (!$this->repositoryExists($row['repository'])) {
+            $this->testData->addDetail(implode(',', $row));
+        }
+    }
+
+    public function getTestResult()
+    {
+        if (!$this->repositoryColumnPresent) {
+            // Repository column not present in file.
+            $this->testData->addResult(sprintf("'repository' column not present in file."));
+
+            return parent::getTestResult();
+        }
+
+        if (0 < count($this->newRepositories)) {
+            $this->testData->setStatusWarn();
+            $this->testData->addResult(sprintf('Number of NEW repository records that will be created by this CSV: %s', count($this->newRepositories)));
+            $this->testData->addResult(sprintf('New repository records will be created for: %s', implode(',', $this->newRepositories)));
+        } else {
+            $this->testData->addResult('No issues detected with repository values.');
+        }
+
+        return parent::getTestResult();
+    }
+
+    protected function repositoryExists($name)
+    {
+        if (isset($this->existingRepositories[$name])) {
+            return true;
+        }
+
+        $repo = $this->ormClasses['QubitFlatfileImport']::createOrFetchRepository(
+            $name,
+            true
+        );
+
+        if (null !== $repo) {
+            $this->existingRepositories[$repo->authorizedFormOfName] = $repo->authorizedFormOfName;
+
+            return true;
+        }
+
+        $this->newRepositories[$name] = $name;
+
+        return false;
+    }
+}

--- a/lib/task/import/validate/csvScriptValidator.class.php
+++ b/lib/task/import/validate/csvScriptValidator.class.php
@@ -26,6 +26,7 @@
 class CsvScriptValidator extends CsvBaseValidator
 {
     const TITLE = 'Script of Description Check';
+    const LIMIT_TO = ['QubitInformationObject'];
 
     protected $scriptOfDescriptionList = [];
     protected $scriptOfDescriptionColumnPresent;

--- a/lib/task/import/validate/csvValidatorCollection.php
+++ b/lib/task/import/validate/csvValidatorCollection.php
@@ -41,6 +41,7 @@ class CsvValidatorCollection
         'CsvDigitalObjectPathValidator' => CsvDigitalObjectPathValidator::class,
         'CsvDigitalObjectUriValidator' => CsvDigitalObjectUriValidator::class,
         'CsvScriptValidator' => CsvScriptValidator::class,
+        'CsvRepoValidator' => CsvRepoValidator::class,
     ];
 
     protected $validators = [];

--- a/test/mock/QubitRepository.php
+++ b/test/mock/QubitRepository.php
@@ -19,29 +19,8 @@
 
 namespace AccessToMemory\test\mock;
 
-class QubitFlatfileImport
+class QubitRepository
 {
-    public static function fetchKeymapEntryBySourceAndTargetName($sourceId, $sourceName, $targetName)
-    {
-        if (!empty($sourceId) && !empty($sourceName) && !empty($targetName)) {
-            return 1;
-        }
-
-        return false;
-    }
-
-    public static function createOrFetchRepository($name, $fetchOnly = false)
-    {
-        if ('Existing Repository' === $name) {
-            return QubitFlatfileImport::createRepository($name);
-        }
-    }
-
-    public static function createRepository($name)
-    {
-        $repo = new QubitRepository();
-        $repo->authorizedFormOfName = $name;
-
-        return $repo;
-    }
+    public $id;
+    public $authorizedFormOfName;
 }

--- a/test/phpunit/csvImportValidator/CsvRepoTest.php
+++ b/test/phpunit/csvImportValidator/CsvRepoTest.php
@@ -1,0 +1,154 @@
+<?php
+
+use org\bovigo\vfs\vfsStream;
+
+/**
+ * @internal
+ * @covers \CsvRepoValidator
+ */
+class CsvRepoTest extends \PHPUnit\Framework\TestCase
+{
+    protected $vdbcon;
+    protected $context;
+
+    public function setUp(): void
+    {
+        $this->context = sfContext::getInstance();
+        $this->vdbcon = $this->createMock(DebugPDO::class);
+
+        $this->csvHeader = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,culture';
+        $this->csvHeaderWithRepo = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,culture';
+
+        $this->csvData = [
+            // Note: leading and trailing whitespace in first row is intentional
+            '"B10101 "," DJ001","ID1 ","Some Photographs","","Extent and medium 1",""',
+            '"","","","Chemise","","","fr"',
+            '"D20202", "DJ002", "", "Voûte, étagère 0074", "", "", ""',
+            '"", "DJ003", "ID4", "Title Four", "","", "en"',
+        ];
+
+        $this->csvDataValidRepos = [
+            '"B10101 "," DJ001","ID1 ","Some Photographs","","Extent and medium 1","","es "',
+            '"","","","Chemise","","","","fr"',
+            '"D20202", "DJ002", "", "Voûte, étagère 0074", "", "", "", "de"',
+            '"", "DJ003", "ID4", "Title Four", "","", "", "en"',
+        ];
+
+        $this->csvDataReposSomeInvalid = [
+            '"B10101 "," DJ001","ID1 ","Some Photographs","","Extent and medium 1","new repo 1","es "',
+            '"","","","Chemise","","","Existing Repository","fr"',
+            '"D20202", "DJ002", "", "Voûte, étagère 0074", "", "", "new repo 2", "de"',
+            '"", "DJ003", "ID4", "Title Four", "","", "new repo 1", "en"',
+        ];
+
+        // define virtual file system
+        $directory = [
+            'unix_csv_without_utf8_bom.csv' => $this->csvHeader."\n".implode("\n", $this->csvData),
+            'unix_csv_valid_repos.csv' => $this->csvHeaderWithRepo."\n".implode("\n", $this->csvDataValidRepos),
+            'unix_csv_repos_some_invalid.csv' => $this->csvHeaderWithRepo."\n".implode("\n", $this->csvDataReposSomeInvalid),
+        ];
+
+        $this->vfs = vfsStream::setup('root', null, $directory);
+
+        $this->ormClasses = [
+            'QubitFlatfileImport' => \AccessToMemory\test\mock\QubitFlatfileImport::class,
+            //'QubitObject' => \AccessToMemory\test\mock\QubitObject::class,
+        ];
+    }
+
+    /**
+     * @dataProvider csvValidatorTestProvider
+     *
+     * Generic test - options and expected results from csvValidatorTestProvider()
+     *
+     * @param mixed $options
+     */
+    public function testCsvValidator($options)
+    {
+        $filename = $this->vfs->url().$options['filename'];
+        $validatorOptions = isset($options['validatorOptions']) ? $options['validatorOptions'] : null;
+
+        $csvValidator = new CsvImportValidator($this->context, null, $validatorOptions);
+        $this->runValidator($csvValidator, $filename, $options['csvValidatorClasses']);
+        $result = $csvValidator->getResultsByFilenameTestname($filename, $options['testname']);
+
+        $this->assertSame($options[CsvValidatorResult::TEST_TITLE], $result[CsvValidatorResult::TEST_TITLE]);
+        $this->assertSame($options[CsvValidatorResult::TEST_STATUS], $result[CsvValidatorResult::TEST_STATUS]);
+        $this->assertSame($options[CsvValidatorResult::TEST_RESULTS], $result[CsvValidatorResult::TEST_RESULTS]);
+        $this->assertSame($options[CsvValidatorResult::TEST_DETAILS], $result[CsvValidatorResult::TEST_DETAILS]);
+    }
+
+    public function csvValidatorTestProvider()
+    {
+        $vfsUrl = 'vfs://root';
+
+        return [
+            /*
+             * Test CsvRepoValidator.class.php
+             *
+             * Tests:
+             * - repository column missing
+             * - repository column present with valid data
+             * - repository column present with mix of valid and invalid data
+             */
+            [
+                'CsvRepoValidator-RepoColMissing' => [
+                    'csvValidatorClasses' => 'CsvRepoValidator',
+                    'filename' => '/unix_csv_without_utf8_bom.csv',
+                    'testname' => 'CsvRepoValidator',
+                    CsvValidatorResult::TEST_TITLE => CsvRepoValidator::TITLE,
+                    CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_INFO,
+                    CsvValidatorResult::TEST_RESULTS => [
+                        "'repository' column not present in file.",
+                    ],
+                    CsvValidatorResult::TEST_DETAILS => [
+                    ],
+                ],
+            ],
+
+            [
+                'CsvRepoValidator-ReposValid' => [
+                    'csvValidatorClasses' => 'CsvRepoValidator',
+                    'filename' => '/unix_csv_valid_repos.csv',
+                    'testname' => 'CsvRepoValidator',
+                    CsvValidatorResult::TEST_TITLE => CsvRepoValidator::TITLE,
+                    CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_INFO,
+                    CsvValidatorResult::TEST_RESULTS => [
+                        'No issues detected with repository values.',
+                    ],
+                    CsvValidatorResult::TEST_DETAILS => [
+                    ],
+                ],
+            ],
+
+            [
+                'CsvRepoValidator-ReposSomeInvalid' => [
+                    'csvValidatorClasses' => 'CsvRepoValidator',
+                    'filename' => '/unix_csv_repos_some_invalid.csv',
+                    'testname' => 'CsvRepoValidator',
+                    CsvValidatorResult::TEST_TITLE => CsvRepoValidator::TITLE,
+                    CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_WARN,
+                    CsvValidatorResult::TEST_RESULTS => [
+                        'Number of NEW repository records that will be created by this CSV: 2',
+                        'New repository records will be created for: new repo 1,new repo 2',
+                    ],
+                    CsvValidatorResult::TEST_DETAILS => [
+                        'B10101,DJ001,ID1,Some Photographs,,Extent and medium 1,new repo 1,es',
+                        'D20202,DJ002,,Voûte, étagère 0074,,,new repo 2,de',
+                        ',DJ003,ID4,Title Four,,,new repo 1,en',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    // Generic Validation
+    protected function runValidator($csvValidator, $filenames, $tests)
+    {
+        $csvValidator->setSpecificTests($tests);
+        $csvValidator->setFilenames(explode(',', $filenames));
+        $csvValidator->setOrmClasses($this->ormClasses);
+
+        return $csvValidator->validate();
+    }
+}


### PR DESCRIPTION
Add new validator for the repository column. Checks if the CSV import
will result in new AtoM repository records being created and, if so,
will trigger a warning. This validator is only valid for information
object import.

Includes:
- new phpunit test for the new validator.
- fix to limit the scriptOfDescription check to info obj CSVs only.