### PR TITLE
Exclude narrower terms link fix, refs #13544

### DIFF
--- a/apps/qubit/modules/term/templates/_directTerms.php
+++ b/apps/qubit/modules/term/templates/_directTerms.php
@@ -5,7 +5,7 @@
           '%1%' => $aggs['direct']['doc_count'], ]); ?>
       <?php $params = $sf_data->getRaw('sf_request')->getGetParameters(); ?>
       <?php unset($params['page']); ?>
-      <a href="<?php echo url_for([$resource, 'module' => 'term'] + $params + ['onlyDirect' => true]); ?>">
+      <a href="<?php echo url_for([$resource, 'module' => 'term', 'action' => $sf_request->getParameter('action')] + $params + ['onlyDirect' => true]); ?>">
         <i class="fa fa-search"></i>
         <?php echo __('Exclude narrower terms'); ?>
       </a>

--- a/apps/qubit/modules/term/templates/relatedAuthoritiesSuccess.php
+++ b/apps/qubit/modules/term/templates/relatedAuthoritiesSuccess.php
@@ -60,7 +60,7 @@
         <?php $params = $sf_data->getRaw('sf_request')->getGetParameters(); ?>
         <?php unset($params['onlyDirect']); ?>
         <?php unset($params['page']); ?>
-        <a href="<?php echo url_for([$resource, 'module' => 'term'] + $params); ?>" class="remove-filter" aria-label="<?php echo __('Remove filter'); ?>"><i aria-hidden="true" class="fa fa-times"></i></a>
+        <a href="<?php echo url_for([$resource, 'module' => 'term', 'action' => 'relatedAuthorities'] + $params); ?>" class="remove-filter" aria-label="<?php echo __('Remove filter'); ?>"><i aria-hidden="true" class="fa fa-times"></i></a>
       </span>
     <?php } ?>
 


### PR DESCRIPTION
PR addresses a routing bug with the "Exclude narrower terms" button in the "Related authority records" tab in term search. It currently routes back to the "Related Archival descriptions tab" rather than staying in the correct tab.

Including the correct action when constructing the url fixes the issue.

147279b05dfcfa46735db5c4e305bff6f97587fa -> I was getting a message about the config file name being incorrect so I renamed it, but I see the issue is more complicated after seeing #1331. My changes aren't triggering the fixer anyway.