### PR TITLE
Add index page section button arrows

### DIFF
--- a/lib/helper/QubitHelper.php
+++ b/lib/helper/QubitHelper.php
@@ -325,7 +325,7 @@ function render_b5_show_value($value, $options = [])
 
 function render_b5_section_label_css_classes($options = [])
 {
-    return 'border-bottom h5 m-0 p-3 text-primary';
+    return 'border-bottom h5 m-0 p-3 text-primary atom-section-button';
 }
 
 function render_b5_section_label($label, $options = [])

--- a/plugins/arDominionB5Plugin/scss/_buttons.scss
+++ b/plugins/arDominionB5Plugin/scss/_buttons.scss
@@ -92,3 +92,24 @@
     }
   }
 }
+
+// Index page section right facing arrows.
+#content a .atom-section-button {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: $spacer $spacer * 1.25;
+  text-align: left;
+  overflow-anchor: none;
+
+  &::after {
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23212529'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
+    transform: rotate(-90deg);
+    width: $spacer * 1.25;
+    height: $spacer * 1.25;
+    margin-left: auto;
+    content: "";
+    background-repeat: no-repeat;
+  }
+}


### PR DESCRIPTION
Add arrow icons pointing to the right for each AtoM index page section
when it is a link.

Arrow icon matches what is used for the B5 accordion header button.