### PR TITLE
Memory profiler atom-worker, refs #13575

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN set -xe \
       libzip-dev \
       oniguruma-dev \
       autoconf \
+      bsd-compat-headers \
       build-base \
     && docker-php-ext-install \
       calendar \
@@ -25,12 +26,14 @@ RUN set -xe \
       sockets \
       xsl \
       zip \
-    && pecl install apcu pcov \
+    && curl -Ls http://downloads.sourceforge.net/project/judy/judy/Judy-1.0.5/Judy-1.0.5.tar.gz | tar xz -C / \
+    && cd /judy-1.0.5 && ./configure && make && make install \
+    && pecl install apcu memprof pcov \
     && curl -Ls https://github.com/websupport-sk/pecl-memcache/archive/NON_BLOCKING_IO_php7.tar.gz | tar xz -C / \
     && cd /pecl-memcache-NON_BLOCKING_IO_php7 \
     && phpize && ./configure && make && make install \
-    && cd / && rm -rf /pecl-memcache-NON_BLOCKING_IO_php7 \
-    && docker-php-ext-enable apcu memcache pcov \
+    && cd / && rm -rf /pecl-memcache-NON_BLOCKING_IO_php7 /judy-1.0.5 \
+    && docker-php-ext-enable apcu memcache memprof pcov \
     && apk add --no-cache --virtual .phpext-rundeps \
       gettext \
       libxslt \

--- a/lib/arMemprofUtils.class.php
+++ b/lib/arMemprofUtils.class.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Utilities for interacting with arnaud-lb/php-memory-profiler
+ * https://github.com/arnaud-lb/php-memory-profiler.
+ *
+ * 1) install arnaud-lb/php-memory-profiler
+ * 2) configure atom-worker.service to include "Environment=MEMPROF_PROFILE=native"
+ * 3) OPTIONAL: set the basepath and name using env var:
+ *    "Environment=MEMPROF_OUTPUT_BASENAME=/vagrant/atom_memprof_file.grind"
+ * 4) run: sudo systemctl daemon-reload
+ * 5) restart the atom-worker
+ *
+ * If MEMPROF_OUTPUT_BASENAME is not set, the grind files will be output
+ * to the AtoM folder (atom_memprof_file.grind.<timestamp>)
+ */
+class arMemprofUtils
+{
+    public static function getMemoryUsageString()
+    {
+        return sprintf(
+            "Worker memory usage (PHP - OS): %.2fMb - %dkb\n",
+            arMemprofUtils::getPhpReportedMemoryUsage(),
+            arMemprofUtils::getLinuxReportedMemoryUsage()
+        );
+    }
+
+    public static function createMemprofGrindFile(string $basename = 'atom_memprof_file.grind')
+    {
+        if (is_callable('memprof_enabled')) {
+            if (memprof_enabled()) {
+                if (false !== $memprof_basename = getenv('MEMPROF_OUTPUT_BASENAME')) {
+                    $basename = $memprof_basename;
+                }
+                $filename = $basename.'.'.arMemprofUtils::getUniqueExtension();
+                memprof_dump_callgrind(fopen($filename, 'w'));
+
+                return $filename;
+            }
+        }
+    }
+
+    public static function getMemprofProfile()
+    {
+        return getenv('MEMPROF_PROFILE');
+    }
+
+    public static function getMemprofEnabled()
+    {
+        if (
+            function_exists('memprof_enabled')
+            && memprof_enabled()
+            && getenv('MEMPROF_PROFILE')
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public static function getLinuxReportedMemoryUsage()
+    {
+        preg_match('/^VmRSS:\s(.*)/m', file_get_contents('/proc/self/status'), $matches);
+
+        try {
+            $memUsage = (int) trim($matches[1]);
+        } catch (Exception $e) {
+            return 0;
+        }
+
+        return $memUsage;
+    }
+
+    public static function getPhpReportedMemoryUsage()
+    {
+        return sprintf('%.2f', memory_get_usage(true) / 1024 / 1024);
+    }
+
+    protected static function getUniqueExtension()
+    {
+        return date('Ymd-His-').substr(microtime(false), 2, 3);
+    }
+}

--- a/lib/task/jobs/jobWorkerTask.class.php
+++ b/lib/task/jobs/jobWorkerTask.class.php
@@ -146,6 +146,11 @@ EOF;
             function ($handle, $job, $e) {
                 ++$this->jobsCompleted;
                 $this->log(sprintf('Jobs completed: %u', $this->getJobsCompleted()));
+
+                if (arMemprofUtils::getMemprofEnabled()) {
+                    $memprof_filename = arMemprofUtils::createMemprofGrindFile();
+                    $this->log(sprintf('Memprof enabled. Dumping grind file: %s', $memprof_filename));
+                }
             },
             Net_Gearman_Worker::JOB_COMPLETE
         );
@@ -179,6 +184,11 @@ EOF;
                     $counter = 0;
 
                     QubitPdo::prepareAndExecute('SELECT 1');
+
+                    if (arMemprofUtils::getMemprofEnabled()) {
+                        $this->log(arMemprofUtils::getMemoryUsageString());
+                        $this->log(sprintf('Memprof profile: %s', arMemprofUtils::getMemprofProfile()));
+                    }
                 }
             }
         );
@@ -223,6 +233,11 @@ EOF;
         // Define shutdown function
         register_shutdown_function(function () {
             $this->log('Job worker stopped.');
+
+            if (arMemprofUtils::getMemprofEnabled()) {
+                $memprof_filename = arMemprofUtils::createMemprofGrindFile();
+                $this->log(sprintf('Memprof enabled. Dumping shutdown grind file: %s', $memprof_filename));
+            }
         });
     }
 }


### PR DESCRIPTION
Add class for interacting with arnaud-lb/php-memory-profiler. Set up for
use in the atom-worker.

https://github.com/arnaud-lb/php-memory-profiler.

1) install arnaud-lb/php-memory-profiler
2) configure atom-worker.service to include
"Environment=MEMPROF_PROFILE=native"
3) OPTIONAL: set the basepath and name using env var:
"Environment=MEMPROF_OUTPUT_BASENAME=/vagrant/atom_memprof_file.grind"
4) run: sudo systemctl daemon-reload
5) restart the atom-worker

If MEMPROF_OUTPUT_BASENAME is not set, the grind files will be output
to the AtoM folder (atom_memprof_file.grind.<timestamp>).