### PR TITLE
Check that CSRF protection is enabled

### DIFF
--- a/cypress/integration/login_spec.js
+++ b/cypress/integration/login_spec.js
@@ -2,6 +2,7 @@ describe('Login', () => {
   it('Logs in through the user menu', () => {
     cy.visit('/')
     cy.contains('Log in').click()
+    cy.get('#csrf_token').should('exist')
     cy.get('input#email').type(Cypress.env('adminEmail'))
     cy.get('input#password').type(Cypress.env('adminPassword'))
     cy.get('#user-menu form').submit()
@@ -12,6 +13,7 @@ describe('Login', () => {
 
   it('Logs in through the login page', () => {
     cy.visit('/user/login')
+    cy.get('#csrf_token').should('exist')
     cy.get('#content input#email').type(Cypress.env('adminEmail'))
     cy.get('#content input#password').type(Cypress.env('adminPassword'))
     cy.get('#content form').submit()
@@ -20,9 +22,10 @@ describe('Login', () => {
     cy.contains('Log out')
   })
 
-  it('Fails loging in with the same error', () => {
+  it('Fails log in with the same error for both login forms', () => {
     cy.visit('/')
     cy.contains('Log in').click()
+    cy.get('#csrf_token').should('exist')
     cy.get('input#email').type('unknown@user.com')
     cy.get('input#password').type(Cypress.env('adminPassword'))
     cy.get('#user-menu form').submit()

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -34,9 +34,16 @@ Cypress.Commands.add('getHiddenInputs', (url, form) =>
 )
 
 Cypress.Commands.add('getCsrfToken', (url, form) =>
-  cy.getHiddenInputs(url, form).then(inputs =>
-    inputs.filter('#csrf_token').val()
-  )
+  cy.getHiddenInputs(url, form).then(inputs => {
+    const token = inputs.filter('#csrf_token')
+
+    if (0 === token.length) {
+      throw 'CSRF seems to be disabled (no #csrf_token hidden input found).' +
+      ' See: https://symfony.com/legacy/doc/reference/1_4/en/04-Settings#chapter_04_sub_csrf_secret'
+    }
+
+    return token.val()
+  })
 )
 
 Cypress.Commands.add('login', () =>


### PR DESCRIPTION
Explicitly test for #csrf_token input, to make it easier to understand
when tests fail because CSRF is disabled.