### PR TITLE
Add ability to apply copyright globally, refs #13570

### DIFF
--- a/apps/qubit/modules/settings/actions/permissionsAction.class.php
+++ b/apps/qubit/modules/settings/actions/permissionsAction.class.php
@@ -136,6 +136,20 @@ class SettingsPermissionsAction extends sfAction
                 $setting->save();
             }
 
+            $setting = QubitSetting::getByName('digitalobject_copyright_statement_apply_globally');
+            if (null === $setting) {
+                $setting = new QubitSetting();
+                $setting->name = 'digitalobject_copyright_statement_apply_globally';
+                $setting->sourceCulture = sfConfig::get('sf_default_culture');
+            }
+            $value = $this->permissionsCopyrightStatementForm->getValue('copyrightStatementApplyGlobally');
+            if (!$this->permissionsCopyrightStatementForm->getValue('copyrightStatementEnabled')) {
+                // Disable applying global copyright if the main setting is disabled too
+                $value = '0';
+            }
+            $setting->setValue($value, ['sourceCulture' => true]);
+            $setting->save();
+
             // Preservation system access statement
             $setting = QubitSetting::getByName('digitalobject_preservation_system_access_statement_enabled');
             if (null === $setting) {

--- a/apps/qubit/modules/settings/templates/permissionsSuccess.php
+++ b/apps/qubit/modules/settings/templates/permissionsSuccess.php
@@ -170,6 +170,17 @@
 
         <input class="btn" type="submit" name="preview" value="<?php echo __('Preview'); ?>"/>
 
+        <br />
+        <br />
+        <?php echo $permissionsCopyrightStatementForm->copyrightStatementApplyGlobally
+            ->label(__('Apply to every %1%', ['%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject'))]))
+            ->renderRow(); ?>
+
+        <br />
+        <div class="alert alert-info">
+          <?php echo __('When enabled, the copyright pop-up will be applied to every %1%, regardless of whether there is an accompanying Rights statement.', ['%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject'))]); ?>
+        </div>
+
       </fieldset>
 
       <fieldset class="collapsible" id="preservationSystemAccessStatementArea">

--- a/lib/form/SettingsPermissionsCopyrightStatementForm.class.php
+++ b/lib/form/SettingsPermissionsCopyrightStatementForm.class.php
@@ -41,5 +41,17 @@ class SettingsPermissionsCopyrightStatementForm extends sfForm
         if (null !== $setting = QubitSetting::getByName('digitalobject_copyright_statement')) {
             $this->setDefault('copyrightStatement', $setting->getValue());
         }
+
+        $this->setWidget('copyrightStatementApplyGlobally', new sfWidgetFormSelectRadio(['choices' => [1 => 'yes', 0 => 'no']], ['class' => 'radio']));
+        $this->setValidator('copyrightStatementApplyGlobally', new sfValidatorInteger(['required' => false]));
+
+        $default = false;
+        if (null !== $setting = QubitSetting::getByName('digitalobject_copyright_statement_apply_globally')) {
+            $value = $setting->getValue(['sourceCulture' => true]);
+            if (!empty($value)) {
+                $default = $value;
+            }
+        }
+        $this->setDefault('copyrightStatementApplyGlobally', $default);
     }
 }

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -3136,6 +3136,14 @@ class QubitDigitalObject extends BaseDigitalObject
      */
     public function hasConditionalCopyright()
     {
+        // Check if the copyright statement is enabled and applies globally
+        if (
+            sfConfig::get('app_digitalobject_copyright_statement_enabled', false)
+            && sfConfig::get('app_digitalobject_copyright_statement_apply_globally', false)
+        ) {
+            return true;
+        }
+
         // Only if this is a master image and copyright statement is enabled
         if (
             QubitTerm::MASTER_ID != $this->usageId


### PR DESCRIPTION
This adds a new setting to the copyright statement section of the
permissions page to always show the copyright popup on every digital
object independently of its accompanying Rights configuration.