### PR TITLE
Fix issues with report page, refs #13553

### DIFF
--- a/apps/qubit/modules/informationobject/actions/reportsAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/reportsAction.class.php
@@ -73,7 +73,7 @@ class InformationObjectReportsAction extends sfAction
                     $choices = [];
                 }
 
-                if ($this->getUser()->isAuthenticated()) {
+                if ($this->getUser()->isAuthenticated() && count($this->resource->getPhysicalObjects())) {
                     $choices[$this->context->routing->generate(null, [$this->resource, 'module' => 'informationobject', 'action' => 'storageLocations'])] = $this->context->i18n->__('Physical storage locations');
                     $choices[$this->context->routing->generate(null, [$this->resource, 'module' => 'informationobject', 'action' => 'boxLabel'])] = $this->context->i18n->__('Box label');
                 }

--- a/apps/qubit/modules/informationobject/templates/reportsSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/reportsSuccess.php
@@ -47,7 +47,9 @@
 <?php slot('after-content'); ?>
   <section class="actions">
     <ul class="clearfix links">
-      <li><input class="form-submit c-btn c-btn-submit" type="submit" value="<?php echo __('Continue'); ?>"/></li>
+      <?php if ($reportsAvailable) { ?>
+        <li><input class="form-submit c-btn c-btn-submit" type="submit" value="<?php echo __('Continue'); ?>"/></li>
+      <?php } ?>
       <li><?php echo link_to(__('Cancel'), [$resource, 'module' => 'informationobject'], ['class' => 'c-btn']); ?></li>
     </ul>
   </section>


### PR DESCRIPTION
Fixed two issues with the report page:
* "Continue" button was showing even when no reports where available to generate
* Physical object-related reports were available even for descriptions with no physical objects