### PR TITLE
CSV validator enhancements, refs #13475

### DIFF
--- a/lib/job/arFileImportJob.class.php
+++ b/lib/job/arFileImportJob.class.php
@@ -173,10 +173,10 @@ class arFileImportJob extends arBaseJob
         $this->warnCount = $results->getWarnCount();
         $this->errorCount = $results->getErrorCount();
 
-        $this->verboseReportContents = CsvValidatorResultCollection::renderResultsAsText($results, true);
+        $this->verboseReportContents = $results->renderResultsAsText(true);
 
         // Return short report.
-        return CsvValidatorResultCollection::renderResultsAsText($results, false);
+        return $results->renderResultsAsText(false);
     }
 
     /**

--- a/lib/job/arValidateCsvJob.class.php
+++ b/lib/job/arValidateCsvJob.class.php
@@ -89,10 +89,10 @@ class arValidateCsvJob extends arBaseJob
         $validator->setFilenames([$file['name'] => $file['tmp_name']]);
         $results = $validator->validate();
 
-        $this->verboseReportContents = CsvValidatorResultCollection::renderResultsAsText($results, true);
+        $this->verboseReportContents = $results->renderResultsAsText(true);
 
         // Return short report.
-        return CsvValidatorResultCollection::renderResultsAsText($results, false);
+        return $results->renderResultsAsText(false);
     }
 
     public static function setOptions($options = [])

--- a/lib/task/import/csvCheckImportTask.class.php
+++ b/lib/task/import/csvCheckImportTask.class.php
@@ -52,8 +52,7 @@ class csvCheckImportTask extends arBaseTask
         $validator->setShowDisplayProgress(true);
         $validator->setFilenames($filenames);
         $results = $validator->validate();
-
-        $output = CsvValidatorResultCollection::renderResultsAsText($results, $this->verbose);
+        $output = $results->renderResultsAsText($this->verbose);
         echo $output;
 
         unset($validator);

--- a/lib/task/import/validate/csvBaseValidator.class.php
+++ b/lib/task/import/validate/csvBaseValidator.class.php
@@ -47,6 +47,7 @@ abstract class CsvBaseValidator
     protected $requiredColumns = [];
     protected $header = [];
     protected $proceedWithRowValidation;
+    protected $rowNumberList = [];
 
     public function __construct(?array $options = null)
     {
@@ -148,6 +149,17 @@ abstract class CsvBaseValidator
         $this->columnDuplicated = [];
         $this->header = [];
         $this->proceedWithRowValidation = null;
+        $this->rowNumberList = [];
+    }
+
+    public function appendToCsvRowList()
+    {
+        $this->rowNumberList[] = $this->rowNumber;
+    }
+
+    public function getCsvRowList(): array
+    {
+        return $this->rowNumberList;
     }
 
     public function setOrmClasses(array $classes)

--- a/lib/task/import/validate/csvCultureValidator.class.php
+++ b/lib/task/import/validate/csvCultureValidator.class.php
@@ -78,10 +78,10 @@ class CsvCultureValidator extends CsvBaseValidator
         // Check if contains pipe.
         if (0 < strpos($row['culture'], '|')) {
             ++$this->rowsWithPipeFoundInCulture;
-            $this->testData->addDetail(implode(',', $row));
+            $this->appendToCsvRowList();
         } else {
             ++$this->rowsWithInvalidCulture;
-            $this->testData->addDetail(implode(',', $row));
+            $this->appendToCsvRowList();
         }
     }
 
@@ -141,6 +141,10 @@ class CsvCultureValidator extends CsvBaseValidator
             && 0 === $this->rowsWithPipeFoundInCulture
         ) {
             $this->testData->addResult(sprintf("'culture' column values are all valid."));
+        }
+
+        if (!empty($this->getCsvRowList())) {
+            $this->testData->addDetail(sprintf('CSV row numbers where issues were found: %s', implode(', ', $this->getCsvRowList())));
         }
 
         return parent::getTestResult();

--- a/lib/task/import/validate/csvDigitalObjectUriValidator.class.php
+++ b/lib/task/import/validate/csvDigitalObjectUriValidator.class.php
@@ -37,7 +37,7 @@ class CsvDigitalObjectUriValidator extends CsvBaseValidator
         $this->setTitle(self::TITLE);
         parent::__construct($options);
 
-        $this->setRequiredColumns(['digitalObjectUri']);
+        $this->setRequiredColumns(['digitalObjectURI']);
     }
 
     public function reset()
@@ -55,40 +55,40 @@ class CsvDigitalObjectUriValidator extends CsvBaseValidator
 
         $row = $this->combineRow($header, $row);
 
-        if (!empty($row['digitalObjectUri'])) {
-            $this->addToUsageSummary($row['digitalObjectUri']);
+        if (!empty($row['digitalObjectURI'])) {
+            $this->addToUsageSummary($row['digitalObjectURI']);
         }
     }
 
     public function getTestResult()
     {
-        if (false === $this->columnPresent('digitalObjectUri')) {
-            $this->testData->addResult(sprintf("Column 'digitalObjectUri' not present in CSV. Nothing to verify."));
+        if (false === $this->columnPresent('digitalObjectURI')) {
+            $this->testData->addResult(sprintf("Column 'digitalObjectURI' not present in CSV. Nothing to verify."));
 
             return parent::getTestResult();
         }
 
-        if ($this->columnDuplicated('digitalObjectUri')) {
-            $this->appendDuplicatedColumnError('digitalObjectUri');
+        if ($this->columnDuplicated('digitalObjectURI')) {
+            $this->appendDuplicatedColumnError('digitalObjectURI');
 
             return parent::getTestResult();
         }
 
-        $this->testData->addResult(sprintf("Column 'digitalObjectUri' found."));
+        $this->testData->addResult(sprintf("Column 'digitalObjectURI' found."));
 
         if (empty($this->digitalObjectUses)) {
-            $this->testData->addResult(sprintf("Column 'digitalObjectUri' is empty."));
+            $this->testData->addResult(sprintf("Column 'digitalObjectURI' is empty."));
 
             return parent::getTestResult();
         }
 
-        $digitalObjectUrisUsedMoreThanOnce = $this->getUsedMoreThanOnce();
+        $digitalObjectURIsUsedMoreThanOnce = $this->getUsedMoreThanOnce();
 
-        if (!empty($digitalObjectUrisUsedMoreThanOnce)) {
+        if (!empty($digitalObjectURIsUsedMoreThanOnce)) {
             $this->testData->setStatusWarn();
             $this->testData->addResult(sprintf('Repeating Digital object URIs found in CSV.'));
 
-            foreach ($digitalObjectUrisUsedMoreThanOnce as $uri) {
+            foreach ($digitalObjectURIsUsedMoreThanOnce as $uri) {
                 $this->testData->addDetail(sprintf("Number of duplicates for URI '%s': %s", $uri, $this->digitalObjectUses[$uri]));
             }
         }
@@ -97,7 +97,7 @@ class CsvDigitalObjectUriValidator extends CsvBaseValidator
 
         if (!empty($invalidUris)) {
             $this->testData->setStatusError();
-            $this->testData->addResult(sprintf('Invalid digitalObjectUri values detected: %s', count($invalidUris)));
+            $this->testData->addResult(sprintf('Invalid digitalObjectURI values detected: %s', count($invalidUris)));
 
             foreach ($invalidUris as $file) {
                 $this->testData->addDetail(sprintf('Invalid URI: %s', $file));
@@ -111,9 +111,9 @@ class CsvDigitalObjectUriValidator extends CsvBaseValidator
     {
         $usedMoreThanOnce = [];
 
-        foreach ($this->digitalObjectUses as $digitalObjectUri => $uses) {
+        foreach ($this->digitalObjectUses as $digitalObjectURI => $uses) {
             if ($uses > 1) {
-                array_push($usedMoreThanOnce, $digitalObjectUri);
+                array_push($usedMoreThanOnce, $digitalObjectURI);
             }
         }
 

--- a/lib/task/import/validate/csvEventValuesValidator.class.php
+++ b/lib/task/import/validate/csvEventValuesValidator.class.php
@@ -93,8 +93,7 @@ class CsvEventValuesValidator extends CsvBaseValidator
         // If the number of fields differ within a row's event fields, count it.
         if (!empty($fieldCounts) && 1 != count(array_unique($fieldCounts))) {
             ++$this->countMismatchedRows;
-
-            $this->testData->addDetail(implode(',', $row));
+            $this->appendToCsvRowList();
         }
     }
 
@@ -109,6 +108,10 @@ class CsvEventValuesValidator extends CsvBaseValidator
         if (0 < $this->countMismatchedRows) {
             $this->testData->setStatusWarn();
             $this->testData->addResult(sprintf('Event value mismatches found: %s', $this->countMismatchedRows));
+        }
+
+        if (!empty($this->getCsvRowList())) {
+            $this->testData->addDetail(sprintf('CSV row numbers where issues were found: %s', implode(', ', $this->getCsvRowList())));
         }
 
         return parent::getTestResult();

--- a/lib/task/import/validate/csvFileEncodingValidator.class.php
+++ b/lib/task/import/validate/csvFileEncodingValidator.class.php
@@ -58,8 +58,8 @@ class CsvFileEncodingValidator extends CsvBaseValidator
         if (!$this->isRowUtf8EncodingCompatible($row)) {
             $this->utf8Compatible = false;
 
-            // Add row that triggered this to the output.
-            $this->testData->addDetail(implode(',', $row));
+            // Add row number that triggered this to the output.
+            $this->appendToCsvRowList();
         }
     }
 
@@ -106,7 +106,15 @@ class CsvFileEncodingValidator extends CsvBaseValidator
             $this->testData->addResult('File encoding is UTF-8 compatible.');
         } else {
             $this->testData->addResult('File encoding does not appear to be UTF-8 compatible.');
+            $this->testData->addResult(sprintf('Count of UTF-8 incompatible CSV rows: %s', count($this->getCsvRowList())));
             $this->testData->setStatusError();
+            // Detail lines: comma sep string of first ten row numbers affected.
+            $this->testData->addDetail(
+                sprintf(
+                    'Affected row numbers (first 10): %s',
+                    implode(', ', array_slice($this->getCsvRowList(), 0, 10, true))
+                )
+            );
         }
 
         if (null !== $this->utf8BomPresent && false !== $this->utf8BomPresent) {

--- a/lib/task/import/validate/csvLanguageValidator.class.php
+++ b/lib/task/import/validate/csvLanguageValidator.class.php
@@ -70,7 +70,7 @@ class CsvLanguageValidator extends CsvBaseValidator
 
             if (!$errorDetailAdded) {
                 ++$this->rowsWithInvalidLanguage;
-                $this->testData->addDetail(implode(',', $row));
+                $this->appendToCsvRowList();
                 $errorDetailAdded = true;
             }
 
@@ -105,6 +105,10 @@ class CsvLanguageValidator extends CsvBaseValidator
 
         if (0 === $this->rowsWithInvalidLanguage) {
             $this->testData->addResult(sprintf("'language' column values are all valid."));
+        }
+
+        if (!empty($this->getCsvRowList())) {
+            $this->testData->addDetail(sprintf('CSV row numbers where issues were found: %s', implode(', ', $this->getCsvRowList())));
         }
 
         return parent::getTestResult();

--- a/lib/task/import/validate/csvRepoValidator.class.php
+++ b/lib/task/import/validate/csvRepoValidator.class.php
@@ -59,7 +59,7 @@ class CsvRepoValidator extends CsvBaseValidator
         }
 
         if (!$this->repositoryExists($row['repository'])) {
-            $this->testData->addDetail(implode(',', $row));
+            $this->appendToCsvRowList();
         }
     }
 
@@ -84,6 +84,10 @@ class CsvRepoValidator extends CsvBaseValidator
             $this->testData->addResult(sprintf('New repository records will be created for: %s', implode(',', $this->newRepositories)));
         } else {
             $this->testData->addResult('No issues detected with repository values.');
+        }
+
+        if (!empty($this->getCsvRowList())) {
+            $this->testData->addDetail(sprintf('CSV row numbers where issues were found: %s', implode(', ', $this->getCsvRowList())));
         }
 
         return parent::getTestResult();

--- a/lib/task/import/validate/csvSampleColumnsValidator.class.php
+++ b/lib/task/import/validate/csvSampleColumnsValidator.class.php
@@ -82,11 +82,13 @@ class CsvSampleValuesValidator extends CsvBaseValidator
     {
         if (isset($this->emptyColumnNames) && !empty($this->emptyColumnNames)) {
             $this->testData->addResult(sprintf('Empty columns detected: %s', implode(',', array_keys($this->emptyColumnNames))));
+            $this->testData->addResult('');
         }
 
         if (isset($this->duplicatedColumnNames) && !empty($this->duplicatedColumnNames)) {
             $this->testData->setStatusError();
             $this->testData->addResult(sprintf('Duplicate column names detected: %s', implode(',', $this->duplicatedColumnNames)));
+            $this->testData->addResult('');
         }
 
         foreach ($this->values as $columnName => $sampleValue) {

--- a/lib/task/import/validate/csvScriptValidator.class.php
+++ b/lib/task/import/validate/csvScriptValidator.class.php
@@ -70,7 +70,7 @@ class CsvScriptValidator extends CsvBaseValidator
 
             if (!$errorDetailAdded) {
                 ++$this->rowsWithInvalidScriptOfDescription;
-                $this->testData->addDetail(implode(',', $row));
+                $this->appendToCsvRowList();
                 $errorDetailAdded = true;
             }
 
@@ -105,6 +105,10 @@ class CsvScriptValidator extends CsvBaseValidator
 
         if (0 === $this->rowsWithInvalidScriptOfDescription) {
             $this->testData->addResult(sprintf("'scriptOfDescription' column values are all valid."));
+        }
+
+        if (!empty($this->getCsvRowList())) {
+            $this->testData->addDetail(sprintf('CSV row numbers where issues were found: %s', implode(', ', $this->getCsvRowList())));
         }
 
         return parent::getTestResult();

--- a/test/phpunit/csvImportValidator/CsvCultureTest.php
+++ b/test/phpunit/csvImportValidator/CsvCultureTest.php
@@ -153,8 +153,7 @@ class CsvCultureTest extends \PHPUnit\Framework\TestCase
                         'Rows with a blank culture value will be imported using AtoM\'s default source culture.',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
-                        ',,,Chemise,,,,fr|en',
-                        'D20202,DJ002,,Voûte, étagère 0074,,,,gg',
+                        'CSV row numbers where issues were found: 3, 4',
                     ],
                 ],
             ],

--- a/test/phpunit/csvImportValidator/CsvDigitalObjectPathTest.php
+++ b/test/phpunit/csvImportValidator/CsvDigitalObjectPathTest.php
@@ -17,8 +17,8 @@ class CsvDigitalObjectPathTest extends \PHPUnit\Framework\TestCase
         $this->vdbcon = $this->createMock(DebugPDO::class);
 
         $this->csvHeader = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,culture';
-        $this->csvHeaderWithDigitalObjectCols = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,digitalObjectPath,digitalObjectUri,culture';
-        $this->csvHeaderDupedPath = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,digitalObjectPath,digitalObjectPath,digitalObjectUri,culture';
+        $this->csvHeaderWithDigitalObjectCols = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,digitalObjectPath,digitalObjectURI,culture';
+        $this->csvHeaderDupedPath = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,digitalObjectPath,digitalObjectPath,digitalObjectURI,culture';
 
         $this->csvData = [
             // Note: leading and trailing whitespace in first row is intentional
@@ -111,7 +111,7 @@ class CsvDigitalObjectPathTest extends \PHPUnit\Framework\TestCase
              * -- duplicated file path
              * -- invalid file path
              * -- empty value
-             * -- digitalObjectUri column present and populated
+             * -- digitalObjectURI column present and populated
              */
             [
                 'CsvDigitalObjectPathValidator-digitalObjectPathMissing' => [
@@ -136,8 +136,9 @@ class CsvDigitalObjectPathTest extends \PHPUnit\Framework\TestCase
                     CsvValidatorResult::TEST_TITLE => CsvDigitalObjectPathValidator::TITLE,
                     CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_INFO,
                     CsvValidatorResult::TEST_RESULTS => [
-                        "Column 'digitalObjectPath' found.",
+                        'Column \'digitalObjectPath\' found.',
                         'Digital object folder location not specified.',
+                        'Column \'digitalObjectPath\' is empty - nothing to validate.',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
                     ],
@@ -157,8 +158,8 @@ class CsvDigitalObjectPathTest extends \PHPUnit\Framework\TestCase
                     CsvValidatorResult::TEST_TITLE => CsvDigitalObjectPathValidator::TITLE,
                     CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_INFO,
                     CsvValidatorResult::TEST_RESULTS => [
-                        "Column 'digitalObjectPath' found.",
-                        "Column 'digitalObjectPath' is empty.",
+                        'Column \'digitalObjectPath\' found.',
+                        'Column \'digitalObjectPath\' is empty - nothing to validate.',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
                     ],
@@ -179,18 +180,18 @@ class CsvDigitalObjectPathTest extends \PHPUnit\Framework\TestCase
                     CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_ERROR,
                     CsvValidatorResult::TEST_RESULTS => [
                         "Column 'digitalObjectPath' found.",
-                        "'digitalObjectPath' will be overridden by 'digitalObjectUri' if both are populated.",
-                        "'digitalObjectPath' values that will be overridden by digitalObjectUri: 2",
+                        "'digitalObjectPath' will be overridden by 'digitalObjectURI' if both are populated.",
+                        "'digitalObjectPath' values that will be overridden by 'digitalObjectURI': 2",
                         'Number of duplicated digital object paths found in CSV: 2',
                         'Digital objects in folder not referenced by CSV: 1',
-                        'Digital object referenced by CSV not found in folder: 2',
+                        'Digital objects referenced by CSV not found in folder: 2',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
                         "Number of duplicates for path 'a.png': 2",
                         "Number of duplicates for path 'b.png': 2",
                         'Unreferenced digital object: c.png',
-                        'Unable to locate digital object: vfs://root/digital_objects/A.PNG',
-                        'Unable to locate digital object: vfs://root/digital_objects/d.png',
+                        'Unable to locate digital object: A.PNG',
+                        'Unable to locate digital object: d.png',
                     ],
                 ],
             ],

--- a/test/phpunit/csvImportValidator/CsvDigitalObjectUriTest.php
+++ b/test/phpunit/csvImportValidator/CsvDigitalObjectUriTest.php
@@ -17,8 +17,8 @@ class CsvDigitalObjectUriTest extends \PHPUnit\Framework\TestCase
         $this->vdbcon = $this->createMock(DebugPDO::class);
 
         $this->csvHeader = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,culture';
-        $this->csvHeaderWithDigitalObjectCols = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,digitalObjectPath,digitalObjectUri,culture';
-        $this->csvHeaderDupedUri = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,digitalObjectPath,digitalObjectUri,digitalObjectUri,culture';
+        $this->csvHeaderWithDigitalObjectCols = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,digitalObjectPath,digitalObjectURI,culture';
+        $this->csvHeaderDupedUri = 'legacyId,parentId,identifier,title,levelOfDescription,extentAndMedium,repository,digitalObjectPath,digitalObjectURI,digitalObjectURI,culture';
 
         $this->csvData = [
             // Note: leading and trailing whitespace in first row is intentional
@@ -104,25 +104,25 @@ class CsvDigitalObjectUriTest extends \PHPUnit\Framework\TestCase
              * Test CsvDigitalObjectUriValidator.class.php
              *
              * Tests:
-             * - digitalObjectUri column missing
-             * - digitalObjectUri column present but empty
-             * - digitalObjectUri column present and populated with:
+             * - digitalObjectURI column missing
+             * - digitalObjectURI column present but empty
+             * - digitalObjectURI column present and populated with:
              * -- valid URI
              * -- incorrect scheme URI (e.g. ftp://)
              * -- duplicated URI
              * -- invalid URI
              * -- empty value
-             * -- digitalObjectUri column present and populated
+             * -- digitalObjectURI column present and populated
              */
             [
-                'CsvDigitalObjectUriValidator-digitalObjectUriMissing' => [
+                'CsvDigitalObjectUriValidator-digitalObjectURIMissing' => [
                     'csvValidatorClasses' => 'CsvDigitalObjectUriValidator',
                     'filename' => '/unix_csv_without_utf8_bom.csv',
                     'testname' => 'CsvDigitalObjectUriValidator',
                     CsvValidatorResult::TEST_TITLE => CsvDigitalObjectUriValidator::TITLE,
                     CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_INFO,
                     CsvValidatorResult::TEST_RESULTS => [
-                        "Column 'digitalObjectUri' not present in CSV. Nothing to verify.",
+                        "Column 'digitalObjectURI' not present in CSV. Nothing to verify.",
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
                     ],
@@ -130,15 +130,15 @@ class CsvDigitalObjectUriTest extends \PHPUnit\Framework\TestCase
             ],
 
             [
-                'CsvDigitalObjectUriValidator-digitalObjectUriEmpty' => [
+                'CsvDigitalObjectUriValidator-digitalObjectURIEmpty' => [
                     'csvValidatorClasses' => 'CsvDigitalObjectUriValidator',
                     'filename' => '/unix_csv_with_digital_object_cols.csv',
                     'testname' => 'CsvDigitalObjectUriValidator',
                     CsvValidatorResult::TEST_TITLE => CsvDigitalObjectUriValidator::TITLE,
                     CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_INFO,
                     CsvValidatorResult::TEST_RESULTS => [
-                        "Column 'digitalObjectUri' found.",
-                        "Column 'digitalObjectUri' is empty.",
+                        "Column 'digitalObjectURI' found.",
+                        "Column 'digitalObjectURI' is empty.",
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
                     ],
@@ -146,7 +146,7 @@ class CsvDigitalObjectUriTest extends \PHPUnit\Framework\TestCase
             ],
 
             [
-                'CsvDigitalObjectUriValidator-digitalObjectUriPopulatedWithDOFolder' => [
+                'CsvDigitalObjectUriValidator-digitalObjectURIPopulatedWithDOFolder' => [
                     'csvValidatorClasses' => 'CsvDigitalObjectUriValidator',
                     'filename' => '/unix_csv_with_digital_object_cols_populated.csv',
                     'testname' => 'CsvDigitalObjectUriValidator',
@@ -158,9 +158,9 @@ class CsvDigitalObjectUriTest extends \PHPUnit\Framework\TestCase
                     CsvValidatorResult::TEST_TITLE => CsvDigitalObjectUriValidator::TITLE,
                     CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_ERROR,
                     CsvValidatorResult::TEST_RESULTS => [
-                        "Column 'digitalObjectUri' found.",
+                        "Column 'digitalObjectURI' found.",
                         'Repeating Digital object URIs found in CSV.',
-                        'Invalid digitalObjectUri values detected: 2',
+                        'Invalid digitalObjectURI values detected: 2',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
                         "Number of duplicates for URI 'https://www.artefactual.com/wp-content/uploads/2018/08/artefactual-logo-white.svg': 2",
@@ -171,7 +171,7 @@ class CsvDigitalObjectUriTest extends \PHPUnit\Framework\TestCase
             ],
 
             [
-                'CsvDigitalObjectUriValidator-digitalObjectUriPopulatedDupedUri' => [
+                'CsvDigitalObjectUriValidator-digitalObjectURIPopulatedDupedUri' => [
                     'csvValidatorClasses' => 'CsvDigitalObjectUriValidator',
                     'filename' => '/unix_csv_with_digital_object_cols_populated_duped_uri.csv',
                     'testname' => 'CsvDigitalObjectUriValidator',
@@ -183,7 +183,7 @@ class CsvDigitalObjectUriTest extends \PHPUnit\Framework\TestCase
                     CsvValidatorResult::TEST_TITLE => CsvDigitalObjectUriValidator::TITLE,
                     CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_ERROR,
                     CsvValidatorResult::TEST_RESULTS => [
-                        '\'digitalObjectUri\' column appears more than once in file.',
+                        '\'digitalObjectURI\' column appears more than once in file.',
                         'Unable to validate because of duplicated columns in CSV.',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [

--- a/test/phpunit/csvImportValidator/CsvEventValuesTest.php
+++ b/test/phpunit/csvImportValidator/CsvEventValuesTest.php
@@ -138,7 +138,7 @@ class CsvEventValuesTest extends \PHPUnit\Framework\TestCase
                         'Event value mismatches found: 1',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
-                        ',,,Chemise,,,creation|donation,2010,01-01-2010,,,fr',
+                        'CSV row numbers where issues were found: 3',
                     ],
                 ],
             ],

--- a/test/phpunit/csvImportValidator/CsvFileEncodingTest.php
+++ b/test/phpunit/csvImportValidator/CsvFileEncodingTest.php
@@ -142,8 +142,11 @@ class CsvFileEncodingTest extends \PHPUnit\Framework\TestCase
                     CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_ERROR,
                     CsvValidatorResult::TEST_RESULTS => [
                         'File encoding does not appear to be UTF-8 compatible.',
+                        'Count of UTF-8 incompatible CSV rows: 1',
                     ],
-                    CsvValidatorResult::TEST_DETAILS => [implode(',', str_getcsv(mb_convert_encoding('"D20202", "DJ002", "", "Voûte, étagère 0074", "", "", "", ""', 'Windows-1252', 'UTF-8')))],
+                    CsvValidatorResult::TEST_DETAILS => [
+                        'Affected row numbers (first 10): 4',
+                    ],
                 ],
             ],
 
@@ -156,8 +159,11 @@ class CsvFileEncodingTest extends \PHPUnit\Framework\TestCase
                     CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_ERROR,
                     CsvValidatorResult::TEST_RESULTS => [
                         'File encoding does not appear to be UTF-8 compatible.',
+                        'Count of UTF-8 incompatible CSV rows: 1',
                     ],
-                    CsvValidatorResult::TEST_DETAILS => [implode(',', str_getcsv(mb_convert_encoding('"D20202", "DJ002", "", "Voûte, étagère 0074", "", "", "", ""', 'Windows-1252', 'UTF-8')))],
+                    CsvValidatorResult::TEST_DETAILS => [
+                        'Affected row numbers (first 10): 4',
+                    ],
                 ],
             ],
 

--- a/test/phpunit/csvImportValidator/CsvLanguageTest.php
+++ b/test/phpunit/csvImportValidator/CsvLanguageTest.php
@@ -137,8 +137,7 @@ class CsvLanguageTest extends \PHPUnit\Framework\TestCase
                         'Invalid language values: Spanish, en_gb',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
-                        'B10101,DJ001,ID1,Some Photographs,,Extent and medium 1,,es,Spanish',
-                        ',DJ003,ID4,Title Four,,,,en,en_gb',
+                        'CSV row numbers where issues were found: 2, 5',
                     ],
                 ],
             ],

--- a/test/phpunit/csvImportValidator/CsvLegacyIdTest.php
+++ b/test/phpunit/csvImportValidator/CsvLegacyIdTest.php
@@ -32,6 +32,14 @@ class CsvLegacyIdTest extends \PHPUnit\Framework\TestCase
             '"B10101 "," DJ001","ID1 ","Some Photographs","","Extent and medium 1","",""',
             '"","","","Chemise","","","","fr"',
             '"D20202", "DJ002", "", "Voûte, étagère 0074", "", "", "", ""',
+            '"B10101", "DJ003", "ID4", "Title Four", "","", "", "fr"',
+            '"B10101", "DJ005", "ID5", "Title Five", "","", "", "en"',
+        ];
+
+        $this->csvDataDuplicatedLegacyIdCulture = [
+            '"B10101 "," DJ001","ID1 ","Some Photographs","","Extent and medium 1","",""',
+            '"","","","Chemise","","","","fr"',
+            '"D20202", "DJ002", "", "Voûte, étagère 0074", "", "", "", ""',
             '"B10101", "DJ003", "ID4", "Title Four", "","", "", "en"',
             '"B10101", "DJ005", "ID5", "Title Five", "","", "", "en"',
         ];
@@ -47,7 +55,7 @@ class CsvLegacyIdTest extends \PHPUnit\Framework\TestCase
             '"B10101 "," DJ001","ID1 ","Some Photographs","","Extent and medium 1","","", ""',
             '"","","","Chemise","","","","fr", ""',
             '"D20202", "DJ002", "", "Voûte, étagère 0074", "", "", "", "", "D20202"',
-            '"B10101", "DJ003", "ID4", "Title Four", "","", "", "en", ""',
+            '"B10101", "DJ003", "ID4", "Title Four", "","", "", "fr", ""',
             '"B10101", "DJ005", "ID5", "Title Five", "","", "", "en", "B10101"',
         ];
 
@@ -55,6 +63,7 @@ class CsvLegacyIdTest extends \PHPUnit\Framework\TestCase
         $directory = [
             'unix_csv_without_utf8_bom.csv' => $this->csvHeader."\n".implode("\n", $this->csvData),
             'unix_csv_with_duplicated_legacy_id.csv' => $this->csvHeader."\n".implode("\n", $this->csvDataDuplicatedLegacyId),
+            'unix_csv_with_duplicated_legacy_id_culture.csv' => $this->csvHeader."\n".implode("\n", $this->csvDataDuplicatedLegacyIdCulture),
             'unix_csv_missing_legacy_id.csv' => $this->csvHeaderMissingLegacyId."\n".implode("\n", $this->csvDataMissingLegacyId),
             'unix_csv_with_duplicated_legacy_id_column.csv' => $this->csvHeaderDupedLegacyId."\n".implode("\n", $this->csvDataDuplicatedLegacyIdColumn),
         ];
@@ -126,8 +135,7 @@ class CsvLegacyIdTest extends \PHPUnit\Framework\TestCase
                         'Future CSV updates may not match these records.',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
-                        ',,,Chemise,,,,fr',
-                        ',DJ003,ID4,Title Four,,,,en',
+                        'CSV row numbers missing \'legacyId\': 3, 5',
                     ],
                 ],
             ],
@@ -138,15 +146,36 @@ class CsvLegacyIdTest extends \PHPUnit\Framework\TestCase
                     'filename' => '/unix_csv_with_duplicated_legacy_id.csv',
                     'testname' => 'CsvLegacyIdValidator',
                     CsvValidatorResult::TEST_TITLE => CsvLegacyIdValidator::TITLE,
-                    CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_ERROR,
+                    CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_WARN,
                     CsvValidatorResult::TEST_RESULTS => [
                         'Rows with non-unique \'legacyId\' values: 1',
                         'Rows with empty \'legacyId\' column: 1',
                         'Future CSV updates may not match these records.',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
-                        ',,,Chemise,,,,fr',
                         'Non-unique \'legacyId\' values: B10101',
+                        'CSV row numbers missing \'legacyId\': 3',
+                    ],
+                ],
+            ],
+
+            [
+                'CsvLegacyTest-DuplicatedLegacyIdCulture' => [
+                    'csvValidatorClasses' => 'CsvLegacyIdValidator',
+                    'filename' => '/unix_csv_with_duplicated_legacy_id_culture.csv',
+                    'testname' => 'CsvLegacyIdValidator',
+                    CsvValidatorResult::TEST_TITLE => CsvLegacyIdValidator::TITLE,
+                    CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_ERROR,
+                    CsvValidatorResult::TEST_RESULTS => [
+                        'Rows with non-unique \'legacyId\' values: 1',
+                        'Consecutive CSV rows with matching legacyId and culture will trigger errors during CSV import.',
+                        'Rows with empty \'legacyId\' column: 1',
+                        'Future CSV updates may not match these records.',
+                    ],
+                    CsvValidatorResult::TEST_DETAILS => [
+                        'Non-unique \'legacyId\' values: B10101',
+                        'Duplicate translation values for: legacyId: B10101; culture: en',
+                        'CSV row numbers missing \'legacyId\': 3',
                     ],
                 ],
             ],

--- a/test/phpunit/csvImportValidator/CsvParentTest.php
+++ b/test/phpunit/csvImportValidator/CsvParentTest.php
@@ -191,12 +191,10 @@ class CsvParentTest extends \PHPUnit\Framework\TestCase
                         'Rows with parentId populated: 3',
                         '\'legacyId\' column not found. Unable to verify parentId values.',
                         'Verifying parentId values against legacyId values in this file.',
-                        'Number of parentID values found for which there is no matching legacyID (will import as top level records): 3',
+                        'Number of parentId values found for which there is no matching legacyID (will import as top level records): 3',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
-                        'DJ001,ID1,Some Photographs,,Extent and medium 1,,',
-                        'DJ002,,Voûte, étagère 0074,,,,',
-                        'DJ003,ID4,Title Four,,,,en',
+                        'CSV row numbers where issues were found: 2, 4, 5',
                     ],
                 ],
             ],
@@ -226,12 +224,10 @@ class CsvParentTest extends \PHPUnit\Framework\TestCase
                     CsvValidatorResult::TEST_RESULTS => [
                         'Rows with parentId populated: 3',
                         'Verifying parentId values against legacyId values in this file.',
-                        'Number of parentID values found for which there is no matching legacyID (will import as top level records): 3',
+                        'Number of parentId values found for which there is no matching legacyID (will import as top level records): 3',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
-                        'B10101,DJ001,ID1,Some Photographs,,Extent and medium 1,,',
-                        'D20202,DJ002,,Voûte, étagère 0074,,,,',
-                        ',DJ003,ID4,Title Four,,,,en',
+                        'CSV row numbers where issues were found: 2, 4, 5',
                     ],
                 ],
             ],
@@ -245,6 +241,7 @@ class CsvParentTest extends \PHPUnit\Framework\TestCase
                     CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_INFO,
                     CsvValidatorResult::TEST_RESULTS => [
                         'Rows with parentId populated: 1',
+                        'Verifying parentId values against legacyId values in this file.',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
                     ],
@@ -263,6 +260,7 @@ class CsvParentTest extends \PHPUnit\Framework\TestCase
                     CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_INFO,
                     CsvValidatorResult::TEST_RESULTS => [
                         'Rows with parentId populated: 1',
+                        'Verifying parentId values against legacyId values in this file, and AtoM database.',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
                     ],
@@ -279,10 +277,10 @@ class CsvParentTest extends \PHPUnit\Framework\TestCase
                     CsvValidatorResult::TEST_RESULTS => [
                         'Rows with parentId populated: 1',
                         'Verifying parentId values against legacyId values in this file.',
-                        'Number of parentID values found for which there is no matching legacyID (will import as top level records): 1',
+                        'Number of parentId values found for which there is no matching legacyID (will import as top level records): 1',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
-                        'D20202,A10101,,Voûte, étagère 0074,,,,',
+                        'CSV row numbers where issues were found: 4',
                     ],
                 ],
             ],
@@ -299,6 +297,7 @@ class CsvParentTest extends \PHPUnit\Framework\TestCase
                     CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_INFO,
                     CsvValidatorResult::TEST_RESULTS => [
                         'Rows with parentId populated: 1',
+                        'Verifying parentId values against legacyId values in this file, and AtoM database.',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
                     ],
@@ -314,10 +313,11 @@ class CsvParentTest extends \PHPUnit\Framework\TestCase
                     CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_ERROR,
                     CsvValidatorResult::TEST_RESULTS => [
                         'Rows with qubitParentSlug populated: 2',
-                        'Number of parentID values found for which there is no matching legacyID (will import as top level records): 1',
+                        'Verifying qubitParentSlug values against object slugs in the AtoM database.',
+                        'Number of qubitParentSlug values found for which there is no matching slug (will import as top level records): 1',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
-                        'X7,missing-slug,TY99,Some stuff,,,,en',
+                        'CSV row numbers where issues were found: 6',
                     ],
                 ],
             ],
@@ -334,6 +334,8 @@ class CsvParentTest extends \PHPUnit\Framework\TestCase
                         'Rows with qubitParentSlug populated: 2',
                         'Rows with both \'parentId\' and \'qubitParentSlug\' populated: 1',
                         'Column \'qubitParentSlug\' will override \'parentId\' if both are populated.',
+                        'Verifying parentId values against legacyId values in this file.',
+                        'Verifying qubitParentSlug values against object slugs in the AtoM database.',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
                     ],

--- a/test/phpunit/csvImportValidator/CsvRepoTest.php
+++ b/test/phpunit/csvImportValidator/CsvRepoTest.php
@@ -142,9 +142,7 @@ class CsvRepoTest extends \PHPUnit\Framework\TestCase
                         'New repository records will be created for: new repo 1,new repo 2',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
-                        'B10101,DJ001,ID1,Some Photographs,,Extent and medium 1,new repo 1,es',
-                        'D20202,DJ002,,Voûte, étagère 0074,,,new repo 2,de',
-                        ',DJ003,ID4,Title Four,,,new repo 1,en',
+                        'CSV row numbers where issues were found: 2, 4, 5',
                     ],
                 ],
             ],

--- a/test/phpunit/csvImportValidator/CsvSampleValuesTest.php
+++ b/test/phpunit/csvImportValidator/CsvSampleValuesTest.php
@@ -76,6 +76,7 @@ class CsvSampleValuesTest extends \PHPUnit\Framework\TestCase
                     CsvValidatorResult::TEST_STATUS => CsvValidatorResult::RESULT_INFO,
                     CsvValidatorResult::TEST_RESULTS => [
                         'Empty columns detected: levelOfDescription,repository',
+                        '',
                         'legacyId:  B10101',
                         'parentId:  DJ001',
                         'identifier:  ID1',

--- a/test/phpunit/csvImportValidator/CsvScriptTest.php
+++ b/test/phpunit/csvImportValidator/CsvScriptTest.php
@@ -137,10 +137,7 @@ class CsvScriptTest extends \PHPUnit\Framework\TestCase
                         'Invalid scriptOfDescription values: Latin, Gggg, HGGG, LATN',
                     ],
                     CsvValidatorResult::TEST_DETAILS => [
-                        'B10101,DJ001,ID1,Some Photographs,,Extent and medium 1,,es,Latin',
-                        ',,,Chemise,,,,fr,Copt|Latin',
-                        'D20202,DJ002,,Voûte, étagère 0074,,,,de,Gggg|HGGG',
-                        ',DJ003,ID4,Title Four,,,,en,LATN',
+                        'CSV row numbers where issues were found: 2, 3, 4, 5',
                     ],
                 ],
             ],

--- a/test/phpunit/csvImportValidator/CsvValidatorResultCollectionTest.php
+++ b/test/phpunit/csvImportValidator/CsvValidatorResultCollectionTest.php
@@ -76,6 +76,6 @@ class CsvValidatorResultCollectionTest extends \PHPUnit\Framework\TestCase
         $resultCollection = new CsvValidatorResultCollection();
         $resultCollection->appendResult($result);
 
-        $this->assertIsString($resultCollection->renderResultsAsText($resultCollection));
+        $this->assertIsString($resultCollection->renderResultsAsText(true));
     }
 }


### PR DESCRIPTION
This commit contains enhancements to the CSV Validation utility:
- Add error and warning numbers to output reports.
- Updates the character encoding validator output to include only the first 10 CSV line numbers that triggered the error.
- In some validators, if an issue was detected in a CSV row, the entire row would be appended to the detailed results. When there are several rows this becomes difficult to read. This commit replaces this output with a summary of the row numbers that triggered the errors.
- Add more specific messaging to the parentId validator when QubitParentSlug is the source of an issue (vs parentId).
- if duplicate legacyIds are consecutive and culture is also the same then throw an error as this will trigger a duplicate translation error on import.
- DO Path check will no longer stop when the digitalObjectPath is populated but the path option is not set. Instead it will complete and output the files that were unable to be found.
- digitalObjectURI validator will now check 'digitalObjectURI' and not 'digitalObjectUri'.