### PR TITLE
Fix treeview settings

### DIFF
--- a/plugins/arDominionB5Plugin/js/fullWidthTreeView.js
+++ b/plugins/arDominionB5Plugin/js/fullWidthTreeView.js
@@ -1,8 +1,16 @@
-"use strict";
-
 (function ($) {
 
-  $(loadTreeView);
+  "use strict";
+
+  $(function()
+  {
+    var $node = $('#fullwidth-treeview');
+
+    if ($node.length)
+    {
+      loadTreeView();
+    }
+  });
 
   function makeFullTreeviewCollapsible ($treeViewConfig, $mainHeader, $fwTreeViewRow)
   {
@@ -24,7 +32,7 @@
     $fwTreeViewRow.appendTo($wrapper);
 
     // Activate toggle button
-    $toggleButton.click(function() {
+    $toggleButton.on('click', function() {
       // Determine appropriate toggle button text
       var toggleText = $treeViewConfig.data('opened-text');
 
@@ -199,7 +207,7 @@
         $('#main-column .breadcrumb').after($(response.find('#main-column > div.messages.error')));
 
         // Attach the Drupal Behaviour so blank.js does its thing
-        Drupal.attachBehaviors(document)
+        Drupal.attachBehaviors(document);
 
         // Update clipboard buttons
         if (jQuery('#clipboard-menu').data('clipboard') !== undefined)
@@ -289,7 +297,7 @@
       .bind('move_node.jstree', moveNodeListener);
 
     // Clicking "more" will add next page of results to tree
-    $moreButton.click(function() {
+    $moreButton.on('click', function() {
       pager.next();
       pager.getAndAppendNodes(function() {
         // Queue is empty so update paging link
@@ -298,12 +306,12 @@
     });
 
     // Clicking reset link will reset paging and tree state
-    $('#fullwidth-treeview-reset-button').click(function()
+    $('#fullwidth-treeview-reset-button').on('click', function()
     {
       pager.reset($moreButton, $resetButton);
     });
 
     // TODO restore window.history states
-    $(window).bind('popstate', function() {});
+    $(window).on('popstate', function() {});
   }
 })(jQuery);

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_treeView.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_treeView.php
@@ -97,7 +97,7 @@
     </ul>
 
   <?php } else { ?>
-    <div class="d-flex justify-content-end flex-wrap gap-2 ms-auto">
+    <div class="d-flex justify-content-end flex-wrap gap-2 ms-auto" id="fullwidth-treeview">
       <input type="button" id="fullwidth-treeview-reset-button" class="btn btn-sm atom-btn-white" value="<?php echo __('Reset'); ?>" />
       <input type="button" id="fullwidth-treeview-more-button" class="btn btn-sm atom-btn-white" data-label="<?php echo __('%1% more'); ?>" value="" />
       <span id="fullwidth-treeview-configuration"

--- a/plugins/arDominionB5Plugin/templates/_layout_end.php
+++ b/plugins/arDominionB5Plugin/templates/_layout_end.php
@@ -40,6 +40,6 @@
     <script src="/js/pager.js"></script>
     <script src="/js/treeViewPager.js"></script>
     <script src="/js/hierarchy.js"></script>
-    <script src="/js/fullWidthTreeView.js"></script>
+    <script src="/plugins/arDominionB5Plugin/js/fullWidthTreeView.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This commit fixes the fullwidth treeview settings allowing it to be
turned on/off from the treeview settings page.

This commit adds further customizations to fullWidthTreeView.js that are
incompatible with the old theme - the old js file has been restored to
the js/ folder for this purpose.