### PR TITLE
Fix actor CSV import error, refs #13576

### DIFF
--- a/lib/task/import/csvAuthorityRecordImportTask.class.php
+++ b/lib/task/import/csvAuthorityRecordImportTask.class.php
@@ -211,7 +211,8 @@ EOF;
                 if ($self->object) {
                     // Warn or abort if identifier's already been used
                     if (
-                        !empty($identifier = $self->columnValue('descriptionIdentifier'))
+                        $self->columnExists('descriptionIdentifier')
+                        && !empty($identifier = $self->columnValue('descriptionIdentifier'))
                         && QubitValidatorActorDescriptionIdentifier::identifierUsedByAnotherActor($identifier, $self->object)
                     ) {
                         $error = sfContext::getInstance()


### PR DESCRIPTION
Fixes error, during authority record CSV import, that occurs when the description identifier column isn't populated.