### PR TITLE
Fix digitalObjectURI export col, refs #13572

### DIFF
--- a/lib/flatfile/QubitFlatfileExport.class.php
+++ b/lib/flatfile/QubitFlatfileExport.class.php
@@ -453,7 +453,9 @@ class QubitFlatfileExport
         $digitalObject = $this->getAllowedDigitalObject();
 
         if (!empty($digitalObject)) {
-            $siteUrl = rtrim(QubitSetting::getByName('siteBaseUrl'), '/ ');
+            $siteUrl = !$digitalObject->derivativesGeneratedFromExternalMaster($digitalObject->usageId) ?
+                rtrim(QubitSetting::getByName('siteBaseUrl'), '/ ') :
+                "";
 
             $this->setColumn(
                 'digitalObjectURI',


### PR DESCRIPTION
Remote digital objects linked via URL will not have the system Base URL
prepended on export.