### PR TITLE
Style content container of ISAD index page

### DIFF
--- a/lib/helper/QubitHelper.php
+++ b/lib/helper/QubitHelper.php
@@ -160,6 +160,10 @@ function render_b5_field($field, $translation = null, $options = [])
 
 function render_show($label, $value, $options = [])
 {
+    if (sfConfig::get('app_b5_theme', false)) {
+        return render_b5_show($label, $value, $options);
+    }
+
     // Optional labels in the div class containing this field, to help with data mining.
     $fieldLabel = isset($options['fieldLabel']) ? ' class="'.$options['fieldLabel'].'"' : '';
 
@@ -172,6 +176,99 @@ function render_show($label, $value, $options = [])
 </div>
 
 contents;
+}
+
+function render_b5_show_field_css_classes($options = [])
+{
+    return 'row g-0';
+}
+
+function render_b5_show_subfield_css_classes($options = [])
+{
+    return 'd-flex flex-wrap';
+}
+
+function render_b5_show($label, $value, $options = [])
+{
+    $tag = 'div';
+    $cssClasses = 'field';
+    if (!isset($options['isSubField'])) {
+        $cssClasses .= ' '.render_b5_show_field_css_classes($options);
+    } else {
+        $cssClasses .= ' '.render_b5_show_subfield_css_classes($options);
+    }
+
+    $labelContainer = render_b5_show_label($label, $options);
+    $valuecontainer = render_b5_show_value($value, $options);
+
+    return render_b5_show_container(
+        $tag, $labelContainer.$valuecontainer, $cssClasses, $options
+    );
+}
+
+function render_b5_show_container($tag, $content, $cssClasses = '', $options = [])
+{
+    $cssClass = $cssClasses ? ' class="'.$cssClasses.'"' : '';
+
+    return "<{$tag}{$cssClass}>{$content}</{$tag}>";
+}
+
+function render_b5_show_label_css_classes($options = [])
+{
+    $result = 'h6 m-0 text-muted text-break';
+    if (!isset($options['isSubField'])) {
+        $result .= ' col-3 border-end text-end p-2';
+    } else {
+        $result .= ' me-1 p-1';
+    }
+
+    return $result;
+}
+
+function render_b5_show_label($label, $options = [])
+{
+    $tag = isset($options['isSubField']) ? 'h4' : 'h3';
+    $cssClasses = render_b5_show_label_css_classes($options);
+
+    return render_b5_show_container($tag, $label, $cssClasses, $options);
+}
+
+function render_b5_show_value_css_classes($options = [])
+{
+    $result = 'h6 m-0';
+    if (!isset($options['isSubField'])) {
+        $result .= ' col-9 p-2';
+    } else {
+        $result .= ' p-1';
+    }
+
+    return $result;
+}
+
+function render_b5_show_value($value, $options = [])
+{
+    $tag = 'div';
+    $cssClasses = render_b5_show_value_css_classes($options);
+
+    return render_b5_show_container($tag, $value, $cssClasses, $options);
+}
+
+function render_b5_section_label_css_classes($options = [])
+{
+    return 'border-bottom h5 m-0 p-3 text-primary';
+}
+
+function render_b5_section_label($label, $options = [])
+{
+    $tag = 'h2';
+    $cssClasses = render_b5_section_label_css_classes($options);
+
+    return render_b5_show_container($tag, $label, $cssClasses, $options);
+}
+
+function render_b5_show_list_css_classes($options = [])
+{
+    return 'm-0 ps-3';
 }
 
 function render_show_repository($label, $resource)

--- a/plugins/arDominionB5Plugin/js/expander.js
+++ b/plugins/arDominionB5Plugin/js/expander.js
@@ -6,7 +6,7 @@
     attach: () => {
       // Get i18n text for read more/less links from footer
       var $i18n = $('#js-i18n #read-more-less-links');
-      $('.search-result .text-block')
+      $('.search-result .text-block, div.field:not(:has(div.field)) > div')
       .expander({
         slicePoint: 255,
         expandText: $i18n.data('read-more-text'),

--- a/plugins/arDominionB5Plugin/modules/arStorageService/templates/_aipDownload.php
+++ b/plugins/arDominionB5Plugin/modules/arStorageService/templates/_aipDownload.php
@@ -1,0 +1,23 @@
+<div class="field <?php echo render_b5_show_field_css_classes(); ?>">
+  <?php echo render_b5_show_label(__('File UUID'), ['isSubField' => true]); ?>
+  <div class="aip-download <?php echo render_b5_show_value_css_classes(['isSubField' => true]); ?>">
+    <?php echo render_value_inline($resource->object->objectUUID); ?>
+    <?php if ($sf_user->checkModuleActionAccess('arStorageService', 'extractFile')) { ?>
+      <a href="<?php echo url_for([$resource, 'module' => 'arStorageService', 'action' => 'extractFile']); ?>" target="_blank">
+        <i class="fa fa-download me-1" aria-hidden="true"></i><?php echo __('Download file'); ?>
+      </a>
+    <?php } ?>
+  </div>
+</div>
+
+<div class="field <?php echo render_b5_show_field_css_classes(); ?>">
+  <?php echo render_b5_show_label(__('AIP UUID'), ['isSubField' => true]); ?>
+  <div class="aip-download <?php echo render_b5_show_value_css_classes(['isSubField' => true]); ?>">
+    <?php echo render_value_inline($resource->object->aipUUID); ?>
+    <?php if ($sf_user->checkModuleActionAccess('arStorageService', 'download')) { ?>
+      <a href="<?php echo url_for([$resource, 'module' => 'arStorageService', 'action' => 'download']); ?>" target="_blank">
+        <i class="fa fa-download me-1" aria-hidden="true"></i><?php echo __('Download AIP'); ?>
+      </a>
+    <?php } ?>
+  </div>
+</div>

--- a/plugins/arDominionB5Plugin/modules/digitalobject/templates/_metadata.php
+++ b/plugins/arDominionB5Plugin/modules/digitalobject/templates/_metadata.php
@@ -4,9 +4,9 @@
   <section>
 
     <?php if ($relatedToIo) { ?>
-      <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationobject'), '<h2>'.__('%1% metadata', ['%1%' => sfConfig::get('app_ui_label_digitalobject')]).'</h2>', [$resource, 'module' => 'digitalobject', 'action' => 'edit'], ['title' => __('Edit %1%', ['%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject'))])]); ?>
+      <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationobject'), render_b5_section_label(__('%1% metadata', ['%1%' => sfConfig::get('app_ui_label_digitalobject')])), [$resource, 'module' => 'digitalobject', 'action' => 'edit'], ['title' => __('Edit %1%', ['%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject'))]), 'class' => 'text-primary']); ?>
     <?php } elseif ($relatedToActor) { ?>
-      <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'actor'), '<h2>'.__('%1% metadata', ['%1%' => sfConfig::get('app_ui_label_digitalobject')]).'</h2>', [$resource, 'module' => 'digitalobject', 'action' => 'edit'], ['title' => __('Edit %1%', ['%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject'))])]); ?>
+      <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'actor'), render_b5_section_label(__('%1% metadata', ['%1%' => sfConfig::get('app_ui_label_digitalobject')])), [$resource, 'module' => 'digitalobject', 'action' => 'edit'], ['title' => __('Edit %1%', ['%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject'))]), 'class' => 'text-primary']); ?>
     <?php } ?>
 
     <div class="accordion">
@@ -20,90 +20,94 @@
             </button>
           </h3>
           <div id="preservation-collapse" class="accordion-collapse collapse show" aria-labelledby="preservation-heading">
-            <div class="accordion-body">
+            <div class="accordion-body p-0">
               <?php if ($showOriginalFileMetadata) { ?>
 
-                <div class="digital-object-metadata-header">
-                  <h3><?php echo __('Original file'); ?> <i class="fa fa-archive<?php if (!$canAccessOriginalFile) { ?> inactive<?php } ?>" aria-hidden="true"></i></h3>
-                </div>
+                <div class="<?php echo render_b5_show_field_css_classes(); ?>">
 
-                <div class="digital-object-metadata-body">
-                  <?php if ($showOriginalFileName) { ?>
-                    <?php echo render_show(__('Filename'), render_value($resource->object->originalFileName), ['fieldLabel' => 'originalFileName']); ?>
-                  <?php } ?>
+                  <h3 class="<?php echo render_b5_show_label_css_classes(); ?>"><?php echo __('Original file'); ?><i class="fa fa-archive ms-2 text-dark<?php if (!$canAccessOriginalFile) { ?> inactive text-muted<?php } ?>" aria-hidden="true"></i></h3>
 
-                  <?php if ($showOriginalFormatName) { ?>
-                    <?php echo render_show(__('Format name'), render_value($resource->object->formatName), ['fieldLabel' => 'originalFileFormatName']); ?>
-                  <?php } ?>
-
-                  <?php if ($showOriginalFormatVersion) { ?>
-                    <?php echo render_show(__('Format version'), render_value($resource->object->formatVersion), ['fieldLabel' => 'originalFileFormatVersion']); ?>
-                  <?php } ?>
-
-                  <?php if ($showOriginalFormatRegistryKey) { ?>
-                    <?php echo render_show(__('Format registry key'), render_value($resource->object->formatRegistryKey), ['fieldLabel' => 'originalFileFormatRegistryKey']); ?>
-                  <?php } ?>
-
-                  <?php if ($showOriginalFormatRegistryName) { ?>
-                    <?php echo render_show(__('Format registry name'), render_value($resource->object->formatRegistryName), ['fieldLabel' => 'originalFileFormatRegistryName']); ?>
-                  <?php } ?>
-
-                  <?php if ($showOriginalFileSize) { ?>
-                    <?php echo render_show(__('Filesize'), hr_filesize(intval((string) $resource->object->originalFileSize)), ['fieldLabel' => 'originalFileSize']); ?>
-                  <?php } ?>
-
-                  <?php if ($showOriginalFileIngestedAt) { ?>
-                    <?php echo render_show(__('Ingested'), format_date($originalFileIngestedAt, 'f'), ['fieldLabel' => 'originalFileIngestedAt']); ?>
-                  <?php } ?>
-
-                  <?php if ($showOriginalFilePermissions) { ?>
-                    <?php echo render_show(__('Permissions'), render_value($accessStatement), ['fieldLabel' => 'originalFilePermissions']); ?>
-                  <?php } ?>
-
-                  <?php if ($sf_user->isAuthenticated() && $relatedToIo) { ?>
-                    <?php if ($storageServicePluginEnabled) { ?>
-                      <?php include_partial(
-                        'arStorageService/aipDownload', ['resource' => $resource]
-                      ); ?>
-                    <?php } else { ?>
-                      <?php echo render_show(
-                        __('File UUID'),
-                        render_value($resource->object->objectUUID),
-                        ['fieldLabel' => 'objectUUID']
-                      ); ?>
-                      <?php echo render_show(
-                        __('AIP UUID'),
-                        render_value($resource->object->aipUUID),
-                        ['fieldLabel' => 'aipUUID']
-                      ); ?>
+                  <div class="digital-object-metadata-body <?php echo render_b5_show_value_css_classes(); ?>">
+                    <?php if ($showOriginalFileName) { ?>
+                      <?php echo render_show(__('Filename'), render_value_inline($resource->object->originalFileName), ['fieldLabel' => 'originalFileName', 'isSubField' => true]); ?>
                     <?php } ?>
-                  <?php } ?>
+
+                    <?php if ($showOriginalFormatName) { ?>
+                      <?php echo render_show(__('Format name'), render_value_inline($resource->object->formatName), ['fieldLabel' => 'originalFileFormatName', 'isSubField' => true]); ?>
+                    <?php } ?>
+
+                    <?php if ($showOriginalFormatVersion) { ?>
+                      <?php echo render_show(__('Format version'), render_value_inline($resource->object->formatVersion), ['fieldLabel' => 'originalFileFormatVersion', 'isSubField' => true]); ?>
+                    <?php } ?>
+
+                    <?php if ($showOriginalFormatRegistryKey) { ?>
+                      <?php echo render_show(__('Format registry key'), render_value_inline($resource->object->formatRegistryKey), ['fieldLabel' => 'originalFileFormatRegistryKey', 'isSubField' => true]); ?>
+                    <?php } ?>
+
+                    <?php if ($showOriginalFormatRegistryName) { ?>
+                      <?php echo render_show(__('Format registry name'), render_value_inline($resource->object->formatRegistryName), ['fieldLabel' => 'originalFileFormatRegistryName', 'isSubField' => true]); ?>
+                    <?php } ?>
+
+                    <?php if ($showOriginalFileSize) { ?>
+                      <?php echo render_show(__('Filesize'), hr_filesize(intval((string) $resource->object->originalFileSize)), ['fieldLabel' => 'originalFileSize', 'isSubField' => true]); ?>
+                    <?php } ?>
+
+                    <?php if ($showOriginalFileIngestedAt) { ?>
+                      <?php echo render_show(__('Ingested'), format_date($originalFileIngestedAt, 'f'), ['fieldLabel' => 'originalFileIngestedAt', 'isSubField' => true]); ?>
+                    <?php } ?>
+
+                    <?php if ($showOriginalFilePermissions) { ?>
+                      <?php echo render_show(__('Permissions'), render_value($accessStatement), ['fieldLabel' => 'originalFilePermissions', 'isSubField' => true]); ?>
+                    <?php } ?>
+
+                    <?php if ($sf_user->isAuthenticated() && $relatedToIo) { ?>
+                      <?php if ($storageServicePluginEnabled) { ?>
+                        <?php include_partial(
+                          'arStorageService/aipDownload', ['resource' => $resource]
+                        ); ?>
+                      <?php } else { ?>
+                        <?php echo render_show(
+                          __('File UUID'),
+                          render_value_inline($resource->object->objectUUID),
+                          ['fieldLabel' => 'objectUUID', 'isSubField' => true]
+                        ); ?>
+                        <?php echo render_show(
+                          __('AIP UUID'),
+                          render_value_inline($resource->object->aipUUID),
+                          ['fieldLabel' => 'aipUUID', 'isSubField' => true]
+                        ); ?>
+                      <?php } ?>
+                    <?php } ?>
+                   </div>
+
                 </div>
 
               <?php } ?>
 
               <?php if ($showPreservationCopyMetadata) { ?>
 
-                <div class="digital-object-metadata-header">
-                  <h3><?php echo __('Preservation copy'); ?> <i class="fa fa-archive<?php if (!$canAccessPreservationCopy) { ?> inactive<?php } ?>" aria-hidden="true"></i></h3>
-                </div>
+                <div class="<?php echo render_b5_show_field_css_classes(); ?>">
 
-                <div class="digital-object-metadata-body">
-                  <?php if ($showPreservationCopyFileName) { ?>
-                    <?php echo render_show(__('Filename'), render_value($resource->object->preservationCopyFileName), ['fieldLabel' => 'preservationCopyFileName']); ?>
-                  <?php } ?>
+                  <h3 class="<?php echo render_b5_show_label_css_classes(); ?>"><?php echo __('Preservation copy'); ?><i class="fa fa-archive ms-2 text-dark<?php if (!$canAccessPreservationCopy) { ?> inactive text-muted<?php } ?>" aria-hidden="true"></i></h3>
 
-                  <?php if ($showPreservationCopyFileSize) { ?>
-                    <?php echo render_show(__('Filesize'), hr_filesize(intval((string) $resource->object->preservationCopyFileSize)), ['fieldLabel' => 'preservationCopyFileSize']); ?>
-                  <?php } ?>
+                  <div class="digital-object-metadata-body <?php echo render_b5_show_value_css_classes(); ?>">
+                    <?php if ($showPreservationCopyFileName) { ?>
+                      <?php echo render_show(__('Filename'), render_value_inline($resource->object->preservationCopyFileName), ['fieldLabel' => 'preservationCopyFileName', 'isSubField' => true]); ?>
+                    <?php } ?>
 
-                  <?php if ($showPreservationCopyNormalizedAt) { ?>
-                    <?php echo render_show(__('Normalized'), format_date($preservationCopyNormalizedAt, 'f'), ['fieldLabel' => 'preservactionCopyNormalizedAt']); ?>
-                  <?php } ?>
+                    <?php if ($showPreservationCopyFileSize) { ?>
+                      <?php echo render_show(__('Filesize'), hr_filesize(intval((string) $resource->object->preservationCopyFileSize)), ['fieldLabel' => 'preservationCopyFileSize', 'isSubField' => true]); ?>
+                    <?php } ?>
 
-                  <?php if ($showPreservationCopyPermissions) { ?>
-                    <?php echo render_show(__('Permissions'), render_value($accessStatement), ['fieldLabel' => 'preservationCopyPermissions']); ?>
-                  <?php } ?>
+                    <?php if ($showPreservationCopyNormalizedAt) { ?>
+                      <?php echo render_show(__('Normalized'), format_date($preservationCopyNormalizedAt, 'f'), ['fieldLabel' => 'preservactionCopyNormalizedAt', 'isSubField' => true]); ?>
+                    <?php } ?>
+
+                    <?php if ($showPreservationCopyPermissions) { ?>
+                      <?php echo render_show(__('Permissions'), render_value($accessStatement), ['fieldLabel' => 'preservationCopyPermissions', 'isSubField' => true]); ?>
+                    <?php } ?>
+                  </div>
+
                 </div>
 
               <?php } ?>
@@ -122,130 +126,136 @@
             </button>
           </h3>
           <div id="access-collapse" class="accordion-collapse collapse<?php echo ($showOriginalFileMetadata || $showPreservationCopyMetadata) ? '' : ' show'; ?>" aria-labelledby="access-heading">
-            <div class="accordion-body">
+            <div class="accordion-body p-0">
               <?php if ($showMasterFileMetadata) { ?>
 
-                <div class="digital-object-metadata-header">
-                  <h3><?php echo __('Master file'); ?> <i class="fa fa-file<?php if (!$canAccessMasterFile) { ?> inactive<?php } ?>" aria-hidden="true"></i></h3>
-                </div>
+                <div class="<?php echo render_b5_show_field_css_classes(); ?>">
 
-                <div class="digital-object-metadata-body">
-                  <?php if ($showMasterFileGoogleMap) { ?>
-                    <div id="front-map" class="simple-map" data-key="<?php echo $googleMapsApiKey; ?>" data-latitude="<?php echo $latitude; ?>" data-longitude="<?php echo $longitude; ?>"></div>
-                  <?php } ?>
+                  <h3 class="<?php echo render_b5_show_label_css_classes(); ?>"><?php echo __('Master file'); ?><i class="fa fa-file ms-2 text-dark<?php if (!$canAccessMasterFile) { ?> inactive text-muted<?php } ?>" aria-hidden="true"></i></h3>
 
-                  <?php if ($showMasterFileGeolocation) { ?>
-                    <?php echo render_show(__('Latitude'), render_value($latitude), ['fieldLabel' => 'latitude']); ?>
-                    <?php echo render_show(__('Longitude'), render_value($longitude), ['fieldLabel' => 'longitude']); ?>
-                  <?php } ?>
-
-                  <?php if ($showMasterFileURL) { ?>
-                    <?php echo render_show(__('URL'), render_value($resource->path), ['fieldLabel' => 'url']); ?>
-                  <?php } ?>
-
-                  <?php if ($showMasterFileName) { ?>
-                    <?php if ($canAccessMasterFile) { ?>
-                      <?php echo render_show(__('Filename'), link_to(render_value_inline($resource->name), $resource->object->getDigitalObjectUrl(), ['target' => '_blank']), ['fieldLabel' => 'filename']); ?>
-                    <?php } else { ?>
-                      <?php echo render_show(__('Filename'), render_value($resource->name), ['fieldLabel' => 'filename']); ?>
+                  <div class="digital-object-metadata-body <?php echo render_b5_show_value_css_classes(); ?>">
+                    <?php if ($showMasterFileGoogleMap) { ?>
+                      <div id="front-map" class="simple-map" data-key="<?php echo $googleMapsApiKey; ?>" data-latitude="<?php echo $latitude; ?>" data-longitude="<?php echo $longitude; ?>"></div>
                     <?php } ?>
-                  <?php } ?>
 
-                  <?php if ($showMasterFileMediaType) { ?>
-                    <?php echo render_show(__('Media type'), render_value($resource->mediaType), ['fieldLabel' => 'mediaType']); ?>
-                  <?php } ?>
+                    <?php if ($showMasterFileGeolocation) { ?>
+                      <?php echo render_show(__('Latitude'), render_value_inline($latitude), ['fieldLabel' => 'latitude', 'isSubField' => true]); ?>
+                      <?php echo render_show(__('Longitude'), render_value_inline($longitude), ['fieldLabel' => 'longitude', 'isSubField' => true]); ?>
+                    <?php } ?>
 
-                  <?php if ($showMasterFileMimeType) { ?>
-                    <?php echo render_show(__('Mime-type'), render_value($resource->mimeType), ['fieldLabel' => 'mimeType']); ?>
-                  <?php } ?>
+                    <?php if ($showMasterFileURL) { ?>
+                      <?php echo render_show(__('URL'), render_value($resource->path), ['fieldLabel' => 'url', 'isSubField' => true]); ?>
+                    <?php } ?>
 
-                  <?php if ($showMasterFileSize) { ?>
-                    <?php echo render_show(__('Filesize'), hr_filesize($resource->byteSize), ['fieldLabel' => 'filesize']); ?>
-                  <?php } ?>
+                    <?php if ($showMasterFileName) { ?>
+                      <?php if ($canAccessMasterFile) { ?>
+                        <?php echo render_show(__('Filename'), link_to(render_value_inline($resource->name), $resource->object->getDigitalObjectUrl(), ['target' => '_blank']), ['fieldLabel' => 'filename', 'isSubField' => true]); ?>
+                      <?php } else { ?>
+                        <?php echo render_show(__('Filename'), render_value_inline($resource->name), ['fieldLabel' => 'filename', 'isSubField' => true]); ?>
+                      <?php } ?>
+                    <?php } ?>
 
-                  <?php if ($showMasterFileCreatedAt) { ?>
-                    <?php echo render_show(__('Uploaded'), format_date($resource->createdAt, 'f'), ['fieldLabel' => 'uploaded']); ?>
-                  <?php } ?>
+                    <?php if ($showMasterFileMediaType) { ?>
+                      <?php echo render_show(__('Media type'), render_value_inline($resource->mediaType), ['fieldLabel' => 'mediaType', 'isSubField' => true]); ?>
+                    <?php } ?>
 
-                  <?php if ($showMasterFilePermissions) { ?>
-                    <?php echo render_show(__('Permissions'), render_value($masterFileDenyReason), ['fieldLabel' => 'masterFilePermissions']); ?>
-                  <?php } ?>
+                    <?php if ($showMasterFileMimeType) { ?>
+                      <?php echo render_show(__('Mime-type'), render_value_inline($resource->mimeType), ['fieldLabel' => 'mimeType', 'isSubField' => true]); ?>
+                    <?php } ?>
+
+                    <?php if ($showMasterFileSize) { ?>
+                      <?php echo render_show(__('Filesize'), hr_filesize($resource->byteSize), ['fieldLabel' => 'filesize', 'isSubField' => true]); ?>
+                    <?php } ?>
+
+                    <?php if ($showMasterFileCreatedAt) { ?>
+                      <?php echo render_show(__('Uploaded'), format_date($resource->createdAt, 'f'), ['fieldLabel' => 'uploaded', 'isSubField' => true]); ?>
+                    <?php } ?>
+
+                    <?php if ($showMasterFilePermissions) { ?>
+                      <?php echo render_show(__('Permissions'), render_value($masterFileDenyReason), ['fieldLabel' => 'masterFilePermissions', 'isSubField' => true]); ?>
+                    <?php } ?>
+                  </div>
+
                 </div>
 
               <?php } ?>
 
               <?php if ($showReferenceCopyMetadata) { ?>
 
-                <div class="digital-object-metadata-header">
-                  <h3><?php echo __('Reference copy'); ?> <i class="fa fa-file<?php if (!$canAccessReferenceCopy) { ?> inactive<?php } ?>" aria-hidden="true"></i></h3>
-                </div>
+                <div class="<?php echo render_b5_show_field_css_classes(); ?>">
 
-                <div class="digital-object-metadata-body">
-                  <?php if ($showReferenceCopyFileName) { ?>
-                    <?php if ($canAccessReferenceCopy && $sf_user->isAuthenticated()) { ?>
-                      <?php echo render_show(__('Filename'), link_to(render_value_inline($referenceCopy->name), $referenceCopy->getFullPath(), ['target' => '_blank']), ['fieldLabel' => 'referenceCopyFileName']); ?>
-                    <?php } else { ?>
-                      <?php echo render_show(__('Filename'), render_value($referenceCopy->name), ['fieldLabel' => 'referenceCopyFileName']); ?>
+                  <h3 class="<?php echo render_b5_show_label_css_classes(); ?>"><?php echo __('Reference copy'); ?><i class="fa fa-file ms-2 text-dark<?php if (!$canAccessReferenceCopy) { ?> inactive text-muted<?php } ?>" aria-hidden="true"></i></h3>
+
+                  <div class="digital-object-metadata-body <?php echo render_b5_show_value_css_classes(); ?>">
+                    <?php if ($showReferenceCopyFileName) { ?>
+                      <?php if ($canAccessReferenceCopy && $sf_user->isAuthenticated()) { ?>
+                        <?php echo render_show(__('Filename'), link_to(render_value_inline($referenceCopy->name), $referenceCopy->getFullPath(), ['target' => '_blank']), ['fieldLabel' => 'referenceCopyFileName', 'isSubField' => true]); ?>
+                      <?php } else { ?>
+                        <?php echo render_show(__('Filename'), render_value_inline($referenceCopy->name), ['fieldLabel' => 'referenceCopyFileName', 'isSubField' => true]); ?>
+                      <?php } ?>
                     <?php } ?>
-                  <?php } ?>
 
-                  <?php if ($showReferenceCopyMediaType) { ?>
-                    <?php echo render_show(__('Media type'), render_value($referenceCopy->mediaType), ['fieldLabel' => 'referenceCopyFileName']); ?>
-                  <?php } ?>
+                    <?php if ($showReferenceCopyMediaType) { ?>
+                      <?php echo render_show(__('Media type'), render_value_inline($referenceCopy->mediaType), ['fieldLabel' => 'referenceCopyFileName', 'isSubField' => true]); ?>
+                    <?php } ?>
 
-                  <?php if ($showReferenceCopyMimeType) { ?>
-                    <?php echo render_show(__('Mime-type'), render_value($referenceCopy->mimeType), ['fieldLabel' => 'referenceCopyMimeType']); ?>
-                  <?php } ?>
+                    <?php if ($showReferenceCopyMimeType) { ?>
+                      <?php echo render_show(__('Mime-type'), render_value_inline($referenceCopy->mimeType), ['fieldLabel' => 'referenceCopyMimeType', 'isSubField' => true]); ?>
+                    <?php } ?>
 
-                  <?php if ($showReferenceCopyFileSize) { ?>
-                    <?php echo render_show(__('Filesize'), hr_filesize($referenceCopy->byteSize), ['fieldLabel' => 'referenceCopyFileSize']); ?>
-                  <?php } ?>
+                    <?php if ($showReferenceCopyFileSize) { ?>
+                      <?php echo render_show(__('Filesize'), hr_filesize($referenceCopy->byteSize), ['fieldLabel' => 'referenceCopyFileSize', 'isSubField' => true]); ?>
+                    <?php } ?>
 
-                  <?php if ($showReferenceCopyCreatedAt) { ?>
-                    <?php echo render_show(__('Uploaded'), format_date($referenceCopy->createdAt, 'f'), ['fieldLabel' => 'referenceCopyUploaded']); ?>
-                  <?php } ?>
+                    <?php if ($showReferenceCopyCreatedAt) { ?>
+                      <?php echo render_show(__('Uploaded'), format_date($referenceCopy->createdAt, 'f'), ['fieldLabel' => 'referenceCopyUploaded', 'isSubField' => true]); ?>
+                    <?php } ?>
 
-                  <?php if ($showReferenceCopyPermissions) { ?>
-                    <?php echo render_show(__('Permissions'), render_value($referenceCopyDenyReason), ['fieldLabel' => 'referenceCopyPermissions']); ?>
-                  <?php } ?>
+                    <?php if ($showReferenceCopyPermissions) { ?>
+                      <?php echo render_show(__('Permissions'), render_value($referenceCopyDenyReason), ['fieldLabel' => 'referenceCopyPermissions', 'isSubField' => true]); ?>
+                    <?php } ?>
+                  </div>
+
                 </div>
 
               <?php } ?>
 
               <?php if ($showThumbnailCopyMetadata) { ?>
 
-                <div class="digital-object-metadata-header">
-                  <h3><?php echo __('Thumbnail copy'); ?> <i class="fa fa-file<?php if (!$canAccessThumbnailCopy) { ?> inactive<?php } ?>" aria-hidden="true"></i></h3>
-                </div>
+                <div class="<?php echo render_b5_show_field_css_classes(); ?>">
 
-                <div class="digital-object-metadata-body">
-                  <?php if ($showThumbnailCopyFileName) { ?>
-                    <?php if ($canAccessThumbnailCopy) { ?>
-                      <?php echo render_show(__('Filename'), link_to(render_value_inline($thumbnailCopy->name), $thumbnailCopy->getFullPath(), ['target' => '_blank']), ['fieldLabel' => 'thumbnailCopyFileName']); ?>
-                    <?php } else { ?>
-                      <?php echo render_show(__('Filename'), render_value($thumbnailCopy->name), ['fieldLabel' => 'thumbnailCopyFileName']); ?>
+                  <h3 class="<?php echo render_b5_show_label_css_classes(); ?>"><?php echo __('Thumbnail copy'); ?><i class="fa fa-file ms-2 text-dark<?php if (!$canAccessThumbnailCopy) { ?> inactive text-muted<?php } ?>" aria-hidden="true"></i></h3>
+
+                  <div class="digital-object-metadata-body <?php echo render_b5_show_value_css_classes(); ?>">
+                    <?php if ($showThumbnailCopyFileName) { ?>
+                      <?php if ($canAccessThumbnailCopy) { ?>
+                        <?php echo render_show(__('Filename'), link_to(render_value_inline($thumbnailCopy->name), $thumbnailCopy->getFullPath(), ['target' => '_blank']), ['fieldLabel' => 'thumbnailCopyFileName', 'isSubField' => true]); ?>
+                      <?php } else { ?>
+                        <?php echo render_show(__('Filename'), render_value_inline($thumbnailCopy->name), ['fieldLabel' => 'thumbnailCopyFileName', 'isSubField' => true]); ?>
+                      <?php } ?>
                     <?php } ?>
-                  <?php } ?>
 
-                  <?php if ($showThumbnailCopyMediaType) { ?>
-                    <?php echo render_show(__('Media type'), render_value($thumbnailCopy->mediaType), ['fieldLabel' => 'thumbnailCopyFileName']); ?>
-                  <?php } ?>
+                    <?php if ($showThumbnailCopyMediaType) { ?>
+                      <?php echo render_show(__('Media type'), render_value_inline($thumbnailCopy->mediaType), ['fieldLabel' => 'thumbnailCopyFileName', 'isSubField' => true]); ?>
+                    <?php } ?>
 
-                  <?php if ($showThumbnailCopyMimeType) { ?>
-                    <?php echo render_show(__('Mime-type'), render_value($thumbnailCopy->mimeType), ['fieldLabel' => 'thumbnailCopyMimeType']); ?>
-                  <?php } ?>
+                    <?php if ($showThumbnailCopyMimeType) { ?>
+                      <?php echo render_show(__('Mime-type'), render_value_inline($thumbnailCopy->mimeType), ['fieldLabel' => 'thumbnailCopyMimeType', 'isSubField' => true]); ?>
+                    <?php } ?>
 
-                  <?php if ($showThumbnailCopyFileSize) { ?>
-                    <?php echo render_show(__('Filesize'), hr_filesize($thumbnailCopy->byteSize), ['fieldLabel' => 'thumbnailCopyFileSize']); ?>
-                  <?php } ?>
+                    <?php if ($showThumbnailCopyFileSize) { ?>
+                      <?php echo render_show(__('Filesize'), hr_filesize($thumbnailCopy->byteSize), ['fieldLabel' => 'thumbnailCopyFileSize', 'isSubField' => true]); ?>
+                    <?php } ?>
 
-                  <?php if ($showThumbnailCopyCreatedAt) { ?>
-                    <?php echo render_show(__('Uploaded'), format_date($thumbnailCopy->createdAt, 'f'), ['fieldLabel' => 'thumbnailCopyUploaded']); ?>
-                  <?php } ?>
+                    <?php if ($showThumbnailCopyCreatedAt) { ?>
+                      <?php echo render_show(__('Uploaded'), format_date($thumbnailCopy->createdAt, 'f'), ['fieldLabel' => 'thumbnailCopyUploaded', 'isSubField' => true]); ?>
+                    <?php } ?>
 
-                  <?php if (!empty($thumbnailCopyDenyReason)) { ?>
-                    <?php echo render_show(__('Permissions'), render_value($thumbnailCopyDenyReason), ['fieldLabel' => 'thumbnailCopyPermissions']); ?>
-                  <?php } ?>
+                    <?php if (!empty($thumbnailCopyDenyReason)) { ?>
+                      <?php echo render_show(__('Permissions'), render_value($thumbnailCopyDenyReason), ['fieldLabel' => 'thumbnailCopyPermissions', 'isSubField' => true]); ?>
+                    <?php } ?>
+                  </div>
+
                 </div>
 
               <?php } ?>

--- a/plugins/arDominionB5Plugin/modules/digitalobject/templates/_rights.php
+++ b/plugins/arDominionB5Plugin/modules/digitalobject/templates/_rights.php
@@ -1,0 +1,43 @@
+<section>
+
+  <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), render_b5_section_label(__('%1% (%2%) rights area', ['%1%' => sfConfig::get('app_ui_label_digitalobject'), '%2%' => $resource->usage])), [$resource, 'module' => 'digitalobject', 'action' => 'edit'], ['title' => __('Edit %1%', ['%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject'))])]); ?>
+
+  <?php foreach ($resource->getRights() as $item) { ?>
+
+    <?php echo get_partial('right/right', ['resource' => $item->object, 'object' => $item]); ?>
+
+  <?php } ?>
+
+</section>
+
+<section>
+
+  <?php if ($child = $resource->getChildByUsageId(QubitTerm::REFERENCE_ID)) { ?>
+
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), render_b5_section_label(__('%1% (%2%) rights area', ['%1%' => sfConfig::get('app_ui_label_digitalobject'), '%2%' => $child->usage])), [$resource, 'module' => 'digitalobject', 'action' => 'edit'], ['title' => __('Edit %1%', ['%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject'))])]); ?>
+
+    <?php foreach ($child->getRights() as $item) { ?>
+
+      <?php echo get_partial('right/right', ['resource' => $item->object, 'object' => $resource]); ?>
+
+    <?php } ?>
+
+  <?php } ?>
+
+</section>
+
+<section>
+
+  <?php if ($child = $resource->getChildByUsageId(QubitTerm::THUMBNAIL_ID)) { ?>
+
+    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), render_b5_section_label(__('%1% (%2%) rights area', ['%1%' => sfConfig::get('app_ui_label_digitalobject'), '%2%' => $child->usage])), [$resource, 'module' => 'digitalobject', 'action' => 'edit'], ['title' => __('Edit %1%', ['%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject'))])]); ?>
+
+    <?php foreach ($child->getRights() as $item) { ?>
+
+      <?php echo get_partial('right/right', ['resource' => $item->object, 'object' => $resource]); ?>
+
+    <?php } ?>
+
+  <?php } ?>
+
+</section>

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_accessions.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_accessions.php
@@ -1,0 +1,10 @@
+<div class="field <?php echo render_b5_show_field_css_classes(); ?>">
+  <?php echo render_b5_show_label(__('Accession number(s)')); ?>
+  <div class="<?php echo render_b5_show_value_css_classes(); ?>">
+    <ul class="<?php echo render_b5_show_list_css_classes(); ?>">
+      <?php foreach ($accessions as $item) { ?>
+        <li><?php echo link_to(render_title($item->object), [$item->object, 'module' => 'accession']); ?></li>
+      <?php } ?>
+    </ul>
+  </div>
+</div>

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_alternativeIdentifiersIndex.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_alternativeIdentifiersIndex.php
@@ -1,0 +1,11 @@
+<div class="field <?php echo render_b5_show_field_css_classes(); ?>">
+
+  <?php echo render_b5_show_label(__('Alternative identifier(s)')); ?>
+
+  <div class="<?php echo render_b5_show_value_css_classes(); ?>">
+    <?php foreach ($resource->getProperties(null, 'alternativeIdentifiers') as $item) { ?>
+      <?php echo render_show(render_value_inline($item->name), $item->getValue(['cultureFallback' => true]), ['isSubField' => true]); ?>
+    <?php } ?>
+  </div>
+
+</div>

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_creatorDetail.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_creatorDetail.php
@@ -1,0 +1,37 @@
+<?php $actorsShown = []; ?>
+<?php foreach ($ancestor->getCreators() as $item) { ?>
+  <?php if (!isset($actorsShown[$item->id])) { ?>
+    <div class="field <?php echo render_b5_show_field_css_classes(); ?>">
+      <?php echo render_b5_show_label(__('Name of creator')); ?>
+      <div class="<?php echo render_b5_show_value_css_classes(); ?>">
+
+        <div class="creator">
+          <?php if (0 < count($resource->getCreators())) { ?>
+            <?php echo link_to(render_title($item), [$item]); ?>
+          <?php } else { ?>
+            <?php echo link_to(render_title($item), [$item], ['title' => __('Inherited from %1%', ['%1%' => $ancestor])]); ?>
+          <?php } ?>
+        </div>
+
+        <?php if (isset($item->datesOfExistence)) { ?>
+          <div class="datesOfExistence">
+            (<?php echo render_value_inline($item->getDatesOfExistence(['cultureFallback' => true])); ?>)
+          </div>
+        <?php } ?>
+
+        <?php if (0 < count($resource->getCreators())) { ?>
+          <div class="field <?php echo render_b5_show_field_css_classes(); ?>">
+            <?php if (QubitTerm::CORPORATE_BODY_ID == $item->entityTypeId) { ?>
+              <?php $history_kind = __('Administrative history'); ?>
+            <?php } else { ?>
+              <?php $history_kind = __('Biographical history'); ?>
+            <?php } ?>
+            <?php echo render_show($history_kind, render_value($item->getHistory(['cultureFallback' => true])), ['isSubField' => true]); ?>
+          </div>
+        <?php } ?>
+
+      </div>
+    </div>
+    <?php $actorsShown[$item->id] = true; ?>
+  <?php } ?>
+<?php } ?>

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_findingAidLink.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_findingAidLink.php
@@ -1,0 +1,6 @@
+<div class="field <?php echo render_b5_show_field_css_classes(); ?>">
+  <?php echo render_b5_show_label($label); ?>
+  <div class="findingAidLink <?php echo render_b5_show_value_css_classes(); ?>">
+    <a href="<?php echo public_path($path); ?>" target="_blank"><?php echo $filename; ?></a>
+  </div>
+</div>

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_genreAccessPoints.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_genreAccessPoints.php
@@ -1,0 +1,29 @@
+<div class="field<?php echo isset($sidebar) ? '' : ' '.render_b5_show_field_css_classes(); ?>">
+
+  <?php if (isset($sidebar)) { ?>
+    <h4><?php echo __('Related genres'); ?></h4>
+  <?php } elseif (isset($mods)) { ?>
+    <?php echo render_b5_show_label(__('Genres')); ?>
+  <?php } else { ?>
+    <?php echo render_b5_show_label(__('Genre access points')); ?>
+  <?php } ?>
+
+  <div<?php echo isset($sidebar) ? '' : ' class="'.render_b5_show_value_css_classes().'"'; ?>>
+    <ul class="<?php echo render_b5_show_list_css_classes(); ?>">
+      <?php foreach ($resource->getTermRelations(QubitTaxonomy::GENRE_ID) as $item) { ?>
+        <li>
+          <?php foreach ($item->term->ancestors->andSelf()->orderBy('lft') as $key => $subject) { ?>
+            <?php if (QubitTerm::ROOT_ID == $subject->id) { ?>
+              <?php continue; ?>
+            <?php } ?>
+            <?php if (1 < $key) { ?>
+              &raquo;
+            <?php } ?>
+            <?php echo link_to(render_title($subject), [$subject, 'module' => 'term']); ?>
+          <?php } ?>
+        </li>
+      <?php } ?>
+    </ul>
+  </div>
+
+</div>

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_nameAccessPoints.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_nameAccessPoints.php
@@ -1,0 +1,33 @@
+<div class="field<?php echo isset($sidebar) ? '' : ' '.render_b5_show_field_css_classes(); ?>">
+
+  <?php if (isset($sidebar)) { ?>
+    <h4><?php echo __('Related people and organizations'); ?></h4>
+  <?php } elseif (isset($mods)) { ?>
+    <?php echo render_b5_show_label(__('Names')); ?>
+  <?php } else { ?>
+    <?php echo render_b5_show_label(__('Name access points')); ?>
+  <?php } ?>
+
+  <div<?php echo isset($sidebar) ? '' : ' class="'.render_b5_show_value_css_classes().'"'; ?>>
+    <ul class="<?php echo render_b5_show_list_css_classes(); ?>">
+      <?php if (isset($showActorEvents) || isset($sidebar)) { ?>
+        <?php $actorsShown = []; ?>
+        <?php foreach ($resource->getActorEvents() as $item) { ?>
+          <?php if (isset($sidebar) || QubitTerm::CREATION_ID != $item->type->id) { ?>
+            <?php if (isset($item->actor) && !isset($actorsShown[$item->actor->id])) { ?>
+              <li><?php echo link_to(render_title($item->actor), [$item->actor]); ?> <span class="note2">(<?php echo render_value_inline($item->type->getRole()); ?>)</span></li>
+              <?php $actorsShown[$item->actor->id] = true; ?>
+            <?php } ?>
+          <?php } ?>
+        <?php } ?>
+      <?php } ?>
+
+      <?php foreach ($resource->relationsRelatedBysubjectId as $item) { ?>
+        <?php if (isset($item->type) && QubitTerm::NAME_ACCESS_POINT_ID == $item->type->id) { ?>
+          <li><?php echo link_to(render_title($item->object), [$item->object, 'module' => 'actor']); ?><span class="note2"> <?php if (!isset($mods)) { ?>(<?php echo __('Subject'); ?>)<?php } ?></span></li>
+        <?php } ?>
+      <?php } ?>
+    </ul>
+  </div>
+
+</div>

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_relatedMaterialDescriptions.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_relatedMaterialDescriptions.php
@@ -1,0 +1,24 @@
+<div class="field <?php echo render_b5_show_field_css_classes(); ?>">
+
+  <?php if ('rad' == $template) { ?>
+    <?php echo render_b5_show_label(__('Related materials')); ?>
+  <?php } else { ?>
+    <?php echo render_b5_show_label(__('Related descriptions')); ?>
+  <?php } ?>
+
+  <div class="<?php echo render_b5_show_value_css_classes(); ?>">
+    <ul class="<?php echo render_b5_show_list_css_classes(); ?>">
+      <?php foreach ($resource->relationsRelatedBysubjectId as $item) { ?>
+        <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
+          <li><?php echo link_to(render_title($item->object), [$item->object, 'module' => 'informationobject']); ?></li>
+        <?php } ?>
+      <?php } ?>
+      <?php foreach ($resource->relationsRelatedByobjectId as $item) { ?>
+        <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
+          <li><?php echo link_to(render_title($item->subject), [$item->subject, 'module' => 'informationobject']); ?></li>
+        <?php } ?>
+      <?php } ?>
+    </ul>
+  </div>
+
+</div>

--- a/plugins/arDominionB5Plugin/modules/object/templates/_placeAccessPoints.php
+++ b/plugins/arDominionB5Plugin/modules/object/templates/_placeAccessPoints.php
@@ -1,0 +1,33 @@
+<div class="field<?php echo isset($sidebar) ? '' : ' '.render_b5_show_field_css_classes(); ?>">
+
+  <?php if (isset($sidebar)) { ?>
+    <h4><?php echo __('Related places'); ?></h4>
+  <?php } elseif (isset($mods)) { ?>
+    <?php echo render_b5_show_label(__('Places')); ?>
+  <?php } else { ?>
+    <?php echo render_b5_show_label(__('Place access points')); ?>
+  <?php } ?>
+
+  <div<?php echo isset($sidebar) ? '' : ' class="'.render_b5_show_value_css_classes().'"'; ?>>
+    <ul class="<?php echo render_b5_show_list_css_classes(); ?>">
+      <?php foreach ($resource->getPlaceAccessPoints() as $item) { ?>
+        <li>
+          <?php foreach ($item->term->ancestors->andSelf()->orderBy('lft') as $key => $place) { ?>
+            <?php if (QubitTerm::ROOT_ID == $place->id) { ?>
+              <?php continue; ?>
+            <?php } ?>
+            <?php if (1 < $key) { ?>
+              &raquo;
+            <?php } ?>
+            <?php if ('QubitActor' == $resource->getClass()) { ?>
+              <?php echo link_to(render_title($place), [$place, 'module' => 'term', 'action' => 'relatedAuthorities']); ?>
+            <?php } else { ?>
+              <?php echo link_to(render_title($place), [$place, 'module' => 'term']); ?>
+            <?php } ?>
+          <?php } ?>
+        </li>
+      <?php } ?>
+    </ul>
+  </div>
+
+</div>

--- a/plugins/arDominionB5Plugin/modules/object/templates/_subjectAccessPoints.php
+++ b/plugins/arDominionB5Plugin/modules/object/templates/_subjectAccessPoints.php
@@ -1,0 +1,33 @@
+<div class="field<?php echo isset($sidebar) ? '' : ' '.render_b5_show_field_css_classes(); ?>">
+
+  <?php if (isset($sidebar)) { ?>
+    <h4><?php echo __('Related subjects'); ?></h4>
+  <?php } elseif (isset($mods)) { ?>
+    <?php echo render_b5_show_label(__('Subjects')); ?>
+  <?php } else { ?>
+    <?php echo render_b5_show_label(__('Subject access points')); ?>
+  <?php } ?>
+
+  <div<?php echo isset($sidebar) ? '' : ' class="'.render_b5_show_value_css_classes().'"'; ?>>
+    <ul class="<?php echo render_b5_show_list_css_classes(); ?>">
+      <?php foreach ($resource->getSubjectAccessPoints() as $item) { ?>
+        <li>
+          <?php foreach ($item->term->ancestors->andSelf()->orderBy('lft') as $key => $subject) { ?>
+            <?php if (QubitTerm::ROOT_ID == $subject->id) { ?>
+              <?php continue; ?>
+            <?php } ?>
+            <?php if (1 < $key) { ?>
+              &raquo;
+            <?php } ?>
+            <?php if ('QubitActor' == $resource->getClass()) { ?>
+              <?php echo link_to(render_title($subject), [$subject, 'module' => 'term', 'action' => 'relatedAuthorities']); ?>
+            <?php } else { ?>
+              <?php echo link_to(render_title($subject), [$subject, 'module' => 'term']); ?>
+            <?php } ?>
+          <?php } ?>
+        </li>
+      <?php } ?>
+    </ul>
+  </div>
+
+</div>

--- a/plugins/arDominionB5Plugin/modules/right/templates/_right.php
+++ b/plugins/arDominionB5Plugin/modules/right/templates/_right.php
@@ -1,0 +1,75 @@
+<div class="field <?php echo render_b5_show_field_css_classes(); ?>">
+  <?php echo render_b5_show_label(__('Related right')); ?>
+  <div class="<?php echo render_b5_show_value_css_classes(); ?>">
+    <?php if (QubitAcl::check($relatedObject, 'update')) { ?>
+      <a href="<?php echo url_for(['module' => 'right', 'action' => 'edit', 'slug' => $resource->slug]); ?>">&nbsp;Edit</a> |
+      <a href="<?php echo url_for(['module' => 'right', 'action' => 'delete', 'slug' => $resource->slug]); ?>">Delete</a>
+    <?php } ?>
+
+    <div>
+      <?php if (isset($inherit)) { ?>
+        <?php echo link_to(render_title($inherit), [$inherit, 'module' => 'informationobject'], ['title' => __('Inherited from %1%', ['%1%' => $inherit])]); ?>
+      <?php } ?>
+
+      <?php echo render_show(__('Basis'), render_value_inline($resource->basis), ['isSubField' => true]); ?>
+
+      <?php echo render_show(__('Start date'), render_value_inline(Qubit::renderDate($resource->startDate)), ['isSubField' => true]); ?>
+
+      <?php echo render_show(__('End date'), render_value_inline(Qubit::renderDate($resource->endDate)), ['isSubField' => true]); ?>
+
+      <?php echo render_show(__('Documentation Identifier Type'), render_value_inline($resource->identifierType), ['isSubField' => true]); ?>
+
+      <?php echo render_show(__('Documentation Identifier Value'), render_value_inline($resource->identifierValue), ['isSubField' => true]); ?>
+
+      <?php echo render_show(__('Documentation Identifier Role'), render_value_inline($resource->identifierRole), ['isSubField' => true]); ?>
+
+      <?php if (isset($resource->rightsHolder)) { ?>
+        <?php echo render_show(__('Rights holder'), link_to(render_value_inline($resource->rightsHolder), [$resource->rightsHolder, 'module' => 'rightsholder']), ['isSubField' => true]); ?>
+      <?php } ?>
+
+      <?php echo render_show(__('Rights note(s)'), render_value_inline($resource->getRightsNote(['cultureFallback' => true])), ['isSubField' => true]); ?>
+
+      <?php if (QubitTerm::RIGHT_BASIS_COPYRIGHT_ID == $resource->basisId) { ?>
+
+        <?php echo render_show(__('Copyright status'), render_value_inline($resource->copyrightStatus), ['isSubField' => true]); ?>
+
+        <?php echo render_show(__('Copyright status determination date'), render_value_inline($resource->copyrightStatusDate), ['isSubField' => true]); ?>
+
+        <?php echo render_show(__('Copyright jurisdiction'), render_value_inline($resource->copyrightJurisdiction), ['isSubField' => true]); ?>
+
+        <?php echo render_show(__('Copyright note'), render_value_inline($resource->getCopyrightNote(['cultureFallback' => true])), ['isSubField' => true]); ?>
+
+      <?php } elseif (QubitTerm::RIGHT_BASIS_LICENSE_ID == $resource->basisId) { ?>
+
+        <?php echo render_show(__('License identifier'), render_value_inline($resource->getIdentifierValue(['cultureFallback' => true])), ['isSubField' => true]); ?>
+
+        <?php echo render_show(__('License terms'), render_value_inline($resource->getLicenseTerms(['cultureFallback' => true])), ['isSubField' => true]); ?>
+
+        <?php echo render_show(__('License note'), render_value_inline($resource->getLicenseNote(['cultureFallback' => true])), ['isSubField' => true]); ?>
+
+      <?php } elseif (QubitTerm::RIGHT_BASIS_STATUTE_ID == $resource->basisId) { ?>
+
+        <?php echo render_show(__('Statute jurisdiction'), render_value_inline($resource->getStatuteJurisdiction(['cultureFallback' => true])), ['isSubField' => true]); ?>
+
+        <?php if (null !== $statuteCitation = $resource->statuteCitation) { ?>
+          <?php echo render_show(__('Statute citation'), render_value_inline($statuteCitation->getName(['cultureFallback' => true])), ['isSubField' => true]); ?>
+        <?php } ?>
+
+        <?php echo render_show(__('Statute determination date'), render_value_inline($resource->statuteDeterminationDate), ['isSubField' => true]); ?>
+
+        <?php echo render_show(__('Statute note'), render_value_inline($resource->getStatuteNote(['cultureFallback' => true])), ['isSubField' => true]); ?>
+
+      <?php } ?>
+
+      <blockquote class="border-top m-0">
+        <?php foreach ($resource->grantedRights as $grantedRight) { ?>
+          <?php echo render_show(__('Act'), render_value_inline($grantedRight->act), ['isSubField' => true]); ?>
+          <?php echo render_show(__('Restriction'), render_value_inline(QubitGrantedRight::getRestrictionString($grantedRight->restriction)), ['isSubField' => true]); ?>
+          <?php echo render_show(__('Start date'), render_value_inline(Qubit::renderDate($grantedRight->startDate)), ['isSubField' => true]); ?>
+          <?php echo render_show(__('End date'), render_value_inline(Qubit::renderDate($grantedRight->endDate)), ['isSubField' => true]); ?>
+          <?php echo render_show(__('Notes'), render_value_inline($grantedRight->notes), ['isSubField' => true]); ?>
+        <?php } ?>
+      </blockquote>
+    </div>
+  </div>
+</div>

--- a/plugins/arDominionB5Plugin/modules/sfIsadPlugin/templates/indexSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfIsadPlugin/templates/indexSuccess.php
@@ -10,7 +10,7 @@
 
   <?php if (isset($errorSchema)) { ?>
     <div class="messages error">
-      <ul>
+      <ul class="<?php echo render_b5_show_list_css_classes(); ?>">
         <?php foreach ($errorSchema as $error) { ?>
           <?php $error = sfOutputEscaper::unescape($error); ?>
           <li><?php echo $error->getMessage(); ?></li>
@@ -51,300 +51,308 @@
 
 <?php end_slot(); ?>
 
-<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)) { ?>
-  <?php echo get_component('digitalobject', 'show', ['link' => $digitalObjectLink, 'resource' => $resource->digitalObjectsRelatedByobjectId[0], 'usageType' => QubitTerm::REFERENCE_ID]); ?>
-<?php } ?>
+<?php slot('content'); ?>
 
-<section id="identityArea">
+  <div id="content" class="p-0">
 
-  <?php if (check_field_visibility('app_element_visibility_isad_identity_area')) { ?>
-    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Identity area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'identity-collapse', 'title' => __('Edit identity area')]); ?>
-  <?php } ?>
+    <?php if (0 < count($resource->digitalObjectsRelatedByobjectId)) { ?>
+      <?php echo get_component('digitalobject', 'show', ['link' => $digitalObjectLink, 'resource' => $resource->digitalObjectsRelatedByobjectId[0], 'usageType' => QubitTerm::REFERENCE_ID]); ?>
+    <?php } ?>
 
-  <?php echo render_show(__('Reference code'), $isad->referenceCode, ['fieldLabel' => 'referenceCode']); ?>
+    <section id="identityArea" class="border-bottom">
 
-  <?php echo render_show(__('Title'), render_title($resource), ['fieldLabel' => 'title']); ?>
+      <?php if (check_field_visibility('app_element_visibility_isad_identity_area')) { ?>
+        <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), render_b5_section_label(__('Identity area')), [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'identity-collapse', 'title' => __('Edit identity area'), 'class' => 'text-primary']); ?>
+      <?php } ?>
 
-  <div class="field">
-    <h3><?php echo __('Date(s)'); ?></h3>
-    <div class="creationDates">
-      <ul>
-        <?php foreach ($resource->getDates() as $item) { ?>
-          <li>
-            <?php echo render_value_inline(Qubit::renderDateStartEnd($item->getDate(['cultureFallback' => true]), $item->startDate, $item->endDate)); ?> (<?php echo $item->getType(['cultureFallback' => true]); ?>)
-          </li>
-        <?php } ?>
-      </ul>
-    </div>
-  </div>
+      <?php echo render_show(__('Reference code'), $isad->referenceCode, ['fieldLabel' => 'referenceCode']); ?>
 
-  <?php echo render_show(__('Level of description'), render_value($resource->levelOfDescription), ['fieldLabel' => 'levelOfDescription']); ?>
+      <?php echo render_show(__('Title'), render_title($resource), ['fieldLabel' => 'title']); ?>
 
-  <?php echo render_show(__('Extent and medium'), render_value($resource->getCleanExtentAndMedium(['cultureFallback' => true])), ['fieldLabel' => 'extentAndMedium']); ?>
-</section> <!-- /section#identityArea -->
-
-<section id="contextArea">
-
-  <?php if (check_field_visibility('app_element_visibility_isad_context_area')) { ?>
-    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Context area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'context-collapse', 'title' => __('Edit context area')]); ?>
-  <?php } ?>
-
-  <div class="creatorHistories">
-    <?php echo get_component('informationobject', 'creatorDetail', [
-        'resource' => $resource,
-        'creatorHistoryLabels' => $creatorHistoryLabels, ]); ?>
-  </div>
-
-  <div class="relatedFunctions">
-    <?php foreach ($functionRelations as $item) { ?>
-      <div class="field">
-        <h3><?php echo __('Related function'); ?></h3>
-        <div>
-          <?php echo link_to(render_title($item->subject->getLabel()), [$item->subject, 'module' => 'function']); ?>
+      <div class="field <?php echo render_b5_show_field_css_classes(); ?>">
+        <?php echo render_b5_show_label(__('Date(s)')); ?>
+        <div class="creationDates <?php echo render_b5_show_value_css_classes(); ?>">
+          <ul class="<?php echo render_b5_show_list_css_classes(); ?>">
+            <?php foreach ($resource->getDates() as $item) { ?>
+              <li>
+                <?php echo render_value_inline(Qubit::renderDateStartEnd($item->getDate(['cultureFallback' => true]), $item->startDate, $item->endDate)); ?> (<?php echo $item->getType(['cultureFallback' => true]); ?>)
+              </li>
+            <?php } ?>
+          </ul>
         </div>
       </div>
-    <?php } ?>
-  </div>
 
-  <div class="repository">
-    <?php echo render_show_repository(__('Repository'), $resource); ?>
-  </div>
+      <?php echo render_show(__('Level of description'), render_value_inline($resource->levelOfDescription), ['fieldLabel' => 'levelOfDescription']); ?>
 
-  <?php if (check_field_visibility('app_element_visibility_isad_archival_history')) { ?>
-    <?php echo render_show(__('Archival history'), render_value($resource->getArchivalHistory(['cultureFallback' => true])), ['fieldLabel' => 'archivalHistory']); ?>
-  <?php } ?>
+      <?php echo render_show(__('Extent and medium'), render_value($resource->getCleanExtentAndMedium(['cultureFallback' => true])), ['fieldLabel' => 'extentAndMedium']); ?>
+</section> <!-- /section#identityArea -->
 
-  <?php if (check_field_visibility('app_element_visibility_isad_immediate_source')) { ?>
-    <?php echo render_show(__('Immediate source of acquisition or transfer'), render_value($resource->getAcquisition(['cultureFallback' => true])), ['fieldLabel' => 'immediateSourceOfAcquisitionOrTransfer']); ?>
-  <?php } ?>
+    <section id="contextArea" class="border-bottom">
 
-</section> <!-- /section#contextArea -->
+      <?php if (check_field_visibility('app_element_visibility_isad_context_area')) { ?>
+        <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), render_b5_section_label(__('Context area')), [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'context-collapse', 'title' => __('Edit context area'), 'class' => 'text-primary']); ?>
+      <?php } ?>
 
-<section id="contentAndStructureArea">
-
-  <?php if (check_field_visibility('app_element_visibility_isad_content_and_structure_area')) { ?>
-    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Content and structure area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'content-collapse', 'title' => __('Edit content and structure area')]); ?>
-  <?php } ?>
-
-  <?php echo render_show(__('Scope and content'), render_value($resource->getScopeAndContent(['cultureFallback' => true])), ['fieldLabel' => 'scopeAndContent']); ?>
-
-  <?php if (check_field_visibility('app_element_visibility_isad_appraisal_destruction')) { ?>
-    <?php echo render_show(__('Appraisal, destruction and scheduling'), render_value($resource->getAppraisal(['cultureFallback' => true])), ['fieldLabel' => 'appraisalDestructionAndScheduling']); ?>
-  <?php } ?>
-
-  <?php echo render_show(__('Accruals'), render_value($resource->getAccruals(['cultureFallback' => true])), ['fieldLabel' => 'accruals']); ?>
-
-  <?php echo render_show(__('System of arrangement'), render_value($resource->getArrangement(['cultureFallback' => true])), ['fieldLabel' => 'systemOfArrangement']); ?>
-</section> <!-- /section#contentAndStructureArea -->
-
-<section id="conditionsOfAccessAndUseArea">
-
-  <?php if (check_field_visibility('app_element_visibility_isad_conditions_of_access_use_area')) { ?>
-    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Conditions of access and use area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'conditions-collapse', 'title' => __('Edit conditions of access and use area')]); ?>
-  <?php } ?>
-
-  <?php echo render_show(__('Conditions governing access'), render_value($resource->getAccessConditions(['cultureFallback' => true])), ['fieldLabel' => 'conditionsGoverningAccess']); ?>
-
-  <?php echo render_show(__('Conditions governing reproduction'), render_value($resource->getReproductionConditions(['cultureFallback' => true])), ['fieldLabel' => 'conditionsGoverningReproduction']); ?>
-
-  <div class="field">
-    <h3><?php echo __('Language of material'); ?></h3>
-    <div class="languageOfMaterial">
-      <ul>
-        <?php foreach ($resource->language as $code) { ?>
-          <li><?php echo format_language($code); ?></li>
-        <?php } ?>
-      </ul>
-    </div>
-  </div>
-
-  <div class="field">
-    <h3><?php echo __('Script of material'); ?></h3>
-    <div class="scriptOfMaterial">
-      <ul>
-        <?php foreach ($resource->script as $code) { ?>
-          <li><?php echo format_script($code); ?></li>
-        <?php } ?>
-      </ul>
-    </div>
-  </div>
-
-  <?php echo render_show(__('Language and script notes'), render_value($isad->languageNotes), ['fieldLabel' => 'languageAndScriptNotes']); ?>
-
-  <?php if (check_field_visibility('app_element_visibility_isad_physical_condition')) { ?>
-    <?php echo render_show(__('Physical characteristics and technical requirements'), render_value($resource->getPhysicalCharacteristics(['cultureFallback' => true])), ['fieldLabel' => 'physicalCharacteristics']); ?>
-  <?php } ?>
-
-  <?php echo render_show(__('Finding aids'), render_value($resource->getFindingAids(['cultureFallback' => true])), ['fieldLabel' => 'findingAids']); ?>
-
-  <?php echo get_component('informationobject', 'findingAidLink', ['resource' => $resource]); ?>
-
-</section> <!-- /section#conditionsOfAccessAndUseArea -->
-
-<section id="alliedMaterialsArea">
-
-  <?php if (check_field_visibility('app_element_visibility_isad_allied_materials_area')) { ?>
-    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Allied materials area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'allied-collapse', 'title' => __('Edit alied materials area')]); ?>
-  <?php } ?>
-
-  <?php echo render_show(__('Existence and location of originals'), render_value($resource->getLocationOfOriginals(['cultureFallback' => true])), ['fieldLabel' => 'existenceAndLocationOfOriginals']); ?>
-
-  <?php echo render_show(__('Existence and location of copies'), render_value($resource->getLocationOfCopies(['cultureFallback' => true])), ['fieldLabel' => 'existenceAndLocationOfCopies']); ?>
-
-  <?php echo render_show(__('Related units of description'), render_value($resource->getRelatedUnitsOfDescription(['cultureFallback' => true])), ['fieldLabel' => 'relatedUnitsOfDescription']); ?>
-
-  <div class="relatedMaterialDescriptions">
-    <?php echo get_partial('informationobject/relatedMaterialDescriptions', ['resource' => $resource, 'template' => 'isad']); ?>
-  </div>
-
-  <?php foreach ($resource->getNotesByType(['noteTypeId' => QubitTerm::PUBLICATION_NOTE_ID]) as $item) { ?>
-    <?php echo render_show(__('Publication note'), render_value($item->getContent(['cultureFallback' => true])), ['fieldLabel' => 'publicationNote']); ?>
-  <?php } ?>
-</section> <!-- /section#alliedMaterialsArea -->
-
-<section id="notesArea">
-
-  <?php if (check_field_visibility('app_element_visibility_isad_notes_area')) { ?>
-    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Notes area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'notes-collapse', 'title' => __('Edit notes area')]); ?>
-  <?php } ?>
-
-  <?php if (check_field_visibility('app_element_visibility_isad_notes')) { ?>
-    <?php foreach ($resource->getNotesByType(['noteTypeId' => QubitTerm::GENERAL_NOTE_ID]) as $item) { ?>
-      <?php echo render_show(__('Note'), render_value($item->getContent(['cultureFallback' => true])), ['fieldLabel' => 'generalNote']); ?>
-    <?php } ?>
-  <?php } ?>
-
-  <div class="alternativeIdentifiers">
-    <?php echo get_partial('informationobject/alternativeIdentifiersIndex', ['resource' => $resource]); ?>
-  </div>
-</section> <!-- /section#notesArea -->
-
-<section id="accessPointsArea">
-
-  <?php if (check_field_visibility('app_element_visibility_isad_access_points_area')) { ?>
-    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Access points').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'access-collapse', 'title' => __('Edit access points')]); ?>
-  <?php } ?>
-
-  <div class="subjectAccessPoints">
-    <?php echo get_partial('object/subjectAccessPoints', ['resource' => $resource]); ?>
-  </div>
-
-  <div class="placeAccessPoints">
-    <?php echo get_partial('object/placeAccessPoints', ['resource' => $resource]); ?>
-  </div>
-
-  <div class="nameAccessPoints">
-    <?php echo get_partial('informationobject/nameAccessPoints', ['resource' => $resource, 'showActorEvents' => true]); ?>
-  </div>
-
-  <div class="genreAccessPoints">
-    <?php echo get_partial('informationobject/genreAccessPoints', ['resource' => $resource]); ?>
-  </div>
-</section> <!-- /section#accessPointsArea -->
-
-<section id="descriptionControlArea">
-
-  <?php if (check_field_visibility('app_element_visibility_isad_description_control_area')) { ?>
-    <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Description control area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'description-collapse', 'title' => __('Edit description control area')]); ?>
-  <?php } ?>
-
-  <?php if (check_field_visibility('app_element_visibility_isad_control_description_identifier')) { ?>
-    <?php echo render_show(__('Description identifier'), $resource->getDescriptionIdentifier(['cultureFallback' => true]), ['fieldLabel' => 'descriptionIdentifier']); ?>
-  <?php } ?>
-
-  <?php if (check_field_visibility('app_element_visibility_isad_control_institution_identifier')) { ?>
-    <?php echo render_show(__('Institution identifier'), $resource->getInstitutionResponsibleIdentifier(['cultureFallback' => true]), ['fieldLabel' => 'institutionIdentifier']); ?>
-  <?php } ?>
-
-  <?php if (check_field_visibility('app_element_visibility_isad_control_rules_conventions')) { ?>
-    <?php echo render_show(__('Rules and/or conventions used'), render_value($resource->getRules(['cultureFallback' => true])), ['fieldLabel' => 'rulesAndOrConventionsUsed']); ?>
-  <?php } ?>
-
-  <?php if (check_field_visibility('app_element_visibility_isad_control_status')) { ?>
-    <?php echo render_show(__('Status'), render_value($resource->descriptionStatus), ['fieldLabel' => 'descriptionStatus']); ?>
-  <?php } ?>
-
-  <?php if (check_field_visibility('app_element_visibility_isad_control_level_of_detail')) { ?>
-    <?php echo render_show(__('Level of detail'), render_value($resource->descriptionDetail), ['fieldLabel' => 'levelOfDetail']); ?>
-  <?php } ?>
-
-  <?php if (check_field_visibility('app_element_visibility_isad_control_dates')) { ?>
-    <?php echo render_show(__('Dates of creation revision deletion'), render_value($resource->getRevisionHistory(['cultureFallback' => true])), ['fieldLabel' => 'datesOfCreationRevisionDeletion']); ?>
-  <?php } ?>
-
-  <?php if (check_field_visibility('app_element_visibility_isad_control_languages')) { ?>
-    <div class="field">
-      <h3><?php echo __('Language(s)'); ?></h3>
-      <div class="languages">
-        <ul>
-          <?php foreach ($resource->languageOfDescription as $code) { ?>
-            <li><?php echo format_language($code); ?></li>
-          <?php } ?>
-        </ul>
+      <div class="creatorHistories">
+        <?php echo get_component('informationobject', 'creatorDetail', [
+            'resource' => $resource,
+            'creatorHistoryLabels' => $creatorHistoryLabels, ]); ?>
       </div>
-    </div>
-  <?php } ?>
 
-  <?php if (check_field_visibility('app_element_visibility_isad_control_scripts')) { ?>
-    <div class="field">
-      <h3><?php echo __('Script(s)'); ?></h3>
-      <div class="scripts">
-        <ul>
-          <?php foreach ($resource->scriptOfDescription as $code) { ?>
-            <li><?php echo format_script($code); ?></li>
-          <?php } ?>
-        </ul>
+      <div class="relatedFunctions">
+        <?php foreach ($functionRelations as $item) { ?>
+          <div class="field <?php echo render_b5_show_field_css_classes(); ?>">
+            <?php echo render_b5_show_label(__('Related function')); ?>
+            <div class="<?php echo render_b5_show_value_css_classes(); ?>">
+              <?php echo link_to(render_title($item->subject->getLabel()), [$item->subject, 'module' => 'function']); ?>
+            </div>
+          </div>
+        <?php } ?>
       </div>
-    </div>
-  <?php } ?>
 
-  <?php if (check_field_visibility('app_element_visibility_isad_control_sources')) { ?>
-    <?php echo render_show(__('Sources'), render_value($resource->getSources(['cultureFallback' => true])), ['fieldLabel' => 'sources']); ?>
-  <?php } ?>
+      <div class="repository">
+        <?php echo render_show_repository(__('Repository'), $resource); ?>
+      </div>
 
-  <?php if (check_field_visibility('app_element_visibility_isad_control_archivists_notes')) { ?>
-    <?php foreach ($resource->getNotesByType(['noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID]) as $item) { ?>
-      <?php echo render_show(__('Archivist\'s note'), render_value($item->getContent(['cultureFallback' => true])), ['fieldLabel' => 'archivistNote']); ?>
+      <?php if (check_field_visibility('app_element_visibility_isad_archival_history')) { ?>
+        <?php echo render_show(__('Archival history'), render_value($resource->getArchivalHistory(['cultureFallback' => true])), ['fieldLabel' => 'archivalHistory']); ?>
+      <?php } ?>
+
+      <?php if (check_field_visibility('app_element_visibility_isad_immediate_source')) { ?>
+        <?php echo render_show(__('Immediate source of acquisition or transfer'), render_value($resource->getAcquisition(['cultureFallback' => true])), ['fieldLabel' => 'immediateSourceOfAcquisitionOrTransfer']); ?>
+      <?php } ?>
+
+    </section> <!-- /section#contextArea -->
+
+    <section id="contentAndStructureArea" class="border-bottom">
+
+      <?php if (check_field_visibility('app_element_visibility_isad_content_and_structure_area')) { ?>
+        <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), render_b5_section_label(__('Content and structure area')), [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'content-collapse', 'title' => __('Edit content and structure area'), 'class' => 'text-primary']); ?>
+      <?php } ?>
+
+      <?php echo render_show(__('Scope and content'), render_value($resource->getScopeAndContent(['cultureFallback' => true])), ['fieldLabel' => 'scopeAndContent']); ?>
+
+      <?php if (check_field_visibility('app_element_visibility_isad_appraisal_destruction')) { ?>
+        <?php echo render_show(__('Appraisal, destruction and scheduling'), render_value($resource->getAppraisal(['cultureFallback' => true])), ['fieldLabel' => 'appraisalDestructionAndScheduling']); ?>
+      <?php } ?>
+
+      <?php echo render_show(__('Accruals'), render_value($resource->getAccruals(['cultureFallback' => true])), ['fieldLabel' => 'accruals']); ?>
+
+      <?php echo render_show(__('System of arrangement'), render_value($resource->getArrangement(['cultureFallback' => true])), ['fieldLabel' => 'systemOfArrangement']); ?>
+    </section> <!-- /section#contentAndStructureArea -->
+
+    <section id="conditionsOfAccessAndUseArea" class="border-bottom">
+
+      <?php if (check_field_visibility('app_element_visibility_isad_conditions_of_access_use_area')) { ?>
+        <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), render_b5_section_label(__('Conditions of access and use area')), [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'conditions-collapse', 'title' => __('Edit conditions of access and use area'), 'class' => 'text-primary']); ?>
+      <?php } ?>
+
+      <?php echo render_show(__('Conditions governing access'), render_value($resource->getAccessConditions(['cultureFallback' => true])), ['fieldLabel' => 'conditionsGoverningAccess']); ?>
+
+      <?php echo render_show(__('Conditions governing reproduction'), render_value($resource->getReproductionConditions(['cultureFallback' => true])), ['fieldLabel' => 'conditionsGoverningReproduction']); ?>
+
+      <div class="field <?php echo render_b5_show_field_css_classes(); ?>">
+        <?php echo render_b5_show_label(__('Language of material')); ?>
+        <div class="languageOfMaterial <?php echo render_b5_show_value_css_classes(); ?>">
+          <ul class="<?php echo render_b5_show_list_css_classes(); ?>">
+            <?php foreach ($resource->language as $code) { ?>
+              <li><?php echo format_language($code); ?></li>
+            <?php } ?>
+          </ul>
+        </div>
+      </div>
+
+      <div class="field <?php echo render_b5_show_field_css_classes(); ?>">
+        <?php echo render_b5_show_label(__('Script of material')); ?>
+        <div class="scriptOfMaterial <?php echo render_b5_show_value_css_classes(); ?>">
+          <ul class="<?php echo render_b5_show_list_css_classes(); ?>">
+            <?php foreach ($resource->script as $code) { ?>
+              <li><?php echo format_script($code); ?></li>
+            <?php } ?>
+          </ul>
+        </div>
+      </div>
+
+      <?php echo render_show(__('Language and script notes'), render_value($isad->languageNotes), ['fieldLabel' => 'languageAndScriptNotes']); ?>
+
+      <?php if (check_field_visibility('app_element_visibility_isad_physical_condition')) { ?>
+        <?php echo render_show(__('Physical characteristics and technical requirements'), render_value($resource->getPhysicalCharacteristics(['cultureFallback' => true])), ['fieldLabel' => 'physicalCharacteristics']); ?>
+      <?php } ?>
+
+      <?php echo render_show(__('Finding aids'), render_value($resource->getFindingAids(['cultureFallback' => true])), ['fieldLabel' => 'findingAids']); ?>
+
+      <?php echo get_component('informationobject', 'findingAidLink', ['resource' => $resource]); ?>
+
+    </section> <!-- /section#conditionsOfAccessAndUseArea -->
+
+    <section id="alliedMaterialsArea" class="border-bottom">
+
+      <?php if (check_field_visibility('app_element_visibility_isad_allied_materials_area')) { ?>
+        <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), render_b5_section_label(__('Allied materials area')), [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'allied-collapse', 'title' => __('Edit alied materials area'), 'class' => 'text-primary']); ?>
+      <?php } ?>
+
+      <?php echo render_show(__('Existence and location of originals'), render_value($resource->getLocationOfOriginals(['cultureFallback' => true])), ['fieldLabel' => 'existenceAndLocationOfOriginals']); ?>
+
+      <?php echo render_show(__('Existence and location of copies'), render_value($resource->getLocationOfCopies(['cultureFallback' => true])), ['fieldLabel' => 'existenceAndLocationOfCopies']); ?>
+
+      <?php echo render_show(__('Related units of description'), render_value($resource->getRelatedUnitsOfDescription(['cultureFallback' => true])), ['fieldLabel' => 'relatedUnitsOfDescription']); ?>
+
+      <div class="relatedMaterialDescriptions">
+        <?php echo get_partial('informationobject/relatedMaterialDescriptions', ['resource' => $resource, 'template' => 'isad']); ?>
+      </div>
+
+      <?php foreach ($resource->getNotesByType(['noteTypeId' => QubitTerm::PUBLICATION_NOTE_ID]) as $item) { ?>
+        <?php echo render_show(__('Publication note'), render_value($item->getContent(['cultureFallback' => true])), ['fieldLabel' => 'publicationNote']); ?>
+      <?php } ?>
+    </section> <!-- /section#alliedMaterialsArea -->
+
+    <section id="notesArea" class="border-bottom">
+
+      <?php if (check_field_visibility('app_element_visibility_isad_notes_area')) { ?>
+        <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), render_b5_section_label(__('Notes area')), [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'notes-collapse', 'title' => __('Edit notes area'), 'class' => 'text-primary']); ?>
+      <?php } ?>
+
+      <?php if (check_field_visibility('app_element_visibility_isad_notes')) { ?>
+        <?php foreach ($resource->getNotesByType(['noteTypeId' => QubitTerm::GENERAL_NOTE_ID]) as $item) { ?>
+          <?php echo render_show(__('Note'), render_value($item->getContent(['cultureFallback' => true])), ['fieldLabel' => 'generalNote']); ?>
+        <?php } ?>
+      <?php } ?>
+
+      <div class="alternativeIdentifiers">
+        <?php echo get_partial('informationobject/alternativeIdentifiersIndex', ['resource' => $resource]); ?>
+      </div>
+    </section> <!-- /section#notesArea -->
+
+    <section id="accessPointsArea" class="border-bottom">
+
+      <?php if (check_field_visibility('app_element_visibility_isad_access_points_area')) { ?>
+        <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), render_b5_section_label(__('Access points')), [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'access-collapse', 'title' => __('Edit access points'), 'class' => 'text-primary']); ?>
+      <?php } ?>
+
+      <div class="subjectAccessPoints">
+        <?php echo get_partial('object/subjectAccessPoints', ['resource' => $resource]); ?>
+      </div>
+
+      <div class="placeAccessPoints">
+        <?php echo get_partial('object/placeAccessPoints', ['resource' => $resource]); ?>
+      </div>
+
+      <div class="nameAccessPoints">
+        <?php echo get_partial('informationobject/nameAccessPoints', ['resource' => $resource, 'showActorEvents' => true]); ?>
+      </div>
+
+      <div class="genreAccessPoints">
+        <?php echo get_partial('informationobject/genreAccessPoints', ['resource' => $resource]); ?>
+      </div>
+    </section> <!-- /section#accessPointsArea -->
+
+    <section id="descriptionControlArea" class="border-bottom">
+
+      <?php if (check_field_visibility('app_element_visibility_isad_description_control_area')) { ?>
+        <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), render_b5_section_label(__('Description control area')), [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'description-collapse', 'title' => __('Edit description control area'), 'class' => 'text-primary']); ?>
+      <?php } ?>
+
+      <?php if (check_field_visibility('app_element_visibility_isad_control_description_identifier')) { ?>
+        <?php echo render_show(__('Description identifier'), $resource->getDescriptionIdentifier(['cultureFallback' => true]), ['fieldLabel' => 'descriptionIdentifier']); ?>
+      <?php } ?>
+
+      <?php if (check_field_visibility('app_element_visibility_isad_control_institution_identifier')) { ?>
+        <?php echo render_show(__('Institution identifier'), $resource->getInstitutionResponsibleIdentifier(['cultureFallback' => true]), ['fieldLabel' => 'institutionIdentifier']); ?>
+      <?php } ?>
+
+      <?php if (check_field_visibility('app_element_visibility_isad_control_rules_conventions')) { ?>
+        <?php echo render_show(__('Rules and/or conventions used'), render_value($resource->getRules(['cultureFallback' => true])), ['fieldLabel' => 'rulesAndOrConventionsUsed']); ?>
+      <?php } ?>
+
+      <?php if (check_field_visibility('app_element_visibility_isad_control_status')) { ?>
+        <?php echo render_show(__('Status'), render_value_inline($resource->descriptionStatus), ['fieldLabel' => 'descriptionStatus']); ?>
+      <?php } ?>
+
+      <?php if (check_field_visibility('app_element_visibility_isad_control_level_of_detail')) { ?>
+        <?php echo render_show(__('Level of detail'), render_value_inline($resource->descriptionDetail), ['fieldLabel' => 'levelOfDetail']); ?>
+      <?php } ?>
+
+      <?php if (check_field_visibility('app_element_visibility_isad_control_dates')) { ?>
+        <?php echo render_show(__('Dates of creation revision deletion'), render_value($resource->getRevisionHistory(['cultureFallback' => true])), ['fieldLabel' => 'datesOfCreationRevisionDeletion']); ?>
+      <?php } ?>
+
+      <?php if (check_field_visibility('app_element_visibility_isad_control_languages')) { ?>
+        <div class="field <?php echo render_b5_show_field_css_classes(); ?>">
+          <?php echo render_b5_show_label(__('Language(s)')); ?>
+          <div class="languages <?php echo render_b5_show_value_css_classes(); ?>">
+            <ul class="<?php echo render_b5_show_list_css_classes(); ?>">
+              <?php foreach ($resource->languageOfDescription as $code) { ?>
+                <li><?php echo format_language($code); ?></li>
+              <?php } ?>
+            </ul>
+          </div>
+        </div>
+      <?php } ?>
+
+      <?php if (check_field_visibility('app_element_visibility_isad_control_scripts')) { ?>
+        <div class="field <?php echo render_b5_show_field_css_classes(); ?>">
+          <?php echo render_b5_show_label(__('Script(s)')); ?>
+          <div class="scripts <?php echo render_b5_show_value_css_classes(); ?>">
+            <ul class="<?php echo render_b5_show_list_css_classes(); ?>">
+              <?php foreach ($resource->scriptOfDescription as $code) { ?>
+                <li><?php echo format_script($code); ?></li>
+              <?php } ?>
+            </ul>
+          </div>
+        </div>
+      <?php } ?>
+
+      <?php if (check_field_visibility('app_element_visibility_isad_control_sources')) { ?>
+        <?php echo render_show(__('Sources'), render_value($resource->getSources(['cultureFallback' => true])), ['fieldLabel' => 'sources']); ?>
+      <?php } ?>
+
+      <?php if (check_field_visibility('app_element_visibility_isad_control_archivists_notes')) { ?>
+        <?php foreach ($resource->getNotesByType(['noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID]) as $item) { ?>
+          <?php echo render_show(__('Archivist\'s note'), render_value($item->getContent(['cultureFallback' => true])), ['fieldLabel' => 'archivistNote']); ?>
+        <?php } ?>
+      <?php } ?>
+
+    </section> <!-- /section#descriptionControlArea -->
+
+    <?php if ($sf_user->isAuthenticated()) { ?>
+
+      <div class="section border-bottom" id="rightsArea">
+
+        <?php echo render_b5_section_label(__('Rights area')); ?>
+
+        <div class="relatedRights">
+          <?php echo get_component('right', 'relatedRights', ['resource' => $resource]); ?>
+        </div>
+
+      </div> <!-- /section#rightsArea -->
+
     <?php } ?>
-  <?php } ?>
 
-</section> <!-- /section#descriptionControlArea -->
+    <?php if (0 < count($resource->digitalObjectsRelatedByobjectId)) { ?>
 
-<?php if ($sf_user->isAuthenticated()) { ?>
+      <div class="digitalObjectMetadata">
+        <?php echo get_component('digitalobject', 'metadata', ['resource' => $resource->digitalObjectsRelatedByobjectId[0], 'object' => $resource]); ?>
+      </div>
 
-  <div class="section" id="rightsArea">
+      <div class="digitalObjectRights">
+        <?php echo get_partial('digitalobject/rights', ['resource' => $resource->digitalObjectsRelatedByobjectId[0]]); ?>
+      </div>
 
-    <h2><?php echo __('Rights area'); ?> </h2>
+    <?php } ?>
 
-    <div class="relatedRights">
-      <?php echo get_component('right', 'relatedRights', ['resource' => $resource]); ?>
-    </div>
+    <section id="accessionArea">
 
-  </div> <!-- /section#rightsArea -->
+      <?php echo render_b5_section_label(__('Accession area')); ?>
 
-<?php } ?>
+      <div class="accessions">
+        <?php echo get_component('informationobject', 'accessions', ['resource' => $resource]); ?>
+      </div>
 
-<?php if (0 < count($resource->digitalObjectsRelatedByobjectId)) { ?>
+    </section> <!-- /section#accessionArea -->
 
-  <div class="digitalObjectMetadata">
-    <?php echo get_component('digitalobject', 'metadata', ['resource' => $resource->digitalObjectsRelatedByobjectId[0], 'object' => $resource]); ?>
   </div>
 
-  <div class="digitalObjectRights">
-    <?php echo get_partial('digitalobject/rights', ['resource' => $resource->digitalObjectsRelatedByobjectId[0]]); ?>
-  </div>
-
-<?php } ?>
-
-<section id="accessionArea">
-
-  <h2><?php echo __('Accession area'); ?></h2>
-
-  <div class="accessions">
-    <?php echo get_component('informationobject', 'accessions', ['resource' => $resource]); ?>
-  </div>
-
-</section> <!-- /section#accessionArea -->
+<?php end_slot(); ?>
 
 <?php slot('after-content'); ?>
   <?php echo get_partial('informationobject/actions', ['resource' => $resource]); ?>

--- a/plugins/arDominionB5Plugin/templates/_layout_end.php
+++ b/plugins/arDominionB5Plugin/templates/_layout_end.php
@@ -26,6 +26,7 @@
     <script src="/plugins/arDominionB5Plugin/js/masonry.js"></script>
     <script src="/plugins/arDominionB5Plugin/js/aclModal.js"></script>
     <script src="/plugins/sfTranslatePlugin/js/l10n_client.js"></script>
+    <script src="/js/blank.js"></script>
     <script src="/js/editingHistory.js"></script>
     <script src="/js/autocomplete.js"></script>
   </body>


### PR DESCRIPTION
This:

* adds a `content` slot to the ISAD index template and styles all its partials and components to use BS5 classes and a 3-9 column layout
* modifies the existing `render_show` helper to render fields and values using BS5 classes and introduces a new `isSubField` option to render fields inside of fields using `flex` containers
* attaches the `expander.js` behaviour to top level field values