### PR TITLE
Add CSV transformation custom order, refs #13565

### DIFF
--- a/lib/QubitCsvTransform.class.php
+++ b/lib/QubitCsvTransform.class.php
@@ -24,6 +24,7 @@ class QubitCsvTransform extends QubitFlatfileImport
     public $rowsPerFile = 1000;
     public $preserveOrder = false;
     public $levelsOfDescription;
+    public $sortOrderCallback;
     public $convertWindowsEncoding = false;
 
     private $link;

--- a/lib/QubitCsvTransformFactory.class.php
+++ b/lib/QubitCsvTransformFactory.class.php
@@ -30,6 +30,7 @@ class QubitCsvTransformFactory
     public $setupLogic;
     public $transformLogic;
     public $preserveOrder;
+    public $sortOrderCallback;
     public $levelsOfDescription;
     public $convertWindowsEncoding;
 
@@ -47,6 +48,7 @@ class QubitCsvTransformFactory
             'setupLogic',
             'transformLogic',
             'preserveOrder',
+            'sortOrderCallback',
             'levelsOfDescription',
             'convertWindowsEncoding',
         ];
@@ -82,6 +84,7 @@ class QubitCsvTransformFactory
             ],
 
             'preserveOrder' => $this->preserveOrder,
+            'sortOrderCallback' => $this->sortOrderCallback,
             'levelsOfDescription' => $this->levelsOfDescription,
             'convertWindowsEncoding' => $this->convertWindowsEncoding,
 
@@ -135,6 +138,7 @@ class QubitCsvTransformFactory
                     ],
 
                     'preserveOrder' => $self->preserveOrder,
+                    'sortOrderCallback' => $self->sortOrderCallback,
                     'levelsOfDescription' => $self->levelsOfDescription,
                     'convertWindowsEncoding' => $self->convertWindowsEncoding,
 
@@ -174,6 +178,8 @@ class QubitCsvTransformFactory
                         if ($levelOfDescriptionAvailable) {
                             if (!empty($self->preserveOrder)) {
                                 $sortorder = $self->getStatus('rows');
+                            } elseif (!empty($self->sortOrderCallback) && is_callable($self->sortOrderCallback)) {
+                                $sortorder = call_user_func_array($self->sortOrderCallback, [$self]);
                             } else {
                                 $sortorder = $self->levelOfDescriptionToSortorder($self->columnValue('levelOfDescription'));
                             }


### PR DESCRIPTION
Added the ability to define a custom sort order, for CSV row output,
using logic defined in a new property, "sortOrderLogic", in the
QubitCsvTransform and QubitCsvTransformFactory classes.