### PR TITLE
Trigger data load from autocomplete, refs #13584

### DIFF
--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -509,6 +509,12 @@
               // On single <select/> item select, simply update the
               // value of this input
               $hidden.val(data[1]).trigger('change');
+
+              // Trigger event to load item data if it's needed
+              $input.trigger({
+                type: 'itemSelected',
+                itemValue: $hidden.attr('value')
+              });
             }
 
             // Update the value of the autocomplete <input/> here

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -86,7 +86,7 @@
           });
 
         // Create YUI container for dialog
-        var $yuiDialogWrapper = $('<div id="' + this.table.id + '">'
+        var $yuiDialogWrapper = $('<div id="' + this.table.id + '_yui_wrap">'
           + '  <div class="hd">'
           + '    ' + this.label
           + '  </div><div class="bd">'


### PR DESCRIPTION
Fire the "itemSelect" event from autocomplete.js when an suggested item
is selected to notify the dialog.js listener to load related resource
data.

Also: change id of YUI dialog.js wrapper to avoid a name collision with
the original <div> id.