### PR TITLE
Dev/issue 13584 fix donor info load

### DIFF
--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -509,6 +509,12 @@
               // On single <select/> item select, simply update the
               // value of this input
               $hidden.val(data[1]).trigger('change');
+
+              // Trigger event to load item data if it's needed
+              $input.trigger({
+                type: 'itemSelected',
+                itemValue: $hidden.attr('value')
+              });
             }
 
             // Update the value of the autocomplete <input/> here

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -86,7 +86,7 @@
           });
 
         // Create YUI container for dialog
-        var $yuiDialogWrapper = $('<div id="' + this.table.id + '">'
+        var $yuiDialogWrapper = $('<div id="' + this.table.id + '_yui_wrap">'
           + '  <div class="hd">'
           + '    ' + this.label
           + '  </div><div class="bd">'
@@ -587,11 +587,11 @@
             // Check for special field render handler
             if (undefined !== this.options.handleFieldRender)
             {
-              var render = thisDialog.options.handleFieldRender;
+              var render = this.options.handleFieldRender;
             }
             else
             {
-              var render = thisDialog.renderField;
+              var render = this.renderField;
             }
 
             var tr = newRowTemplate.replace('{' + this.fieldPrefix + '[id]}', this.id);
@@ -610,13 +610,17 @@
               {
                 return rowId == this.id;
               });
+
+            // Hide so we can show the row with an animation later
+            var $tr = $(tr).hide();
+
             if (!$row.length)
             {
-              var $tr = $(tr).appendTo(displayTable);
+              $tr.appendTo(displayTable);
             }
             else
             {
-              var $tr = $(tr).replaceAll($row);
+              $tr.replaceAll($row);
             }
 
             // Bind events
@@ -629,6 +633,8 @@
               {
                 thisDialog.remove($(this).closest('tr').attr('id'));
               });
+
+            $tr.fadeIn();
           }
 
         // Submit dialog

--- a/plugins/qtAccessionPlugin/js/relatedDonor.js
+++ b/plugins/qtAccessionPlugin/js/relatedDonor.js
@@ -1,0 +1,89 @@
+(function ($) {
+  $(document).ready(function() {
+    // Add validator to ensure a related donor is selected/created
+    var validator = function () {
+      var relation = $('#relatedDonor_resource').val();
+
+      if (!relation.length) {
+        // Display error message
+        $('#relatedDonorError').css('display', 'block');
+
+        return false;
+      } else {
+        // Hide error message until required again
+        $('#relatedDonorError').css('display', 'none');
+      }
+    }
+
+    // Hide error on cancel
+    var afterCancelLogic = function () {
+      $('#relatedDonorError').css('display', 'none');
+    }
+
+    var $newRowTemplate = $('#\\{relatedDonor\\[id\\]\\}');
+
+    // Remove row template from DOM
+    $newRowTemplate.detach();
+    $newRowTemplate.removeClass('hidden');
+
+    // Define dialog
+    var dialog = new QubitDialog('relatedDonor',
+      {
+        'displayTable': 'relatedDonorDisplay',
+        'newRowTemplate': $newRowTemplate[0].outerHTML,
+        'validator': validator,
+        'afterCancelLogic': afterCancelLogic,
+        'relationTableMap': function (response) {
+          response.resource = response.object;
+          response.resourceDisplay = response.objectDisplay;
+
+          return response;
+        }
+      }
+    );
+
+    // Add edit button to pre-existing donor rows
+    var editImgTag = $newRowTemplate.find('img[src="/images/pencil.png"]');
+    $('#relatedDonorDisplay tr[id]')
+      .click(function () {
+        dialog.open(this.id);
+      })
+      .find('td:last')
+      .prepend(editImgTag);
+
+    // Clear donor info when the selected donor is changed
+    var unselect = function() {
+      dialog.clear();
+      $('#relatedDonor .yui-ac-input').off('input', unselect);
+    }
+
+    // Load primary contact data when a new item is selected.
+    // Can't use dialog.loadData() with the donor primary contact url
+    // as it loads the data with a different id. The contact data must
+    // be obtained first and then update the dialog using the current dialog id
+    $('#relatedDonor .yui-ac-input').on('itemSelected', function (e) {
+      var dataSource = new YAHOO.util.XHRDataSource(e.itemValue + '/donor/primaryContact');
+      dataSource.responseType = YAHOO.util.DataSourceBase.TYPE_JSON;
+      dataSource.parseJSONData = function (request, response) {
+        response = dialog.options.relationTableMap.call(dialog, response);
+
+        return {
+          results: [new (function (response) {
+            for (i in response) {
+              this[dialog.fieldPrefix + '[' + i + ']'] = response[i];
+            }
+          })(response)]
+        };
+      }
+
+      dataSource.sendRequest(null, {
+        success: function (request, response) {
+          dialog.updateDialog(dialog.id, response.results[0]);
+
+          // Clear donor info if donor name is changed
+          $('#relatedDonor .yui-ac-input').on('input', unselect);
+        }
+      });
+    });
+  });
+})(jQuery);

--- a/plugins/qtAccessionPlugin/modules/accession/templates/_relatedDonor.php
+++ b/plugins/qtAccessionPlugin/modules/accession/templates/_relatedDonor.php
@@ -1,145 +1,73 @@
-<?php $sf_response->addJavaScript('/vendor/yui/datasource/datasource-min', 'last'); ?>
-<?php $sf_response->addJavaScript('/vendor/yui/container/container-min', 'last'); ?>
+<?php $sf_response->addJavaScript(
+    '/vendor/yui/datasource/datasource-min', 'last'
+); ?>
+<?php $sf_response->addJavaScript(
+    '/vendor/yui/container/container-min', 'last'
+); ?>
 <?php $sf_response->addJavaScript('/vendor/yui/tabview/tabview-min', 'last'); ?>
 <?php $sf_response->addJavaScript('dialog', 'last'); ?>
 <?php $sf_response->addJavaScript('multiDelete', 'last'); ?>
+<?php $sf_response->addJavaScript(
+  '/plugins/qtAccessionPlugin/js/relatedDonor', 'last'
+); ?>
 
 <?php use_helper('Javascript'); ?>
 
 <div class="section">
-
   <table id="relatedDonorDisplay" class="table table-bordered">
     <caption>
       <?php echo __('Related donors'); ?>
-    </caption><thead>
+    </caption>
+    <thead>
       <tr>
         <th colspan="2">
           <?php echo __('Name'); ?>
         </th>
       </tr>
-    </thead><tbody>
+    </thead>
+    <tbody>
       <?php foreach ($relatedDonorRecord as $item) { ?>
-        <tr class="<?php echo 0 == @@++$row % 2 ? 'even' : 'odd'; ?> related_obj_<?php echo $item->id; ?>" id="<?php echo url_for([$item, 'module' => 'accession', 'action' => 'relatedDonor']); ?>">
+        <tr class="<?php echo 0 == @@++$row % 2 ? 'even' : 'odd'; ?>
+          related_obj_<?php echo $item->id; ?>"
+          id="<?php echo url_for(
+            [$item, 'module' => 'accession', 'action' => 'relatedDonor']
+          ); ?>">
           <td>
             <?php echo render_title($item->object); ?>
           </td><td style="text-align: right;">
-            <input class="multiDelete" name="deleteRelations[]" type="checkbox" value="<?php echo url_for([$item, 'module' => 'relation']); ?>"/>
+            <input class="multiDelete" name="deleteRelations[]" type="checkbox"
+              value="<?php echo url_for([$item, 'module' => 'relation']); ?>"/>
           </td>
         </tr>
       <?php } ?>
+
+      <?php /* Row template for adding related donors via relatedDonor.js */ ?>
+      <tr id="{<?php echo $form->getWidgetSchema()->generateName('id'); ?>}"
+        class="hidden">
+        <td>
+          {<?php echo $form->resource->renderName(); ?>}
+        </td>
+        <td style="text-align: right">
+          <?php echo image_tag(
+            'pencil',
+            ['alt' => __('Edit'), 'style' => 'align: top']);
+          ?>
+          <button class="delete-small" name="delete" type="button" />
+        </td>
+      </tr>
     </tbody>
   </table>
 
-<?php
-
-// Template for new display table rows
-$editHtml = image_tag('pencil', ['alt' => __('Edit'), 'style' => 'align: top']);
-
-$rowTemplate = json_encode(<<<value
-<tr id="{{$form->getWidgetSchema()->generateName('id')}}">
-  <td>
-    {{$form->resource->renderName()}}
-  </td><td style="text-align: right">
-    {$editHtml} <button class="delete-small" name="delete" type="button"/>
-  </td>
-</tr>
-
-value
-);
-
-echo javascript_tag(<<<content
-Drupal.behaviors.relatedDonor = {
-  attach: function (context)
-    {
-      // Add validator to ensure a related donor is selected/created
-      var validator = function() {
-          var relation = jQuery('#relatedDonor_resource').val();
-
-          if (!relation.length) {
-            // Display error message
-            jQuery('#relatedDonorError').css('display', 'block');
-
-            return false;
-          } else {
-            // Hide error message until required again
-            jQuery('#relatedDonorError').css('display', 'none');
-          }
-      }
-
-      // Hide error on cancel
-      var afterCancelLogic = function () {
-          jQuery('#relatedDonorError').css('display', 'none');
-      }
-
-      // Define dialog
-      var dialog = new QubitDialog('relatedDonor', {
-        'displayTable': 'relatedDonorDisplay',
-        'newRowTemplate': {$rowTemplate},
-        'validator': validator,
-        'afterCancelLogic': afterCancelLogic,
-        'relationTableMap': function (response)
-          {
-            response.resource = response.object;
-            response.resourceDisplay = response.objectDisplay;
-
-            return response;
-          } });
-
-      // Add edit button to rows
-      jQuery('#relatedDonorDisplay tr[id]', context)
-        .click(function ()
-          {
-            dialog.open(this.id);
-          })
-        .find('td:last')
-        .prepend('{$editHtml}');
-
-      // Load primary contact data when a new item is selected.
-      // Can't use dialog.loadData() with the donor primary contact url
-      // as it loads the data with a different id. The contact data must
-      // be obtained first and then update the dialog using the current dialog id
-      jQuery('#relatedDonor .yui-ac-input').on('itemSelected', function (e)
-        {
-          var dataSource = new YAHOO.util.XHRDataSource(e.itemValue + '/donor/primaryContact');
-          dataSource.responseType = YAHOO.util.DataSourceBase.TYPE_JSON;
-          dataSource.parseJSONData = function (request, response)
-            {
-              response = dialog.options.relationTableMap.call(dialog, response);
-
-              return { results: [new (function (response)
-                {
-                  for (name in response)
-                  {
-                    this[dialog.fieldPrefix + '[' + name + ']'] = response[name];
-                  }
-                })(response)] };
-            }
-
-          dataSource.sendRequest(null, {
-            success: function (request, response)
-              {
-                dialog.updateDialog(dialog.id, response.results[0]);
-              } });
-        });
-    } }
-
-content
-); ?>
-
-  <!-- NOTE dialog.js wraps this *entire* table in a YUI dialog -->
+  <?php /* NOTE: dialog.js wraps this *entire* table in a YUI dialog */ ?>
   <div class="section" id="relatedDonor">
-
+    <?php echo $form->renderHiddenFields(); ?>
     <h3><?php echo __('Related donor record'); ?></h3>
-
     <div>
-
       <div class="messages error" id="relatedDonorError" style="display: none">
         <ul>
           <li><?php echo __('Please complete all required fields.'); ?></li>
         </ul>
       </div>
-
-      <?php echo $form->renderHiddenFields(); ?>
 
       <div class="form-item">
         <?php echo $form->resource
@@ -147,82 +75,77 @@ content
             ->renderLabel(); ?>
         <?php echo $form->resource->render(['class' => 'form-autocomplete']); ?>
         <?php echo $form->resource
-            ->help(__('This is the legal entity field and provides the contact information for the person(s) or the institution that donated or transferred the materials. It has the option of multiple instances and provides the option of creating more than one contact record using the same form.'))
+            ->help(
+              __(
+                'This is the legal entity field and provides the contact
+                information for the person(s) or the institution that donated or
+                transferred the materials. It has the option of multiple
+                instances and provides the option of creating more than one
+                contact record using the same form.'
+              )
+            )
             ->renderHelp(); ?>
-        <input class="add" type="hidden" data-link-existing="true" value="<?php echo url_for(['module' => 'donor', 'action' => 'add']); ?> #authorizedFormOfName"/>
-        <input class="list" type="hidden" value="<?php echo url_for(['module' => 'donor', 'action' => 'autocomplete']); ?>"/>
+        <input class="add" type="hidden" data-link-existing="true"
+          value="<?php echo url_for(
+            ['module' => 'donor', 'action' => 'add']
+          ); ?> #authorizedFormOfName"/>
+        <input class="list" type="hidden"
+          value="<?php echo url_for(
+            ['module' => 'donor', 'action' => 'autocomplete']
+          ); ?>"/>
       </div>
 
       <fieldset>
-
         <legend><?php echo __('Primary contact information'); ?></legend>
-
         <div id="contactInformationRelationTabView" class="yui-navset">
-
           <ul class="yui-nav">
-
-            <li class="selected"><a href="#contactInformationRelation_Tab1"><em><?php echo __('Main'); ?></em></a></li>
-            <li><a href="#contactInformationRelation_Tab2"><em><?php echo __('Physical location'); ?></em></a></li>
-            <li><a href="#contactInformationRelation_Tab3"><em><?php echo __('Other details'); ?></em></a></li>
-
+            <li class="selected">
+              <a href="#contactInformationRelation_Tab1">
+                <em><?php echo __('Main'); ?></em>
+              </a>
+            </li>
+            <li>
+              <a href="#contactInformationRelation_Tab2">
+                <em><?php echo __('Physical location'); ?></em>
+              </a>
+            </li>
+            <li>
+              <a href="#contactInformationRelation_Tab3">
+                <em><?php echo __('Other details'); ?></em>
+              </a>
+            </li>
           </ul>
 
           <div class="yui-content">
-
             <div id="contactInformationRelation_Tab1">
-
               <?php echo $form->contactPerson->renderRow(); ?>
-
               <?php echo $form->telephone->renderRow(); ?>
-
               <?php echo $form->fax->renderRow(); ?>
-
               <?php echo $form->email->renderRow(); ?>
-
               <?php echo $form->website
                   ->label(__('URL'))
                   ->renderRow(); ?>
-
             </div>
-
             <div id="contactInformationRelation_Tab2">
-
               <?php echo $form->streetAddress->renderRow(); ?>
-
               <?php echo $form->region
                   ->label(__('Region/province'))
                   ->renderRow(); ?>
-
               <?php echo $form->countryCode
                   ->label(__('Country'))
                   ->renderRow(); ?>
-
               <?php echo $form->postalCode->renderRow(); ?>
-
               <?php echo $form->city->renderRow(); ?>
-
               <?php echo $form->latitude->renderRow(); ?>
-
               <?php echo $form->longitude->renderRow(); ?>
-
             </div>
-
             <div id="contactInformationRelation_Tab3">
-
               <?php echo $form->contactType->renderRow(); ?>
-
               <?php echo $form->note->renderRow(); ?>
-
             </div>
-
           </div>
-
         </div>
-
       </fieldset>
-
     </div>
-
   </div>
-
 </div>


### PR DESCRIPTION
Fire the "itemSelect" event from autocomplete.js when an suggested item
is selected to notify the dialog.js listener to load related resource
data.

Also: 
- change id of YUI dialog.js wrapper to avoid a name collision with
  the original <div> id
- Move JavaScript code from _relatedDonor.php template file to it's own
  relatedDonor.js file to make it easier to read and debug and to allow
  automatic code formatting
- When a pre-existing donor is selected in the relatedDonor dialog, their
  contact information is loaded.  If the donor is then changed, clear
  their contact information from the dialog 