### PR TITLE
Fullwidth treeview fixes, refs #13530

### DIFF
--- a/plugins/arDominionB5Plugin/js/imageflow.js
+++ b/plugins/arDominionB5Plugin/js/imageflow.js
@@ -1,40 +1,54 @@
 (($) => {
   "use strict";
-  $(() => {
-    var node = $("#atom-digital-object-carousel");
+  Drupal.behaviors.imageflow = {
+    attach: () => {
+      var node = $("#atom-digital-object-carousel");
 
-    if ($(node).length) {
-      $("#atom-slider-images").slick({
-        slidesToShow: 1,
-        slidesToScroll: 1,
-        asNavFor: "#atom-slider-title",
-        dots: true,
-        centerMode: true,
-        instructionsText: $(node).data("carousel-instructions-text-image-link"),
-        regionLabel: $(node).data("data-carousel-images-region-label"),
-        variableWidth: true,
-        centerPadding: "60px",
-        nextArrow:
-          '<button class="slick-next slick-arrow" type="button" style=""><span class="slick-next-icon" aria-hidden="true"></span><span class="slick-sr-only">' +
-          $(node).data("carousel-next-arrow-button-text") +
-          "</span></button>",
-        prevArrow:
-          '<button class="slick-prev slick-arrow" type="button" style=""><span class="slick-prev-icon" aria-hidden="true"></span><span class="slick-sr-only">' +
-          $(node).data("carousel-prev-arrow-button-text") +
-          "</span></button>",
-      });
+      if (!$(node).length) {
+        return;
+      }
 
-      $("#atom-slider-title").slick({
-        centerMode: true,
-        slidesToShow: 1,
-        slidesToScroll: 1,
-        draggable: false,
-        swipe: false,
-        arrows: false,
-        fade: true,
-        instructionsText: $(node).data("carousel-instructions-text-text-link"),
-        regionLabel: $(node).data("data-carousel-title-region-label"),
-      });
-    }
-  });
+      $(node)
+        .imagesLoaded()
+        .always(() => {
+          $("#atom-slider-images").slick({
+            slidesToShow: 1,
+            slidesToScroll: 1,
+            asNavFor: "#atom-slider-title",
+            dots: true,
+            centerMode: true,
+            instructionsText: $(node).data(
+              "carousel-instructions-text-image-link"
+            ),
+            regionLabel: $(node).data("data-carousel-images-region-label"),
+            variableWidth: true,
+            centerPadding: "60px",
+            nextArrow:
+              '<button class="slick-next slick-arrow" type="button" style=""><span class="slick-next-icon" aria-hidden="true"></span><span class="slick-sr-only">' +
+              $(node).data("carousel-next-arrow-button-text") +
+              "</span></button>",
+            prevArrow:
+              '<button class="slick-prev slick-arrow" type="button" style=""><span class="slick-prev-icon" aria-hidden="true"></span><span class="slick-sr-only">' +
+              $(node).data("carousel-prev-arrow-button-text") +
+              "</span></button>",
+          });
+
+          $("#atom-slider-title").slick({
+            centerMode: true,
+            slidesToShow: 1,
+            slidesToScroll: 1,
+            draggable: false,
+            swipe: false,
+            arrows: false,
+            fade: true,
+            instructionsText: $(node).data(
+              "carousel-instructions-text-text-link"
+            ),
+            regionLabel: $(node).data("data-carousel-title-region-label"),
+          });
+
+          $("#atom-slider-images").slick("slickGoTo", 0);
+        });
+    },
+  };
 })(jQuery);

--- a/plugins/arDominionB5Plugin/js/mediaelement.js
+++ b/plugins/arDominionB5Plugin/js/mediaelement.js
@@ -1,0 +1,16 @@
+(function ($) {
+  "use strict";
+
+  Drupal.behaviors.mediaelement = {
+    attach: function (context) {
+      $("video, audio", context).each(function () {
+        $(this).mediaelementplayer({
+          pluginPath: "node_modules/mediaelement/build/",
+          renderers: ["html5", "flash_video"],
+          alwaysShowControls: true,
+          stretching: "responsive",
+        });
+      });
+    },
+  };
+})(jQuery);

--- a/plugins/arDominionB5Plugin/modules/digitalobject/templates/_showAudio.php
+++ b/plugins/arDominionB5Plugin/modules/digitalobject/templates/_showAudio.php
@@ -9,7 +9,7 @@
 <?php } elseif (QubitTerm::REFERENCE_ID == $usageType) { ?>
 
   <?php if ($showMediaPlayer) { ?>
-    <audio class="mejs__player mw-100" data-mejsoptions='{"pluginPath": "node_modules/mediaelement/build/", "renderers": ["html5", "flash_video"], "alwaysShowControls": "true", "stretching": "responsive"}' src="<?php echo public_path($representation->getFullPath()); ?>">
+    <audio class="mw-100" src="<?php echo public_path($representation->getFullPath()); ?>">
       <?php echo get_component('digitalobject', 'show', ['resource' => $resource, 'usageType' => QubitTerm::CHAPTERS_ID]); ?>
     </audio>
   <?php } else { ?>

--- a/plugins/arDominionB5Plugin/modules/digitalobject/templates/_showVideo.php
+++ b/plugins/arDominionB5Plugin/modules/digitalobject/templates/_showVideo.php
@@ -25,7 +25,7 @@
 <?php } elseif (QubitTerm::REFERENCE_ID == $usageType) { ?>
 
   <?php if ($showMediaPlayer) { ?>
-    <video preload="metadata" class="mejs__player mw-100" data-mejsoptions='{"pluginPath": "node_modules/mediaelement/build/", "renderers": ["html5", "flash_video"], "alwaysShowControls": "true", "stretching": "responsive"}' src="<?php echo public_path($representation->getFullPath()); ?>">
+    <video preload="metadata" class="mw-100" src="<?php echo public_path($representation->getFullPath()); ?>">
       <?php echo get_component('digitalobject', 'show', ['resource' => $resource, 'usageType' => QubitTerm::CHAPTERS_ID]); ?>
       <?php echo get_component('digitalobject', 'show', ['resource' => $resource, 'usageType' => QubitTerm::SUBTITLES_ID]); ?>
     </video>

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_treeView.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_treeView.php
@@ -118,7 +118,7 @@
 
     </div>
   <?php } else { ?>
-    <div id="fullwidth-treeview" hidden>
+    <div id="fullwidth-treeview-capable" data-treeview-alert-close="<?php echo __('Close'); ?>" hidden>
       <input type="button" id="fullwidth-treeview-reset-button" value="<?php echo __('Reset'); ?>" />
       <input type="button" id="fullwidth-treeview-more-button" data-label="<?php echo __('%1% more'); ?>" value="" />
       <span

--- a/plugins/arDominionB5Plugin/scss/_fullwidthtreeview.scss
+++ b/plugins/arDominionB5Plugin/scss/_fullwidthtreeview.scss
@@ -1,57 +1,42 @@
 // From css/fullWidthTreeView.css
-#fullwidth-treeview-header {
-  border: 1px solid #ddd;
-  border-bottom: none;
-  height: 20px;
-}
-
-#fullwidth-treeview-header div {
-  float: left;
-  background-color: #eee;
-  padding-left: 7px;
-}
-
 #fullwidth-treeview-row {
-  margin-bottom: 30px;
-  border: 1px solid #ddd;
   clear: both;
 }
 
 #fullwidth-treeview {
   overflow-x: hidden;
   height: 100%;
-  background-color: #ffffff;
+  background-color: $white;
+  border: $border-width solid $border-color;
+  border-top-left-radius: $border-radius;
+  border-top-right-radius: $border-radius;
+  margin-bottom: $spacer;
+}
+
+#fullwidth-treeview-row {
+  margin-bottom: $spacer * 1.5;
+  clear: both;
 }
 
 .ui-resizable-s {
   background-image: url("/images/resizable_grip.png");
-  height: 9px;
-  border: 1px solid #ddd;
+  height: $spacer * 0.75;
+  border: $border-width solid $border-color;
+  border-bottom-right-radius: $border-radius;
+  border-bottom-left-radius: $border-radius;
   cursor: ns-resize;
   background-repeat: no-repeat;
   background-position: center center;
-  background-color: #eee;
-  bottom: -11px;
-  left: -1px;
-  margin: -1px;
-}
-
-.fullwidth-treeview-toggle.active {
-  border: 1px inset #eee;
-}
-
-#fullwidth-treeview-loading {
-  float: right;
-  margin-right: 110px;
-  margin-top: 4px;
+  background-color: $gray-200;
+  bottom: -$spacer * 0.7;
 }
 
 .ui-resizable-s:hover {
-  background-color: #ddd;
+  background-color: $gray-300;
 }
 
 #treeview-menu li.disabled a {
-  color: #ddd;
+  color: $gray-300;
 }
 
 #fullwidth-treeview-row a.jstree-anchor {
@@ -60,18 +45,19 @@
   text-overflow: ellipsis;
 }
 
+.jstree-default .jstree-clicked {
+  background-color: $gray-400 !important;
+}
+
+.jstree-anchor {
+  &:hover {
+    background-color: $gray-200;
+  }
+}
+
 .hierarchy > .container > input[type="button"],
 #main-column > input[type="button"] {
   margin-top: 14px;
   margin-left: 6px;
   float: right;
-}
-
-// From search.less
-.full-treeview-section {
-  background-color: $gray-200;
-  border: 1px solid $black;
-  .actions {
-    margin-bottom: -20px;
-  }
 }

--- a/plugins/arDominionB5Plugin/templates/_layout_end.php
+++ b/plugins/arDominionB5Plugin/templates/_layout_end.php
@@ -39,6 +39,7 @@
     <script src="/plugins/arDominionB5Plugin/js/modal.js"></script>
     <script src="/plugins/arDominionB5Plugin/js/advancedSearch.js"></script>
     <script src="/plugins/arDominionB5Plugin/js/permissionSettings.js"></script>
+    <script src="/plugins/arDominionB5Plugin/js/mediaelement.js"></script>
     <script src="/plugins/sfTranslatePlugin/js/l10n_client.js"></script>
     <script src="/js/blank.js"></script>
     <script src="/js/editingHistory.js"></script>


### PR DESCRIPTION
These commits address various issues with the Treeview in B5:
- add imageflow.js to common behaviours - fixes carousel after treeview reload.
- add mediaelement.js to common behaviours - fixes mediaelement player after treeview reload.
- fix ambiguous reference to "#main-column .row".
- tooltip styling updated
- modified Treeview styling
- changed the id that is used to allow the display of the treeview on an index page to be "#fullwidth-treeview-capable" instead of "#fullwidth-treeview" which was already in use.

Treeview alert box handling:
- leave "job initiated" messages in place unless another move is started
- if another move is started, remove job initiated alerts as they will be recreated.
