### PR TITLE
arDominionBS5Plugin: fix edit rights behaviour

### DIFF
--- a/plugins/arDominionB5Plugin/lib/arB5WidgetFormSchemaFormatter.class.php
+++ b/plugins/arDominionB5Plugin/lib/arB5WidgetFormSchemaFormatter.class.php
@@ -19,8 +19,6 @@
 
 class arB5WidgetFormSchemaFormatter extends sfWidgetFormSchemaFormatter
 {
-    protected $rowFormat = "<div class=\"mb-3\">\n  %label%\n  %field%\n"
-        ."  %error%\n  %help%\n  %hidden_fields%\n</div>";
     protected $errorListFormatInARow = '<div class="invalid-feedback"'
         ." id=\"%errors_id%\">\n  %errors%\n</div>\n";
     protected $errorRowFormatInARow = "<span>%error%</span>\n";
@@ -63,5 +61,25 @@ class arB5WidgetFormSchemaFormatter extends sfWidgetFormSchemaFormatter
             $this->helpFormat,
             ['%help_id%' => $this->name.'-help']
         );
+    }
+
+    public function getRowFormat()
+    {
+        // HACK ->formatRow() lacks access to lots of information about the field,
+        // including the name.  So to add the name to the row markup, we must
+        // either,
+        //  * Add it outside ->formatRow(), perhaps using FluentDOM
+        //  * Extract the name from the field markup with regex
+        //  * Take advantage that ->renderRow() always calls ->renderLabel(), which
+        //    calls ->generateLabel(), before ->renderRow()
+        return <<<return
+<div class="mb-3 form-row-{$this->name}">
+  %label%
+  %error%%field%
+  %help%
+  %hidden_fields%
+</div>
+
+return;
     }
 }

--- a/plugins/arDominionB5Plugin/modules/user/templates/indexSuccess.mod_cas.php
+++ b/plugins/arDominionB5Plugin/modules/user/templates/indexSuccess.mod_cas.php
@@ -1,3 +1,17 @@
+<h1><?php echo __('User %1%', ['%1%' => render_title($resource)]); ?></h1>
+
+<?php echo get_component('user', 'aclMenu'); ?>
+
+<?php if (!$resource->active) { ?>
+  <div class="messages error">
+    <ul>
+      <?php if (!$resource->active) { ?>
+        <li><?php echo __('This user is inactive'); ?></li>
+      <?php } ?>
+    </ul>
+  </div>
+<?php } ?>
+
 <section id="content">
 
   <section id="userDetails">

--- a/plugins/arDominionB5Plugin/modules/user/templates/indexSuccess.mod_standard.php
+++ b/plugins/arDominionB5Plugin/modules/user/templates/indexSuccess.mod_standard.php
@@ -1,3 +1,17 @@
+<h1><?php echo __('User %1%', ['%1%' => render_title($resource)]); ?></h1>
+
+<?php echo get_component('user', 'aclMenu'); ?>
+
+<?php if (!$resource->active) { ?>
+  <div class="messages error">
+    <ul>
+      <?php if (!$resource->active) { ?>
+        <li><?php echo __('This user is inactive'); ?></li>
+      <?php } ?>
+    </ul>
+  </div>
+<?php } ?>
+
 <section id="content">
 
   <section id="userDetails">


### PR DESCRIPTION
I've updated the form row formatter so the divs have a .form-row class. It's not a BS5 layout requirement but it's necessary in the old edit/rights behaviour to easily target form fields by their names.