### PR TITLE
Fix terms useFor display, refs #13580

### DIFF
--- a/plugins/arDominionB5Plugin/modules/term/templates/_fields.php
+++ b/plugins/arDominionB5Plugin/modules/term/templates/_fields.php
@@ -67,9 +67,6 @@
     <?php
         $equivalentTerms = [];
         foreach ($resource->otherNames as $item) {
-            if ($item->sourceCulture != $sf_user->getCulture()) {
-                continue;
-            }
             $equivalentTerms[] = __('UF %1%', ['%1%' => render_title($item)]);
         }
         echo render_show(render_title($resource), $equivalentTerms, ['isSubField' => true]);


### PR DESCRIPTION
Do not hide translated 'use for' names when browsing a term.