### PR TITLE
Carousel dot placement issue

### DIFF
--- a/plugins/arDominionB5Plugin/scss/_layout.scss
+++ b/plugins/arDominionB5Plugin/scss/_layout.scss
@@ -50,6 +50,10 @@
     }
   }
 
+  .slick-dots {
+    position: relative;
+  }
+
   .slick-arrow.slick-prev {
     left: -30px;
   }


### PR DESCRIPTION
Update the styling so that the Carousel dots are positioned relative to
the images in the carousel. This prevents the images overlaying the dots
when there are a large number of images.