### PR TITLE
Fix Digital Object filter tag behaviour, refs #13547

### DIFF
--- a/apps/qubit/modules/actor/actions/browseAction.class.php
+++ b/apps/qubit/modules/actor/actions/browseAction.class.php
@@ -375,8 +375,10 @@ class ActorBrowseAction extends DefaultBrowseAction
         // Set label for has digital object filter tag
         if (filter_var($request->hasDigitalObject, FILTER_VALIDATE_BOOLEAN)) {
             $this->setFilterTagLabel('hasDigitalObject', $this->i18n->__('With digital objects'));
-        } else {
+        } elseif ('0' === $request->hasDigitalObject) {
             $this->setFilterTagLabel('hasDigitalObject', $this->i18n->__('Without digital objects'));
+        } else {
+            unset($request->hasDigitalObject);
         }
 
         if (!empty($request->emptyField)) {

--- a/apps/qubit/modules/informationobject/actions/browseAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/browseAction.class.php
@@ -503,8 +503,10 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
         // Set label for has digital object filter tag
         if (filter_var($request->onlyMedia, FILTER_VALIDATE_BOOLEAN)) {
             $this->setFilterTagLabel('onlyMedia', $i18n->__('With digital objects'));
-        } else {
+        } elseif ('0' === $request->onlyMedia) {
             $this->setFilterTagLabel('onlyMedia', $i18n->__('Without digital objects'));
+        } else {
+            unset($request->onlyMedia);
         }
 
         // Set label for languages filter tag


### PR DESCRIPTION
Unset hasDigitalObject/onlyMedia tag when "Digital Object Available" option is left blank in Advanced Search of Authority Records and Archival Descriptions.