### PR TITLE
arDominionB5Plugin: update password validation

### DIFF
--- a/plugins/arDominionB5Plugin/js/user.js
+++ b/plugins/arDominionB5Plugin/js/user.js
@@ -1,0 +1,181 @@
+(($) => {
+  "use strict";
+
+  const $element = $("input.password-strength[type=password]");
+  $(() => new PasswordStrength($element));
+
+  class PasswordStrength {
+    constructor($element) {
+      if (!$element.length) {
+        return;
+      }
+
+      this.$form = $element.parents("form");
+      this.$passwordInput = $element;
+      this.$confirmInput = $("input.password-confirm", this.$form);
+      this.$usernameInput = $("input[name=username]", this.$form);
+      this.settings = this.$form
+        .find(".password-strength-settings")
+        .get(0).dataset;
+
+      // Prevent the form from running its validation logic when the form is
+      // submitted. Otherwise our submit handler will not be executed if
+      // native validation kicks in and finds a validation issue.
+      this.$form.attr("novalidate", "novalidate");
+
+      this.$progressBar = this.$form
+        .find(".template")
+        .removeAttr("hidden")
+        .find(".progress-bar");
+
+      this.$passwordInput.on("focus input", this.passwordCheck.bind(this));
+      this.$form.on("submit", this.submit.bind(this));
+    }
+
+    passwordCheck(event) {
+      const input = this.$passwordInput.get(0);
+      const password = input.value;
+      const score = PasswordStrength.score(
+        password,
+        this.$usernameInput.val(),
+        this.settings
+      );
+
+      // Update the progress bar.
+      this.$progressBar
+        .css("width", score.strength + "%")
+        .attr("aria-valuenow", score.strength)
+        .removeClass()
+        .addClass(() => {
+          const classes = ["progress-bar"];
+          if (score.strength < 50) {
+            classes.push("bg-danger");
+          } else if (score.strength < 100) {
+            classes.push("bg-warning");
+          } else {
+            classes.push("bg-success");
+          }
+          return classes;
+        });
+
+      // Inject password hints.
+      const $container = this.$progressBar.parent().parent();
+      $container.children("ul").remove();
+      score.strength < 100 &&
+        $container.append(score.message).find("ul").addClass("text-danger");
+
+      input.setCustomValidity(
+        score.strength < 100 ? this.settings.notStrong : ""
+      );
+    }
+
+    // Update the validity state of the confirm input.
+    passwordMatchCheck() {
+      const input = this.$confirmInput.get(0);
+      const password = this.$passwordInput.val();
+
+      input.setCustomValidity("");
+
+      if (!password.length) {
+        return;
+      }
+
+      if (password != input.value) {
+        input.setCustomValidity(this.settings.confirmFailure);
+      }
+    }
+
+    // Prevent submission when fields are invalid.
+    submit(event) {
+      let input = this.$form.find("input[name=email]").get(0);
+      if (input.validity.typeMismatch) {
+        input.reportValidity();
+        event.preventDefault();
+        return;
+      }
+
+      input = this.$form.find("input[name=password]").get(0);
+      if (!input.validity.valid && !!this.settings.requireStrongPassword) {
+        input.reportValidity();
+        event.preventDefault();
+        return;
+      }
+
+      this.passwordMatchCheck();
+      input = this.$confirmInput.get(0);
+      if (!input.validity.valid) {
+        input.reportValidity();
+        event.preventDefault();
+        return;
+      }
+    }
+
+    static score(password, username, translate) {
+      var weaknesses = 0,
+        strength = 100,
+        msg = [];
+
+      var hasLowercase = password.match(/[a-z]+/);
+      var hasUppercase = password.match(/[A-Z]+/);
+      var hasNumbers = password.match(/[0-9]+/);
+      var hasPunctuation = password.match(/[^a-zA-Z0-9]+/);
+
+      // Lose 5 points for every character less than 6, plus a 30 point penalty.
+      if (password.length < 6) {
+        msg.push(translate.tooShort);
+        strength -= (6 - password.length) * 5 + 30;
+      }
+
+      // Count weaknesses.
+      if (!hasLowercase) {
+        msg.push(translate.addLowerCase);
+        weaknesses++;
+      }
+      if (!hasUppercase) {
+        msg.push(translate.addUpperCase);
+        weaknesses++;
+      }
+      if (!hasNumbers) {
+        msg.push(translate.addNumbers);
+        weaknesses++;
+      }
+      if (!hasPunctuation) {
+        msg.push(translate.addPunctuation);
+        weaknesses++;
+      }
+
+      // Apply penalty for each weakness (balanced against length penalty).
+      switch (weaknesses) {
+        case 1:
+          strength -= 12.5;
+          break;
+
+        case 2:
+          strength -= 25;
+          break;
+
+        case 3:
+          strength -= 40;
+          break;
+
+        case 4:
+          strength -= 40;
+          break;
+      }
+
+      // Check if password is the same as the username.
+      if (
+        password !== "" &&
+        password.toLowerCase() === username.toLowerCase()
+      ) {
+        msg.push(translate.sameAsUsername);
+        // Passwords the same as username are always very weak.
+        strength = 5;
+      }
+
+      // Assemble the final message.
+      msg = "<ul><li>" + msg.join("</li><li>") + "</li></ul>";
+      return { strength: strength, message: msg };
+    }
+  }
+})(jQuery);

--- a/plugins/arDominionB5Plugin/modules/user/templates/editSuccess.mod_standard.php
+++ b/plugins/arDominionB5Plugin/modules/user/templates/editSuccess.mod_standard.php
@@ -27,30 +27,46 @@
           <div class="accordion-body">
             <?php echo render_field($form->username); ?>
 
-            <?php echo render_field($form->email); ?>
+            <?php echo render_field($form->email, null, ['type' => 'email']); ?>
 
-            <?php $settings = json_encode(['password' => [
-                'strengthTitle' => __('Password strength:'),
-                'hasWeaknesses' => __('To make your password stronger:'),
-                'tooShort' => __('Make it at least six characters'),
-                'addLowerCase' => __('Add lowercase letters'),
-                'addUpperCase' => __('Add uppercase letters'),
-                'addNumbers' => __('Add numbers'),
-                'addPunctuation' => __('Add punctuation'),
-                'sameAsUsername' => __('Make it different from your username'),
-                'confirmSuccess' => __('Yes'),
-                'confirmFailure' => __('No'),
-                'confirmTitle' => __('Passwords match:'),
-                'username' => '',
-            ]]); ?>
+            <div class="row">
 
-            <?php if (isset($sf_request->getAttribute('sf_route')->resource)) { ?>
-              <?php echo render_field($form->password->label(__('Change password'))); ?>
-            <?php } else { ?>
-              <?php echo render_field($form->password->label(__('Password'))); ?>
-            <?php } ?>
+              <div class="col-md-6">
 
-            <?php echo render_field($form->password->label(__('Confirm password'))); ?>
+                <div
+                  hidden
+                  class="password-strength-settings"
+                  data-not-strong="<?php echo __('Your password is not strong enough.'); ?>"
+                  data-strength-title="<?php echo __('Password strength:'); ?>"
+                  data-require-strong-password="<?php echo sfConfig::get('app_require_strong_passwords', false); ?>"
+                  data-too-short="<?php echo __('Make it at least six characters'); ?>"
+                  data-add-lower-case="<?php echo __('Add lowercase letters'); ?>"
+                  data-add-upper-case="<?php echo __('Add uppercase letters'); ?>"
+                  data-add-numbers="<?php echo __('Add numbers'); ?>"
+                  data-add-punctuation="<?php echo __('Add punctuation'); ?>"
+                  data-same-as-username="<?php echo __('Make it different from your username'); ?>"
+                  data-confirm-failure="<?php echo __('Your password confirmation did not match your password.'); ?>"
+                >
+                </div>
+
+                <?php if (isset($sf_request->getAttribute('sf_route')->resource)) { ?>
+                  <?php echo render_field($form->password->label(__('Change password')), null, ['class' => 'password-strength']); ?>
+                <?php } else { ?>
+                  <?php echo render_field($form->password->label(__('Password')), null, ['class' => 'password-strength']); ?>
+                <?php } ?>
+
+                <?php echo render_field($form->confirmPassword->label(__('Confirm password')), null, ['class' => 'password-confirm']); ?>
+
+              </div>
+
+              <div class="col-md-6 template" hidden>
+                <div class="mb-3 bg-light p-3 rounded border-start border-4">
+                  <label class="form-label"><?php echo __('Password strength:'); ?></label>
+                  <div class="progress mb-3">
+                    <div class="progress-bar" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+                  </div>
+                </div>
+              </div>
 
             <?php if ($sf_user->user != $resource) { ?>
               <?php echo render_field($form->active->label(__('Active'))); ?>

--- a/plugins/arDominionB5Plugin/templates/_layout_end.php
+++ b/plugins/arDominionB5Plugin/templates/_layout_end.php
@@ -35,6 +35,7 @@
     <script src="/plugins/arDominionB5Plugin/js/multiRow.js"></script>
     <script src="/plugins/arDominionB5Plugin/js/date.js"></script>
     <script src="/plugins/arDominionB5Plugin/js/treeView.js"></script>
+    <script src="/plugins/arDominionB5Plugin/js/user.js"></script>
     <script src="/plugins/sfTranslatePlugin/js/l10n_client.js"></script>
     <script src="/js/blank.js"></script>
     <script src="/js/editingHistory.js"></script>


### PR DESCRIPTION
* Add password hints (code and translations were already there),
* Add client-side strong password requirement (when enabled),
* Use the Bootstrap 5 Progress component to represent strength, and
* Validate password confirmation and email using the Constraint validation API

![image](https://user-images.githubusercontent.com/606459/129930056-1169621d-2d83-46a0-b49f-eb7e54638701.png)
