### PR TITLE
Start styling user index page

### DIFF
--- a/plugins/arDominionB5Plugin/modules/user/templates/_aclMenu.php
+++ b/plugins/arDominionB5Plugin/modules/user/templates/_aclMenu.php
@@ -1,0 +1,17 @@
+<ul class="nav nav-pills">
+  <?php foreach ($userAclMenu->getChildren() as $item) { ?>
+    <?php $options = ['class' => 'nav-link']; ?>
+    <?php if (
+        str_replace(
+            '%currentSlug%',
+            $sf_request->getAttribute('sf_route')->resource->slug,
+            $item->path
+        )
+        == $sf_context->getRouting()->getCurrentInternalUri()
+    ) { ?>
+      <?php $options['class'] .= ' active'; ?>
+      <?php $options['aria-current'] = 'page'; ?>
+    <?php } ?>
+    <li class="nav-item"><?php echo link_to($item->getLabel(['cultureFallback' => true]), $item->getPath(['getUrl' => true, 'resolveAlias' => true]), $options); ?></li>
+  <?php } ?>
+</ul>

--- a/plugins/arDominionB5Plugin/modules/user/templates/indexSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/user/templates/indexSuccess.php
@@ -89,16 +89,19 @@
 
     <?php if (sfConfig::get('app_audit_log_enabled', false)) { ?>
       <div id="editing-history-wrapper">
-        <div class="accordion">
+        <div class="accordion hidden" id="editingHistory">
           <div class="accordion-item">
             <h2 class="accordion-header" id="history-heading">
               <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#history-collapse" aria-expanded="false" aria-controls="history-collapse">
                 <?php echo __('Editing history'); ?>
-                <?php echo image_tag('/vendor/jstree/themes/default/throbber.gif', ['id' => 'editingHistoryActivityIndicator', 'class' => 'hidden', 'alt' => __('Loading ...')]); ?>
+                <span id="editingHistoryActivityIndicator">
+                  <i class="fas fa-spinner fa-spin ms-2" aria-hidden="true"></i>
+                  <span class="visually-hidden"><?php echo __('Loading ...'); ?></span>
+                </span>
               </button>
             </h2>
             <div id="history-collapse" class="accordion-collapse collapse" aria-labelledby="history-heading">
-              <div class="accordion-body">
+              <div class="accordion-body table-responsive">
                 <table class="table table-bordered table-striped sticky-enabled">
                   <thead>
                     <tr>
@@ -117,9 +120,9 @@
                   </tbody>
                 </table>
 
-                <div class="text-right">
-                  <input class="btn" type="button" id='previousButton' value='<?php echo __('Previous'); ?>'>
-                  <input class="btn" type="button" id='nextButton' value='<?php echo __('Next'); ?>'>
+                <div class="text-end">
+                  <input class="btn atom-btn-white" type="button" id='previousButton' value='<?php echo __('Previous'); ?>'>
+                  <input class="btn atom-btn-white" type="button" id='nextButton' value='<?php echo __('Next'); ?>'>
                 </div>
               </div>
             </div>

--- a/plugins/arDominionB5Plugin/scss/_layout.scss
+++ b/plugins/arDominionB5Plugin/scss/_layout.scss
@@ -85,3 +85,8 @@
     right: -30px;
   }
 }
+
+.hidden {
+  display: none;
+  visibility: hidden;
+}

--- a/plugins/arDominionB5Plugin/scss/_variables.scss
+++ b/plugins/arDominionB5Plugin/scss/_variables.scss
@@ -47,6 +47,7 @@ $accordion-button-active-bg: $gray-200 !default;
 $accordion-button-focus-box-shadow: $atom-gray-box-shadow !default;
 $accordion-bg: $white !default;
 $table-bg: $white !default;
+$table-striped-bg: $gray-200 !default;
 $input-border-color: $gray-300 !default;
 
 // Font Awesome

--- a/plugins/arDominionB5Plugin/templates/_layout_end.php
+++ b/plugins/arDominionB5Plugin/templates/_layout_end.php
@@ -12,5 +12,6 @@
     <script src="/plugins/arDominionB5Plugin/js/navbarWrap.js"></script>
     <script src="/plugins/arDominionB5Plugin/js/imageflow.js"></script>
     <script src="/plugins/arDominionB5Plugin/js/aggregations.js"></script>
+    <script src="/js/editingHistory.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This updates the following elements of the user index page:

* The navigation "pills" at the top of the page
* The `Edition history` accordion markup to reuse the existing `/js/editingHistory.js` script and adds the `hidden` CSS class as implemented in BS 2.3.2 and a wrapper for the loading spinner and text
* Makes the table in the accordion responsive and updates the classes of its pager buttons and the background color of the strips