### PR TITLE
Fix CLI SKOS import issue, refs #13571

### DIFF
--- a/lib/task/import/importBulkTask.class.php
+++ b/lib/task/import/importBulkTask.class.php
@@ -88,7 +88,7 @@ EOF;
             // Recurse into the import folder
             $files = $this->dir_tree(rtrim($arguments['folder'], '/'));
         } else {
-            $files = [$arguments['folder']];
+            $files = [realpath($arguments['folder'])];
         }
 
         // TODO: Add some colour


### PR DESCRIPTION
Turns relative paths of import files into absolute paths so the import of SKOS files doesn't fail.