### PR TITLE
Fix ListIdentifiers timeframe params, refs #13568

### DIFF
--- a/plugins/arOaiPlugin/lib/arOaiPluginComponent.class.php
+++ b/plugins/arOaiPlugin/lib/arOaiPluginComponent.class.php
@@ -79,7 +79,12 @@ abstract class arOaiPluginComponent extends sfComponent
         }
     }
 
-    public function getUpdates($options = [])
+    /**
+     * Get OAI-PMH results by collection and updated_at datetime range.
+     *
+     * @param array $options optional parameters
+     */
+    public function getUpdates(array $options = [])
     {
         $presetOptions = [
             'from' => $this->from,

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/actions/listIdentifiersComponent.class.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/actions/listIdentifiersComponent.class.php
@@ -26,6 +26,8 @@ class arOaiPluginListIdentifiersComponent extends arOaiPluginComponent
 {
     public function execute($request)
     {
+        $options = [];
+
         $this->setUpdateParametersFromRequest($request);
 
         // Restrict to top-level descriptions for EAD given children get nested


### PR DESCRIPTION
Ensure `$this->getUpdates($options);` argument is an array to avoid
`array_merge($presetOptions, $options);` returning a null value and
ignoring all `$options` values.