### PR TITLE
Use aria-invalid when a field has errors

### DIFF
--- a/lib/helper/QubitHelper.php
+++ b/lib/helper/QubitHelper.php
@@ -115,6 +115,7 @@ function render_b5_field($field, $translation = null, $options = [])
 
     if ($field->hasError()) {
         $options['class'] .= ' is-invalid';
+        $options['aria-invalid'] = 'true';
         if (isset($options['aria-describedby'])) {
             $options['aria-describedby'] .= ' '.$name.'-errors';
         } else {


### PR DESCRIPTION
[`aria-invalid`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-invalid_attribute) seems to be an effective way to indicate validity state in server-side validation for assitive technologies. In this [post](https://stackoverflow.com/a/52651709), the author says:

> So to cover all your bases, I would recommend setting aria-invalid. It's great that you don't want to be redundant, but at least being redundant doesn't hurt anything. It's just extra code or typing you have to do.