### PR TITLE
Remove unnecessary data from ES, refs #13386

### DIFF
--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -406,11 +406,20 @@ mapping:
       timestamp: true
       rawFields:  [title]
       sortFields: [title]
+    _partial_foreign_types:
+      creators:
+        _i18nFields: [authorizedFormOfName]
+        dynamic: strict
+        properties:
+          id: { type: integer }
+        _foreign_types:
+          other_names: other_name
+          parallel_names: other_name
+          standardized_names: other_name
     _foreign_types:
       accession_events: accession_event
       alternative_identifiers: other_name
       donors: donor
-      creators: actor
     dynamic: strict
     properties:
       slug: { type: keyword }
@@ -485,6 +494,10 @@ mapping:
         - creators.parallelNames.name
         - creators.standardizedNames.name
         - inheritedCreators.authorizedFormOfName
+        - inheritedCreators.history
+        - inheritedCreators.otherNames.name
+        - inheritedCreators.parallelNames.name
+        - inheritedCreators.standardizedNames.name
         - subjects.name
         - places.name
         - genres.name
@@ -519,18 +532,45 @@ mapping:
           other_names: other_name
           parallel_names: other_name
           standardized_names: other_name
+      creators:
+        _i18nFields: [authorizedFormOfName, history]
+        dynamic: strict
+        properties:
+          id: { type: integer }
+        _foreign_types:
+          other_names: other_name
+          parallel_names: other_name
+          standardized_names: other_name
+      inherited_creators:
+        _i18nFields: [authorizedFormOfName, history]
+        dynamic: strict
+        properties:
+          id: { type: integer }
+        _foreign_types:
+          other_names: other_name
+          parallel_names: other_name
+          standardized_names: other_name
+      subjects:
+        _i18nFields: [name]
+        dynamic: strict
+        properties:
+          id: { type: integer }
+      places:
+        _i18nFields: [name]
+        dynamic: strict
+        properties:
+          id: { type: integer }
+      genres:
+        _i18nFields: [name]
+        dynamic: strict
+        properties:
+          id: { type: integer }
     _foreign_types:
-      creators: actor
-      inherited_creators: actor
-      subjects: term
-      places: term
-      genres: term
       dates: event
       aip: aip
       mets_data: mets_data
       act_rights: act_right
       basis_rights: basis_right
-      physical_objects: physical_object
       title_statement_of_responsibility: property
       general_notes: note
       alpha_numeric_notes: note

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchAccession.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchAccession.class.php
@@ -161,7 +161,20 @@ class arElasticSearchAccession extends arElasticSearchModelBase
 
         foreach (QubitRelation::getRelationsByObjectId($id, ['typeId' => QubitTerm::CREATION_ID]) as $item) {
             $node = new arElasticSearchActorPdo($item->subject->id);
-            $serialized['creators'][] = $node->serialize();
+
+            $creators = [
+                'id' => $node->id,
+                'i18n' => arElasticSearchModelBase::serializeI18ns(
+                    $node->id,
+                    ['QubitActor'],
+                    ['fields' => ['authorized_form_of_name']]
+                ),
+            ];
+
+            // Add other names, parallel names, and standardized names
+            $creators += $node->serializeAltNames();
+
+            $serialized['creators'][] = $creators;
         }
 
         $serialized['accessionEvents'] = self::getAccessionEvents($id);


### PR DESCRIPTION
Creators:
- Keep authorized form of name, parallel names, other forms of name.
- Keep admin/bio history
- Remove everything else

Place, subject, genre terms:
- Keep term name.
- Remove everything else.

Removed all physical storage fields from information object ES index document.

Removed all 'Part of' details from the information object ES index document.