### PR TITLE
Fix fwtv move on touchscreen, refs #12628

### DIFF
--- a/js/fullWidthTreeView.js
+++ b/js/fullWidthTreeView.js
@@ -81,6 +81,7 @@
         // - Multiple node drag
         // - Root node drag
         'copy': false,
+        'touch': 'selected',
         'open_timeout': 0,
         'drag_selection': false,
         'is_draggable': function (nodes) {


### PR DESCRIPTION
Fix touchscreen on fullwidth treeview move by adding the 'dnd' touch
option 'selected'.

Previous to this fix, touching the treeview always resulted in a
treeview move event for authenticated users. Adding this option makes it
so only selected nodes can be dragged on touch devices otherwise touch
will scroll the treeview.