### PR TITLE
CSV Validator output changes, refs #13475

### DIFF
--- a/lib/task/import/validate/csvColumnNameValidator.class.php
+++ b/lib/task/import/validate/csvColumnNameValidator.class.php
@@ -78,9 +78,7 @@ class CsvColumnNameValidator extends CsvBaseValidator
         if (0 < count($this->unknownColumnNames)) {
             $this->testData->setStatusWarn();
             $this->testData->addResult('Unrecognized columns will be ignored by AtoM when the CSV is imported.');
-            foreach ($this->unknownColumnNames as $unknownColumnName) {
-                $this->testData->addDetail(sprintf('Unrecognized column: %s', $unknownColumnName));
-            }
+            $this->testData->addResult(sprintf('Unrecognized column names: %s', implode(',', $this->unknownColumnNames)));
         }
 
         if (0 < count($this->trimIssuesColumnNames)) {
@@ -91,7 +89,7 @@ class CsvColumnNameValidator extends CsvBaseValidator
 
         if (0 < count($this->caseIssuesColumnNameMap)) {
             $this->testData->setStatusWarn();
-            $this->testData->addResult(sprintf('Number of unrecognized columns that may be case related: %s', count($this->caseIssuesColumnNameMap)));
+            $this->testData->addResult(sprintf('Number of unrecognized columns that may be letter case related: %s', count($this->caseIssuesColumnNameMap)));
             foreach ($this->caseIssuesColumnNameMap as $key => $value) {
                 $this->testData->addDetail(sprintf('Possible match for %s: %s', $key, $value));
             }

--- a/lib/task/import/validate/csvDigitalObjectUriValidator.class.php
+++ b/lib/task/import/validate/csvDigitalObjectUriValidator.class.php
@@ -30,44 +30,46 @@ class CsvDigitalObjectUriValidator extends CsvBaseValidator
     public const TITLE = 'Digital Object URI Test';
     public const LIMIT_TO = ['QubitInformationObject'];
 
-    protected $digitalObjectUriColumnPresent;
     protected $digitalObjectUses = [];
 
     public function __construct(?array $options = null)
     {
         $this->setTitle(self::TITLE);
-
         parent::__construct($options);
+
+        $this->setRequiredColumns(['digitalObjectUri']);
     }
 
     public function reset()
     {
         $this->digitalObjectUses = [];
-        $this->digitalObjectUriColumnPresent = null;
 
         parent::reset();
     }
 
     public function testRow(array $header, array $row)
     {
-        parent::testRow($header, $row);
-        $row = $this->combineRow($header, $row);
-
-        if (!isset($this->digitalObjectUriColumnPresent)) {
-            $this->digitalObjectUriColumnPresent = isset($row['digitalObjectUri']);
+        if (!parent::testRow($header, $row)) {
+            return;
         }
 
-        if ($this->digitalObjectUriColumnPresent) {
-            if (!empty($row['digitalObjectUri'])) {
-                $this->addToUsageSummary($row['digitalObjectUri']);
-            }
+        $row = $this->combineRow($header, $row);
+
+        if (!empty($row['digitalObjectUri'])) {
+            $this->addToUsageSummary($row['digitalObjectUri']);
         }
     }
 
     public function getTestResult()
     {
-        if (false === $this->digitalObjectUriColumnPresent) {
+        if (false === $this->columnPresent('digitalObjectUri')) {
             $this->testData->addResult(sprintf("Column 'digitalObjectUri' not present in CSV. Nothing to verify."));
+
+            return parent::getTestResult();
+        }
+
+        if ($this->columnDuplicated('digitalObjectUri')) {
+            $this->appendDuplicatedColumnError('digitalObjectUri');
 
             return parent::getTestResult();
         }

--- a/lib/task/import/validate/csvRepoValidator.class.php
+++ b/lib/task/import/validate/csvRepoValidator.class.php
@@ -30,18 +30,17 @@ class CsvRepoValidator extends CsvBaseValidator
 
     protected $existingRepositories = [];
     protected $newRepositories = [];
-    protected $repositoryColumnPresent;
 
     public function __construct(?array $options = null)
     {
         $this->setTitle(self::TITLE);
-
         parent::__construct($options);
+
+        $this->setRequiredColumns(['repository']);
     }
 
     public function reset()
     {
-        $this->repositoryColumnPresent = null;
         $this->newRepositories = [];
 
         parent::reset();
@@ -49,15 +48,13 @@ class CsvRepoValidator extends CsvBaseValidator
 
     public function testRow(array $header, array $row)
     {
-        parent::testRow($header, $row);
-        $row = $this->combineRow($header, $row);
-
-        // Set if repository column is present.
-        if (!isset($this->repositoryColumnPresent)) {
-            $this->repositoryColumnPresent = isset($row['repository']);
+        if (!parent::testRow($header, $row)) {
+            return;
         }
 
-        if (!$this->repositoryColumnPresent || empty($row['repository'])) {
+        $row = $this->combineRow($header, $row);
+
+        if (empty($row['repository'])) {
             return;
         }
 
@@ -68,9 +65,15 @@ class CsvRepoValidator extends CsvBaseValidator
 
     public function getTestResult()
     {
-        if (!$this->repositoryColumnPresent) {
+        if (!$this->columnPresent('repository')) {
             // Repository column not present in file.
             $this->testData->addResult(sprintf("'repository' column not present in file."));
+
+            return parent::getTestResult();
+        }
+
+        if ($this->columnDuplicated('repository')) {
+            $this->appendDuplicatedColumnError('repository');
 
             return parent::getTestResult();
         }

--- a/lib/task/import/validate/csvScriptValidator.class.php
+++ b/lib/task/import/validate/csvScriptValidator.class.php
@@ -29,7 +29,6 @@ class CsvScriptValidator extends CsvBaseValidator
     public const LIMIT_TO = ['QubitInformationObject'];
 
     protected $scriptOfDescriptionList = [];
-    protected $scriptOfDescriptionColumnPresent;
     protected $rowsWithInvalidScriptOfDescription = 0;
     protected $invalidScriptOfDescriptionList = [];
 
@@ -38,12 +37,12 @@ class CsvScriptValidator extends CsvBaseValidator
         $this->setTitle(self::TITLE);
         parent::__construct($options);
 
+        $this->setRequiredColumns(['scriptOfDescription']);
         $this->scriptOfDescriptionList = array_keys(sfCultureInfo::getInstance()->getScripts());
     }
 
     public function reset()
     {
-        $this->scriptOfDescriptionColumnPresent = null;
         $this->rowsWithInvalidScriptOfDescription = 0;
         $this->invalidScriptOfDescriptionList = [];
 
@@ -52,15 +51,13 @@ class CsvScriptValidator extends CsvBaseValidator
 
     public function testRow(array $header, array $row)
     {
-        parent::testRow($header, $row);
-        $row = $this->combineRow($header, $row);
-
-        // Set if scriptOfDescription column is present.
-        if (!isset($this->scriptOfDescriptionColumnPresent)) {
-            $this->scriptOfDescriptionColumnPresent = isset($row['scriptOfDescription']);
+        if (!parent::testRow($header, $row)) {
+            return;
         }
 
-        if (!$this->scriptOfDescriptionColumnPresent || empty($row['scriptOfDescription'])) {
+        $row = $this->combineRow($header, $row);
+
+        if (empty($row['scriptOfDescription'])) {
             return;
         }
 
@@ -86,9 +83,15 @@ class CsvScriptValidator extends CsvBaseValidator
 
     public function getTestResult()
     {
-        if (!$this->scriptOfDescriptionColumnPresent) {
+        if (!$this->columnPresent('scriptOfDescription')) {
             // scriptOfDescription column not present in file.
             $this->testData->addResult(sprintf("'scriptOfDescription' column not present in file."));
+
+            return parent::getTestResult();
+        }
+
+        if ($this->columnDuplicated('scriptOfDescription')) {
+            $this->appendDuplicatedColumnError('scriptOfDescription');
 
             return parent::getTestResult();
         }

--- a/lib/task/import/validate/csvValidatorResultCollection.php
+++ b/lib/task/import/validate/csvValidatorResultCollection.php
@@ -155,6 +155,11 @@ class CsvValidatorResultCollection implements Iterator
                 } else {
                     $outputString .= sprintf("\nNo issues detected.\n");
                 }
+
+                // Add double line divider unless there are no results to display.
+                if ($verbose || (!empty($warnCount) || !empty($errorCount))) {
+                    $outputString .= sprintf("%s\n%s\n", str_repeat('-', 80), str_repeat('-', 80));
+                }
             }
 
             if (CsvValidatorResult::RESULT_INFO === $result->getStatus() && !$verbose) {
@@ -181,7 +186,7 @@ class CsvValidatorResultCollection implements Iterator
     {
         $outputString = '';
 
-        $outputString .= sprintf("\n%s - %s\n", $result->getTitle(), CsvValidatorResult::formatStatus($result->getStatus()));
+        $outputString .= sprintf("\n%s - %s\n", strtoupper(CsvValidatorResult::formatStatus($result->getStatus())), $result->getTitle());
         $outputString .= sprintf("%s\n", str_repeat('-', strlen($result->getTitle())));
 
         $results = $result->getResults();

--- a/test/phpunit/csvImportValidator/CsvBaseValidatorTest.php
+++ b/test/phpunit/csvImportValidator/CsvBaseValidatorTest.php
@@ -58,4 +58,22 @@ class CsvBaseValidatorTest extends \PHPUnit\Framework\TestCase
         $csvValidator = new CsvMockValidator([]);
         $this->assertSame('CsvMockValidator', $csvValidator->getClassname());
     }
+
+    public function testColumnPresent()
+    {
+        $csvValidator = new CsvMockValidator([]);
+        $csvValidator->setHeader(['test1', 'test2', 'test3']);
+        $this->assertSame(true, $csvValidator->columnPresent('test1'));
+        $this->assertSame(false, $csvValidator->columnPresent('test0'));
+    }
+
+    public function testColumnDuplicated()
+    {
+        $csvValidator = new CsvMockValidator([]);
+        $csvValidator->setHeader(['test1', 'test2', 'test3']);
+        $this->assertSame(false, $csvValidator->columnDuplicated('test1', ['test1', 'test2', 'test3']));
+        $this->assertSame(false, $csvValidator->columnDuplicated('test5', ['test1', 'test2', 'test3']));
+        $csvValidator->setHeader(['test0', 'test2', 'test0']);
+        $this->assertSame(true, $csvValidator->columnDuplicated('test0', ['test0', 'test2', 'test0']));
+    }
 }

--- a/test/phpunit/csvImportValidator/CsvColumnNameTest.php
+++ b/test/phpunit/csvImportValidator/CsvColumnNameTest.php
@@ -125,9 +125,9 @@ class CsvColumnNameTest extends \PHPUnit\Framework\TestCase
                     CsvValidatorResult::TEST_RESULTS => [
                         'Number of unrecognized column names found in CSV: 1',
                         'Unrecognized columns will be ignored by AtoM when the CSV is imported.',
+                        'Unrecognized column names: levilOfDescrooption',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
-                        'Unrecognized column: levilOfDescrooption',
                     ],
                 ],
             ],
@@ -146,12 +146,11 @@ class CsvColumnNameTest extends \PHPUnit\Framework\TestCase
                     CsvValidatorResult::TEST_RESULTS => [
                         'Number of unrecognized column names found in CSV: 2',
                         'Unrecognized columns will be ignored by AtoM when the CSV is imported.',
+                        'Unrecognized column names:  identifier,Title',
                         'Number of column names with leading or trailing whitespace characters: 1',
-                        'Number of unrecognized columns that may be case related: 1',
+                        'Number of unrecognized columns that may be letter case related: 1',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
-                        'Unrecognized column:  identifier',
-                        'Unrecognized column: Title',
                         'Column names with leading or trailing whitespace: identifier',
                         'Possible match for Title: title',
                     ],

--- a/test/phpunit/csvImportValidator/CsvCultureTest.php
+++ b/test/phpunit/csvImportValidator/CsvCultureTest.php
@@ -18,6 +18,7 @@ class CsvCultureTest extends \PHPUnit\Framework\TestCase
 
         $this->csvHeader = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,culture';
         $this->csvHeaderMissingCulture = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository';
+        $this->csvHeaderDupedCulture = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,culture,culture';
 
         $this->csvData = [
             // Note: leading and trailing whitespace in first row is intentional
@@ -49,6 +50,14 @@ class CsvCultureTest extends \PHPUnit\Framework\TestCase
             '"F20202", "DJ004", "DD8989", "pdf documents", "","", "", ""',
         ];
 
+        $this->csvDataDupedCulturesSomeInvalid = [
+            '"B10101 "," DJ001","ID1 ","Some Photographs","","Extent and medium 1","","es ","fr"',
+            '"","","","Chemise","","","","fr|en","fr"',
+            '"D20202", "DJ002", "", "Voûte, étagère 0074", "", "", "", "gg","fr"',
+            '"E20202", "DJ003", "ID4", "Title Four", "","", "", "en","fr"',
+            '"F20202", "DJ004", "DD8989", "pdf documents", "","", "", "","fr"',
+        ];
+
         // define virtual file system
         $directory = [
             'unix_csv_without_utf8_bom.csv' => $this->csvHeader."\n".implode("\n", $this->csvData),
@@ -56,6 +65,7 @@ class CsvCultureTest extends \PHPUnit\Framework\TestCase
             'unix_csv_missing_culture.csv' => $this->csvHeaderMissingCulture."\n".implode("\n", $this->csvDataMissingCulture),
             'unix_csv_valid_cultures.csv' => $this->csvHeader."\n".implode("\n", $this->csvDataValidCultures),
             'unix_csv_cultures_some_invalid.csv' => $this->csvHeader."\n".implode("\n", $this->csvDataCulturesSomeInvalid),
+            'unix_csv_duped_culture.csv' => $this->csvHeaderDupedCulture."\n".implode("\n", $this->csvDataDupedCulturesSomeInvalid),
         ];
 
         $this->vfs = vfsStream::setup('root', null, $directory);
@@ -145,6 +155,22 @@ class CsvCultureTest extends \PHPUnit\Framework\TestCase
                     CsvValidatorResult::TEST_DETAILS => [
                         ',,,Chemise,,,,fr|en',
                         'D20202,DJ002,,Voûte, étagère 0074,,,,gg',
+                    ],
+                ],
+            ],
+
+            [
+                'CsvCultureValidator-DupedCulture' => [
+                    'csvValidatorClasses' => 'CsvCultureValidator',
+                    'filename' => '/unix_csv_duped_culture.csv',
+                    'testname' => 'CsvCultureValidator',
+                    CsvValidatorResult::TEST_TITLE => CsvCultureValidator::TITLE,
+                    CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_ERROR,
+                    CsvValidatorResult::TEST_RESULTS => [
+                        '\'culture\' column appears more than once in file.',
+                        'Unable to validate because of duplicated columns in CSV.',
+                    ],
+                    CsvValidatorResult::TEST_DETAILS => [
                     ],
                 ],
             ],

--- a/test/phpunit/csvImportValidator/CsvDigitalObjectPathTest.php
+++ b/test/phpunit/csvImportValidator/CsvDigitalObjectPathTest.php
@@ -18,6 +18,7 @@ class CsvDigitalObjectPathTest extends \PHPUnit\Framework\TestCase
 
         $this->csvHeader = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,culture';
         $this->csvHeaderWithDigitalObjectCols = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,digitalObjectPath,digitalObjectUri,culture';
+        $this->csvHeaderDupedPath = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,digitalObjectPath,digitalObjectPath,digitalObjectUri,culture';
 
         $this->csvData = [
             // Note: leading and trailing whitespace in first row is intentional
@@ -45,11 +46,23 @@ class CsvDigitalObjectPathTest extends \PHPUnit\Framework\TestCase
             '"", "DJ003", "ID5", "Title Four", "","", "","","ftp://www.artefactual.com/wp-content/uploads/2018/08/artefactual-logo-white.svg", "en"',
         ];
 
+        $this->csvDataWithDigitalObjectColsPopulatedDupedPath = [
+            '"B10101 "," DJ001","ID1 ","Some Photographs","","Extent and medium 1","","a.png","","",""',
+            '"A10101","","","Chemise","","","","A.PNG","","fr",""',
+            '"D20202", "DJ002", "", "Voûte, étagère 0074", "", "", "","b.png","https://www.artefactual.com/wp-content/uploads/2018/08/artefactual-logo-white.svg", "",""',
+            '"", "DJ003", "ID4", "Title Four", "","", "","a.png","", "en",""',
+            '"E10101 "," DJ004","ID1 ","Some Photographs","","Extent and medium 1","","b.png","https://www.artefactual.com/wp-content/uploads/2018/08/artefactual-logo-white.svg","",""',
+            '"G30303","","","Sweater","","","","d.png","","fr",""',
+            '"F20202", "DJ005", "", "Voûte, étagère 0074", "", "", "","","www.google.com", "",""',
+            '"", "DJ003", "ID5", "Title Four", "","", "","","ftp://www.artefactual.com/wp-content/uploads/2018/08/artefactual-logo-white.svg", "en", ""',
+        ];
+
         // define virtual file system
         $directory = [
             'unix_csv_without_utf8_bom.csv' => $this->csvHeader."\n".implode("\n", $this->csvData),
             'unix_csv_with_digital_object_cols.csv' => $this->csvHeaderWithDigitalObjectCols."\n".implode("\n", $this->csvDataWithDigitalObjectCols),
             'unix_csv_with_digital_object_cols_populated.csv' => $this->csvHeaderWithDigitalObjectCols."\n".implode("\n", $this->csvDataWithDigitalObjectColsPopulated),
+            'unix_csv_with_digital_object_cols_populated_duped_path.csv' => $this->csvHeaderDupedPath."\n".implode("\n", $this->csvDataWithDigitalObjectColsPopulatedDupedPath),
             'digital_objects' => [
                 'a.png' => random_bytes(100),
                 'b.png' => random_bytes(100),
@@ -139,7 +152,6 @@ class CsvDigitalObjectPathTest extends \PHPUnit\Framework\TestCase
                     'validatorOptions' => [
                         'source' => 'testsourcefile.csv',
                         'className' => 'QubitInformationObject',
-                        'className' => 'QubitInformationObject',
                         'pathToDigitalObjects' => 'vfs://root/digital_objects',
                     ],
                     CsvValidatorResult::TEST_TITLE => CsvDigitalObjectPathValidator::TITLE,
@@ -161,7 +173,6 @@ class CsvDigitalObjectPathTest extends \PHPUnit\Framework\TestCase
                     'validatorOptions' => [
                         'source' => 'testsourcefile.csv',
                         'className' => 'QubitInformationObject',
-                        'className' => 'QubitInformationObject',
                         'pathToDigitalObjects' => 'vfs://root/digital_objects',
                     ],
                     CsvValidatorResult::TEST_TITLE => CsvDigitalObjectPathValidator::TITLE,
@@ -180,6 +191,27 @@ class CsvDigitalObjectPathTest extends \PHPUnit\Framework\TestCase
                         'Unreferenced digital object: c.png',
                         'Unable to locate digital object: vfs://root/digital_objects/A.PNG',
                         'Unable to locate digital object: vfs://root/digital_objects/d.png',
+                    ],
+                ],
+            ],
+
+            [
+                'CsvDigitalObjectPathValidator-digitalObjectPathDupedPath' => [
+                    'csvValidatorClasses' => 'CsvDigitalObjectPathValidator',
+                    'filename' => '/unix_csv_with_digital_object_cols_populated_duped_path.csv',
+                    'testname' => 'CsvDigitalObjectPathValidator',
+                    'validatorOptions' => [
+                        'source' => 'testsourcefile.csv',
+                        'className' => 'QubitInformationObject',
+                        'pathToDigitalObjects' => 'vfs://root/digital_objects',
+                    ],
+                    CsvValidatorResult::TEST_TITLE => CsvDigitalObjectPathValidator::TITLE,
+                    CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_ERROR,
+                    CsvValidatorResult::TEST_RESULTS => [
+                        '\'digitalObjectPath\' column appears more than once in file.',
+                        'Unable to validate because of duplicated columns in CSV.',
+                    ],
+                    CsvValidatorResult::TEST_DETAILS => [
                     ],
                 ],
             ],

--- a/test/phpunit/csvImportValidator/CsvDigitalObjectUriTest.php
+++ b/test/phpunit/csvImportValidator/CsvDigitalObjectUriTest.php
@@ -18,6 +18,7 @@ class CsvDigitalObjectUriTest extends \PHPUnit\Framework\TestCase
 
         $this->csvHeader = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,culture';
         $this->csvHeaderWithDigitalObjectCols = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,digitalObjectPath,digitalObjectUri,culture';
+        $this->csvHeaderDupedUri = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,digitalObjectPath,digitalObjectUri,digitalObjectUri,culture';
 
         $this->csvData = [
             // Note: leading and trailing whitespace in first row is intentional
@@ -45,11 +46,23 @@ class CsvDigitalObjectUriTest extends \PHPUnit\Framework\TestCase
             '"", "DJ003", "ID5", "Title Four", "","", "","","ftp://www.artefactual.com/wp-content/uploads/2018/08/artefactual-logo-white.svg", "en"',
         ];
 
+        $this->csvDataWithDigitalObjectColsPopulatedDupedUri = [
+            '"B10101 "," DJ001","ID1 ","Some Photographs","","Extent and medium 1","","a.png","","",""',
+            '"A10101","","","Chemise","","","","A.PNG","","","fr"',
+            '"D20202", "DJ002", "", "Voûte, étagère 0074", "", "", "","b.png","https://www.artefactual.com/wp-content/uploads/2018/08/artefactual-logo-white.svg","", ""',
+            '"", "DJ003", "ID4", "Title Four", "","", "","a.png","","", "en"',
+            '"E10101 "," DJ004","ID1 ","Some Photographs","","Extent and medium 1","","b.png","https://www.artefactual.com/wp-content/uploads/2018/08/artefactual-logo-white.svg", "",""',
+            '"G30303","","","Sweater","","","","d.png","","" ,"fr"',
+            '"F20202", "DJ005", "", "Voûte, étagère 0074", "", "", "","","www.google.com","" , ""',
+            '"", "DJ003", "ID5", "Title Four", "","", "","","ftp://www.artefactual.com/wp-content/uploads/2018/08/artefactual-logo-white.svg", "", "en"',
+        ];
+
         // define virtual file system
         $directory = [
             'unix_csv_without_utf8_bom.csv' => $this->csvHeader."\n".implode("\n", $this->csvData),
             'unix_csv_with_digital_object_cols.csv' => $this->csvHeaderWithDigitalObjectCols."\n".implode("\n", $this->csvDataWithDigitalObjectCols),
             'unix_csv_with_digital_object_cols_populated.csv' => $this->csvHeaderWithDigitalObjectCols."\n".implode("\n", $this->csvDataWithDigitalObjectColsPopulated),
+            'unix_csv_with_digital_object_cols_populated_duped_uri.csv' => $this->csvHeaderDupedUri."\n".implode("\n", $this->csvDataWithDigitalObjectColsPopulatedDupedUri),
             'digital_objects' => [
                 'a.png' => random_bytes(100),
                 'b.png' => random_bytes(100),
@@ -153,6 +166,27 @@ class CsvDigitalObjectUriTest extends \PHPUnit\Framework\TestCase
                         "Number of duplicates for URI 'https://www.artefactual.com/wp-content/uploads/2018/08/artefactual-logo-white.svg': 2",
                         'Invalid URI: www.google.com',
                         'Invalid URI: ftp://www.artefactual.com/wp-content/uploads/2018/08/artefactual-logo-white.svg',
+                    ],
+                ],
+            ],
+
+            [
+                'CsvDigitalObjectUriValidator-digitalObjectUriPopulatedDupedUri' => [
+                    'csvValidatorClasses' => 'CsvDigitalObjectUriValidator',
+                    'filename' => '/unix_csv_with_digital_object_cols_populated_duped_uri.csv',
+                    'testname' => 'CsvDigitalObjectUriValidator',
+                    'validatorOptions' => [
+                        'source' => 'testsourcefile.csv',
+                        'className' => 'QubitInformationObject',
+                        'pathToDigitalObjects' => 'vfs://root/digital_objects',
+                    ],
+                    CsvValidatorResult::TEST_TITLE => CsvDigitalObjectUriValidator::TITLE,
+                    CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_ERROR,
+                    CsvValidatorResult::TEST_RESULTS => [
+                        '\'digitalObjectUri\' column appears more than once in file.',
+                        'Unable to validate because of duplicated columns in CSV.',
+                    ],
+                    CsvValidatorResult::TEST_DETAILS => [
                     ],
                 ],
             ],

--- a/test/phpunit/csvImportValidator/CsvParentTest.php
+++ b/test/phpunit/csvImportValidator/CsvParentTest.php
@@ -22,6 +22,7 @@ class CsvParentTest extends \PHPUnit\Framework\TestCase
         $this->csvHeaderMissingParentIdLegacyId = 'identifier,title,levelOfDescription,extentAndMedium,repository,culture';
         $this->csvHeaderWithQubitParentSlug = 'legacyId,qubitParentSlug,identifier,title,levelOfDescription,extentAndMedium,repository,culture';
         $this->csvHeaderWithParentIdQubitParentSlug = 'legacyId,parentId,qubitParentSlug,identifier,title,levelOfDescription,extentAndMedium,repository,culture';
+        $this->csvHeaderDupedParentId = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,culture,parentId';
 
         $this->csvData = [
             // Note: leading and trailing whitespace in first row is intentional
@@ -88,10 +89,17 @@ class CsvParentTest extends \PHPUnit\Framework\TestCase
             '"X7","", "parent-slug-again", "ID4", "Title Four", "","", "", "en"',
         ];
 
+        $this->csvDataDupedParentId = [
+            // Note: leading and trailing whitespace in first row is intentional
+            '"B10101 "," DJ001","ID1 ","Some Photographs","","Extent and medium 1","","",""',
+            '"","","","Chemise","","","","fr", ""',
+            '"D20202", "DJ002", "", "Voûte, étagère 0074", "", "", "", "","" ',
+            '"", "DJ003", "ID4", "Title Four", "","", "", "en",""',
+        ];
+
         // define virtual file system
         $directory = [
             'unix_csv_without_utf8_bom.csv' => $this->csvHeader."\n".implode("\n", $this->csvData),
-
             'unix_csv_missing_parent_id.csv' => $this->csvHeaderMissingParentId."\n".implode("\n", $this->csvDataMissingParentId),
             'unix_csv_missing_legacy_id.csv' => $this->csvHeaderMissingLegacyId."\n".implode("\n", $this->csvDataMissingLegacyId),
             'unix_csv_missing_parent_id_legacy_id.csv' => $this->csvHeaderMissingParentIdLegacyId."\n".implode("\n", $this->csvDataMissingParentIdLegacyId),
@@ -100,6 +108,7 @@ class CsvParentTest extends \PHPUnit\Framework\TestCase
             'unix_csv_parent_id_matches_in_keymap.csv' => $this->csvHeader."\n".implode("\n", $this->csvDataParentIdMatchesInKeymap),
             'unix_csv_qubit_parent_slug.csv' => $this->csvHeaderWithQubitParentSlug."\n".implode("\n", $this->csvDataQubitParentSlug),
             'unix_csv_parent_id_and_qubit_parent_slug.csv' => $this->csvHeaderWithParentIdQubitParentSlug."\n".implode("\n", $this->csvDataParentIdAndQubitParentSlug),
+            'unix_csv_duped_parent_id.csv' => $this->csvHeaderDupedParentId."\n".implode("\n", $this->csvDataDupedParentId),
         ];
 
         $this->vfs = vfsStream::setup('root', null, $directory);
@@ -325,6 +334,22 @@ class CsvParentTest extends \PHPUnit\Framework\TestCase
                         'Rows with qubitParentSlug populated: 2',
                         'Rows with both \'parentId\' and \'qubitParentSlug\' populated: 1',
                         'Column \'qubitParentSlug\' will override \'parentId\' if both are populated.',
+                    ],
+                    CsvValidatorResult::TEST_DETAILS => [
+                    ],
+                ],
+            ],
+
+            [
+                'CsvParentValidator-DupedParentId' => [
+                    'csvValidatorClasses' => 'CsvParentValidator',
+                    'filename' => '/unix_csv_duped_parent_id.csv',
+                    'testname' => 'CsvParentValidator',
+                    CsvValidatorResult::TEST_TITLE => CsvParentValidator::TITLE,
+                    CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_ERROR,
+                    CsvValidatorResult::TEST_RESULTS => [
+                        '\'parentId\' column appears more than once in file.',
+                        'Unable to validate because of duplicated columns in CSV.',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
                     ],

--- a/test/phpunit/csvImportValidator/CsvSampleValuesTest.php
+++ b/test/phpunit/csvImportValidator/CsvSampleValuesTest.php
@@ -75,6 +75,7 @@ class CsvSampleValuesTest extends \PHPUnit\Framework\TestCase
                     CsvValidatorResult::TEST_TITLE => CsvSampleValuesValidator::TITLE,
                     CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_INFO,
                     CsvValidatorResult::TEST_RESULTS => [
+                        'Empty columns detected: levelOfDescription,repository',
                         'legacyId:  B10101',
                         'parentId:  DJ001',
                         'identifier:  ID1',


### PR DESCRIPTION
Column specific tests to check if a column is present or is duplicated
moved to the base validator. New php_unit tests added for the case where
a column is duplicated in the CSV file.

This commit includes formatting changes to the output report
- add two lines separating the summary at the top of the report from the
following test specific sections.
- format the test titles so the result is first and in all caps.
- update column name check result so that the list of unknown column
names is returned with the non-verbose version of the output.
