### PR TITLE
Remove get_magic_quotes_gpc() calls, refs #13462

### DIFF
--- a/vendor/htmlpurifier/library/HTMLPurifier/Config.php
+++ b/vendor/htmlpurifier/library/HTMLPurifier/Config.php
@@ -751,14 +751,13 @@ class HTMLPurifier_Config
      * @param array $array $_GET or $_POST array to import
      * @param string|bool $index Index/name that the config variables are in
      * @param array|bool $allowed List of allowed namespaces/directives
-     * @param bool $mq_fix Boolean whether or not to enable magic quotes fix
      * @param HTMLPurifier_ConfigSchema $schema Schema to use, if not global copy
      *
      * @return mixed
      */
-    public static function loadArrayFromForm($array, $index = false, $allowed = true, $mq_fix = true, $schema = null)
+    public static function loadArrayFromForm($array, $index = false, $allowed = true, $schema = null)
     {
-        $ret = HTMLPurifier_Config::prepareArrayFromForm($array, $index, $allowed, $mq_fix, $schema);
+        $ret = HTMLPurifier_Config::prepareArrayFromForm($array, $index, $allowed, $schema);
         $config = HTMLPurifier_Config::create($ret, $schema);
         return $config;
     }
@@ -769,11 +768,10 @@ class HTMLPurifier_Config
      * @param array $array $_GET or $_POST array to import
      * @param string|bool $index Index/name that the config variables are in
      * @param array|bool $allowed List of allowed namespaces/directives
-     * @param bool $mq_fix Boolean whether or not to enable magic quotes fix
      */
-    public function mergeArrayFromForm($array, $index = false, $allowed = true, $mq_fix = true)
+    public function mergeArrayFromForm($array, $index = false, $allowed = true)
     {
-         $ret = HTMLPurifier_Config::prepareArrayFromForm($array, $index, $allowed, $mq_fix, $this->def);
+         $ret = HTMLPurifier_Config::prepareArrayFromForm($array, $index, $allowed, $this->def);
          $this->loadArray($ret);
     }
 
@@ -784,17 +782,15 @@ class HTMLPurifier_Config
      * @param array $array $_GET or $_POST array to import
      * @param string|bool $index Index/name that the config variables are in
      * @param array|bool $allowed List of allowed namespaces/directives
-     * @param bool $mq_fix Boolean whether or not to enable magic quotes fix
      * @param HTMLPurifier_ConfigSchema $schema Schema to use, if not global copy
      *
      * @return array
      */
-    public static function prepareArrayFromForm($array, $index = false, $allowed = true, $mq_fix = true, $schema = null)
+    public static function prepareArrayFromForm($array, $index = false, $allowed = true, $schema = null)
     {
         if ($index !== false) {
             $array = (isset($array[$index]) && is_array($array[$index])) ? $array[$index] : array();
         }
-        $mq = $mq_fix && function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc();
 
         $allowed = HTMLPurifier_Config::getAllowedDirectivesForForm($allowed, $schema);
         $ret = array();
@@ -808,8 +804,7 @@ class HTMLPurifier_Config
             if (!isset($array[$skey])) {
                 continue;
             }
-            $value = $mq ? stripslashes($array[$skey]) : $array[$skey];
-            $ret[$ns][$directive] = $value;
+            $ret[$ns][$directive] = $array[$skey];
         }
         return $ret;
     }

--- a/vendor/symfony/lib/request/sfWebRequest.class.php
+++ b/vendor/symfony/lib/request/sfWebRequest.class.php
@@ -25,7 +25,7 @@ class sfWebRequest extends sfRequest
   const
     PORT_HTTP  = 80,
     PORT_HTTPS = 443;
-  
+
   protected
     $languages              = null,
     $charsets               = null,
@@ -74,7 +74,7 @@ class sfWebRequest extends sfRequest
     parent::initialize($dispatcher, $parameters, $attributes, $options);
 
     // GET parameters
-    $this->getParameters = get_magic_quotes_gpc() ? sfToolkit::stripslashesDeep($_GET) : $_GET;
+    $this->getParameters = $_GET;
     $this->parameterHolder->add($this->getParameters);
 
     $postParameters = $_POST;
@@ -135,7 +135,7 @@ class sfWebRequest extends sfRequest
       $this->setMethod(self::GET);
     }
 
-    $this->postParameters = get_magic_quotes_gpc() ? sfToolkit::stripslashesDeep($postParameters) : $postParameters;
+    $this->postParameters = $postParameters;
     $this->parameterHolder->add($this->postParameters);
 
     if (isset($this->options['formats']))
@@ -557,7 +557,7 @@ class sfWebRequest extends sfRequest
 
     if (isset($_COOKIE[$name]))
     {
-      $retval = get_magic_quotes_gpc() ? sfToolkit::stripslashesDeep($_COOKIE[$name]) : $_COOKIE[$name];
+      $retval = $_COOKIE[$name];
     }
 
     return $retval;


### PR DESCRIPTION
The get_magic_quotes_gpc() function is deprecated as of PHP 7.4.0 and
removed as of PHP 8.0.0.  As the function always returns false in PHP
7.4.0+ replace it with a false value in all conditionals.