### PR TITLE
Fix digitalObjectURI export col, refs #13572

### DIFF
--- a/lib/flatfile/QubitFlatfileExport.class.php
+++ b/lib/flatfile/QubitFlatfileExport.class.php
@@ -453,11 +453,15 @@ class QubitFlatfileExport
         $digitalObject = $this->getAllowedDigitalObject();
 
         if (!empty($digitalObject)) {
-            $siteUrl = rtrim(QubitSetting::getByName('siteBaseUrl'), '/ ');
+            $digitalObjectUri = $digitalObject->getFullPath();
+
+            if (!$digitalObject->derivativesGeneratedFromExternalMaster($digitalObject->usageId)) {
+                $digitalObjectUri = rtrim(QubitSetting::getByName('siteBaseUrl'), '/ ').$digitalObjectUri;
+            }
 
             $this->setColumn(
                 'digitalObjectURI',
-                $siteUrl.$digitalObject->getFullPath()
+                $digitalObjectUri
             );
             $this->setColumn(
                 'digitalObjectChecksum',


### PR DESCRIPTION
Remote digital objects linked via URL will not have the system Base URL
prepended on export.