### PR TITLE
Set manual L.O.D. in CSV transform, refs #13557

### DIFF
--- a/lib/QubitCsvTransformFactory.class.php
+++ b/lib/QubitCsvTransformFactory.class.php
@@ -30,6 +30,7 @@ class QubitCsvTransformFactory
     public $setupLogic;
     public $transformLogic;
     public $preserveOrder;
+    public $levelsOfDescription;
     public $convertWindowsEncoding;
 
     public function __construct($options = [])
@@ -46,6 +47,7 @@ class QubitCsvTransformFactory
             'setupLogic',
             'transformLogic',
             'preserveOrder',
+            'levelsOfDescription',
             'convertWindowsEncoding',
         ];
 
@@ -80,6 +82,7 @@ class QubitCsvTransformFactory
             ],
 
             'preserveOrder' => $this->preserveOrder,
+            'levelsOfDescription' => $this->levelsOfDescription,
             'convertWindowsEncoding' => $this->convertWindowsEncoding,
 
             'setupLogic' => $this->setupLogic,
@@ -132,6 +135,7 @@ class QubitCsvTransformFactory
                     ],
 
                     'preserveOrder' => $self->preserveOrder,
+                    'levelsOfDescription' => $self->levelsOfDescription,
                     'convertWindowsEncoding' => $self->convertWindowsEncoding,
 
                     'errorLog' => $self->errorLog,


### PR DESCRIPTION
Added logic to allow available levels of description, used to order
the output of CSV rows by level of description hierarchy, to be set
manually rather than being restricted to the default AtoM levels of
description.

Also made numberedFilePathVariation method static so a script can
be used to generate an import Bash script for CSV transformations
that generate a lot of CSV files.