### PR TITLE
arDominionB5Plugin: style repository logo and other elements

### DIFF
--- a/lib/model/QubitMenu.php
+++ b/lib/model/QubitMenu.php
@@ -401,6 +401,10 @@ class QubitMenu extends BaseMenu
                 $anchorOptions['data-toggle'] = 'dropdown';
             }
 
+            if (isset($options['anchorClasses'])) {
+                $anchorOptions['class'] .= $options['anchorClasses'];
+            }
+
             // Construct the link
             $a = link_to($anchorLabel, $anchorPath, $anchorOptions);
 

--- a/plugins/arDominionB5Plugin/modules/menu/templates/_browseMenuInstitution.php
+++ b/plugins/arDominionB5Plugin/modules/menu/templates/_browseMenuInstitution.php
@@ -1,0 +1,8 @@
+<div class="dropdown mb-2 d-grid">
+  <button class="btn atom-btn-white dropdown-toggle" type="button" id="browse-menu-institution-button" data-bs-toggle="dropdown" aria-expanded="false">
+    <?php echo $browseMenuInstitution->getLabel(['cultureFallback' => true]); ?>
+  </button>
+  <ul class="dropdown-menu" aria-labelledby="browse-menu-institution-button">
+    <?php echo QubitMenu::displayHierarchyAsList($browseMenuInstitution, 0, ['anchorClasses' => 'dropdown-item']); ?>
+  </ul>
+</div>

--- a/plugins/arDominionB5Plugin/modules/repository/templates/_holdings.php
+++ b/plugins/arDominionB5Plugin/modules/repository/templates/_holdings.php
@@ -1,6 +1,6 @@
 <form class="mb-3" role="search" aria-label="<?php echo sfConfig::get('app_ui_label_holdings'); ?>" action="<?php echo url_for(['module' => 'informationobject', 'action' => 'browse']); ?>">
   <input type="hidden" name="repos" value="<?php echo $resource->id; ?>">
-  <div class="input-group input-group-sm">
+  <div class="input-group">
     <input type="text" class="form-control" name="query" aria-label="<?php echo __('Search %1%', ['%1%' => sfConfig::get('app_ui_label_holdings')]); ?>" placeholder="<?php echo __('Search %1%', ['%1%' => strtolower(sfConfig::get('app_ui_label_holdings'))]); ?>">
     <button class="btn atom-btn-white" type="submit" aria-label=<?php echo __('Search'); ?>>
       <i aria-hidden="true" class="fas fa-search"></i>

--- a/plugins/arDominionB5Plugin/modules/repository/templates/_holdingsInstitution.php
+++ b/plugins/arDominionB5Plugin/modules/repository/templates/_holdingsInstitution.php
@@ -1,38 +1,24 @@
-<section id="repo-holdings" class="list-menu"
-  data-total-pages="<?php echo $pager->getLastPage(); ?>"
-  data-url="<?php echo url_for(['module' => 'repository', 'action' => 'holdingsInstitution', 'id' => $resource->id]); ?>">
+<section class="card mb-4">
 
-  <div class="panel panel-gray">
-    <div class="panel-body">
-
-      <?php use_helper('Text'); ?>
-
-      <div class="repository-logo<?php echo $resource->existsLogo() ? '' : ' repository-logo-text'; ?>">
-        <a href="<?php echo url_for([$resource, 'module' => 'repository']); ?>">
-          <?php if ($resource->existsLogo()) { ?>
-            <?php echo image_tag($resource->getLogoPath(),
-                  ['alt' => __('Go to %1%',
-                  ['%1%' => truncate_text(strip_markdown($resource), 100)])]); ?>
-          <?php } else { ?>
-            <h2><?php echo render_title($resource); ?></h2>
-          <?php } ?>
-        </a>
-      </div>
-
-      <h3><?php echo sfConfig::get('app_ui_label_institutionSearchHoldings'); ?></h3>
-
-      <form class="mb-3" role="search" aria-label="<?php echo sfConfig::get('app_ui_label_institutionSearchHoldings'); ?>" action="<?php echo url_for(['module' => 'informationobject', 'action' => 'browse']); ?>">
-        <input type="hidden" name="repos" value="<?php echo $resource->id; ?>">
-        <div class="input-group input-group-sm">
-          <input type="text" class="form-control" name="query" aria-label="<?php echo __('Search'); ?>" value="<?php echo $sf_request->query; ?>" placeholder="<?php echo __('Search'); ?>">
-          <button class="btn atom-btn-white" type="submit" aria-label=<?php echo __('Search'); ?>>
-            <i aria-hidden="true" class="fas fa-search"></i>
-          </button>
-        </div>
-      </form>
-
-      <?php echo get_component('menu', 'browseMenuInstitution', ['sf_cache_key' => $sf_user->getCulture().$sf_user->getUserID()]); ?>
-
-    </div>
+  <div class="p-4">
+    <?php include_component('repository', 'logo'); ?>
   </div>
+
+  <div class="card-body">
+
+    <form class="mb-4" role="search" aria-label="<?php echo sfConfig::get('app_ui_label_institutionSearchHoldings'); ?>" action="<?php echo url_for(['module' => 'informationobject', 'action' => 'browse']); ?>">
+      <input type="hidden" name="repos" value="<?php echo $resource->id; ?>">
+      <label for="institution-search-query" class="h5 mb-2 form-label"><?php echo sfConfig::get('app_ui_label_institutionSearchHoldings'); ?></label>
+      <div class="input-group">
+        <input type="text" class="form-control" id="institution-search-query" name="query" value="<?php echo $sf_request->query; ?>" placeholder="<?php echo __('Search'); ?>" required>
+        <button class="btn atom-btn-white" type="submit" aria-label=<?php echo __('Search'); ?>>
+          <i aria-hidden="true" class="fas fa-search"></i>
+        </button>
+      </div>
+    </form>
+
+    <?php echo get_component('menu', 'browseMenuInstitution', ['sf_cache_key' => 'dominion-b5'.$sf_user->getCulture().$sf_user->getUserID()]); ?>
+
+  </div>
+
 </section>

--- a/plugins/arDominionB5Plugin/modules/repository/templates/_logo.php
+++ b/plugins/arDominionB5Plugin/modules/repository/templates/_logo.php
@@ -1,0 +1,24 @@
+<?php use_helper('Text'); ?>
+
+<?php if ($resource->existsLogo()) { ?>
+  <div class="repository-logo mb-4 mx-auto">
+    <a class="text-decoration-none" href="<?php echo url_for([$resource, 'module' => 'repository']); ?>">
+      <?php echo image_tag(
+        $resource->getLogoPath(),
+        [
+            'alt' => __('Go to %1%', ['%1%' => truncate_text(strip_markdown($resource), 100)]),
+            'class' => 'img-fluid img-thumbnail border-4 shadow-sm bg-white',
+        ],
+      ); ?>
+    </a>
+  </div>
+<?php } else { ?>
+  <div class="repository-logo-text mb-4">
+    <a class="text-decoration-none" href="<?php echo url_for([$resource, 'module' => 'repository']); ?>">
+      <h2 class="h4 p-2 text-muted text-start border border-4 shadow-sm bg-white mx-auto">
+        <?php echo render_title($resource); ?>
+      </h2>
+    </a>
+  </div>
+<?php } ?>
+

--- a/plugins/arDominionB5Plugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
@@ -28,9 +28,9 @@
   </nav>
 
   <?php if ($resource->existsBanner()) { ?>
-    <div class="row" id="repository-banner">
-      <div class="span7">
-        <?php echo image_tag($resource->getBannerPath(), ['alt' => '']); ?>
+    <div class="row mb-3" id="repository-banner">
+      <div class="col-md-9">
+        <?php echo image_tag($resource->getBannerPath(), ['alt' => '', 'class' => 'img-fluid rounded']); ?>
       </div>
     </div>
   <?php } ?>

--- a/plugins/arDominionB5Plugin/scss/_layout.scss
+++ b/plugins/arDominionB5Plugin/scss/_layout.scss
@@ -213,3 +213,10 @@ body > iframe {
 #treeview-search .alert {
   border-color: $border-color !important;
 }
+
+// Repository logo with an approximate shape of a square.
+.repository-logo,
+.repository-logo-text h2 {
+  min-height: 180px;
+  max-width: 220px;
+}


### PR DESCRIPTION
* Restores the square-y shape of the repository logo
* Styles institutional scoping cues (search box and browse drop-down menu)
* Styles the repository banner with .img-fluid and 9 columns

---

![image](https://user-images.githubusercontent.com/606459/129527435-7503b26f-88b6-4cae-8c07-803cdc4c7a4b.png)

![image](https://user-images.githubusercontent.com/606459/129527460-aa3c4262-26b1-431c-a2da-03cfaa822590.png)

![image](https://user-images.githubusercontent.com/606459/129527498-33ebaf76-763e-4775-9b61-2c2004ba9f7c.png)
