### PR TITLE
Fix fwtv move on touchscreen, refs #12628

### DIFF
--- a/plugins/arDominionB5Plugin/js/fullWidthTreeView.js
+++ b/plugins/arDominionB5Plugin/js/fullWidthTreeView.js
@@ -45,6 +45,7 @@
           // - Multiple node drag
           // - Root node drag
           copy: false,
+          touch: "selected",
           open_timeout: 0,
           drag_selection: false,
           is_draggable: function (nodes) {

--- a/plugins/arDominionB5Plugin/js/fullWidthTreeView.js
+++ b/plugins/arDominionB5Plugin/js/fullWidthTreeView.js
@@ -7,6 +7,7 @@
       this.$treeViewConfig = $("#fullwidth-treeview-configuration");
       this.collectionUrl = this.$treeViewConfig.data("collection-url");
       this.itemsPerPage = this.$treeViewConfig.data("items-per-page");
+      this.dndEnabled = this.$treeViewConfig.data("enable-dnd") == "yes";
       this.pathToApi = "/informationobject/fullWidthTreeView";
       this.$fwTreeView = $('<div id="fullwidth-treeview"></div>');
       this.$fwTreeViewRow = $('<div id="fullwidth-treeview-row"></div>');
@@ -49,7 +50,7 @@
           open_timeout: 0,
           drag_selection: false,
           is_draggable: function (nodes) {
-            return nodes[0].parent !== "#";
+            return this.dndEnabled && nodes[0].parent !== "#";
           },
         },
         core: {

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_treeView.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_treeView.php
@@ -127,7 +127,8 @@
         data-collapse-enabled="<?php echo $collapsible; ?>"
         data-opened-text="<?php echo sfConfig::get('app_ui_label_fullTreeviewCollapseOpenedButtonText'); ?>"
         data-closed-text="<?php echo sfConfig::get('app_ui_label_fullTreeviewCollapseClosedButtonText'); ?>"
-        data-items-per-page="<?php echo $itemsPerPage; ?>">
+        data-items-per-page="<?php echo $itemsPerPage; ?>"
+        data-enable-dnd="<?php echo $sf_user->isAuthenticated() ? 'yes' : 'no'; ?>">
       </span>
     </div>
   <?php } ?>


### PR DESCRIPTION
Fix touchscreen on fullwidth treeview move by adding the 'dnd' touch
option 'selected'.

Previous to this fix, touching the treeview always resulted in a
treeview move event for authenticated users. Adding this option makes it
so only selected nodes can be dragged on touch devices otherwise touch
will scroll the treeview.