### PR TITLE
Refactor finding aid methods

### DIFF
--- a/apps/qubit/modules/informationobject/actions/findingAidComponent.class.php
+++ b/apps/qubit/modules/informationobject/actions/findingAidComponent.class.php
@@ -36,14 +36,14 @@ class InformationObjectFindingAidComponent extends sfComponent
 
         // Public users can only see the download link if the file exists
         if (!$this->getUser()->isAuthenticated()) {
-            if (!empty($findingAid->getPath())) {
-                $this->path = $findingAid->getPath();
-                $this->showDownload = true;
-
-                return;
+            if (empty($findingAid->getPath())) {
+                return sfView::NONE;
             }
 
-            return sfView::NONE;
+            $this->path = $findingAid->getPath();
+            $this->showDownload = true;
+
+            return;
         }
 
         $lastJobStatus = arFindingAidJob::getStatus($this->resource->id);

--- a/lib/QubitFindingAidGenerator.class.php
+++ b/lib/QubitFindingAidGenerator.class.php
@@ -233,7 +233,8 @@ class QubitFindingAidGenerator
         // Ensure 'downloads' directory exists
         Qubit::createDownloadsDirIfNeeded();
 
-        // Get the path to this resource's cached EAD file, if caching is enabled
+        // Get the path to this resource's cached EAD file, if caching is
+        // enabled
         $eadFilePath = $this->getEadCacheFilePath();
 
         // Generate an EAD file, if there is no cached EAD file
@@ -245,8 +246,10 @@ class QubitFindingAidGenerator
         $this->path = $this->generateFindingAid($foFilePath);
 
         $findingAid = new QubitFindingAid($this->resource);
+        $findingAid->setLogger($this->logger);
         $findingAid->setPath($this->path);
         $findingAid->setStatus(QubitFindingAid::GENERATED_STATUS);
+        $findingAid->save();
 
         $this->logger->info(
             sprintf('Finding aid generated successfully: %s', $this->path)
@@ -255,8 +258,8 @@ class QubitFindingAidGenerator
         // Delete temporary files
         unlink($foFilePath);
 
-        // Only delete the EAD file if XML caching is disabled, so we don't delete
-        // the cache file
+        // Only delete the EAD file if XML caching is disabled, so we don't
+        // delete the cache file
         if (!$this->isXmlCachingEnabled()) {
             unlink($eadFilePath);
         }

--- a/test/phpunit/QubitFindingAidTest.php
+++ b/test/phpunit/QubitFindingAidTest.php
@@ -135,4 +135,31 @@ class QubitFindingAidTest extends \PHPUnit\Framework\TestCase
             $findingAid->getFormat()
         );
     }
+
+    public function testSetStatus()
+    {
+        $findingAid = new QubitFindingAid(new QubitInformationObject());
+        $findingAid->setStatus(QubitFindingAid::GENERATED_STATUS);
+
+        $this->assertSame(
+            QubitFindingAid::GENERATED_STATUS,
+            $findingAid->getStatus()
+        );
+    }
+
+    public function testSetStatusInvalidInteger()
+    {
+        $findingAid = new QubitFindingAid(new QubitInformationObject());
+
+        $this->expectException(UnexpectedValueException::class);
+        $findingAid->setStatus(10);
+    }
+
+    public function testSetTranscript()
+    {
+        $findingAid = new QubitFindingAid(new QubitInformationObject());
+        $findingAid->setTranscript('Nothing to see here');
+
+        $this->assertSame('Nothing to see here', $findingAid->getTranscript());
+    }
 }


### PR DESCRIPTION
This refactor was originally done as part of a fix for issue #13596 to
save generated finding aid text, but it was decided that functionality
was saving redundant data already in the descriptive metadata.

Improvements:
- Create an QubitFindingAid::save() method to explicity trigger saving
  finding aid data to the database and search index
- Create status and findingAid property accessors and mutators
- Untangle finding aid text extraction, local storage (in property),
  and persistence (database/ES storage)
- Improve logging for finding aid generation, and PDF text extraction
- Update unit tests

Don't save generated finding aids transcripts