### PR TITLE
Embedded form constructor params, Refs #13450

### DIFF
--- a/apps/qubit/modules/actor/actions/occupationsComponent.class.php
+++ b/apps/qubit/modules/actor/actions/occupationsComponent.class.php
@@ -22,8 +22,7 @@ class ActorOccupationsComponent extends sfComponent
     public function execute($request)
     {
         // Create form. The note field has to be named content to allow translations
-        $this->form = new sfForm();
-        $this->form->disableCSRFProtection();
+        $this->form = new sfForm([], [], false);
         $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
         $this->form->setValidator('occupation', new sfValidatorString());
         $this->form->setValidator('content', new sfValidatorString());

--- a/apps/qubit/modules/contactinformation/actions/editComponent.class.php
+++ b/apps/qubit/modules/contactinformation/actions/editComponent.class.php
@@ -98,8 +98,7 @@ class ContactInformationEditComponent extends sfComponent
 
     public function execute($request)
     {
-        $this->form = new sfForm();
-        $this->form->disableCSRFProtection();
+        $this->form = new sfForm([], [], false);
         $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
         $this->form->getWidgetSchema()->setNameFormat('editContactInformation[%s]');
 

--- a/apps/qubit/modules/event/actions/editComponent.class.php
+++ b/apps/qubit/modules/event/actions/editComponent.class.php
@@ -92,8 +92,7 @@ class EventEditComponent extends sfComponent
 
     public function execute($request)
     {
-        $this->form = new sfForm();
-        $this->form->disableCSRFProtection();
+        $this->form = new sfForm([], [], false);
         $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
         $this->form->getWidgetSchema()->setNameFormat('editEvent[%s]');
 

--- a/apps/qubit/modules/informationobject/actions/alternativeIdentifiersComponent.class.php
+++ b/apps/qubit/modules/informationobject/actions/alternativeIdentifiersComponent.class.php
@@ -21,8 +21,7 @@ class InformationObjectAlternativeIdentifiersComponent extends sfComponent
 {
     public function execute($request)
     {
-        $this->form = new sfForm();
-        $this->form->disableCSRFProtection();
+        $this->form = new sfForm([], [], false);
         $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
 
         $this->addField('label');

--- a/apps/qubit/modules/informationobject/actions/notesComponent.class.php
+++ b/apps/qubit/modules/informationobject/actions/notesComponent.class.php
@@ -21,8 +21,7 @@ class InformationObjectNotesComponent extends sfComponent
 {
     public function execute($request, $options = [])
     {
-        $this->form = new sfForm();
-        $this->form->disableCSRFProtection();
+        $this->form = new sfForm([], [], false);
         $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
 
         $this->addField('content');

--- a/apps/qubit/modules/relation/actions/editComponent.class.php
+++ b/apps/qubit/modules/relation/actions/editComponent.class.php
@@ -67,8 +67,7 @@ class RelationEditComponent extends sfComponent
 
     public function execute($request)
     {
-        $this->form = new sfForm();
-        $this->form->disableCSRFProtection();
+        $this->form = new sfForm([], [], false);
         $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
 
         foreach ($this::$NAMES as $name) {

--- a/plugins/qtAccessionPlugin/modules/accession/actions/alternativeIdentifiersComponent.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/alternativeIdentifiersComponent.class.php
@@ -31,8 +31,7 @@ class AccessionAlternativeIdentifiersComponent extends sfComponent
         }
 
         // Define form used to add/edit identifiers
-        $this->form = new sfForm();
-        $this->form->disableCSRFProtection();
+        $this->form = new sfForm([], [], false);
         $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
 
         $this->addField('identifierType');

--- a/plugins/qtAccessionPlugin/modules/accession/actions/eventsComponent.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/eventsComponent.class.php
@@ -31,8 +31,7 @@ class AccessionEventsComponent extends sfComponent
         }
 
         // Define form used to add/edit events
-        $this->form = new sfForm();
-        $this->form->disableCSRFProtection();
+        $this->form = new sfForm([], [], false);
         $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
 
         $this->addField('eventType');


### PR DESCRIPTION
Embedded sfForm objects must be created with params "[], [], false" to
avoid inadvertently creating a new CSRF token. Default is "[], [], null"
which sets a CSRF token - when this occurs an exception is trigggered
preventing the field from being saved. Subsequent instantiations of
sfForm within the same form succeed because the sfForm::bind() method
removes the static token. If the constuctor is set with these params,
calling disableCSRFProtection() is not required.