### PR TITLE
arDominionB5Plugin: add sidebar treeview fixes

### DIFF
--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_treeView.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_treeView.php
@@ -118,7 +118,7 @@
 
     </div>
   <?php } else { ?>
-    <div class="d-flex justify-content-end flex-wrap gap-2 ms-auto" id="fullwidth-treeview">
+    <div id="fullwidth-treeview" hidden>
       <input type="button" id="fullwidth-treeview-reset-button" value="<?php echo __('Reset'); ?>" />
       <input type="button" id="fullwidth-treeview-more-button" data-label="<?php echo __('%1% more'); ?>" value="" />
       <span

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_treeView.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_treeView.php
@@ -132,7 +132,7 @@
     </div>
   <?php } ?>
 
-  <div class="tab-pane fade<?php echo ('sidebar' != $treeviewType) ? ' show active' : ''; ?>" id="treeview-search" role="tabpanel" aria-labelledby="treeview-search-tab">
+  <div class="tab-pane fade bg-white<?php echo ('sidebar' != $treeviewType) ? ' show active' : ''; ?>" id="treeview-search" role="tabpanel" aria-labelledby="treeview-search-tab">
 
     <form method="get" role="search" action="<?php echo url_for(['module' => 'search', 'action' => 'index', 'collection' => $resource->getCollectionRoot()->id]); ?>" data-not-found="<?php echo __('No results found.'); ?>">
       <div class="input-group p-2 bg-gray border">


### PR DESCRIPTION
* Adds background to the sidebar treeview, fixing the following issue happening when the user chooses a different background color:
  ![error1](https://user-images.githubusercontent.com/606459/130921944-2070d313-9cf2-4c23-999c-97de8127e45f.png)
* Hides `#fullwidth-treeview` which `fullWidthTreeView.js` seems to be using only to extract its contents, but not its properties. E.g. in informationobject/reports.
   ![error2](https://user-images.githubusercontent.com/606459/130921949-88b0d687-7745-4275-8bbb-dcce34a4791e.png)
