### PR TITLE
Fix Carousel paging issue

### DIFF
--- a/plugins/arDominionB5Plugin/js/imageflow.js
+++ b/plugins/arDominionB5Plugin/js/imageflow.js
@@ -5,7 +5,7 @@
 
     if ($(node).length) {
       $('#atom-slider-images').slick({
-        slidesToShow: 3,
+        slidesToShow: 1,
         slidesToScroll: 1,
         asNavFor: '#atom-slider-title',
         dots: true,


### PR DESCRIPTION
Fixes issue where carousel dots not shown when there were fewer than 4
images. Carousel behaviour going forward will be:

- one image in carousel will display centered with no dots or arrows.
- two or more images in carousel will display dots and arrows.