### PR TITLE
Fix OAI-PMH resumptionToken dates, refs #13574

### DIFF
--- a/lib/oai/QubitOai.class.php
+++ b/lib/oai/QubitOai.class.php
@@ -147,7 +147,7 @@ class QubitOai
     }
 
     /**
-     * Returns formated date.
+     * Returns ISO 8601 formatted UTC date.
      *
      * @param string $date optional date value
      *
@@ -160,6 +160,22 @@ class QubitOai
         }
 
         return gmdate('Y-m-d\TH:i:s\Z', strtotime($date));
+    }
+
+    /**
+     * Returns a MySQL formatted date using local AtoM timezone.
+     *
+     * @param string $date in ISO 8601 UTC format
+     *
+     * @return null|string a MySQL formatted local datetime, or null
+     */
+    public static function mysqlDate($date)
+    {
+        if (empty($date)) {
+            return;
+        }
+
+        return date('Y-m-d H:i:s', strtotime($date));
     }
 
     /**

--- a/plugins/arOaiPlugin/lib/arOaiPluginComponent.class.php
+++ b/plugins/arOaiPlugin/lib/arOaiPluginComponent.class.php
@@ -50,13 +50,13 @@ abstract class arOaiPluginComponent extends sfComponent
         if (!isset($request->from)) {
             $this->from = '';
         } else {
-            $this->from = strtotime($request->from);
+            $this->from = $request->from;
         }
 
         if (!isset($request->until)) {
             $this->until = '';
         } else {
-            $this->until = strtotime($request->until);
+            $this->until = $request->until;
         }
 
         if (!isset($request->set)) {
@@ -87,8 +87,8 @@ abstract class arOaiPluginComponent extends sfComponent
     public function getUpdates(array $options = [])
     {
         $presetOptions = [
-            'from' => $this->from,
-            'until' => $this->until,
+            'from' => QubitOai::mysqlDate($this->from),
+            'until' => QubitOai::mysqlDate($this->until),
             'offset' => $this->cursor,
             'limit' => QubitSetting::getByName('resumption_token_limit')->__toString(),
         ];
@@ -106,13 +106,18 @@ abstract class arOaiPluginComponent extends sfComponent
         $this->publishedRecords = $update['data'];
         $this->remaining = $update['remaining'];
         $this->recordsCount = count($this->publishedRecords);
-        $resumptionCursor = $this->cursor + $options['limit'];
-        $this->resumptionToken = base64_encode(json_encode(['from' => $this->from,
-            'until' => $this->until,
-            'cursor' => $resumptionCursor,
-            'metadataPrefix' => $this->metadataPrefix,
-            'set' => $this->set,
-        ]));
+
+        $this->resumptionToken = base64_encode(
+            json_encode(
+                [
+                    'from' => $this->from,
+                    'until' => $this->until,
+                    'cursor' => $this->cursor + $options['limit'],
+                    'metadataPrefix' => $this->metadataPrefix,
+                    'set' => $this->set,
+                ]
+            )
+        );
     }
 
     public function setRequestAttributes($request)


### PR DESCRIPTION
This also fixes issue #13025 by correctly converting OAI-PMH UTC "from"
and "until" dates to local MySQL dates for ORM queries.

- Use ISO 8601 UTC format to represent from & until dates internally and
  in OAI-PMH output (e.g. "2021-10-08T21:53:17Z")
- Pass datetimes to MySQL in MySQL date format using local app time
  (e.g. "2021-10-08 14:53:17" for default_timezone="America/Vancouver")