### PR TITLE
Fix terms useFor display, refs #13580

### DIFF
--- a/apps/qubit/modules/term/templates/_fields.php
+++ b/apps/qubit/modules/term/templates/_fields.php
@@ -78,9 +78,6 @@
       <div>
         <ul>
           <?php foreach ($resource->otherNames as $item) { ?>
-            <?php if ($item->sourceCulture != $sf_user->getCulture()) { ?>
-              <?php continue; ?>
-            <?php } ?>
             <li><?php echo __('UF %1%', ['%1%' => render_title($item)]); ?></li>
           <?php } ?>
         </ul>


### PR DESCRIPTION
Do not hide translated 'use for' names when browsing a term.