### PR TITLE
Embed events component forms, refs issue #13511

### DIFF
--- a/apps/qubit/modules/actor/actions/eventComponent.class.php
+++ b/apps/qubit/modules/actor/actions/eventComponent.class.php
@@ -18,19 +18,19 @@
  */
 
 /**
- * Form for adding and editing related events.
+ * Add, edit and delete actor events.
  *
  * @author     David Juhasz <david@artefactual.com>
  */
-class InformationObjectEventComponent extends EventEditComponent
+class ActorEventComponent extends EventEditComponent
 {
-    // Don't update the search index when saving an event object
-    public $indexOnSave = false;
+    // Update the search index when saving an event object
+    public $indexOnSave = true;
 
     // Arrays not allowed in class constants
     public static $NAMES = [
         'id',
-        'actor',
+        'object',
         'date',
         'endDate',
         'startDate',
@@ -40,18 +40,37 @@ class InformationObjectEventComponent extends EventEditComponent
     ];
 
     /**
-     * Add event to QubitInformationObject::eventsRelatedByobjectId[] list
-     * to ensure the event object is create after the QubitInformatinObject.
+     * Add event to QubitActor::events[] list to ensure the event object is
+     * create after the QubitActor object.
      */
     public function addEvent(QubitEvent $event): QubitEvent
     {
-        $this->resource->eventsRelatedByobjectId[] = $event;
+        $this->resource->events[] = $event;
 
         return $event;
     }
 
-    public function getEvents()
+    public function processEventForm($form, $data)
     {
-        return $this->resource->eventsRelatedByobjectId;
+        parent::processEventForm($form, $data);
+    }
+
+    public function processField($field)
+    {
+        switch ($field->getName()) {
+            case 'object':
+                unset($this->event->object);
+
+                $value = $this->form->getValue('object');
+                if (isset($value)) {
+                    $params = $this->context->routing->parse(Qubit::pathInfo($value));
+                    $this->event->object = $params['_sf_route']->resource;
+                }
+
+                break;
+
+            default:
+                return parent::processField($field);
+        }
     }
 }

--- a/apps/qubit/modules/contactinformation/actions/editComponent.class.php
+++ b/apps/qubit/modules/contactinformation/actions/editComponent.class.php
@@ -61,12 +61,18 @@ class ContactInformationEditComponent extends sfComponent
                 continue;
             }
 
+            // Bind event form data
             $this->form->bind($item);
+
             if ($this->form->isValid()) {
                 if (isset($item['id'])) {
-                    $this->contactInformation = QubitContactInformation::getById(preg_replace('/^.*\/(\d+)$/', '$1', $item['id']));
+                    $this->contactInformation =
+                        QubitContactInformation::getById(preg_replace('/^.*\/(\d+)$/',
+                        '$1', $item['id']));
                 } else {
-                    $this->resource->contactInformations[] = $this->contactInformation = new QubitContactInformation();
+                    $this->resource->contactInformations[] =
+                        $this->contactInformation =
+                        new QubitContactInformation();
                 }
 
                 foreach ($this->form as $field) {
@@ -112,15 +118,25 @@ class ContactInformationEditComponent extends sfComponent
     {
         switch ($name) {
             case 'countryCode':
-                $this->form->setValidator('countryCode', new sfValidatorI18nChoiceCountry());
-                $this->form->setWidget('countryCode', new sfWidgetFormI18nChoiceCountry(['add_empty' => true, 'culture' => $this->context->user->getCulture()]));
+                $this->form->setValidator(
+                    'countryCode',
+                    new sfValidatorI18nChoiceCountry()
+                );
+                $this->form->setWidget('countryCode',
+                    new sfWidgetFormI18nChoiceCountry([
+                        'add_empty' => true,
+                        'culture' => $this->context->user->getCulture(),
+                    ])
+                );
 
                 break;
 
             case 'primaryContact':
                 $this->form->setDefault('primaryContact', false);
-                $this->form->setValidator('primaryContact', new sfValidatorBoolean());
-                $this->form->setWidget('primaryContact', new sfWidgetFormInputCheckbox());
+                $this->form->setValidator('primaryContact',
+                    new sfValidatorBoolean());
+                $this->form->setWidget('primaryContact',
+                    new sfWidgetFormInputCheckbox());
 
                 break;
 
@@ -134,7 +150,8 @@ class ContactInformationEditComponent extends sfComponent
             case 'streetAddress':
             case 'note':
                 $this->form->setValidator($name, new sfValidatorString());
-                $this->form->setWidget($name, new sfWidgetFormTextArea([], ['rows' => 2]));
+                $this->form->setWidget($name, new sfWidgetFormTextArea([],
+                    ['rows' => 2]));
 
                 break;
 
@@ -148,6 +165,7 @@ class ContactInformationEditComponent extends sfComponent
 
     protected function processField($field)
     {
-        $this->contactInformation[$field->getName()] = $this->form->getValue($field->getName());
+        $this->contactInformation[$field->getName()] =
+            $this->form->getValue($field->getName());
     }
 }

--- a/apps/qubit/modules/default/actions/editAction.class.php
+++ b/apps/qubit/modules/default/actions/editAction.class.php
@@ -26,7 +26,7 @@ class DefaultEditAction extends sfAction
             $this->forward404();
         }
 
-        $this->form = new sfForm();
+        $this->form = new QubitForm();
 
         // Call early execute logic, if defined by a child class
         if (method_exists($this, 'earlyExecute')) {

--- a/apps/qubit/modules/event/actions/editComponent.class.php
+++ b/apps/qubit/modules/event/actions/editComponent.class.php
@@ -145,6 +145,36 @@ characters of the term name. Alternatively, type a new term to create and link
 to a new place term.
 EOL
             ),
+            'type' => __(
+<<<'EOL'
+Select the type of activity that established the relation between the authority
+record and the archival description (e.g. creation, accumulation, collection,
+publication, etc.)
+EOL
+            ),
+            'startDate' => __(
+<<<'EOL'
+Enter the start year. Do not use any qualifiers or typographical symbols to
+express uncertainty. Acceptable date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM,
+YYYY.
+EOL
+            ),
+            'endDate' => __(
+<<<'EOL'
+Enter the end year. Do not use any qualifiers or typographical symbols to
+express uncertainty. Acceptable date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM,
+YYYY.
+EOL
+            ),
+            'description' => __(
+<<<'EOL'
+Make notes on dates and any details pertaining to the dates of creation,
+publication, or distribution, of the unit being described that are not included
+in the Date(s) of creation, including publication, distribution, etc., area and
+that are considered to be important." (RAD 1.8B8) "Make notes on the date(s) of
+accumulation or collection of the unit being described." (RAD 1.8B8a)
+EOL
+            ),
         ]);
     }
 

--- a/apps/qubit/modules/event/actions/editComponent.class.php
+++ b/apps/qubit/modules/event/actions/editComponent.class.php
@@ -49,15 +49,19 @@ class EventEditComponent extends sfComponent
             $this->form->bind($item);
             if ($this->form->isValid()) {
                 if (isset($item['id'])) {
-                    $params = $this->context->routing->parse(Qubit::pathInfo($item['id']));
+                    $params = $this->context->routing->parse(
+                        Qubit::pathInfo($item['id'])
+                    );
 
-                    // Do not add exiting events to the eventsRelatedByobjectId or events
-                    // array, as they could be deleted before saving the resource
+                    // Do not add exiting events to the eventsRelatedByobjectId
+                    // or events array, as they could be deleted before saving
+                    // the resource
                     $this->event = $params['_sf_route']->resource;
                 } elseif ($this->resource instanceof QubitActor) {
                     $this->resource->events[] = $this->event = new QubitEvent();
                 } else {
-                    $this->resource->eventsRelatedByobjectId[] = $this->event = new QubitEvent();
+                    $this->resource->eventsRelatedByobjectId[] =
+                        $this->event = new QubitEvent();
                 }
 
                 foreach ($this->form as $field) {
@@ -82,7 +86,9 @@ class EventEditComponent extends sfComponent
 
         if (isset($this->request->deleteEvents)) {
             foreach ($this->request->deleteEvents as $item) {
-                $params = $this->context->routing->parse(Qubit::pathInfo($item));
+                $params = $this->context->routing->parse(
+                    Qubit::pathInfo($item)
+                );
                 $event = $params['_sf_route']->resource;
                 $event->indexOnSave = $indexOnSave;
                 $event->delete();
@@ -93,8 +99,9 @@ class EventEditComponent extends sfComponent
     public function execute($request)
     {
         $this->form = new sfForm();
-        $this->form->disableCSRFProtection();
-        $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
+        $this->form->getValidatorSchema()->setOption(
+            'allow_extra_fields', true
+        );
         $this->form->getWidgetSchema()->setNameFormat('editEvent[%s]');
 
         foreach ($this::$NAMES as $name) {
@@ -109,7 +116,14 @@ class EventEditComponent extends sfComponent
                 $this->form->setValidator('date', new sfValidatorString());
                 $this->form->setWidget('date', new sfWidgetFormInput());
 
-                $this->form->getWidgetSchema()->date->setHelp($this->context->i18n->__('Enter free-text information, including qualifiers or typographical symbols to express uncertainty, to change the way the date displays. If this field is not used, the default will be the start and end years only.'));
+                $this->form->getWidgetSchema()->date->setHelp(
+                    $this->context->i18n->__(
+                        'Enter free-text information, including qualifiers or
+                        typographical symbols to express uncertainty, to change
+                        the way the date displays. If this field is not used,
+                        the default will be the start and end years only.'
+                    )
+                );
 
                 break;
 
@@ -117,8 +131,16 @@ class EventEditComponent extends sfComponent
                 $this->form->setValidator('endDate', new sfValidatorString());
                 $this->form->setWidget('endDate', new sfWidgetFormInput());
 
-                $this->form->getWidgetSchema()->endDate->setHelp($this->context->i18n->__('Enter the end year. Do not use any qualifiers or typographical symbols to express uncertainty. Acceptable date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM, YYYY.'));
-                $this->form->getWidgetSchema()->endDate->setLabel($this->context->i18n->__('End'));
+                $this->form->getWidgetSchema()->endDate->setHelp(
+                    $this->context->i18n->__(
+                        'Enter the end year. Do not use any qualifiers or
+                        typographical symbols to express uncertainty. Acceptable
+                        date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM, YYYY.'
+                    )
+                );
+                $this->form->getWidgetSchema()->endDate->setLabel(
+                    $this->context->i18n->__('End')
+                );
 
                 break;
 
@@ -126,14 +148,25 @@ class EventEditComponent extends sfComponent
                 $this->form->setValidator('startDate', new sfValidatorString());
                 $this->form->setWidget('startDate', new sfWidgetFormInput());
 
-                $this->form->getWidgetSchema()->startDate->setHelp($this->context->i18n->__('Enter the start year. Do not use any qualifiers or typographical symbols to express uncertainty. Acceptable date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM, YYYY.'));
-                $this->form->getWidgetSchema()->startDate->setLabel($this->context->i18n->__('Start'));
+                $this->form->getWidgetSchema()->startDate->setHelp(
+                    $this->context->i18n->__(
+                        'Enter the start year. Do not use any qualifiers or
+                        typographical symbols to express uncertainty. Acceptable
+                        date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM, YYYY.'
+                    )
+                );
+                $this->form->getWidgetSchema()->startDate->setLabel(
+                    $this->context->i18n->__('Start')
+                );
 
                 break;
 
             case 'type':
                 // Event types, Dublin Core is restricted
-                $eventTypes = QubitTaxonomy::getTermsById(QubitTaxonomy::EVENT_TYPE_ID);
+                $eventTypes = QubitTaxonomy::getTermsById(
+                    QubitTaxonomy::EVENT_TYPE_ID
+                );
+
                 if ('sfDcPlugin' == $this->request->module) {
                     $eventTypes = sfDcPlugin::eventTypes();
                 }
@@ -142,14 +175,25 @@ class EventEditComponent extends sfComponent
                 foreach ($eventTypes as $item) {
                     // Default event type is creation
                     if (QubitTerm::CREATION_ID == $item->id) {
-                        $this->form->setDefault('type', $this->context->routing->generate(null, [$item, 'module' => 'term']));
+                        $this->form->setDefault(
+                            'type',
+                            $this->context->routing->generate(
+                                null, [$item, 'module' => 'term']
+                            )
+                        );
                     }
 
-                    $choices[$this->context->routing->generate(null, [$item, 'module' => 'term'])] = $item->__toString();
+                    $choices += [
+                        $this->context->routing->generate(
+                            null, [$item, 'module' => 'term']
+                        ) => $item->__toString(),
+                    ];
                 }
 
                 $this->form->setValidator('type', new sfValidatorString());
-                $this->form->setWidget('type', new sfWidgetFormSelect(['choices' => $choices]));
+                $this->form->setWidget('type', new sfWidgetFormSelect(
+                    ['choices' => $choices]
+                ));
 
                 break;
         }
@@ -164,8 +208,11 @@ class EventEditComponent extends sfComponent
 
                 $value = $this->form->getValue($field->getName());
                 if (isset($value)) {
-                    $params = $this->context->routing->parse(Qubit::pathInfo($value));
-                    $this->event[$field->getName()] = $params['_sf_route']->resource;
+                    $params = $this->context->routing->parse(
+                        Qubit::pathInfo($value)
+                    );
+                    $this->event[$field->getName()] =
+                        $params['_sf_route']->resource;
                 }
 
                 break;
@@ -173,10 +220,18 @@ class EventEditComponent extends sfComponent
             case 'startDate':
             case 'endDate':
                 $value = $this->form->getValue($field->getName());
-                if (isset($value) && preg_match('/^\d{8}\z/', trim($value), $matches)) {
-                    $value = substr($matches[0], 0, 4).'-'.substr($matches[0], 4, 2).'-'.substr($matches[0], 6, 2);
-                } elseif (isset($value) && preg_match('/^\d{6}\z/', trim($value), $matches)) {
-                    $value = substr($matches[0], 0, 4).'-'.substr($matches[0], 4, 2);
+                if (
+                    isset($value)
+                    && preg_match('/^\d{8}\z/', trim($value), $matches)
+                ) {
+                    $value = substr($matches[0], 0, 4).'-'.
+                        substr($matches[0], 4, 2).'-'.substr($matches[0], 6, 2);
+                } elseif (
+                    isset($value)
+                    && preg_match('/^\d{6}\z/', trim($value), $matches)
+                ) {
+                    $value = substr($matches[0], 0, 4).'-'.
+                        substr($matches[0], 4, 2);
                 }
 
                 $this->event[$field->getName()] = $value;
@@ -184,7 +239,9 @@ class EventEditComponent extends sfComponent
                 break;
 
             default:
-                $this->event[$field->getName()] = $this->form->getValue($field->getName());
+                $this->event[$field->getName()] = $this->form->getValue(
+                    $field->getName()
+                );
         }
     }
 }

--- a/apps/qubit/modules/informationobject/actions/editAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/editAction.class.php
@@ -39,6 +39,7 @@ class InformationObjectEditAction extends DefaultEditAction
 
         if ($request->isMethod('post')) {
             $this->form->bind($request->getPostParameters());
+
             if ($this->form->isValid()) {
                 $this->processForm();
 

--- a/apps/qubit/modules/informationobject/actions/eventComponent.class.php
+++ b/apps/qubit/modules/informationobject/actions/eventComponent.class.php
@@ -40,6 +40,14 @@ class InformationObjectEventComponent extends EventEditComponent
     ];
 
     /**
+     * Get related events.
+     */
+    public function getRelatedEvents()
+    {
+        return $this->resource->eventsRelatedByobjectId;
+    }
+
+    /**
      * Add event to QubitInformationObject::eventsRelatedByobjectId[] list
      * to ensure the event object is create after the QubitInformatinObject.
      */
@@ -48,10 +56,5 @@ class InformationObjectEventComponent extends EventEditComponent
         $this->resource->eventsRelatedByobjectId[] = $event;
 
         return $event;
-    }
-
-    public function getEvents()
-    {
-        return $this->resource->eventsRelatedByobjectId;
     }
 }

--- a/apps/qubit/modules/informationobject/templates/_event.php
+++ b/apps/qubit/modules/informationobject/templates/_event.php
@@ -11,15 +11,15 @@ use_helper('Javascript');
 $editHtml = image_tag('pencil', ['alt' => __('Edit'), 'style' => 'align: top']);
 
 $rowTemplate = json_encode(<<<value
-<tr id="{{$form->getWidgetSchema()->generateName('id')}}">
+<tr id="{{$event->getWidgetSchema()->generateName('id')}}">
   <td>
-    {{$form->actor->renderName()}}
+    {{$event->actor->renderName()}}
   </td><td>
-    {{$form->type->renderName()}}
+    {{$event->type->renderName()}}
   </td><td>
-    {{$form->place->renderName()}}
+    {{$event->place->renderName()}}
   </td><td>
-    {{$form->date->renderName()}}
+    {{$event->date->renderName()}}
   </td><td style="text-align: right">
     {$editHtml} <button class="delete-small" name="delete" type="button"/>
   </td>
@@ -81,45 +81,45 @@ content
 
   <div class="form-item">
 
-    <?php echo $form->actor
+    <?php echo $event->actor
         ->label(__('Actor name'))
         ->renderLabel(); ?>
-    <?php echo $form->actor->render(['class' => 'form-autocomplete']); ?>
+    <?php echo $event->actor->render(['class' => 'form-autocomplete']); ?>
 
     <?php if (QubitAcl::check(QubitActor::getRoot(), 'create')) { ?>
       <input class="add" type="hidden" data-link-existing="true" value="<?php echo url_for(['module' => 'actor', 'action' => 'add']); ?> #authorizedFormOfName"/>
     <?php } ?>
 
     <input class="list" type="hidden" value="<?php echo url_for(['module' => 'actor', 'action' => 'autocomplete']); ?>"/>
-    <?php echo $form->actor->renderHelp(); ?>
+    <?php echo $event->actor->renderHelp(); ?>
 
   </div>
 
-  <?php echo $form->type
+  <?php echo $event->type
       ->label(__('Event type'))
       ->renderRow(); ?>
 
   <div class="form-item form-item-place">
 
-    <?php echo $form->place->renderLabel(); ?>
-    <?php echo $form->place->render(['class' => 'form-autocomplete']); ?>
+    <?php echo $event->place->renderLabel(); ?>
+    <?php echo $event->place->render(['class' => 'form-autocomplete']); ?>
 
     <?php if (QubitAcl::check(QubitTaxonomy::getById(QubitTaxonomy::PLACE_ID), 'createTerm')) { ?>
       <input class="add" type="hidden" data-link-existing="true" value="<?php echo url_for(['module' => 'term', 'action' => 'add', 'taxonomy' => url_for([QubitTaxonomy::getById(QubitTaxonomy::PLACE_ID), 'module' => 'taxonomy'])]); ?> #name"/>
     <?php } ?>
 
     <input class="list" type="hidden" value="<?php echo url_for(['module' => 'term', 'action' => 'autocomplete', 'taxonomy' => url_for([QubitTaxonomy::getById(QubitTaxonomy::PLACE_ID), 'module' => 'taxonomy'])]); ?>"/>
-    <?php echo $form->place->renderHelp(); ?>
+    <?php echo $event->place->renderHelp(); ?>
 
   </div>
 
-  <?php echo $form->date->renderRow(); ?>
+  <?php echo $event->date->renderRow(); ?>
 
-  <?php echo $form->startDate->renderRow(); ?>
+  <?php echo $event->startDate->renderRow(); ?>
 
-  <?php echo $form->endDate->renderRow(); ?>
+  <?php echo $event->endDate->renderRow(); ?>
 
-  <?php echo $form->description
+  <?php echo $event->description
       ->label(__('Event note'))
       ->renderRow(); ?>
 

--- a/apps/qubit/modules/relation/actions/editComponent.class.php
+++ b/apps/qubit/modules/relation/actions/editComponent.class.php
@@ -42,13 +42,19 @@ class RelationEditComponent extends sfComponent
                 continue;
             }
 
+            // Bind event form data
             $this->form->bind($item);
+
             if ($this->form->isValid()) {
                 if (isset($item['id'])) {
-                    $params = $this->context->routing->parse(Qubit::pathInfo($item['id']));
+                    $params = $this->context->routing->parse(
+                        Qubit::pathInfo($item['id'])
+                    );
                     $this->relation = $params['_sf_route']->resource;
                 } else {
-                    $this->resource->relationsRelatedBysubjectId[] = $this->relation = new QubitRelation();
+                    $this->relation = new QubitRelation();
+                    $this->resource->relationsRelatedBysubjectId[] =
+                        $this->relation;
                 }
 
                 foreach ($this->form as $field) {
@@ -116,9 +122,18 @@ class RelationEditComponent extends sfComponent
             case 'resource':
                 $this->form->setValidator('resource', new sfValidatorAnd([
                     new sfValidatorString(),
-                    new QubitValidatorForbiddenValues(['forbidden_values' => [$this->context->routing->generate(null, $this->resource)]]),
+                    new QubitValidatorForbiddenValues(
+                        [
+                            'forbidden_values' => [
+                                $this->context->routing->generate(
+                                    null, $this->resource
+                                ),
+                            ],
+                        ]
+                    ),
                 ], ['required' => true]));
-                $this->form->setWidget('resource', new sfWidgetFormSelect(['choices' => []]));
+                $this->form->setWidget('resource',
+                    new sfWidgetFormSelect(['choices' => []]));
 
                 break;
         }
@@ -132,7 +147,8 @@ class RelationEditComponent extends sfComponent
 
                 $value = $this->form->getValue('resource');
                 if (isset($value)) {
-                    $params = $this->context->routing->parse(Qubit::pathInfo($value));
+                    $params =
+                        $this->context->routing->parse(Qubit::pathInfo($value));
                     $this->relation->object = $params['_sf_route']->resource;
                 }
 
@@ -143,14 +159,16 @@ class RelationEditComponent extends sfComponent
 
                 $value = $this->form->getValue('type');
                 if (isset($value)) {
-                    $params = $this->context->routing->parse(Qubit::pathInfo($value));
+                    $params =
+                        $this->context->routing->parse(Qubit::pathInfo($value));
                     $this->relation->type = $params['_sf_route']->resource;
                 }
 
                 break;
 
             default:
-                $this->relation[$field->getName()] = $this->form->getValue($field->getName());
+                $this->relation[$field->getName()] =
+                    $this->form->getValue($field->getName());
         }
     }
 }

--- a/lib/form/EventForm.class.php
+++ b/lib/form/EventForm.class.php
@@ -7,47 +7,55 @@
  */
 class EventForm extends QubitForm
 {
-    public const DATE_REGEX = '/^\d{4}-?\d{0,2}-?\d{0,2}$/';
-
     public function configureId()
     {
-        $this->setValidator('id', new sfValidatorString(
-            ['max_length' => 255],
-            ['max_length' => 'Id must be less than 255 characters']
-        ));
+        $this->setValidator(
+            'id',
+            new sfValidatorString(
+                ['max_length' => 255],
+                ['max_length' => 'Too long (Max. %max_length% characters)']
+            )
+        );
         $this->setWidget('id', new sfWidgetFormInputHidden());
     }
 
     public function configureDate()
     {
-        $this->setValidator('date', new sfValidatorString(
-            ['max_length' => 255],
-            ['max_length' => 'Date must be less than 255 characters']
-        ));
+        $this->setValidator(
+            'date',
+            new sfValidatorString(
+                ['max_length' => 255],
+                ['max_length' => 'Too long (Max. %max_length% characters)']
+            )
+        );
         $this->setWidget('date', new sfWidgetFormInput());
     }
 
     public function configureStartDate()
     {
-        $this->setValidator('startDate', new sfValidatorRegex(
-            ['max_length' => 10, 'pattern' => self::DATE_REGEX],
-            [
-                'invalid' => 'Start date must be in the format YYYY-MM-DD or
-                    YYYYMMDD',
-            ],
-        ));
+        // Don't check date format because we can't show validation errors
+        // in the events modal dialog.
+        $this->setValidator(
+            'startDate',
+            new sfValidatorString(
+                ['max_length' => 255],
+                ['max_length' => 'Too long (Max. %max_length% characters)']
+            )
+        );
         $this->setWidget('startDate', new sfWidgetFormInput());
     }
 
     public function configureEndDate()
     {
-        $this->setValidator('endDate', new sfValidatorRegex(
-            ['max_length' => 10, 'pattern' => self::DATE_REGEX],
-            [
-                'invalid' => 'End date must be in the format YYYY-MM-DD or
-                    YYYYMMDD',
-            ],
-        ));
+        // Don't check date format because we can't show validation errors
+        // in the events modal dialog.
+        $this->setValidator(
+            'endDate',
+            new sfValidatorString(
+                ['max_length' => 255],
+                ['max_length' => 'Too long (Max. %max_length% characters)']
+            )
+        );
         $this->setWidget('endDate', new sfWidgetFormInput());
     }
 
@@ -74,19 +82,37 @@ class EventForm extends QubitForm
 
     public function configureActor()
     {
-        $this->setValidator('actor', new sfValidatorString());
+        $this->setValidator(
+            'actor',
+            new sfValidatorString(
+                ['max_length' => 1024],
+                ['max_length' => 'Too long (Max. %max_length% characters)']
+            )
+        );
         $this->setWidget('actor', new sfWidgetFormSelect(['choices' => []]));
     }
 
     public function configureDescription()
     {
-        $this->setValidator('description', new sfValidatorString());
+        $this->setValidator(
+            'description',
+            new sfValidatorString(
+                ['max_length' => 10000],
+                ['max_length' => 'Too long (Max. %max_length% characters)']
+            )
+        );
         $this->setWidget('description', new sfWidgetFormInput());
     }
 
     public function configurePlace()
     {
-        $this->setValidator('place', new sfValidatorString());
+        $this->setValidator(
+            'place',
+            new sfValidatorString(
+                ['max_length' => 1024],
+                ['max_length' => 'Too long (Max. %max_length% characters)']
+            )
+        );
         $this->setWidget('place', new sfWidgetFormSelect(['choices' => []]));
     }
 
@@ -105,8 +131,9 @@ class EventForm extends QubitForm
     public function configureFields()
     {
         $this->configureId();
-        $this->configureType();
         $this->configureActor();
+        $this->configureType();
+        $this->configurePlace();
         $this->configureDate();
         $this->configureStartDate();
         $this->configureEndDate();

--- a/lib/form/EventForm.class.php
+++ b/lib/form/EventForm.class.php
@@ -90,15 +90,26 @@ class EventForm extends QubitForm
         $this->setWidget('place', new sfWidgetFormSelect(['choices' => []]));
     }
 
+    /**
+     * Configure event form.
+     */
     public function configure()
     {
         $this->getWidgetSchema()->setNameFormat('event[%s]');
+        $this->configureFields();
+    }
 
-        // Configure fields included in all event forms
+    /**
+     * Configure general event form fields.
+     */
+    public function configureFields()
+    {
         $this->configureId();
+        $this->configureType();
+        $this->configureActor();
         $this->configureDate();
         $this->configureStartDate();
         $this->configureEndDate();
-        $this->configureType();
+        $this->configureDescription();
     }
 }

--- a/lib/form/EventForm.class.php
+++ b/lib/form/EventForm.class.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * Events form.
+ *
+ * @author     David Juhasz <david@artefactual.com>
+ */
+class EventForm extends QubitForm
+{
+    public const DATE_REGEX = '/^\d{4}-?\d{0,2}-?\d{0,2}$/';
+
+    public function configureId()
+    {
+        $this->setValidator('id', new sfValidatorString(
+            ['max_length' => 255],
+            ['max_length' => 'Id must be less than 255 characters']
+        ));
+        $this->setWidget('id', new sfWidgetFormInputHidden());
+    }
+
+    public function configureDate()
+    {
+        $this->setValidator('date', new sfValidatorString(
+            ['max_length' => 255],
+            ['max_length' => 'Date must be less than 255 characters']
+        ));
+        $this->setWidget('date', new sfWidgetFormInput());
+    }
+
+    public function configureStartDate()
+    {
+        $this->setValidator('startDate', new sfValidatorRegex(
+            ['max_length' => 10, 'pattern' => self::DATE_REGEX],
+            [
+                'invalid' => 'Start date must be in the format YYYY-MM-DD or
+                    YYYYMMDD',
+            ],
+        ));
+        $this->setWidget('startDate', new sfWidgetFormInput());
+    }
+
+    public function configureEndDate()
+    {
+        $this->setValidator('endDate', new sfValidatorRegex(
+            ['max_length' => 10, 'pattern' => self::DATE_REGEX],
+            [
+                'invalid' => 'End date must be in the format YYYY-MM-DD or
+                    YYYYMMDD',
+            ],
+        ));
+        $this->setWidget('endDate', new sfWidgetFormInput());
+    }
+
+    public function configureType()
+    {
+        $choices = [];
+        $eventTypes = sfIsadPlugin::eventTypes();
+
+        foreach ($eventTypes as $item) {
+            $route = sfContext::getInstance()->routing->generate(
+                null,
+                [$item, 'module' => 'term']
+            );
+            $choices += [$route => $item->__toString()];
+        }
+
+        $this->setValidator('type', new sfValidatorChoice(
+            ['choices' => array_keys($choices)]
+        ));
+        $this->setWidget('type', new sfWidgetFormSelect(
+            ['choices' => $choices]
+        ));
+    }
+
+    public function configureActor()
+    {
+        $this->setValidator('actor', new sfValidatorString());
+        $this->setWidget('actor', new sfWidgetFormSelect(['choices' => []]));
+    }
+
+    public function configureDescription()
+    {
+        $this->setValidator('description', new sfValidatorString());
+        $this->setWidget('description', new sfWidgetFormInput());
+    }
+
+    public function configurePlace()
+    {
+        $this->setValidator('place', new sfValidatorString());
+        $this->setWidget('place', new sfWidgetFormSelect(['choices' => []]));
+    }
+
+    public function configure()
+    {
+        $this->getWidgetSchema()->setNameFormat('event[%s]');
+
+        // Configure fields included in all event forms
+        $this->configureId();
+        $this->configureDate();
+        $this->configureStartDate();
+        $this->configureEndDate();
+        $this->configureType();
+    }
+}

--- a/lib/form/QubitForm.class.php
+++ b/lib/form/QubitForm.class.php
@@ -134,7 +134,7 @@ class QubitForm extends sfForm
         // Concatenate embedded form hidden field to output string
         if (!empty($this->embeddedForms)) {
             foreach ($this->embeddedForms as $name => $form) {
-                $output .= $form->renderHiddenFields($recursive);
+                $output .= $form->renderHiddenFields(false);
             }
         }
 

--- a/lib/form/QubitForm.class.php
+++ b/lib/form/QubitForm.class.php
@@ -120,4 +120,24 @@ class QubitForm extends sfForm
 
         return true;
     }
+
+    /**
+     * Return all hidden fields as a string.
+     *
+     * @param bool $recursive False will prevent hidden fields from embedded
+     *                        forms from rendering
+     */
+    public function renderHiddenFields($recursive = true): string
+    {
+        $output = $this->getFormFieldSchema()->renderHiddenFields($recursive);
+
+        // Concatenate embedded form hidden field to output string
+        if (!empty($this->embeddedForms)) {
+            foreach ($this->embeddedForms as $name => $form) {
+                $output .= $form->renderHiddenFields($recursive);
+            }
+        }
+
+        return $output;
+    }
 }

--- a/lib/form/QubitForm.class.php
+++ b/lib/form/QubitForm.class.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Add extra form features to sfForm.
+ */
+class QubitForm extends sfForm
+{
+    /**
+     * Embeds a sfForm into the current form.
+     *
+     * Added to sfForm method: update embedded form widget name format to avoid
+     * name clashes with current form widgets.
+     *
+     * @param string $name      The field name
+     * @param sfForm $form      A sfForm instance
+     * @param string $decorator A HTML decorator for the embedded form
+     */
+    public function embedForm($name, sfForm $form, $decorator = null)
+    {
+        parent::embedForm($name, $form, $decorator);
+
+        // Concatenate parent HTML element name format with embedded form name
+        if ('%s' === $this->getWidgetSchema()->getNameFormat()) {
+            // e.g. embeddedFormName[%s]
+            $nameFormat = $name.'[%s]';
+        } else {
+            // e.g. parentFormName[embeddedFormName][%s]
+            $nameFormat = sprintf(
+                '%s[%s][%%s]',
+                str_replace(
+                    '[%s]', '', $this->getWidgetSchema()->getNameFormat()
+                ),
+                $name
+            );
+        }
+
+        $form->getWidgetSchema()->setNameFormat($nameFormat);
+    }
+
+    /**
+     * Binds the form with input values.
+     *
+     * Added to sfForm method: Bind embedded form values recursively.
+     *
+     * @param array $taintedValues An array of input values
+     * @param array $taintedFiles  An array of uploaded files (in the $_FILES
+     *                             or $_GET format)
+     */
+    public function bind(
+        array $taintedValues = null,
+        array $taintedFiles = null
+    ) {
+        parent::bind($taintedValues, $taintedFiles);
+
+        if (!empty($this->embeddedForms)) {
+            $this->bindEmbeddedForms($taintedValues, $taintedFiles);
+        }
+    }
+
+    /**
+     * Recursively bind input data to embedded forms.
+     *
+     * @param array $taintedValues An array of input values
+     * @param array $taintedFiles  An array of uploaded files (in the $_FILES
+     *                             or $_GET format)
+     */
+    public function bindEmbeddedForms(
+        array $taintedValues = null,
+        array $taintedFiles = null
+    ) {
+        foreach ($this->embeddedForms as $name => $form) {
+            if (
+                isset($taintedValues[$name])
+                || isset($taintedFiles[$name])
+            ) {
+                // Bind relevant input values to embedded form
+                $form->bind($taintedValues[$name], $taintedFiles[$name]);
+            } else {
+                // Delete the embedded form if there is no POST data associated
+                // with it (i.e. it was removed from the form)
+                unset($this->embeddedForms[$name]);
+            }
+        }
+    }
+
+    /**
+     * Recursively check validity of this form and embedded forms.
+     */
+    public function isValid()
+    {
+        if (!parent::isValid()) {
+            return false;
+        }
+
+        // Check validity of embedded forms
+        if (!empty($this->embeddedForms)) {
+            foreach ($this->embeddedForms as $name => $form) {
+                if (!$form->isValid()) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/lib/form/dcEventForm.class.php
+++ b/lib/form/dcEventForm.class.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Dublin Core event form.
+ *
+ * @author     David Juhasz <david@artefactual.com>
+ */
+class dcEventForm extends eventForm
+{
+    public function configureType()
+    {
+        $eventTypes = sfDcPlugin::eventTypes();
+
+        parent::configureType();
+    }
+}

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -213,7 +213,10 @@ class QubitInformationObject extends BaseInformationObject
 
             // TODO Needed if $this is new, should be transparent
             $item->object = $this;
-            $item->save($connection);
+
+            if (!$item->deleted) {
+                $item->save($connection);
+            }
         }
 
         // Save new digital objects

--- a/plugins/sfIsadPlugin/lib/sfIsadEventForm.class.php
+++ b/plugins/sfIsadPlugin/lib/sfIsadEventForm.class.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * ISAD(G) dates event form.
+ *
+ * @author     David Juhasz <david@artefactual.com>
+ */
+class sfIsadEventForm extends EventForm
+{
+    public function configureFields()
+    {
+        // Configure ISAD dates event form fields
+        $this->configureId();
+        $this->configureType();
+        $this->configureDate();
+        $this->configureStartDate();
+        $this->configureEndDate();
+    }
+}

--- a/plugins/sfIsadPlugin/lib/sfIsadEventForm.class.php
+++ b/plugins/sfIsadPlugin/lib/sfIsadEventForm.class.php
@@ -7,6 +7,32 @@
  */
 class sfIsadEventForm extends EventForm
 {
+    public const DATE_REGEX = '/^\d{4}-?\d{0,2}-?\d{0,2}$/';
+
+    public function configureStartDate()
+    {
+        $this->setValidator('startDate', new sfValidatorRegex(
+            ['max_length' => 10, 'pattern' => self::DATE_REGEX],
+            [
+                'invalid' => 'Start date must be in the format YYYY-MM-DD or
+                    YYYYMMDD',
+            ],
+        ));
+        $this->setWidget('startDate', new sfWidgetFormInput());
+    }
+
+    public function configureEndDate()
+    {
+        $this->setValidator('endDate', new sfValidatorRegex(
+            ['max_length' => 10, 'pattern' => self::DATE_REGEX],
+            [
+                'invalid' => 'End date must be in the format YYYY-MM-DD or
+                    YYYYMMDD',
+            ],
+        ));
+        $this->setWidget('endDate', new sfWidgetFormInput());
+    }
+
     public function configureFields()
     {
         // Configure ISAD dates event form fields

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/actions/editAction.class.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/actions/editAction.class.php
@@ -90,6 +90,7 @@ class sfIsadPluginEditAction extends InformationObjectEditAction
 
         $this->eventComponent = new sfIsadPluginEventComponent($this->context, 'sfIsadPlugin', 'event');
         $this->eventComponent->resource = $this->resource;
+        $this->eventComponent->form = $this->form;
         $this->eventComponent->execute($this->request);
 
         $this->publicationNotesComponent = new InformationObjectNotesComponent($this->context, 'informationobject', 'notes');
@@ -199,14 +200,14 @@ class sfIsadPluginEditAction extends InformationObjectEditAction
 
         $this->alternativeIdentifiersComponent->processForm();
 
-        $this->eventComponent->processForm();
-
         $this->publicationNotesComponent->processForm();
 
         $this->notesComponent->processForm();
 
         $this->archivistsNotesComponent->processForm();
 
-        return parent::processForm();
+        parent::processForm();
+
+        $this->eventComponent->processForm();
     }
 }

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/actions/eventComponent.class.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/actions/eventComponent.class.php
@@ -62,8 +62,10 @@ class sfIsadPluginEventComponent extends InformationObjectEventComponent
      */
     protected function getFormDefaults(QubitEvent $event)
     {
+        sfApplicationConfiguration::getActive()->loadHelpers(['Url']);
+
         return [
-            'id' => $event->id,
+            'id' => url_for([$event, 'module' => 'event']),
             'date' => $event->date,
             'startDate' => Qubit::renderDate($event->startDate),
             'endDate' => Qubit::renderDate($event->endDate),
@@ -119,6 +121,16 @@ class sfIsadPluginEventComponent extends InformationObjectEventComponent
      */
     protected function addEventForms()
     {
+        // Create empty "events" form to hold "event" sub-forms
+        $this->events = new QubitForm();
+        $this->events->getValidatorSchema()->setOption(
+            'allow_extra_fields', true
+        );
+
+        // Embed "events" form in the main page form
+        $this->form->embedForm('events', $this->events);
+
+        // Add embedded events sub-forms
         if ($this->request->isMethod('post')) {
             $this->addPostEventForms();
         } else {

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/actions/eventComponent.class.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/actions/eventComponent.class.php
@@ -58,7 +58,8 @@ class sfIsadPluginEventComponent extends InformationObjectEventComponent
                     $this->event = $params['_sf_route']->resource;
                     array_push($finalEventIds, $this->event->id);
                 } else {
-                    $this->resource->eventsRelatedByobjectId[] = $this->event = new QubitEvent();
+                    $this->event = new QubitEvent();
+                    $this->resource->eventsRelatedByobjectId[] = $this->event;
                 }
 
                 foreach ($this->form as $field) {
@@ -76,19 +77,24 @@ class sfIsadPluginEventComponent extends InformationObjectEventComponent
             }
         }
 
-        // Delete the old events if they don't appear in the table (removed by multiRow.js)
-        // Check date events as they are the only ones added in this table
+        // Delete the old events if they don't appear in the table (removed by
+        // multiRow.js) Check date events as they are the only ones added in
+        // this table
         foreach ($this->resource->getDates() as $item) {
-            if (isset($item->id) && false === array_search($item->id, $finalEventIds)) {
+            if (
+                isset($item->id)
+                && false === array_search($item->id, $finalEventIds)
+            ) {
                 // Will be indexed when description is saved
                 $item->indexOnSave = false;
 
                 // Only delete event if it has no associated actor
-                if (null === $item->actor) {
+                if (!isset($item->actor)) {
                     $item->indexOnSave = false;
                     $item->delete();
                 } else {
-                    // Handle specially as data wasn't created using ISAD template
+                    // Handle specially as data wasn't created using ISAD
+                    // template
                     $item->startDate = null;
                     $item->endDate = null;
                     $item->date = null;
@@ -111,14 +117,25 @@ class sfIsadPluginEventComponent extends InformationObjectEventComponent
                 foreach ($eventTypes as $item) {
                     // Default event type is creation
                     if (QubitTerm::CREATION_ID == $item->id) {
-                        $this->form->setDefault('type', $this->context->routing->generate(null, [$item, 'module' => 'term']));
+                        $this->form->setDefault(
+                            'type',
+                            $this->context->routing->generate(
+                                null, [$item, 'module' => 'term']
+                            )
+                        );
                     }
 
-                    $choices[$this->context->routing->generate(null, [$item, 'module' => 'term'])] = $item->__toString();
+                    $choices[
+                        $this->context->routing->generate(
+                            null, [$item, 'module' => 'term']
+                        )
+                    ] = $item->__toString();
                 }
 
                 $this->form->setValidator('type', new sfValidatorString());
-                $this->form->setWidget('type', new sfWidgetFormSelect(['choices' => $choices]));
+                $this->form->setWidget('type', new sfWidgetFormSelect(
+                    ['choices' => $choices])
+                );
 
                 break;
 

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/_event.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/_event.php
@@ -17,57 +17,34 @@
           <?php echo __('End'); ?>
         </th>
       </tr>
-    </thead><tbody>
-
-      <?php $i = 0; foreach ($resource->getDates() as $item) { ?>
-
-        <?php $form->getWidgetSchema()->setNameFormat("editEvents[{$i}][%s]"); ++$i; ?>
-
-        <tr class="date <?php echo 0 == ++$i % 2 ? 'even' : 'odd'; ?> related_obj_<?php echo $item->id; ?>">
+    </thead>
+    <tbody>
+      <?php $i = 0; ?>
+      <?php foreach ($events->getEmbeddedForms() as $item) { ?>
+        <tr class="date <?php echo (0 == $i % 2) ? 'even' : 'odd'; ?>
+          related_obj_<?php echo $i; ?>">
           <td>
-            <div class="animateNicely">
-              <input name="<?php echo $form->getWidgetSchema()->generateName('id'); ?>" type="hidden" value="<?php echo url_for([$item, 'module' => 'event']); ?>"/>
-              <?php $save = $form->type->choices; $form->type->choices += [url_for([$item->type, 'module' => 'term']) => $item->type]; echo $form->getWidgetSchema()->renderField('type', url_for([$item->type, 'module' => 'term'])); $form->type->choices = $save; ?>
-            </div>
+            <?php echo $item['type']->renderError(); ?>
+            <?php echo $item['type']->render(); ?>
           </td><td>
-            <div class="animateNicely">
-              <?php echo $form->getWidgetSchema()->renderField('date', $item->getDate(['cultureFallback' => true])); ?>
-            </div>
+            <?php echo $item['date']->renderError(); ?>
+            <?php echo $item['date']->render(); ?>
           </td><td>
-            <div class="animateNicely">
-              <?php echo $form->getWidgetSchema()->renderField('startDate', Qubit::renderDate($item->startDate)); ?>
-            </div>
+            <?php echo $item['startDate']->renderError(); ?>
+            <?php echo $item['startDate']->render(); ?>
           </td><td>
-            <div class="animateNicely">
-              <?php echo $form->getWidgetSchema()->renderField('endDate', Qubit::renderDate($item->endDate)); ?>
-            </div>
+            <?php echo $item['endDate']->renderError(); ?>
+            <?php echo $item['endDate']->render(); ?>
           </td>
         </tr>
-
+        <?php ++$i; ?>
       <?php } ?>
-
-      <?php $form->getWidgetSchema()->setNameFormat("editEvents[{$i}][%s]"); ++$i; ?>
-
-      <tr class="date <?php echo 0 == ++$i % 2 ? 'even' : 'odd'; ?>">
-        <td>
-          <div class="animateNicely">
-            <?php echo $form->type; ?>
-          </div>
-        </td><td>
-          <?php echo $form->date; ?>
-        </td><td>
-          <?php echo $form->startDate; ?>
-        </td><td>
-          <?php echo $form->endDate; ?>
-        </td>
-      </tr>
-
-      <tfoot>
-        <tr>
-          <td colspan="5"><a href="#" class="multiRowAddButton"><?php echo __('Add new'); ?></a></td>
-        </tr>
-      </tfoot>
     </tbody>
+    <tfoot>
+      <tr>
+        <td colspan="5"><a href="#" class="multiRowAddButton"><?php echo __('Add new'); ?></a></td>
+      </tr>
+    </tfoot>
   </table>
 
   <?php if (isset($help)) { ?>

--- a/plugins/sfRadPlugin/lib/sfRadEventForm.class.php
+++ b/plugins/sfRadPlugin/lib/sfRadEventForm.class.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Rules for Archival Description (RAD) Events form.
+ *
+ * @author     David Juhasz <david@artefactual.com>
+ */
+class sfRadEventForm extends EventForm
+{
+    public function configure()
+    {
+        $this->getWidgetSchema()->setNameFormat('event[%s]');
+
+        // Configure fields included in all event forms
+        $this->configureId();
+        $this->configureType();
+        $this->configureActor();
+        $this->configureDate();
+        $this->configureStartDate();
+        $this->configureEndDate();
+        $this->configureDescription();
+    }
+}

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/actions/editAction.class.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/actions/editAction.class.php
@@ -104,14 +104,12 @@ class sfRadPluginEditAction extends InformationObjectEditAction
         $this->alternativeIdentifiersComponent->resource = $this->resource;
         $this->alternativeIdentifiersComponent->execute($this->request);
 
-        $this->eventComponent = new InformationObjectEventComponent($this->context, 'informationobject', 'event');
+        $this->eventComponent = new InformationObjectEventComponent(
+            $this->context, 'informationobject', 'event'
+        );
         $this->eventComponent->resource = $this->resource;
+        $this->eventComponent->form = $this->form;
         $this->eventComponent->execute($this->request);
-
-        $this->eventComponent->form->getWidgetSchema()->date->setHelp($this->context->i18n->__('"Give the date(s) of creation of the unit being described either as a single date, or range of dates (for inclusive dates and/or predominant dates). Always give the inclusive dates. When providing predominant dates, specify them as such, preceded by the word predominant..." (RAD 1.4B2) Record probable and uncertain dates in square brackets, using the conventions described in 1.4B5.'));
-        $this->eventComponent->form->getWidgetSchema()->description->setHelp($this->context->i18n->__('"Make notes on dates and any details pertaining to the dates of creation, publication, or distribution, of the unit being described that are not included in the Date(s) of creation, including publication, distribution, etc., area and that are considered to be important." (RAD 1.8B8) "Make notes on the date(s) of accumulation or collection of the unit being described." (RAD 1.8B8a)'));
-        $this->eventComponent->form->getWidgetSchema()->place->setHelp($this->context->i18n->__("\"For an item, transcribe a place of publication, distribution, etc., in the form and the grammatical case in which it appears.\" (RAD 1.4C1) {$this->eventComponent->form->getWidgetSchema()->place->getHelp()}"));
-        $this->eventComponent->form->getWidgetSchema()->type->setHelp($this->context->i18n->__('Select the type of activity that established the relation between the authority record and the archival description (e.g. creation, accumulation, collection, publication, etc.)'));
 
         $this->titleNotesComponent = new InformationObjectNotesComponent($this->context, 'informationobject', 'notes');
         $this->titleNotesComponent->resource = $this->resource;
@@ -251,15 +249,11 @@ class sfRadPluginEditAction extends InformationObjectEditAction
         $this->resource->sourceStandard = 'RAD version Jul2008';
 
         $this->alternativeIdentifiersComponent->processForm();
-
         $this->eventComponent->processForm();
-
         $this->titleNotesComponent->processForm();
-
         $this->notesComponent->processForm();
-
         $this->otherNotesComponent->processForm();
 
-        return parent::processForm();
+        parent::processForm();
     }
 }

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/actions/eventComponent.class.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/actions/eventComponent.class.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class sfRadPluginEventComponent extends InformationObjectEventComponent
+{
+    public function setHelps($form)
+    {
+        $this->context->getConfiguration()->loadHelpers(['I18N']);
+
+        $form->getWidgetSchema()->setHelps([
+            'date' => __(
+<<<'EOL'
+"Give the date(s) of creation of the unit being described either as a single
+date, or range of dates (for inclusive dates and/or predominant dates). Always
+give the inclusive dates. When providing predominant dates, specify them as
+such, preceded by the word predominant..." (RAD 1.4B2) Record probable and
+uncertain dates in square brackets, using the conventions described in 1.4B5.
+EOL
+            ),
+            'description' => __(
+<<<'EOL'
+"Make notes on dates and any details pertaining to the dates of creation,
+publication, or distribution, of the unit being described that are not included
+in the Date(s) of creation, including publication, distribution, etc., area and
+that are considered to be important." (RAD 1.8B8) "Make notes on the date(s) of
+accumulation or collection of the unit being described." (RAD 1.8B8a)
+EOL
+            ),
+            'place' => __(
+<<<'EOL'
+"For an item, transcribe a place of publication, distribution, etc., in the form
+and the grammatical case in which it appears." (RAD 1.4C1)
+EOL
+            ),
+            'type' => __(
+<<<'EOL'
+Select the type of activity that established the relation between the authority
+record and the archival description (e.g. creation, accumulation, collection,
+publication, etc.)
+EOL
+            ),
+        ]);
+    }
+
+    /**
+     * Add event sub-forms to $this->events form.
+     *
+     * Add one event sub-form for each event linked to $resource
+     */
+    protected function addEventForms()
+    {
+        $i = 0;
+
+        // Add one event sub-form for each event related to this resource, to
+        // allow editing the existing events
+        foreach ($this->getEvents() as $event) {
+            // Embed the event sub-form into the $this->events form
+            $form = new sfRadEventForm($this->getFormDefaults($event));
+            $this->events->embedForm($i++, $form);
+        }
+    }
+}


### PR DESCRIPTION
Embed events component forms into the InformationObjectEditAction main edit page
form.

- Add ActorEventComponent and moved logic specific to actor-event
  relationships there
- Move most event form logic to base EventEditComponent class
- Move information object-event logic to
  InformationObjectEventComponent (extends EventEditComponent)
- Move *ISAD* specific event logic to sfIsadPluginEventComponent
  (extends InformationObjectEventComponent)
- Add QubitForm class to improve sfForm embedding
- Set widget name format for embedded forms to nicely nest POST data
  and avoid name clashes
- Recursively bind submitted form data to embedded forms
- Rename eventForm.class.php -> EventForm.class.php
- Allow extra fields on $this->events holding form to avoid a validation
  error
- Don't pass POST data directory to processEventForm()
- Simplify logic for linking events to $this->resource by relying on
  check for deleted event objects in QubitInformationObject->save()
- Add QubitForm::isValid() method to recursively check validity of form
  and embedded forms
- Prevent a validation error when an embedded form has no corresponding
  POST data.
- Match date validation regex to the whole date string to prevent
  invalid characters before or after a valid date.
- Don't include the "date" form value in the "invalid" message to
  prevent very long strings from being echoed to page in the validator
  warning.