### PR TITLE
Add reindex message to task output, refs #13387

### DIFF
--- a/lib/task/propel/propelBuildNestedSetTask.class.php
+++ b/lib/task/propel/propelBuildNestedSetTask.class.php
@@ -93,6 +93,11 @@ class propelBuildNestedSetTask extends sfBaseTask
             $this->conn->commit();
         }
 
+        $this->logSection(
+            'propel',
+            'Note: you will need to rebuild your search index for updates to show up properly in search results.'
+        );
+
         $this->logSection('propel', 'Done!');
     }
 


### PR DESCRIPTION
Redmine issue [#13387](https://projects.artefactual.com/issues/13387) includes the following:

> After propel:build-nested-set there are reportedly issues if the search index isn't re-indexed afterwards. This is reportedly not documented. We should document this and also modify the propel:build-nested-set task to warn the user.

This PR adds a brief log output message reminding the user to reindex after running the build-nested-set task. I modeled the change after a similar message in the generate-slugs task. 

Once approved, I will also add a reminder in the relevant documentation. 