### PR TITLE
Show anchored accordions in edit forms

### DIFF
--- a/js/editingHistory.js
+++ b/js/editingHistory.js
@@ -4,7 +4,11 @@
 
   var page = 1;
 
-  $(loadEditingHistory);
+  $(() => {
+    if ($('body').is('.user.index')) {
+      $(loadEditingHistory);
+    }
+  });
 
   function startActivity()
   {

--- a/plugins/arDominionB5Plugin/js/collapse.js
+++ b/plugins/arDominionB5Plugin/js/collapse.js
@@ -1,0 +1,17 @@
+($ => {
+
+  'use strict';
+
+  $(() => {
+    if ($('#editForm .accordion-item').length) {
+      var $collapseToShow = $(location.hash);
+      if ($collapseToShow.length) {
+        $collapseToShow.on('shown.bs.collapse', e => {
+          window.scrollTo(0, $(e.target).parent().offset().top);
+        });
+        bootstrap.Collapse.getOrCreateInstance($collapseToShow);
+      }
+    }
+  });
+
+})(jQuery);

--- a/plugins/arDominionB5Plugin/modules/accession/templates/editSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/accession/templates/editSuccess.php
@@ -28,11 +28,11 @@
     <div class="accordion">
       <div class="accordion-item">
         <h2 class="accordion-header" id="basic-heading">
-          <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#basic-collapse" aria-expanded="true" aria-controls="basic-collapse">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#basic-collapse" aria-expanded="false" aria-controls="basic-collapse">
             <?php echo __('Basic info'); ?>
           </button>
         </h2>
-        <div id="basic-collapse" class="accordion-collapse collapse show" aria-labelledby="basic-heading">
+        <div id="basic-collapse" class="accordion-collapse collapse" aria-labelledby="basic-heading">
           <div class="accordion-body">
             <?php echo $form->identifier
                 ->help(__('Accession number should be a combination of values recorded in the field and should be a unique accession number for the repository'))

--- a/plugins/arDominionB5Plugin/modules/accession/templates/indexSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/accession/templates/indexSuccess.php
@@ -43,7 +43,7 @@
 
 <div class="section" id="donorArea">
 
-  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Donor/Transferring body area').'</h2>', [$resource, 'module' => 'accession', 'action' => 'edit'], ['anchor' => 'donorArea', 'title' => __('Edit donor/transferring body area')]); ?>
+  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Donor/Transferring body area').'</h2>', [$resource, 'module' => 'accession', 'action' => 'edit'], ['anchor' => 'donor-collapse', 'title' => __('Edit donor/transferring body area')]); ?>
 
   <?php foreach (QubitRelation::getRelationsBySubjectId($resource->id, ['typeId' => QubitTerm::DONOR_ID]) as $item) { ?>
 
@@ -59,7 +59,7 @@
 
 <div class="section" id="administrativeArea">
 
-  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Administrative area').'</h2>', [$resource, 'module' => 'accession', 'action' => 'edit'], ['anchor' => 'administrativeArea', 'title' => __('Edit administrative area')]); ?>
+  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Administrative area').'</h2>', [$resource, 'module' => 'accession', 'action' => 'edit'], ['anchor' => 'admin-collapse', 'title' => __('Edit administrative area')]); ?>
 
   <?php echo render_show(__('Acquisition type'), render_value($resource->acquisitionType)); ?>
 
@@ -155,7 +155,7 @@
 
 <div class="section" id="rightsArea">
 
-  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Rights area').'</h2>', [$resource, 'module' => 'accession', 'action' => 'edit'], ['anchor' => 'rightsArea', 'title' => __('Edit rights area')]); ?>
+  <h2><?php echo __('Rights area'); ?></h2>
 
   <?php echo get_component('right', 'relatedRights', ['resource' => $resource]); ?>
 
@@ -163,7 +163,7 @@
 
 <div class="section" id="informationObjectArea">
 
-  <h2><?php echo __('%1% area', ['%1%' => sfConfig::get('app_ui_label_informationobject')]); ?></h2>
+  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('%1% area', ['%1%' => sfConfig::get('app_ui_label_informationobject')]).'</h2>', [$resource, 'module' => 'accession', 'action' => 'edit'], ['anchor' => 'io-collapse', 'title' => __('Edit %1% area', ['%1%' => sfConfig::get('app_ui_label_informationobject')])]); ?>
 
   <?php foreach (QubitRelation::getRelationsByObjectId($resource->id, ['typeId' => QubitTerm::ACCESSION_ID]) as $item) { ?>
 

--- a/plugins/arDominionB5Plugin/modules/arDacsPlugin/templates/indexSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/arDacsPlugin/templates/indexSuccess.php
@@ -1,0 +1,303 @@
+<?php decorate_with('layout_3col'); ?>
+
+<?php slot('sidebar'); ?>
+  <?php include_component('informationobject', 'contextMenu'); ?>
+<?php end_slot(); ?>
+
+<?php slot('title'); ?>
+
+  <h1><?php echo render_title($dacs); ?></h1>
+
+  <?php if (isset($errorSchema)) { ?>
+    <div class="messages error">
+      <ul>
+        <?php foreach ($errorSchema as $error) { ?>
+          <?php $error = sfOutputEscaper::unescape($error); ?>
+          <li><?php echo $error->getMessage(); ?></li>
+        <?php } ?>
+      </ul>
+    </div>
+  <?php } ?>
+
+  <?php if (QubitInformationObject::ROOT_ID != $resource->parentId) { ?>
+    <?php echo include_partial('default/breadcrumb', ['resource' => $resource, 'objects' => $resource->getAncestors()->andSelf()->orderBy('lft')]); ?>
+  <?php } ?>
+
+  <?php echo get_component('default', 'translationLinks', ['resource' => $resource]); ?>
+
+<?php end_slot(); ?>
+
+<?php slot('context-menu'); ?>
+
+  <?php echo get_partial('informationobject/actionIcons', ['resource' => $resource]); ?>
+
+  <?php echo get_partial('object/subjectAccessPoints', ['resource' => $resource, 'sidebar' => true]); ?>
+
+  <?php echo get_partial('informationobject/nameAccessPoints', ['resource' => $resource, 'sidebar' => true]); ?>
+
+  <?php echo get_partial('informationobject/genreAccessPoints', ['resource' => $resource, 'sidebar' => true]); ?>
+
+  <?php echo get_partial('object/placeAccessPoints', ['resource' => $resource, 'sidebar' => true]); ?>
+
+  <?php if (check_field_visibility('app_element_visibility_physical_storage')) { ?>
+    <?php echo get_component('physicalobject', 'contextMenu', ['resource' => $resource]); ?>
+  <?php } ?>
+
+<?php end_slot(); ?>
+
+<?php slot('before-content'); ?>
+
+  <?php echo get_component('digitalobject', 'imageflow', ['resource' => $resource]); ?>
+
+<?php end_slot(); ?>
+
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)) { ?>
+  <?php echo get_component('digitalobject', 'show', ['link' => $digitalObjectLink, 'resource' => $resource->digitalObjectsRelatedByobjectId[0], 'usageType' => QubitTerm::REFERENCE_ID]); ?>
+<?php } ?>
+
+<section id="identityArea">
+
+  <?php if (check_field_visibility('app_element_visibility_dacs_identity_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Identity elements').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'identity-collapse', 'title' => __('Edit identity elements')]); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Reference code'), $dacs->referenceCode); ?>
+
+  <?php echo render_show_repository(__('Name and location of repository'), $resource); ?>
+
+  <?php echo render_show(__('Level of description'), render_value($resource->levelOfDescription)); ?>
+
+  <?php echo render_show(__('Title'), render_value($resource->getTitle(['cultureFallback' => true]))); ?>
+
+  <div class="field">
+    <h3><?php echo __('Date(s)'); ?></h3>
+    <div>
+      <ul>
+        <?php foreach ($resource->getDates() as $item) { ?>
+          <li>
+            <?php echo render_value_inline(Qubit::renderDateStartEnd($item->getDate(['cultureFallback' => true]), $item->startDate, $item->endDate)); ?> (<?php echo $item->getType(['cultureFallback' => true]); ?>)
+          </li>
+        <?php } ?>
+      </ul>
+    </div>
+  </div>
+
+  <?php echo render_show(__('Extent'), render_value($resource->getCleanExtentAndMedium(['cultureFallback' => true]))); ?>
+
+  <?php echo get_component('informationobject', 'creatorDetail', [
+      'resource' => $resource,
+      'creatorHistoryLabels' => $creatorHistoryLabels, ]); ?>
+
+  <?php foreach ($functionRelations as $item) { ?>
+    <div class="field">
+      <h3><?php echo __('Related function'); ?></h3>
+      <div>
+        <?php echo link_to(render_title($item->subject->getLabel()), [$item->subject, 'module' => 'function']); ?>
+      </div>
+    </div>
+  <?php } ?>
+
+</section> <!-- /section#identityArea -->
+
+<section id="contentAndStructureArea">
+
+  <?php if (check_field_visibility('app_element_visibility_dacs_content_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Content and structure elements').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'content-collapse', 'title' => __('Edit context and structure elements')]); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Scope and content'), render_value($resource->getScopeAndContent(['cultureFallback' => true]))); ?>
+
+  <?php echo render_show(__('System of arrangement'), render_value($resource->getArrangement(['cultureFallback' => true]))); ?>
+
+</section> <!-- /section#contentAndStructureArea -->
+
+<section id="conditionsOfAccessAndUseArea">
+
+  <?php if (check_field_visibility('app_element_visibility_dacs_conditions_of_access_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Conditions of access and use elements').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'conditions-collapse', 'title' => __('Edit conditions of access and use elements')]); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Conditions governing access'), render_value($resource->getAccessConditions(['cultureFallback' => true]))); ?>
+
+  <?php if (check_field_visibility('app_element_visibility_dacs_physical_access')) { ?>
+    <?php echo render_show(__('Physical access'), render_value($resource->getPhysicalCharacteristics(['cultureFallback' => true]))); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Technical access'), render_value($dacs->__get('technicalAccess', ['cultureFallback' => true]))); ?>
+
+  <?php echo render_show(__('Conditions governing reproduction'), render_value($resource->getReproductionConditions(['cultureFallback' => true]))); ?>
+
+  <div class="field">
+    <h3><?php echo __('Languages of the material'); ?></h3>
+    <div>
+      <ul>
+        <?php foreach ($resource->language as $code) { ?>
+          <li><?php echo format_language($code); ?></li>
+        <?php } ?>
+      </ul>
+    </div>
+  </div>
+
+  <div class="field">
+    <h3><?php echo __('Scripts of the material'); ?></h3>
+    <div>
+      <ul>
+        <?php foreach ($resource->script as $code) { ?>
+          <li><?php echo format_script($code); ?></li>
+        <?php } ?>
+      </ul>
+    </div>
+  </div>
+
+  <?php echo render_show(__('Language and script notes'), render_value($dacs->languageNotes)); ?>
+
+  <?php echo render_show(__('Finding aids'), render_value($resource->getFindingAids(['cultureFallback' => true]))); ?>
+
+  <?php echo get_component('informationobject', 'findingAidLink', ['resource' => $resource]); ?>
+
+</section> <!-- /section#conditionsOfAccessAndUseArea -->
+
+<section id="acquisitionAndAppraisalArea">
+
+  <?php if (check_field_visibility('app_element_visibility_dacs_acquisition_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Acquisition and appraisal elements').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'acquisition-collapse', 'title' => __('Edit acquisition and appraisal elements')]); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Custodial history'), render_value($resource->getArchivalHistory(['cultureFallback' => true]))); ?>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_immediate_source')) { ?>
+    <?php echo render_show(__('Immediate source of acquisition'), render_value($resource->getAcquisition(['cultureFallback' => true]))); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_appraisal_destruction')) { ?>
+    <?php echo render_show(__('Appraisal, destruction and scheduling information'), render_value($resource->getAppraisal(['cultureFallback' => true]))); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Accruals'), render_value($resource->getAccruals(['cultureFallback' => true]))); ?>
+
+</section> <!-- /section#acquisitionAndAppraisalArea -->
+
+<section id="alliedMaterialsArea">
+
+  <?php if (check_field_visibility('app_element_visibility_dacs_materials_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Related materials elements').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'related-collapse', 'title' => __('Edit related materials elements')]); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Existence and location of originals'), render_value($resource->getLocationOfOriginals(['cultureFallback' => true]))); ?>
+
+  <?php echo render_show(__('Existence and location of copies'), render_value($resource->getLocationOfCopies(['cultureFallback' => true]))); ?>
+
+  <?php echo render_show(__('Related archival materials'), render_value($resource->getRelatedUnitsOfDescription(['cultureFallback' => true]))); ?>
+
+  <?php echo get_partial('informationobject/relatedMaterialDescriptions', ['resource' => $resource, 'template' => 'isad']); ?>
+
+  <?php foreach ($resource->getNotesByType(['noteTypeId' => QubitTerm::PUBLICATION_NOTE_ID]) as $item) { ?>
+    <?php echo render_show(__('Publication notes'), render_value($item->getContent(['cultureFallback' => true]))); ?>
+  <?php } ?>
+
+</section> <!-- /section#alliedMaterialsArea -->
+
+<section id="notesArea">
+
+  <?php if (check_field_visibility('app_element_visibility_dacs_notes_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Notes element').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'notes-collapse', 'title' => __('Edit notes element')]); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_notes')) { ?>
+
+    <?php foreach ($resource->getNotesByType(['noteTypeId' => QubitTerm::GENERAL_NOTE_ID]) as $item) { ?>
+      <?php echo render_show(__('General note'), render_value($item->getContent(['cultureFallback' => true]))); ?>
+    <?php } ?>
+
+    <div class="field">
+      <h3><?php echo __('Specialized notes'); ?></h3>
+      <div>
+        <ul>
+          <?php foreach ($resource->getNotesByTaxonomy(['taxonomyId' => QubitTaxonomy::DACS_NOTE_ID]) as $item) { ?>
+            <li><?php echo render_value_inline($item->type); ?>: <?php echo render_value_inline($item->getContent(['cultureFallback' => true])); ?></li>
+          <?php } ?>
+        </ul>
+      </div>
+    </div>
+
+  <?php } ?>
+
+  <?php echo get_partial('informationobject/alternativeIdentifiersIndex', ['resource' => $resource]); ?>
+
+</section> <!-- /section#notesArea -->
+
+<section id="descriptionControlArea">
+
+  <?php if (check_field_visibility('app_element_visibility_dacs_control_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Description control element').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'description-collapse', 'title' => __('Edit description control element')]); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_control_rules_conventions')) { ?>
+    <?php echo render_show(__('Rules or conventions'), render_value($resource->getRules(['cultureFallback' => true]))); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_control_sources')) { ?>
+    <?php echo render_show(__('Sources used'), render_value($resource->getSources(['cultureFallback' => true]))); ?>
+  <?php } ?>
+
+  <!-- TODO: Make $archivistsNotesComponent to include ISAD 3.7.3 Date(s) of description as the first note and editable -->
+
+  <?php if (check_field_visibility('app_element_visibility_isad_control_archivists_notes')) { ?>
+    <?php foreach ($resource->getNotesByType(['noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID]) as $item) { ?>
+      <?php echo render_show(__('Archivist\'s note'), render_value($item->getContent(['cultureFallback' => true]))); ?>
+    <?php } ?>
+  <?php } ?>
+
+</section> <!-- /section#descriptionControlArea -->
+
+<section id="accessPointsArea">
+
+  <?php if (check_field_visibility('app_element_visibility_dacs_access_points_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Access points').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'access-collapse', 'title' => __('Edit access points')]); ?>
+  <?php } ?>
+
+  <?php echo get_partial('object/subjectAccessPoints', ['resource' => $resource]); ?>
+
+  <?php echo get_partial('object/placeAccessPoints', ['resource' => $resource]); ?>
+
+  <?php echo get_partial('informationobject/nameAccessPoints', ['resource' => $resource, 'showActorEvents' => true]); ?>
+
+  <?php echo get_partial('informationobject/genreAccessPoints', ['resource' => $resource]); ?>
+
+</section> <!-- /section#accessPointsArea -->
+
+<?php if ($sf_user->isAuthenticated()) { ?>
+
+  <div class="section" id="rightsArea">
+
+    <?php if (QubitAcl::check($resource, 'update')) { ?>
+      <h2><?php echo __('Rights area'); ?> </h2>
+    <?php } ?>
+
+    <?php echo get_component('right', 'relatedRights', ['resource' => $resource]); ?>
+
+  </div> <!-- /section#rightsArea -->
+
+<?php } ?>
+
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)) { ?>
+
+  <?php echo get_component('digitalobject', 'metadata', ['resource' => $resource->digitalObjectsRelatedByobjectId[0], 'object' => $resource]); ?>
+
+  <?php echo get_partial('digitalobject/rights', ['resource' => $resource->digitalObjectsRelatedByobjectId[0]]); ?>
+
+<?php } ?>
+
+<section id="accessionArea">
+
+  <h2><?php echo __('Accession area'); ?></h2>
+
+  <?php echo get_component('informationobject', 'accessions', ['resource' => $resource]); ?>
+
+</section> <!-- /section#accessionArea -->
+
+<?php slot('after-content'); ?>
+  <?php echo get_partial('informationobject/actions', ['resource' => $resource]); ?>
+<?php end_slot(); ?>
+
+<?php echo get_component('object', 'gaInstitutionsDimension', ['resource' => $resource]); ?>

--- a/plugins/arDominionB5Plugin/modules/sfDcPlugin/templates/editSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfDcPlugin/templates/editSuccess.php
@@ -34,11 +34,11 @@
     <div class="accordion">
       <div class="accordion-item">
         <h2 class="accordion-header" id="elements-heading">
-          <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#elements-collapse" aria-expanded="true" aria-controls="elements-collapse">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#elements-collapse" aria-expanded="false" aria-controls="elements-collapse">
             <?php echo __('Elements area'); ?>
           </button>
         </h2>
-        <div id="elements-collapse" class="accordion-collapse collapse show" aria-labelledby="elements-heading">
+        <div id="elements-collapse" class="accordion-collapse collapse" aria-labelledby="elements-heading">
           <div class="accordion-body">
             <?php echo $form->identifier
                 ->help(__('The unambiguous reference code used to uniquely identify this resource.'))

--- a/plugins/arDominionB5Plugin/modules/sfDcPlugin/templates/indexSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfDcPlugin/templates/indexSuccess.php
@@ -1,0 +1,161 @@
+<?php decorate_with('layout_3col'); ?>
+
+<?php slot('sidebar'); ?>
+  <?php include_component('informationobject', 'contextMenu'); ?>
+<?php end_slot(); ?>
+
+<?php slot('title'); ?>
+
+  <?php echo get_component('informationobject', 'descriptionHeader', ['resource' => $resource, 'title' => (string) $dc, 'hideLevelOfDescription' => true]); ?>
+
+  <?php if (isset($errorSchema)) { ?>
+    <div class="messages error">
+      <ul>
+        <?php foreach ($errorSchema as $error) { ?>
+          <?php $error = sfOutputEscaper::unescape($error); ?>
+          <li><?php echo $error->getMessage(); ?></li>
+        <?php } ?>
+      </ul>
+    </div>
+  <?php } ?>
+
+  <?php if (QubitInformationObject::ROOT_ID != $resource->parentId) { ?>
+    <?php echo include_partial('default/breadcrumb', ['resource' => $resource, 'objects' => $resource->getAncestors()->andSelf()->orderBy('lft')]); ?>
+  <?php } ?>
+
+  <?php echo get_component('default', 'translationLinks', ['resource' => $resource]); ?>
+
+<?php end_slot(); ?>
+
+<?php slot('context-menu'); ?>
+
+  <?php echo get_partial('informationobject/actionIcons', ['resource' => $resource]); ?>
+
+  <?php echo get_partial('object/subjectAccessPoints', ['resource' => $resource, 'sidebar' => true]); ?>
+
+  <?php echo get_partial('informationobject/nameAccessPoints', ['resource' => $resource, 'sidebar' => true]); ?>
+
+  <?php echo get_partial('object/placeAccessPoints', ['resource' => $resource, 'sidebar' => true]); ?>
+
+  <?php if (check_field_visibility('app_element_visibility_physical_storage')) { ?>
+    <?php echo get_component('physicalobject', 'contextMenu', ['resource' => $resource]); ?>
+  <?php } ?>
+
+<?php end_slot(); ?>
+
+<?php slot('before-content'); ?>
+
+  <?php echo get_component('digitalobject', 'imageflow', ['resource' => $resource]); ?>
+
+<?php end_slot(); ?>
+
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)) { ?>
+  <?php echo get_component('digitalobject', 'show', ['link' => $digitalObjectLink, 'resource' => $resource->digitalObjectsRelatedByobjectId[0], 'usageType' => QubitTerm::REFERENCE_ID]); ?>
+<?php } ?>
+
+<section id="elementsArea">
+
+  <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Elements area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'elements-collapse', 'title' => __('Edit elements area')]); ?>
+
+  <?php echo render_show(__('Identifier'), $resource->identifier); ?>
+
+  <?php echo render_show(__('Title'), render_value($resource->getTitle(['cultureFallback' => true]))); ?>
+
+  <?php $actorsShown = []; ?>
+  <?php foreach ($resource->getCreators() as $item) { ?>
+    <?php if (!isset($actorsShown[$item->id])) { ?>
+      <div class="field">
+        <h3><?php echo __('Creator'); ?></h3>
+        <div>
+          <?php echo link_to(render_title($item), [$item, 'module' => 'actor']); ?><?php if (0 < strlen($value = $item->getDatesOfExistence(['cultureFallback' => true]))) { ?> <span class="note2">(<?php echo $value; ?>)</span><?php } ?>
+        </div>
+      </div>
+      <?php $actorsShown[$item->id] = true; ?>
+    <?php } ?>
+  <?php } ?>
+
+  <?php foreach ($resource->getPublishers() as $item) { ?>
+    <div class="field">
+      <h3><?php echo __('Publisher'); ?></h3>
+      <div>
+        <?php echo link_to(render_title($item), [$item, 'module' => 'actor']); ?><?php if ($value = $item->getDatesOfExistence(['cultureFallback' => true])) { ?> <span class="note2">(<?php echo $value; ?>)</span><?php } ?>
+      </div>
+    </div>
+  <?php } ?>
+
+  <?php foreach ($resource->getContributors() as $item) { ?>
+    <div class="field">
+      <h3><?php echo __('Contributor'); ?></h3>
+      <div>
+        <?php echo link_to(render_title($item), [$item, 'module' => 'actor']); ?><?php if ($value = $item->getDatesOfExistence(['cultureFallback' => true])) { ?> <span class="note2">(<?php echo $value; ?>)</span><?php } ?>
+      </div>
+    </div>
+  <?php } ?>
+
+  <?php echo get_partial('informationobject/dates', ['resource' => $resource]); ?>
+
+  <?php foreach ($resource->getSubjectAccessPoints() as $item) { ?>
+    <?php echo render_show(__('Subject'), link_to(render_title($item->term), [$item->term, 'module' => 'term'])); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Description'), render_value($resource->getScopeAndContent(['cultureFallback' => true]))); ?>
+
+  <?php foreach ($dc->type as $item) { ?>
+    <?php echo render_show(__('Type'), render_value($item)); ?>
+  <?php } ?>
+
+  <?php foreach ($dc->format as $item) { ?>
+    <?php echo render_show(__('Format'), render_value($item)); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Source'), render_value($resource->getLocationOfOriginals(['cultureFallback' => true]))); ?>
+
+  <?php foreach ($resource->language as $code) { ?>
+    <?php echo render_show(__('Language'), format_language($code)); ?>
+  <?php } ?>
+
+  <?php echo render_show_repository(__('Relation (isLocatedAt)'), $resource); ?>
+
+  <?php foreach ($dc->coverage as $item) { ?>
+    <?php echo render_show(__('Coverage (spatial)'), link_to(render_title($item), [$item, 'module' => 'term'])); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Rights'), render_value($resource->getAccessConditions(['cultureFallback' => true]))); ?>
+
+</section> <!-- /section#elementsArea -->
+
+<?php if ($sf_user->isAuthenticated()) { ?>
+
+  <section id="rightsArea">
+
+    <?php if (QubitAcl::check($resource, 'update')) { ?>
+      <h2><?php echo __('Rights area'); ?> </h2>
+    <?php } ?>
+
+    <?php echo get_component('right', 'relatedRights', ['resource' => $resource]); ?>
+
+  </section> <!-- /section#rightsArea -->
+
+<?php } ?>
+
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)) { ?>
+
+  <?php echo get_component('digitalobject', 'metadata', ['resource' => $resource->digitalObjectsRelatedByobjectId[0], 'object' => $resource]); ?>
+
+  <?php echo get_partial('digitalobject/rights', ['resource' => $resource->digitalObjectsRelatedByobjectId[0]]); ?>
+
+<?php } ?>
+
+<section id="accessionArea">
+
+  <h2><?php echo __('Accession area'); ?></h2>
+
+  <?php echo get_component('informationobject', 'accessions', ['resource' => $resource]); ?>
+
+</section> <!-- /section#accessionArea -->
+
+<?php slot('after-content'); ?>
+  <?php echo get_partial('informationobject/actions', ['resource' => $resource]); ?>
+<?php end_slot(); ?>
+
+<?php echo get_component('object', 'gaInstitutionsDimension', ['resource' => $resource]); ?>

--- a/plugins/arDominionB5Plugin/modules/sfIsaarPlugin/templates/editSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfIsaarPlugin/templates/editSuccess.php
@@ -23,11 +23,11 @@
     <div class="accordion">
       <div class="accordion-item">
         <h2 class="accordion-header" id="identity-heading">
-          <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#identity-collapse" aria-expanded="true" aria-controls="identity-collapse">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#identity-collapse" aria-expanded="false" aria-controls="identity-collapse">
             <?php echo __('Identity area'); ?>
           </button>
         </h2>
-        <div id="identity-collapse" class="accordion-collapse collapse show" aria-labelledby="identity-heading">
+        <div id="identity-collapse" class="accordion-collapse collapse" aria-labelledby="identity-heading">
           <div class="accordion-body">
             <?php echo $form->entityType
                 ->help(__('"Specify the type of entity that is being described in this authority record." (ISAAR 5.1.1) Select Corporate body, Family or Person from the drop-down menu.'))

--- a/plugins/arDominionB5Plugin/modules/sfIsaarPlugin/templates/indexSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfIsaarPlugin/templates/indexSuccess.php
@@ -66,7 +66,7 @@
 
 <section id="identityArea">
 
-  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Identity area').'</h2>', [$resource, 'module' => 'actor', 'action' => 'edit'], ['anchor' => 'identityArea', 'title' => __('Edit identity area')]); ?>
+  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Identity area').'</h2>', [$resource, 'module' => 'actor', 'action' => 'edit'], ['anchor' => 'identity-collapse', 'title' => __('Edit identity area')]); ?>
 
   <?php echo render_show(__('Type of entity'), render_value($resource->entityType)); ?>
 
@@ -111,7 +111,7 @@
 
 <section id="descriptionArea">
 
-  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Description area').'</h2>', [$resource, 'module' => 'actor', 'action' => 'edit'], ['anchor' => 'descriptionArea', 'title' => __('Edit description area')]); ?>
+  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Description area').'</h2>', [$resource, 'module' => 'actor', 'action' => 'edit'], ['anchor' => 'description-collapse', 'title' => __('Edit description area')]); ?>
 
   <?php echo render_show(__('Dates of existence'), render_value($resource->getDatesOfExistence(['cultureFallback' => true]))); ?>
 
@@ -133,7 +133,7 @@
 
 <section id="relationshipsArea">
 
-  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Relationships area').'</h2>', [$resource, 'module' => 'actor', 'action' => 'edit'], ['anchor' => 'relationshipsArea', 'title' => __('Edit relationships area')]); ?>
+  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Relationships area').'</h2>', [$resource, 'module' => 'actor', 'action' => 'edit'], ['anchor' => 'relationships-collapse', 'title' => __('Edit relationships area')]); ?>
 
   <?php foreach ($resource->getActorRelations() as $item) { ?>
     <?php $relatedEntity = $item->getOpposedObject($resource->id); ?>
@@ -173,7 +173,7 @@
 
 <section id="accessPointsArea">
 
-  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Access points area').'</h2>', [$resource, 'module' => 'actor', 'action' => 'edit'], ['anchor' => 'accessPointsArea', 'title' => __('Edit access points area')]); ?>
+  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Access points area').'</h2>', [$resource, 'module' => 'actor', 'action' => 'edit'], ['anchor' => 'access-collapse', 'title' => __('Edit access points area')]); ?>
 
   <div class="subjectAccessPoints">
     <?php echo get_partial('object/subjectAccessPoints', ['resource' => $resource]); ?>
@@ -202,7 +202,7 @@
 
 <section id="controlArea">
 
-  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Control area').'</h2>', [$resource, 'module' => 'actor', 'action' => 'edit'], ['anchor' => 'controlArea', 'title' => __('Edit control area')]); ?>
+  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Control area').'</h2>', [$resource, 'module' => 'actor', 'action' => 'edit'], ['anchor' => 'control-collapse', 'title' => __('Edit control area')]); ?>
 
   <?php echo render_show(__('Authority record identifier'), $resource->descriptionIdentifier); ?>
 

--- a/plugins/arDominionB5Plugin/modules/sfIsadPlugin/templates/editSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfIsadPlugin/templates/editSuccess.php
@@ -33,11 +33,11 @@
     <div class="accordion">
       <div class="accordion-item">
         <h2 class="accordion-header" id="identity-heading">
-          <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#identity-collapse" aria-expanded="true" aria-controls="identity-collapse">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#identity-collapse" aria-expanded="false" aria-controls="identity-collapse">
             <?php echo __('Identity area'); ?>
           </button>
         </h2>
-        <div id="identity-collapse" class="accordion-collapse collapse show" aria-labelledby="identity-heading">
+        <div id="identity-collapse" class="accordion-collapse collapse" aria-labelledby="identity-heading">
           <div class="accordion-body">
             <?php echo render_show(__('Reference code'), render_value($isad->referenceCode)); ?>
 

--- a/plugins/arDominionB5Plugin/modules/sfIsadPlugin/templates/indexSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfIsadPlugin/templates/indexSuccess.php
@@ -1,0 +1,353 @@
+<?php decorate_with('layout_3col'); ?>
+
+<?php slot('sidebar'); ?>
+  <?php include_component('informationobject', 'contextMenu'); ?>
+<?php end_slot(); ?>
+
+<?php slot('title'); ?>
+
+  <?php echo get_component('informationobject', 'descriptionHeader', ['resource' => $resource, 'title' => (string) $isad]); ?>
+
+  <?php if (isset($errorSchema)) { ?>
+    <div class="messages error">
+      <ul>
+        <?php foreach ($errorSchema as $error) { ?>
+          <?php $error = sfOutputEscaper::unescape($error); ?>
+          <li><?php echo $error->getMessage(); ?></li>
+        <?php } ?>
+      </ul>
+    </div>
+  <?php } ?>
+
+  <?php if (QubitInformationObject::ROOT_ID != $resource->parentId) { ?>
+    <?php echo include_partial('default/breadcrumb', ['resource' => $resource, 'objects' => $resource->getAncestors()->andSelf()->orderBy('lft')]); ?>
+  <?php } ?>
+
+  <?php echo get_component('default', 'translationLinks', ['resource' => $resource]); ?>
+
+<?php end_slot(); ?>
+
+<?php slot('context-menu'); ?>
+
+  <?php echo get_partial('informationobject/actionIcons', ['resource' => $resource]); ?>
+
+  <?php echo get_partial('object/subjectAccessPoints', ['resource' => $resource, 'sidebar' => true]); ?>
+
+  <?php echo get_partial('informationobject/nameAccessPoints', ['resource' => $resource, 'sidebar' => true]); ?>
+
+  <?php echo get_partial('informationobject/genreAccessPoints', ['resource' => $resource, 'sidebar' => true]); ?>
+
+  <?php echo get_partial('object/placeAccessPoints', ['resource' => $resource, 'sidebar' => true]); ?>
+
+  <?php if (check_field_visibility('app_element_visibility_physical_storage')) { ?>
+    <?php echo get_component('physicalobject', 'contextMenu', ['resource' => $resource]); ?>
+  <?php } ?>
+
+<?php end_slot(); ?>
+
+<?php slot('before-content'); ?>
+
+  <?php echo get_component('digitalobject', 'imageflow', ['resource' => $resource]); ?>
+
+<?php end_slot(); ?>
+
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)) { ?>
+  <?php echo get_component('digitalobject', 'show', ['link' => $digitalObjectLink, 'resource' => $resource->digitalObjectsRelatedByobjectId[0], 'usageType' => QubitTerm::REFERENCE_ID]); ?>
+<?php } ?>
+
+<section id="identityArea">
+
+  <?php if (check_field_visibility('app_element_visibility_isad_identity_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Identity area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'identity-collapse', 'title' => __('Edit identity area')]); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Reference code'), $isad->referenceCode, ['fieldLabel' => 'referenceCode']); ?>
+
+  <?php echo render_show(__('Title'), render_title($resource), ['fieldLabel' => 'title']); ?>
+
+  <div class="field">
+    <h3><?php echo __('Date(s)'); ?></h3>
+    <div class="creationDates">
+      <ul>
+        <?php foreach ($resource->getDates() as $item) { ?>
+          <li>
+            <?php echo render_value_inline(Qubit::renderDateStartEnd($item->getDate(['cultureFallback' => true]), $item->startDate, $item->endDate)); ?> (<?php echo $item->getType(['cultureFallback' => true]); ?>)
+          </li>
+        <?php } ?>
+      </ul>
+    </div>
+  </div>
+
+  <?php echo render_show(__('Level of description'), render_value($resource->levelOfDescription), ['fieldLabel' => 'levelOfDescription']); ?>
+
+  <?php echo render_show(__('Extent and medium'), render_value($resource->getCleanExtentAndMedium(['cultureFallback' => true])), ['fieldLabel' => 'extentAndMedium']); ?>
+</section> <!-- /section#identityArea -->
+
+<section id="contextArea">
+
+  <?php if (check_field_visibility('app_element_visibility_isad_context_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Context area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'context-collapse', 'title' => __('Edit context area')]); ?>
+  <?php } ?>
+
+  <div class="creatorHistories">
+    <?php echo get_component('informationobject', 'creatorDetail', [
+        'resource' => $resource,
+        'creatorHistoryLabels' => $creatorHistoryLabels, ]); ?>
+  </div>
+
+  <div class="relatedFunctions">
+    <?php foreach ($functionRelations as $item) { ?>
+      <div class="field">
+        <h3><?php echo __('Related function'); ?></h3>
+        <div>
+          <?php echo link_to(render_title($item->subject->getLabel()), [$item->subject, 'module' => 'function']); ?>
+        </div>
+      </div>
+    <?php } ?>
+  </div>
+
+  <div class="repository">
+    <?php echo render_show_repository(__('Repository'), $resource); ?>
+  </div>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_archival_history')) { ?>
+    <?php echo render_show(__('Archival history'), render_value($resource->getArchivalHistory(['cultureFallback' => true])), ['fieldLabel' => 'archivalHistory']); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_immediate_source')) { ?>
+    <?php echo render_show(__('Immediate source of acquisition or transfer'), render_value($resource->getAcquisition(['cultureFallback' => true])), ['fieldLabel' => 'immediateSourceOfAcquisitionOrTransfer']); ?>
+  <?php } ?>
+
+</section> <!-- /section#contextArea -->
+
+<section id="contentAndStructureArea">
+
+  <?php if (check_field_visibility('app_element_visibility_isad_content_and_structure_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Content and structure area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'content-collapse', 'title' => __('Edit content and structure area')]); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Scope and content'), render_value($resource->getScopeAndContent(['cultureFallback' => true])), ['fieldLabel' => 'scopeAndContent']); ?>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_appraisal_destruction')) { ?>
+    <?php echo render_show(__('Appraisal, destruction and scheduling'), render_value($resource->getAppraisal(['cultureFallback' => true])), ['fieldLabel' => 'appraisalDestructionAndScheduling']); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Accruals'), render_value($resource->getAccruals(['cultureFallback' => true])), ['fieldLabel' => 'accruals']); ?>
+
+  <?php echo render_show(__('System of arrangement'), render_value($resource->getArrangement(['cultureFallback' => true])), ['fieldLabel' => 'systemOfArrangement']); ?>
+</section> <!-- /section#contentAndStructureArea -->
+
+<section id="conditionsOfAccessAndUseArea">
+
+  <?php if (check_field_visibility('app_element_visibility_isad_conditions_of_access_use_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Conditions of access and use area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'conditions-collapse', 'title' => __('Edit conditions of access and use area')]); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Conditions governing access'), render_value($resource->getAccessConditions(['cultureFallback' => true])), ['fieldLabel' => 'conditionsGoverningAccess']); ?>
+
+  <?php echo render_show(__('Conditions governing reproduction'), render_value($resource->getReproductionConditions(['cultureFallback' => true])), ['fieldLabel' => 'conditionsGoverningReproduction']); ?>
+
+  <div class="field">
+    <h3><?php echo __('Language of material'); ?></h3>
+    <div class="languageOfMaterial">
+      <ul>
+        <?php foreach ($resource->language as $code) { ?>
+          <li><?php echo format_language($code); ?></li>
+        <?php } ?>
+      </ul>
+    </div>
+  </div>
+
+  <div class="field">
+    <h3><?php echo __('Script of material'); ?></h3>
+    <div class="scriptOfMaterial">
+      <ul>
+        <?php foreach ($resource->script as $code) { ?>
+          <li><?php echo format_script($code); ?></li>
+        <?php } ?>
+      </ul>
+    </div>
+  </div>
+
+  <?php echo render_show(__('Language and script notes'), render_value($isad->languageNotes), ['fieldLabel' => 'languageAndScriptNotes']); ?>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_physical_condition')) { ?>
+    <?php echo render_show(__('Physical characteristics and technical requirements'), render_value($resource->getPhysicalCharacteristics(['cultureFallback' => true])), ['fieldLabel' => 'physicalCharacteristics']); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Finding aids'), render_value($resource->getFindingAids(['cultureFallback' => true])), ['fieldLabel' => 'findingAids']); ?>
+
+  <?php echo get_component('informationobject', 'findingAidLink', ['resource' => $resource]); ?>
+
+</section> <!-- /section#conditionsOfAccessAndUseArea -->
+
+<section id="alliedMaterialsArea">
+
+  <?php if (check_field_visibility('app_element_visibility_isad_allied_materials_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Allied materials area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'allied-collapse', 'title' => __('Edit alied materials area')]); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Existence and location of originals'), render_value($resource->getLocationOfOriginals(['cultureFallback' => true])), ['fieldLabel' => 'existenceAndLocationOfOriginals']); ?>
+
+  <?php echo render_show(__('Existence and location of copies'), render_value($resource->getLocationOfCopies(['cultureFallback' => true])), ['fieldLabel' => 'existenceAndLocationOfCopies']); ?>
+
+  <?php echo render_show(__('Related units of description'), render_value($resource->getRelatedUnitsOfDescription(['cultureFallback' => true])), ['fieldLabel' => 'relatedUnitsOfDescription']); ?>
+
+  <div class="relatedMaterialDescriptions">
+    <?php echo get_partial('informationobject/relatedMaterialDescriptions', ['resource' => $resource, 'template' => 'isad']); ?>
+  </div>
+
+  <?php foreach ($resource->getNotesByType(['noteTypeId' => QubitTerm::PUBLICATION_NOTE_ID]) as $item) { ?>
+    <?php echo render_show(__('Publication note'), render_value($item->getContent(['cultureFallback' => true])), ['fieldLabel' => 'publicationNote']); ?>
+  <?php } ?>
+</section> <!-- /section#alliedMaterialsArea -->
+
+<section id="notesArea">
+
+  <?php if (check_field_visibility('app_element_visibility_isad_notes_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Notes area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'notes-collapse', 'title' => __('Edit notes area')]); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_notes')) { ?>
+    <?php foreach ($resource->getNotesByType(['noteTypeId' => QubitTerm::GENERAL_NOTE_ID]) as $item) { ?>
+      <?php echo render_show(__('Note'), render_value($item->getContent(['cultureFallback' => true])), ['fieldLabel' => 'generalNote']); ?>
+    <?php } ?>
+  <?php } ?>
+
+  <div class="alternativeIdentifiers">
+    <?php echo get_partial('informationobject/alternativeIdentifiersIndex', ['resource' => $resource]); ?>
+  </div>
+</section> <!-- /section#notesArea -->
+
+<section id="accessPointsArea">
+
+  <?php if (check_field_visibility('app_element_visibility_isad_access_points_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Access points').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'access-collapse', 'title' => __('Edit access points')]); ?>
+  <?php } ?>
+
+  <div class="subjectAccessPoints">
+    <?php echo get_partial('object/subjectAccessPoints', ['resource' => $resource]); ?>
+  </div>
+
+  <div class="placeAccessPoints">
+    <?php echo get_partial('object/placeAccessPoints', ['resource' => $resource]); ?>
+  </div>
+
+  <div class="nameAccessPoints">
+    <?php echo get_partial('informationobject/nameAccessPoints', ['resource' => $resource, 'showActorEvents' => true]); ?>
+  </div>
+
+  <div class="genreAccessPoints">
+    <?php echo get_partial('informationobject/genreAccessPoints', ['resource' => $resource]); ?>
+  </div>
+</section> <!-- /section#accessPointsArea -->
+
+<section id="descriptionControlArea">
+
+  <?php if (check_field_visibility('app_element_visibility_isad_description_control_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Description control area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'description-collapse', 'title' => __('Edit description control area')]); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_control_description_identifier')) { ?>
+    <?php echo render_show(__('Description identifier'), $resource->getDescriptionIdentifier(['cultureFallback' => true]), ['fieldLabel' => 'descriptionIdentifier']); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_control_institution_identifier')) { ?>
+    <?php echo render_show(__('Institution identifier'), $resource->getInstitutionResponsibleIdentifier(['cultureFallback' => true]), ['fieldLabel' => 'institutionIdentifier']); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_control_rules_conventions')) { ?>
+    <?php echo render_show(__('Rules and/or conventions used'), render_value($resource->getRules(['cultureFallback' => true])), ['fieldLabel' => 'rulesAndOrConventionsUsed']); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_control_status')) { ?>
+    <?php echo render_show(__('Status'), render_value($resource->descriptionStatus), ['fieldLabel' => 'descriptionStatus']); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_control_level_of_detail')) { ?>
+    <?php echo render_show(__('Level of detail'), render_value($resource->descriptionDetail), ['fieldLabel' => 'levelOfDetail']); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_control_dates')) { ?>
+    <?php echo render_show(__('Dates of creation revision deletion'), render_value($resource->getRevisionHistory(['cultureFallback' => true])), ['fieldLabel' => 'datesOfCreationRevisionDeletion']); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_control_languages')) { ?>
+    <div class="field">
+      <h3><?php echo __('Language(s)'); ?></h3>
+      <div class="languages">
+        <ul>
+          <?php foreach ($resource->languageOfDescription as $code) { ?>
+            <li><?php echo format_language($code); ?></li>
+          <?php } ?>
+        </ul>
+      </div>
+    </div>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_control_scripts')) { ?>
+    <div class="field">
+      <h3><?php echo __('Script(s)'); ?></h3>
+      <div class="scripts">
+        <ul>
+          <?php foreach ($resource->scriptOfDescription as $code) { ?>
+            <li><?php echo format_script($code); ?></li>
+          <?php } ?>
+        </ul>
+      </div>
+    </div>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_control_sources')) { ?>
+    <?php echo render_show(__('Sources'), render_value($resource->getSources(['cultureFallback' => true])), ['fieldLabel' => 'sources']); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_isad_control_archivists_notes')) { ?>
+    <?php foreach ($resource->getNotesByType(['noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID]) as $item) { ?>
+      <?php echo render_show(__('Archivist\'s note'), render_value($item->getContent(['cultureFallback' => true])), ['fieldLabel' => 'archivistNote']); ?>
+    <?php } ?>
+  <?php } ?>
+
+</section> <!-- /section#descriptionControlArea -->
+
+<?php if ($sf_user->isAuthenticated()) { ?>
+
+  <div class="section" id="rightsArea">
+
+    <h2><?php echo __('Rights area'); ?> </h2>
+
+    <div class="relatedRights">
+      <?php echo get_component('right', 'relatedRights', ['resource' => $resource]); ?>
+    </div>
+
+  </div> <!-- /section#rightsArea -->
+
+<?php } ?>
+
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)) { ?>
+
+  <div class="digitalObjectMetadata">
+    <?php echo get_component('digitalobject', 'metadata', ['resource' => $resource->digitalObjectsRelatedByobjectId[0], 'object' => $resource]); ?>
+  </div>
+
+  <div class="digitalObjectRights">
+    <?php echo get_partial('digitalobject/rights', ['resource' => $resource->digitalObjectsRelatedByobjectId[0]]); ?>
+  </div>
+
+<?php } ?>
+
+<section id="accessionArea">
+
+  <h2><?php echo __('Accession area'); ?></h2>
+
+  <div class="accessions">
+    <?php echo get_component('informationobject', 'accessions', ['resource' => $resource]); ?>
+  </div>
+
+</section> <!-- /section#accessionArea -->
+
+<?php slot('after-content'); ?>
+  <?php echo get_partial('informationobject/actions', ['resource' => $resource]); ?>
+<?php end_slot(); ?>
+
+<?php echo get_component('object', 'gaInstitutionsDimension', ['resource' => $resource]); ?>

--- a/plugins/arDominionB5Plugin/modules/sfIsdfPlugin/templates/editSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfIsdfPlugin/templates/editSuccess.php
@@ -22,11 +22,11 @@
     <div class="accordion">
       <div class="accordion-item">
         <h2 class="accordion-header" id="identity-heading">
-          <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#identity-collapse" aria-expanded="true" aria-controls="identity-collapse">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#identity-collapse" aria-expanded="false" aria-controls="identity-collapse">
             <?php echo __('Identity area'); ?>
           </button>
         </h2>
-        <div id="identity-collapse" class="accordion-collapse collapse show" aria-labelledby="identity-heading">
+        <div id="identity-collapse" class="accordion-collapse collapse" aria-labelledby="identity-heading">
           <div class="accordion-body">
             <?php echo $form->type
                 ->help(__('"Specify whether the description is a function or one of its subdivisions." (ISDF 5.1.1) Select the type from the drop-down menu; these values are drawn from the ISDF Function Types taxonomy.'))

--- a/plugins/arDominionB5Plugin/modules/sfIsdfPlugin/templates/indexSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfIsdfPlugin/templates/indexSuccess.php
@@ -34,7 +34,7 @@
 
 <div class="section" id="identityArea">
 
-  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Identity area').'</h2>', [$resource, 'module' => 'function', 'action' => 'edit'], ['anchor' => 'identityArea', 'title' => __('Edit identity area')]); ?>
+  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Identity area').'</h2>', [$resource, 'module' => 'function', 'action' => 'edit'], ['anchor' => 'identity-collapse', 'title' => __('Edit identity area')]); ?>
 
   <?php echo render_show(__('Type'), render_value($resource->type)); ?>
 
@@ -68,7 +68,7 @@
 
 <div class="section" id="contextArea">
 
-  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Context area').'</h2>', [$resource, 'module' => 'function', 'action' => 'edit'], ['anchor' => 'contextArea', 'title' => __('Edit context area')]); ?>
+  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Context area').'</h2>', [$resource, 'module' => 'function', 'action' => 'edit'], ['anchor' => 'context-collapse', 'title' => __('Edit context area')]); ?>
 
   <?php echo render_show(__('Dates'), render_value($resource->getDates(['cultureFallback' => true]))); ?>
 
@@ -82,7 +82,7 @@
 
 <div class="section" id="relationshipsArea">
 
-  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Relationships area').'</h2>', [$resource, 'module' => 'function', 'action' => 'edit'], ['anchor' => 'relationshipsArea', 'title' => __('Edit relationships area')]); ?>
+  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Relationships area').'</h2>', [$resource, 'module' => 'function', 'action' => 'edit'], ['anchor' => 'relationships-collapse', 'title' => __('Edit relationships area')]); ?>
 
   <?php foreach ($isdf->relatedFunction as $item) { ?>
     <div class="field">
@@ -148,7 +148,7 @@
 
 <div class="section" id="controlArea">
 
-  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Control area').'</h2>', [$resource, 'module' => 'function', 'action' => 'edit'], ['anchor' => 'controlArea', 'title' => __('Edit control area')]); ?>
+  <?php echo link_to_if(QubitAcl::check($resource, 'update'), '<h2>'.__('Control area').'</h2>', [$resource, 'module' => 'function', 'action' => 'edit'], ['anchor' => 'control-collapse', 'title' => __('Edit control area')]); ?>
 
   <?php echo render_show(__('Description identifier'), render_value($resource->descriptionIdentifier)); ?>
 

--- a/plugins/arDominionB5Plugin/modules/sfIsdiahPlugin/templates/editSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfIsdiahPlugin/templates/editSuccess.php
@@ -13,7 +13,7 @@
   <?php echo $form->renderGlobalErrors(); ?>
 
   <?php if (isset($sf_request->getAttribute('sf_route')->resource)) { ?>
-    <?php echo $form->renderFormTag(url_for([$resource, 'module' => 'repository', 'action' => 'edit'])); ?>
+    <?php echo $form->renderFormTag(url_for([$resource, 'module' => 'repository', 'action' => 'edit']), ['id' => 'editForm']); ?>
   <?php } else { ?>
     <?php echo $form->renderFormTag(url_for(['module' => 'repository', 'action' => 'add'])); ?>
   <?php } ?>
@@ -23,11 +23,11 @@
     <div class="accordion">
       <div class="accordion-item">
         <h2 class="accordion-header" id="identity-heading">
-          <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#identity-collapse" aria-expanded="true" aria-controls="identity-collapse">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#identity-collapse" aria-expanded="false" aria-controls="identity-collapse">
             <?php echo __('Identity area'); ?>
           </button>
         </h2>
-        <div id="identity-collapse" class="accordion-collapse collapse show" aria-labelledby="identity-heading">
+        <div id="identity-collapse" class="accordion-collapse collapse" aria-labelledby="identity-heading">
           <div class="accordion-body">
             <?php echo $form->identifier
                 ->help(__('"Record the numeric or alpha-numeric code identifying the institution in accordance with the relevant international and national standards." (ISDIAH 5.1.1)'))

--- a/plugins/arDominionB5Plugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
@@ -82,7 +82,7 @@
 
 <section id="identifyArea">
 
-  <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'repository'), '<h2>'.__('Identity area').'</h2>', [$resource, 'module' => 'repository', 'action' => 'edit'], ['anchor' => 'identityArea', 'title' => __('Edit identity area')]); ?>
+  <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'repository'), '<h2>'.__('Identity area').'</h2>', [$resource, 'module' => 'repository', 'action' => 'edit'], ['anchor' => 'identity-collapse', 'title' => __('Edit identity area')]); ?>
 
   <?php echo render_show(__('Identifier'), $resource->identifier); ?>
 
@@ -125,7 +125,7 @@
 
 <section id="contactArea">
 
-  <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'repository'), '<h2>'.__('Contact area').'</h2>', [$resource, 'module' => 'repository', 'action' => 'edit'], ['anchor' => 'contactArea', 'title' => __('Edit contact area')]); ?>
+  <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'repository'), '<h2>'.__('Contact area').'</h2>', [$resource, 'module' => 'repository', 'action' => 'edit'], ['anchor' => 'contact-collapse', 'title' => __('Edit contact area')]); ?>
 
   <?php foreach ($resource->contactInformations as $contactItem) { ?>
     <?php echo get_partial('contactinformation/contactInformation', ['contactInformation' => $contactItem]); ?>
@@ -135,7 +135,7 @@
 
 <section id="descriptionArea">
 
-  <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'repository'), '<h2>'.__('Description area').'</h2>', [$resource, 'module' => 'repository', 'action' => 'edit'], ['anchor' => 'descriptionArea', 'title' => __('Edit description area')]); ?>
+  <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'repository'), '<h2>'.__('Description area').'</h2>', [$resource, 'module' => 'repository', 'action' => 'edit'], ['anchor' => 'description-collapse', 'title' => __('Edit description area')]); ?>
 
   <?php echo render_show(__('History'), render_value($resource->getHistory(['cultureFallback' => true]))); ?>
 
@@ -157,7 +157,7 @@
 
 <section id="accessArea">
 
-  <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'repository'), '<h2>'.__('Access area').'</h2>', [$resource, 'module' => 'repository', 'action' => 'edit'], ['anchor' => 'accessArea', 'title' => __('Edit access area')]); ?>
+  <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'repository'), '<h2>'.__('Access area').'</h2>', [$resource, 'module' => 'repository', 'action' => 'edit'], ['anchor' => 'access-collapse', 'title' => __('Edit access area')]); ?>
 
   <?php echo render_show(__('Opening times'), render_value($resource->getOpeningTimes(['cultureFallback' => true]))); ?>
 
@@ -169,7 +169,7 @@
 
 <section id="servicesArea">
 
-  <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'repository'), '<h2>'.__('Services area').'</h2>', [$resource, 'module' => 'repository', 'action' => 'edit'], ['anchor' => 'servicesArea', 'title' => __('Edit services area')]); ?>
+  <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'repository'), '<h2>'.__('Services area').'</h2>', [$resource, 'module' => 'repository', 'action' => 'edit'], ['anchor' => 'services-collapse', 'title' => __('Edit services area')]); ?>
 
   <?php echo render_show(__('Research services'), render_value($resource->getResearchServices(['cultureFallback' => true]))); ?>
 
@@ -181,7 +181,7 @@
 
 <section id="controlArea">
 
-  <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'repository'), '<h2>'.__('Control area').'</h2>', [$resource, 'module' => 'repository', 'action' => 'edit'], ['anchor' => 'controlArea', 'title' => __('Edit control area')]); ?>
+  <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'repository'), '<h2>'.__('Control area').'</h2>', [$resource, 'module' => 'repository', 'action' => 'edit'], ['anchor' => 'control-collapse', 'title' => __('Edit control area')]); ?>
 
   <?php echo render_show(__('Description identifier'), render_value($resource->descIdentifier)); ?>
 
@@ -225,7 +225,7 @@
 
 <section id="accessPointsArea">
 
-  <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'repository'), '<h2>'.__('Access points').'</h2>', [$resource, 'module' => 'repository', 'action' => 'edit'], ['anchor' => 'accessPointsArea', 'title' => __('Edit access points')]); ?>
+  <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'repository'), '<h2>'.__('Access points').'</h2>', [$resource, 'module' => 'repository', 'action' => 'edit'], ['anchor' => 'points-collapse', 'title' => __('Edit access points')]); ?>
   <div class="field">
     <h3><?php echo __('Access Points'); ?></h3>
     <div>

--- a/plugins/arDominionB5Plugin/modules/sfModsPlugin/templates/editSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfModsPlugin/templates/editSuccess.php
@@ -34,11 +34,11 @@
     <div class="accordion">
       <div class="accordion-item">
         <h2 class="accordion-header" id="elements-heading">
-          <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#elements-collapse" aria-expanded="true" aria-controls="elements-collapse">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#elements-collapse" aria-expanded="false" aria-controls="elements-collapse">
             <?php echo __('Elements area'); ?>
           </button>
         </h2>
-        <div id="elements-collapse" class="accordion-collapse collapse show" aria-labelledby="elements-heading">
+        <div id="elements-collapse" class="accordion-collapse collapse" aria-labelledby="elements-heading">
           <div class="accordion-body">
             <?php echo $form->identifier
                 ->help(__('Contains a unique standard number or code that distinctively identifies a resource.'))

--- a/plugins/arDominionB5Plugin/modules/sfModsPlugin/templates/indexSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfModsPlugin/templates/indexSuccess.php
@@ -1,0 +1,159 @@
+<?php decorate_with('layout_3col'); ?>
+
+<?php slot('sidebar'); ?>
+  <?php include_component('informationobject', 'contextMenu'); ?>
+<?php end_slot(); ?>
+
+<?php slot('title'); ?>
+
+  <?php echo get_component('informationobject', 'descriptionHeader', ['resource' => $resource, 'title' => (string) $mods]); ?>
+
+  <?php if (isset($errorSchema)) { ?>
+    <div class="messages error">
+      <ul>
+        <?php foreach ($errorSchema as $error) { ?>
+          <?php $error = sfOutputEscaper::unescape($error); ?>
+          <li><?php echo $error->getMessage(); ?></li>
+        <?php } ?>
+      </ul>
+    </div>
+  <?php } ?>
+
+  <?php if (QubitInformationObject::ROOT_ID != $resource->parentId) { ?>
+    <?php echo include_partial('default/breadcrumb', ['resource' => $resource, 'objects' => $resource->getAncestors()->andSelf()->orderBy('lft')]); ?>
+  <?php } ?>
+
+  <?php echo get_component('default', 'translationLinks', ['resource' => $resource]); ?>
+
+<?php end_slot(); ?>
+
+<?php slot('context-menu'); ?>
+
+  <?php echo get_partial('informationobject/actionIcons', ['resource' => $resource]); ?>
+
+  <?php echo get_partial('object/subjectAccessPoints', ['resource' => $resource, 'sidebar' => true]); ?>
+
+  <?php echo get_partial('informationobject/nameAccessPoints', ['resource' => $resource, 'sidebar' => true]); ?>
+
+  <?php echo get_partial('object/placeAccessPoints', ['resource' => $resource, 'sidebar' => true]); ?>
+
+  <?php if (check_field_visibility('app_element_visibility_physical_storage')) { ?>
+    <?php echo get_component('physicalobject', 'contextMenu', ['resource' => $resource]); ?>
+  <?php } ?>
+
+<?php end_slot(); ?>
+
+<?php slot('before-content'); ?>
+
+  <?php echo get_component('digitalobject', 'imageflow', ['resource' => $resource]); ?>
+
+<?php end_slot(); ?>
+
+<section id="elementsArea">
+
+  <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Elements area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'elements-collapse', 'title' => __('Edit elements area')]); ?>
+
+  <?php if (0 < count($resource->digitalObjectsRelatedByobjectId)) { ?>
+    <?php echo get_component('digitalobject', 'show', ['link' => $digitalObjectLink, 'resource' => $resource->digitalObjectsRelatedByobjectId[0], 'usageType' => QubitTerm::REFERENCE_ID]); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Identifier'), $resource->identifier); ?>
+
+  <?php echo render_show(__('Title'), render_value($resource->getTitle(['cultureFallback' => true]))); ?>
+
+  <?php echo get_partial('informationobject/dates', ['resource' => $resource]); ?>
+
+  <?php foreach ($mods->typeOfResource as $item) { ?>
+    <?php echo render_show(__('Type of resource'), render_value($item->term)); ?>
+  <?php } ?>
+
+  <?php foreach ($resource->language as $code) { ?>
+    <?php echo render_show(__('Language'), format_language($code)); ?>
+  <?php } ?>
+
+  <?php if (0 < count($resource->digitalObjectsRelatedByobjectId)) { ?>
+    <?php echo render_show(__('Internet media type'), render_value($resource->digitalObjectsRelatedByobjectId[0]->mimeType)); ?>
+  <?php } ?>
+
+  <?php echo get_partial('object/subjectAccessPoints', ['resource' => $resource, 'mods' => true]); ?>
+
+  <?php echo get_partial('object/placeAccessPoints', ['resource' => $resource, 'mods' => true]); ?>
+
+  <?php echo get_partial('informationobject/nameAccessPoints', ['resource' => $resource, 'mods' => true, 'showActorEvents' => true]); ?>
+
+  <?php echo render_show(__('Access condition'), render_value($resource->getAccessConditions(['cultureFallback' => true]))); ?>
+
+  <?php if (0 < count($resource->digitalObjectsRelatedByobjectId)) { ?>
+    <?php echo render_show(__('URL'), link_to(null, $resource->getDigitalObjectPublicUrl())); ?>
+  <?php } ?>
+
+  <div class="field">
+    <h3><?php echo __('Physical location'); ?></h3>
+    <div>
+      <?php if (isset($resource->repository)) { ?>
+
+        <?php if (isset($resource->repository->identifier)) { ?>
+          <?php echo render_value_inline($resource->repository->identifier); ?> -
+        <?php } ?>
+
+        <?php echo link_to(render_title($resource->repository), [$resource->repository, 'module' => 'repository']); ?>
+
+        <?php if (null !== $contact = $resource->repository->getPrimaryContact()) { ?>
+
+          <?php if (isset($contact->city)) { ?>
+            <?php echo render_value_inline($contact->city); ?>
+          <?php } ?>
+
+          <?php if (isset($contact->region)) { ?>
+            <?php echo render_value_inline($contact->region); ?>
+          <?php } ?>
+
+          <?php if (isset($contact->countryCode)) { ?>
+            <?php echo format_country($contact->countryCode); ?>
+          <?php } ?>
+
+        <?php } ?>
+
+      <?php } ?>
+    </div>
+  </div>
+
+  <?php echo render_show(__('Description'), render_value($resource->getScopeAndContent(['cultureFallback' => true]))); ?>
+
+</section> <!-- /section#elementsArea -->
+
+<?php if ($sf_user->isAuthenticated()) { ?>
+
+  <section id="rightsArea">
+
+    <?php if (QubitAcl::check($resource, 'update')) { ?>
+      <h2><?php echo __('Rights area'); ?> </h2>
+    <?php } ?>
+
+    <?php echo get_component('right', 'relatedRights', ['resource' => $resource]); ?>
+
+  </section> <!-- /section#rightsArea -->
+
+<?php } ?>
+
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)) { ?>
+
+  <?php echo get_component('digitalobject', 'metadata', ['resource' => $resource->digitalObjectsRelatedByobjectId[0], 'object' => $resource]); ?>
+
+  <?php echo get_partial('digitalobject/rights', ['resource' => $resource->digitalObjectsRelatedByobjectId[0]]); ?>
+
+<?php } ?>
+
+<section id="accessionArea">
+
+  <h2><?php echo __('Accession area'); ?></h2>
+
+  <?php echo get_component('informationobject', 'accessions', ['resource' => $resource]); ?>
+
+</section> <!-- /section#accessionArea -->
+
+<?php slot('after-content'); ?>
+  <?php echo get_partial('informationobject/actions', ['resource' => $resource]); ?>
+<?php end_slot(); ?>
+
+<?php echo get_component('object', 'gaInstitutionsDimension', ['resource' => $resource]); ?>

--- a/plugins/arDominionB5Plugin/modules/sfRadPlugin/templates/editSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfRadPlugin/templates/editSuccess.php
@@ -34,11 +34,11 @@
     <div class="accordion">
       <div class="accordion-item">
         <h2 class="accordion-header" id="title-heading">
-          <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#title-collapse" aria-expanded="true" aria-controls="title-collapse">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#title-collapse" aria-expanded="false" aria-controls="title-collapse">
             <?php echo __('Title and statement of responsibility area'); ?>
           </button>
         </h2>
-        <div id="title-collapse" class="accordion-collapse collapse show" aria-labelledby="title-heading">
+        <div id="title-collapse" class="accordion-collapse collapse" aria-labelledby="title-heading">
           <div class="accordion-body">
             <?php echo render_field($form->title
                 ->help(__('Enter the title proper, either transcribed or supplied. (RAD 1.1B)'))

--- a/plugins/arDominionB5Plugin/modules/sfRadPlugin/templates/indexSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfRadPlugin/templates/indexSuccess.php
@@ -1,0 +1,422 @@
+<?php decorate_with('layout_3col'); ?>
+
+<?php slot('sidebar'); ?>
+  <?php include_component('informationobject', 'contextMenu'); ?>
+<?php end_slot(); ?>
+
+<?php slot('title'); ?>
+
+  <?php echo get_component('informationobject', 'descriptionHeader', ['resource' => $resource, 'title' => (string) $rad]); ?>
+
+  <?php if (isset($errorSchema)) { ?>
+    <div class="messages error">
+      <ul>
+        <?php foreach ($errorSchema as $error) { ?>
+          <?php $error = sfOutputEscaper::unescape($error); ?>
+          <li><?php echo $error->getMessage(); ?></li>
+        <?php } ?>
+      </ul>
+    </div>
+  <?php } ?>
+
+  <?php if (QubitInformationObject::ROOT_ID != $resource->parentId) { ?>
+    <?php echo include_partial('default/breadcrumb', ['resource' => $resource, 'objects' => $resource->getAncestors()->andSelf()->orderBy('lft')]); ?>
+  <?php } ?>
+
+  <?php echo get_component('default', 'translationLinks', ['resource' => $resource]); ?>
+
+<?php end_slot(); ?>
+
+<?php slot('context-menu'); ?>
+
+  <?php echo get_partial('informationobject/actionIcons', ['resource' => $resource]); ?>
+
+  <?php echo get_partial('object/subjectAccessPoints', ['resource' => $resource, 'sidebar' => true]); ?>
+
+  <?php echo get_partial('informationobject/nameAccessPoints', ['resource' => $resource, 'sidebar' => true]); ?>
+
+  <?php echo get_partial('object/placeAccessPoints', ['resource' => $resource, 'sidebar' => true]); ?>
+
+  <?php echo get_partial('informationobject/genreAccessPoints', ['resource' => $resource, 'sidebar' => true]); ?>
+
+  <?php if (check_field_visibility('app_element_visibility_physical_storage')) { ?>
+    <?php echo get_component('physicalobject', 'contextMenu', ['resource' => $resource]); ?>
+  <?php } ?>
+
+<?php end_slot(); ?>
+
+<?php slot('before-content'); ?>
+
+  <?php echo get_component('digitalobject', 'imageflow', ['resource' => $resource]); ?>
+
+<?php end_slot(); ?>
+
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)) { ?>
+  <?php echo get_component('digitalobject', 'show', ['link' => $digitalObjectLink, 'resource' => $resource->digitalObjectsRelatedByobjectId[0], 'usageType' => QubitTerm::REFERENCE_ID]); ?>
+<?php } ?>
+
+<section id="titleAndStatementOfResponsibilityArea">
+
+  <?php if (check_field_visibility('app_element_visibility_rad_title_responsibility_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Title and statement of responsibility area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'title-collapse', 'title' => __('Edit title and statement of responsibility area')]); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Title proper'), render_value($resource->getTitle(['cultureFallback' => true])), ['fieldLabel' => 'title']); ?>
+
+  <div class="field">
+    <h3><?php echo __('General material designation'); ?></h3>
+    <div class="generalMaterialDesignation">
+      <ul>
+        <?php foreach ($resource->getMaterialTypes() as $materialType) { ?>
+          <li><?php echo render_value_inline($materialType->term); ?></li>
+        <?php } ?>
+      </ul>
+    </div>
+  </div>
+
+
+  <?php echo render_show(__('Parallel title'), render_value($resource->getAlternateTitle(['cultureFallback' => true])), ['fieldLabel' => 'parallelTitle']); ?>
+
+  <?php echo render_show(__('Other title information'), render_value($rad->__get('otherTitleInformation', ['cultureFallback' => true])), ['fieldLabel' => 'otherTitleInformation']); ?>
+
+  <?php echo render_show(__('Title statements of responsibility'), render_value($rad->__get('titleStatementOfResponsibility', ['cultureFallback' => true])), ['fieldLabel' => 'titleStatementsOfResponsibility']); ?>
+
+  <div class="field">
+    <h3><?php echo __('Title notes'); ?></h3>
+    <div class="titleNotes">
+      <ul>
+        <?php foreach ($resource->getNotesByTaxonomy(['taxonomyId' => QubitTaxonomy::RAD_TITLE_NOTE_ID]) as $item) { ?>
+          <li><?php echo render_value_inline($item->type); ?>: <?php echo render_value_inline($item->getContent(['cultureFallback' => true])); ?></li>
+        <?php } ?>
+      </ul>
+    </div>
+  </div>
+
+  <?php echo render_show(__('Level of description'), render_value($resource->levelOfDescription), ['fieldLabel' => 'levelOfDescription']); ?>
+
+  <div class="repository">
+    <?php echo render_show_repository(__('Repository'), $resource); ?>
+  </div>
+
+  <?php echo render_show(__('Reference code'), $rad->__get('referenceCode', ['cultureFallback' => true]), ['fieldLabel' => 'referenceCode']); ?>
+
+</section> <!-- /section#titleAndStatementOfResponsibilityArea -->
+
+<section id="editionArea">
+
+  <?php if (check_field_visibility('app_element_visibility_rad_edition_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Edition area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'edition-collapse', 'title' => __('Edit edition area')]); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Edition statement'), render_value($resource->getEdition(['cultureFallback' => true])), ['fieldLabel' => 'editionStatement']); ?>
+
+  <?php echo render_show(__('Edition statement of responsibility'), render_value($rad->__get('editionStatementOfResponsibility', ['cultureFallback' => true])), ['fieldLabel' => 'editionStatementOfResponsibility']); ?>
+
+</section> <!-- /section#editionArea -->
+
+<section class="section" id="classOfMaterialSpecificDetailsArea">
+
+  <?php if (check_field_visibility('app_element_visibility_rad_material_specific_details_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Class of material specific details area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'class-collapse', 'title' => __('Edit class of material specific details area')]); ?>
+  <?php } ?>
+
+
+  <?php echo render_show(__('Statement of scale (cartographic)'), render_value($rad->__get('statementOfScaleCartographic', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfScale']); ?>
+
+  <?php echo render_show(__('Statement of projection (cartographic)'), render_value($rad->__get('statementOfProjection', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfProjection']); ?>
+
+  <?php echo render_show(__('Statement of coordinates (cartographic)'), render_value($rad->__get('statementOfCoordinates', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfCoordinates']); ?>
+
+  <?php echo render_show(__('Statement of scale (architectural)'), render_value($rad->__get('statementOfScaleArchitectural', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfScale']); ?>
+
+  <?php echo render_show(__('Issuing jurisdiction and denomination (philatelic)'), render_value($rad->__get('issuingJurisdictionAndDenomination', ['cultureFallback' => true])), ['fieldLabel' => 'issuingJurisdictionAndDenomination']); ?>
+</section> <!-- /section#classOfMaterialSpecificDetailsArea -->
+
+<section class="section" id="datesOfCreationArea">
+
+  <?php if (check_field_visibility('app_element_visibility_rad_dates_of_creation_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Dates of creation area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'dates-collapse', 'title' => __('Edit dates of creation area')]); ?>
+  <?php } ?>
+
+  <div class="datesOfCreation">
+    <?php echo get_partial('informationobject/dates', ['resource' => $resource]); ?>
+  </div>
+
+</section> <!-- /section#datesOfCreationArea -->
+
+<section id="physicalDescriptionArea">
+
+  <?php if (check_field_visibility('app_element_visibility_rad_physical_description_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Physical description area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'physical-collapse', 'title' => __('Edit physical description area')]); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Physical description'), render_value($resource->getCleanExtentAndMedium(['cultureFallback' => true])), ['fieldLabel' => 'physicalDescription']); ?>
+
+</section> <!-- /section#physicalDescriptionArea -->
+
+<section id="publishersSeriesArea">
+
+  <?php if (check_field_visibility('app_element_visibility_rad_publishers_series_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Publisher\'s series area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'publisher-collapse', 'title' => __('Edit publisher\'s series area')]); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Title proper of publisher\'s series'), render_value($rad->__get('titleProperOfPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'titleProperOfPublishersSeries']); ?>
+
+  <?php echo render_show(__('Parallel titles of publisher\'s series'), render_value($rad->__get('parallelTitleOfPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'parallelTitleOfPublishersSeries']); ?>
+
+  <?php echo render_show(__('Other title information of publisher\'s series'), render_value($rad->__get('otherTitleInformationOfPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'otherTitleInformationOfPublishersSeries']); ?>
+
+  <?php echo render_show(__('Statement of responsibility relating to publisher\'s series'), render_value($rad->__get('statementOfResponsibilityRelatingToPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfResponsibilityRelatingToPublishersSeries']); ?>
+
+  <?php echo render_show(__('Numbering within publisher\'s series'), render_value($rad->__get('numberingWithinPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'numberingWithinPublishersSeries']); ?>
+
+  <?php echo render_show(__('Note on publisher\'s series'), render_value($rad->__get('noteOnPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'noteOnPublishersSeries']); ?>
+
+</section> <!-- /section#publishersSeriesArea -->
+
+<section id="archivalDescriptionArea">
+
+  <?php if (check_field_visibility('app_element_visibility_rad_archival_description_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Archival description area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'archival-collapse', 'title' => __('Edit archival description area')]); ?>
+  <?php } ?>
+
+  <?php echo get_component('informationobject', 'creatorDetail', [
+      'resource' => $resource,
+      'creatorHistoryLabels' => $creatorHistoryLabels, ]); ?>
+
+  <?php if (check_field_visibility('app_element_visibility_rad_archival_history')) { ?>
+    <?php echo render_show(__('Custodial history'), render_value($resource->getArchivalHistory(['cultureFallback' => true])), ['fieldLabel' => 'custodialHistory']); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Scope and content'), render_value($resource->getScopeAndContent(['cultureFallback' => true])), ['fieldLabel' => 'scopeAndContent']); ?>
+
+</section> <!-- /section#archivalDescriptionArea -->
+
+<section class="section" id="notesArea">
+
+  <?php if (check_field_visibility('app_element_visibility_rad_notes_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Notes area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'notes-collapse', 'title' => __('Edit notes area')]); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_rad_physical_condition')) { ?>
+    <?php echo render_show(__('Physical condition'), render_value($resource->getPhysicalCharacteristics(['cultureFallback' => true])), ['fieldLabel' => 'physicalCondition']); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_rad_immediate_source')) { ?>
+    <?php echo render_show(__('Immediate source of acquisition'), render_value($resource->getAcquisition(['cultureFallback' => true])), ['fieldLabel' => 'immediateSourceOfAcquisition']); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Arrangement'), render_value($resource->getArrangement(['cultureFallback' => true])), ['fieldLabel' => 'arrangement']); ?>
+
+  <div class="field">
+    <h3><?php echo __('Language of material'); ?></h3>
+    <div class="languageOfMaterial">
+      <ul>
+        <?php foreach ($resource->language as $code) { ?>
+          <li><?php echo format_language($code); ?></li>
+        <?php } ?>
+      </ul>
+    </div>
+  </div>
+
+  <div class="field">
+    <h3><?php echo __('Script of material'); ?></h3>
+    <div class="scriptOfMaterial">
+      <ul>
+        <?php foreach ($resource->script as $code) { ?>
+          <li><?php echo format_script($code); ?></li>
+        <?php } ?>
+      </ul>
+    </div>
+  </div>
+
+  <?php foreach ($resource->getNotesByType(['noteTypeId' => QubitTerm::LANGUAGE_NOTE_ID]) as $item) { ?>
+    <?php echo render_show(__('Language and script note'), render_value($item->getContent(['cultureFallback' => true])), ['fieldLabel' => 'languageAndScriptNote']); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Location of originals'), render_value($resource->getLocationOfOriginals(['cultureFallback' => true])), ['fieldLabel' => 'locationOfOriginals']); ?>
+
+  <?php echo render_show(__('Availability of other formats'), render_value($resource->getLocationOfCopies(['cultureFallback' => true])), ['fieldLabel' => 'availabilityOfOtherFormats']); ?>
+
+  <?php echo render_show(__('Restrictions on access'), render_value($resource->getAccessConditions(['cultureFallback' => true])), ['fieldLabel' => 'restrictionsOnAccess']); ?>
+
+  <?php echo render_show(__('Terms governing use, reproduction, and publication'), render_value($resource->getReproductionConditions(['cultureFallback' => true])), ['fieldLabel' => 'termsGoverningUseReproductionAndPublication']); ?>
+
+  <?php echo render_show(__('Finding aids'), render_value($resource->getFindingAids(['cultureFallback' => true])), ['fieldLabel' => 'findingAids']); ?>
+
+  <?php echo get_component('informationobject', 'findingAidLink', ['resource' => $resource]); ?>
+
+  <?php echo render_show(__('Associated materials'), render_value($resource->getRelatedUnitsOfDescription(['cultureFallback' => true])), ['fieldLabel' => 'associatedMaterials']); ?>
+
+  <div class="relatedMaterialDescriptions">
+    <?php echo get_partial('informationobject/relatedMaterialDescriptions', ['resource' => $resource, 'template' => 'rad']); ?>
+  </div>
+
+  <?php echo render_show(__('Accruals'), render_value($resource->getAccruals(['cultureFallback' => true])), ['fieldLabel' => 'accruals']); ?>
+
+  <?php if (check_field_visibility('app_element_visibility_rad_general_notes')) { ?>
+    <?php foreach ($resource->getNotesByType(['noteTypeId' => QubitTerm::GENERAL_NOTE_ID]) as $item) { ?>
+      <?php echo render_show(__('General note'), render_value($item->getContent(['cultureFallback' => true])), ['fieldLabel' => 'generalNote']); ?>
+    <?php } ?>
+  <?php } ?>
+
+  <?php foreach ($resource->getNotesByTaxonomy(['taxonomyId' => QubitTaxonomy::RAD_NOTE_ID]) as $item) { ?>
+
+    <?php $type = $item->getType(['sourceCulture' => true]); ?>
+
+    <?php if ('Conservation' == $type && !check_field_visibility('app_element_visibility_rad_conservation_notes')) { ?>
+      <?php continue; ?>
+    <?php } ?>
+
+    <?php if ('Rights' == $type && !check_field_visibility('app_element_visibility_rad_rights_notes')) { ?>
+      <?php continue; ?>
+    <?php } ?>
+
+    <div class="field">
+      <h3><?php echo __(render_value_inline($item->type)); ?></h3>
+      <div class="radNote">
+        <?php echo render_value($item->getContent(['cultureFallback' => true])); ?>
+      </div>
+    </div>
+
+  <?php } ?>
+
+  <div class="alternativeIdentifiers">
+    <?php echo get_partial('informationobject/alternativeIdentifiersIndex', ['resource' => $resource]); ?>
+  </div>
+
+</section> <!-- /section#notesArea -->
+
+<section id="standardNumberArea">
+
+  <?php if (check_field_visibility('app_element_visibility_rad_standard_number_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Standard number area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'standard-collapse', 'title' => __('Edit standard number area')]); ?>
+  <?php } ?>
+
+  <?php echo render_show(__('Standard number'), render_value($rad->__get('standardNumber', ['cultureFallback' => true])), ['fieldLabel' => 'standardNumber']); ?>
+
+</section> <!-- /section#standardNumberArea -->
+
+<section id="accessPointsArea">
+
+  <?php if (check_field_visibility('app_element_visibility_rad_access_points_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Access points').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'access-collapse', 'title' => __('Edit access points')]); ?>
+  <?php } ?>
+
+  <div class="subjectAccessPoints">
+    <?php echo get_partial('object/subjectAccessPoints', ['resource' => $resource]); ?>
+  </div>
+
+  <div class="placeAccessPoints">
+    <?php echo get_partial('object/placeAccessPoints', ['resource' => $resource]); ?>
+  </div>
+
+  <div class="nameAccessPoints">
+    <?php echo get_partial('informationobject/nameAccessPoints', ['resource' => $resource]); ?>
+  </div>
+
+  <div class="genreAccessPoints">
+    <?php echo get_partial('informationobject/genreAccessPoints', ['resource' => $resource]); ?>
+  </div>
+
+</section> <!-- /section#accessPointsArea -->
+
+<section class="section" id="descriptionControlArea">
+
+  <?php if (check_field_visibility('app_element_visibility_rad_description_control_area')) { ?>
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Control area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'control-collapse', 'title' => __('Edit control area')]); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_rad_control_description_identifier')) { ?>
+    <?php echo render_show(__('Description record identifier'), $resource->descriptionIdentifier, ['fieldLabel' => 'descriptionRecordIdentifier']); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_rad_control_institution_identifier')) { ?>
+    <?php echo render_show(__('Institution identifier'), $resource->getInstitutionResponsibleIdentifier(['cultureFallback' => true]), ['fieldLabel' => 'institutionIdentifier']); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_rad_control_rules_conventions')) { ?>
+    <?php echo render_show(__('Rules or conventions'), render_value($resource->getRules(['cultureFallback' => true])), ['fieldLabel' => 'rulesOrConventions']); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_rad_control_status')) { ?>
+    <?php echo render_show(__('Status'), render_value($resource->descriptionStatus), ['fieldLabel' => 'status']); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_rad_control_level_of_detail')) { ?>
+    <?php echo render_show(__('Level of detail'), render_value($resource->descriptionDetail), ['fieldLabel' => 'levelOfDetail']); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_rad_control_dates')) { ?>
+    <?php echo render_show(__('Dates of creation, revision and deletion'), render_value($resource->getRevisionHistory(['cultureFallback' => true])), ['fieldLabel' => 'datesOfCreationRevisionAndDeletion']); ?>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_rad_control_language')) { ?>
+    <div class="field">
+      <h3><?php echo __('Language of description'); ?></h3>
+      <div class="languageOfDescription">
+        <ul>
+          <?php foreach ($resource->languageOfDescription as $code) { ?>
+            <li><?php echo format_language($code); ?></li>
+          <?php } ?>
+        </ul>
+      </div>
+    </div>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_rad_control_script')) { ?>
+    <div class="field">
+      <h3><?php echo __('Script of description'); ?></h3>
+      <div class="scriptOfDescription">
+        <ul>
+          <?php foreach ($resource->scriptOfDescription as $code) { ?>
+            <li><?php echo format_script($code); ?></li>
+          <?php } ?>
+        </ul>
+      </div>
+    </div>
+  <?php } ?>
+
+  <?php if (check_field_visibility('app_element_visibility_rad_control_sources')) { ?>
+    <?php echo render_show(__('Sources'), render_value($resource->getSources(['cultureFallback' => true])), ['fieldLabel' => 'sources']); ?>
+  <?php } ?>
+
+</section> <!-- /section#descriptionControlArea -->
+
+<?php if ($sf_user->isAuthenticated()) { ?>
+
+  <section id="rightsArea">
+
+    <h2><?php echo __('Rights area'); ?> </h2>
+
+    <div class="relatedRights">
+      <?php echo get_component('right', 'relatedRights', ['resource' => $resource]); ?>
+    </div>
+
+  </section> <!-- /section#rightsArea -->
+
+<?php } ?>
+
+<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)) { ?>
+  <div class="digitalObjectMetadata">
+    <?php echo get_component('digitalobject', 'metadata', ['resource' => $resource->digitalObjectsRelatedByobjectId[0], 'object' => $resource]); ?>
+  </div>
+  <div class="digitalObjectRights">
+    <?php echo get_partial('digitalobject/rights', ['resource' => $resource->digitalObjectsRelatedByobjectId[0]]); ?>
+  </div>
+<?php } ?>
+
+<section id="accessionArea">
+
+  <h2><?php echo __('Accession area'); ?></h2>
+
+  <div class="accessions">
+    <?php echo get_component('informationobject', 'accessions', ['resource' => $resource]); ?>
+  </div>
+</section> <!-- /section#accessionArea -->
+
+<?php slot('after-content'); ?>
+  <?php echo get_partial('informationobject/actions', ['resource' => $resource]); ?>
+<?php end_slot(); ?>
+
+<?php echo get_component('object', 'gaInstitutionsDimension', ['resource' => $resource]); ?>

--- a/plugins/arDominionB5Plugin/modules/sfSkosPlugin/templates/importSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfSkosPlugin/templates/importSuccess.php
@@ -60,11 +60,11 @@
       </div>
       <div class="accordion-item">
         <h2 class="accordion-header" id="select-heading">
-          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#select-collapse" aria-expanded="false" aria-controls="select-collapse">
+          <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#select-collapse" aria-expanded="true" aria-controls="select-collapse">
             <?php echo __('Select source'); ?>
           </button>
         </h2>
-        <div id="select-collapse" class="accordion-collapse collapse" aria-labelledby="select-heading">
+        <div id="select-collapse" class="accordion-collapse collapse show" aria-labelledby="select-heading">
           <div class="accordion-body">
             <?php echo $form->file
                 ->label(__('Select a file to import'))

--- a/plugins/arDominionB5Plugin/templates/_layout_end.php
+++ b/plugins/arDominionB5Plugin/templates/_layout_end.php
@@ -15,6 +15,7 @@
     <script src="/plugins/arDominionB5Plugin/js/aggregations.js"></script>
     <script src="/plugins/arDominionB5Plugin/js/expander.js"></script>
     <script src="/plugins/arDominionB5Plugin/js/clipboard.js"></script>
+    <script src="/plugins/arDominionB5Plugin/js/collapse.js"></script>
     <script src="/js/editingHistory.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This implements a new `collapse.js` script that shows and scrolls to the accordions targeted from various index actions.

It also restricts the `js/editingHistory.js` script to load the history only from the user index page.