### PR TITLE
Add CSV import audit CLI task, refs #13569

### DIFF
--- a/lib/CsvImportAuditer.class.php
+++ b/lib/CsvImportAuditer.class.php
@@ -1,0 +1,307 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once __DIR__.'/../vendor/composer/autoload.php';
+
+/**
+ * Auditer for CSV imports.
+ *
+ * @author  Mike Cantelon <mike@artefactual.com>
+ */
+class CsvImportAuditer
+{
+    protected $sourceName;
+    protected $targetName = 'information_object';
+    protected $filename;
+    protected $ormClasses;
+    protected $errorLogHandle;
+    protected $rowsAudited = 0;
+    protected $rowsTotal = 0;
+    protected $missingIds = [];
+
+    // Default options
+    protected $options = [
+        'quiet' => false,
+        'errorLog' => null,
+        'progressFrequency' => 1,
+        'idColumnName' => 'legacyId',
+    ];
+
+    //
+    // Public methods
+    //
+
+    public function __construct($options = [])
+    {
+        $this->setOrmClasses([
+            'keymap' => QubitKeymap::class,
+        ]);
+
+        $this->setOptions(array_merge($this->options, $options));
+    }
+
+    public function setOrmClasses(array $classes): void
+    {
+        $this->ormClasses = $classes;
+    }
+
+    public function setSourceName($sourceName): void
+    {
+        $this->sourceName = $sourceName;
+    }
+
+    public function getSourceName(): string
+    {
+        return $this->sourceName ?? '';
+    }
+
+    public function setTargetName($targetName): void
+    {
+        if (empty($targetName)) {
+            throw new ValueError("Target name can't be blank.");
+        }
+
+        $this->targetName = $targetName;
+    }
+
+    public function getTargetName(): string
+    {
+        return $this->targetName;
+    }
+
+    public function setFilename($filename): void
+    {
+        $this->filename = $this->validateFilename($filename);
+
+        if (empty($this->getSourceName())) {
+            $this->setSourceName(basename($filename));
+        }
+    }
+
+    public function getFilename(): string
+    {
+        return $this->filename;
+    }
+
+    public function validateFilename($filename): string
+    {
+        if (empty($filename)) {
+            throw new sfException('Please specify a filename for import');
+        }
+
+        if (!file_exists($filename)) {
+            throw new sfException("Can not find file {$filename}");
+        }
+
+        if (!is_readable($filename)) {
+            throw new sfException("Can not read {$filename}");
+        }
+
+        return $filename;
+    }
+
+    public function setOptions(array $options = null): void
+    {
+        if (empty($options)) {
+            return;
+        }
+
+        foreach ($options as $name => $val) {
+            $this->setOption($name, $val);
+        }
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    public function setOption(string $name, $value): void
+    {
+        $this->options[$name] = $value;
+    }
+
+    public function getOption(string $name)
+    {
+        return $this->options[$name] ?? null;
+    }
+
+    public function countRowsAudited(): int
+    {
+        return $this->rowsAudited;
+    }
+
+    public function countRowsTotal(): int
+    {
+        return $this->rowsTotal;
+    }
+
+    public function doAudit($filename = null): void
+    {
+        if (null !== $filename) {
+            $this->setFilename($filename);
+        }
+
+        $records = $this->loadCsvData($this->filename);
+
+        foreach ($records as $record) {
+            try {
+                $this->processRow($record);
+            } catch (UnexpectedValueException $e) {
+                $this->logError(sprintf(
+                    'Warning! skipped row [%u/%u]: %s',
+                    $this->rowsAudited,
+                    $this->rowsTotal,
+                    $e->getMessage()
+                ));
+
+                continue;
+            }
+
+            ++$this->rowsAudited;
+            $this->log($this->progressUpdate($this->rowsAudited));
+        }
+
+        if (!empty($this->missingIds)) {
+            $this->log("\nSource IDs not found in keymap data:");
+
+            foreach ($this->missingIds as $sourceId => $rowNumber) {
+                $this->log(sprintf('* %d (row %d)', $sourceId, $rowNumber));
+            }
+        }
+    }
+
+    public function loadCsvData($filename): League\Csv\ResultSet
+    {
+        $this->validateFileName($filename);
+
+        $reader = $this->readCsvFile($filename);
+        $stmt = new \League\Csv\Statement();
+        $records = $this->getRecords($reader, $stmt);
+
+        $this->rowsTotal = count($records);
+
+        return $records;
+    }
+
+    public function processRow($data): void
+    {
+        // Determine column name to check
+        $idColumnName = $this->getOption('idColumnName');
+
+        // Throw error if not ID value is found
+        if (empty($data[$idColumnName])) {
+            throw new UnexpectedValueException(sprintf('ID column %s not found', $idColumnName));
+        }
+
+        // Attempt to fetch keymap entry corresponding to source ID
+        $sourceId = trim($data[$idColumnName]);
+
+        if (false === $this->ormClasses['keymap']::getTargetId(
+            $this->getSourceName(),
+            $sourceId,
+            $this->getTargetName()
+        )) {
+            $this->missingIds[$sourceId] = $this->rowsAudited + 1;
+        }
+    }
+
+    public function progressUpdate($count): string
+    {
+        $freq = $this->getOption('progressFrequency');
+
+        if (1 == $freq) {
+            $msg = 'Row [%u/%u] audited';
+
+            $output = sprintf(
+                $msg,
+                $count,
+                $this->rowsTotal
+            );
+        } elseif ($freq > 1 && 0 == $count % $freq) {
+            $output = sprintf(
+                'Audited %u of %u rows...',
+                $count,
+                $this->rowsTotal
+            );
+        }
+
+        return $output;
+    }
+
+    public function getMissingIds(): array
+    {
+        return $this->missingIds;
+    }
+
+    //
+    // Protected methods
+    //
+
+    protected function log($msg): void
+    {
+        if (!$this->getOption('quiet')) {
+            echo $msg.PHP_EOL;
+        }
+    }
+
+    protected function logError($msg): void
+    {
+        // Write to error log (but not STDERR)
+        if (STDERR != $this->getErrorLogHandle()) {
+            fwrite($this->getErrorLogHandle(), $msg.PHP_EOL);
+        }
+    }
+
+    protected function getErrorLogHandle(): resource
+    {
+        if (null === $filename = $this->getOption('errorLog')) {
+            return STDERR;
+        }
+
+        if (!isset($this->errorLogHandle)) {
+            $this->errorLogHandle = fopen($filename, 'w');
+        }
+
+        return $this->errorLogHandle;
+    }
+
+    protected function readCsvFile($filename): object
+    {
+        $reader = \League\Csv\Reader::createFromPath($filename, 'r');
+
+        if (!isset($this->options['header'])) {
+            // Use first row of CSV file as header
+            $reader->setHeaderOffset(0);
+        }
+
+        return $reader;
+    }
+
+    protected function getRecords($reader, $stmt): League\Csv\ResultSet
+    {
+        if (isset($this->options['header'])) {
+            $records = $stmt->process($reader, $this->options['header']);
+        } else {
+            $records = $stmt->process($reader);
+        }
+
+        return $records;
+    }
+}

--- a/lib/model/QubitKeymap.php
+++ b/lib/model/QubitKeymap.php
@@ -19,4 +19,10 @@
 
 class QubitKeymap extends BaseKeymap
 {
+    public static function getTargetId($sourceName, $sourceId, $targetName = 'information_object')
+    {
+        $sql = 'SELECT target_id FROM keymap WHERE source_name=? AND target_name=? AND source_id=?';
+
+        return QubitPdo::fetchColumn($sql, [$sourceName, $targetName, $sourceId]);
+    }
 }

--- a/lib/task/import/csvAuditImportTask.class.php
+++ b/lib/task/import/csvAuditImportTask.class.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Audit CSV import.
+ *
+ * @author  Mike Cantelon <mike@artefactual.com>
+ */
+class csvAuditImportTask extends arBaseTask
+{
+    /**
+     * @see sfTask
+     *
+     * @param mixed $arguments
+     * @param mixed $options
+     */
+    public function execute($arguments = [], $options = [])
+    {
+        parent::execute($arguments, $options);
+
+        $auditOptions = $this->setAuditOptions($options);
+
+        $auditer = new CsvImportAuditer($auditOptions);
+        $auditer->setSourceName($arguments['sourcename']);
+        $auditer->setFilename($arguments['filename']);
+
+        if (!empty($options['target-name'])) {
+            $auditer->setTargetName($options['target-name']);
+        }
+
+        $this->log(sprintf(
+            'Auditing import data from %s...'.PHP_EOL,
+            $auditer->getFilename()
+        ));
+
+        $auditer->doAudit();
+
+        $this->log(
+            sprintf(
+                PHP_EOL.'Done! Audited %u rows.'.PHP_EOL,
+                $auditer->countRowsTotal()
+            )
+        );
+    }
+
+    /**
+     * @see sfBaseTask
+     */
+    protected function configure()
+    {
+        $this->addArguments([
+            new sfCommandArgument(
+                'sourcename',
+                sfCommandArgument::REQUIRED,
+                'The source name of the previous import.'
+            ),
+            new sfCommandArgument(
+                'filename',
+                sfCommandArgument::REQUIRED,
+                'The input file name (CSV format).'
+            ),
+        ]);
+
+        $this->addOptions([
+            new sfCommandOption(
+                'application',
+                null,
+                sfCommandOption::PARAMETER_OPTIONAL,
+                'The application name',
+                'qubit'
+            ),
+            new sfCommandOption(
+                'env',
+                null,
+                sfCommandOption::PARAMETER_REQUIRED,
+                'The environment',
+                'cli'
+            ),
+            new sfCommandOption(
+                'connection',
+                null,
+                sfCommandOption::PARAMETER_REQUIRED,
+                'The connection name',
+                'propel'
+            ),
+
+            // Audit options
+            new sfCommandOption(
+                'target-name',
+                null,
+                sfCommandOption::PARAMETER_OPTIONAL,
+                'Keymap target name',
+                null
+            ),
+            new sfCommandOption(
+                'id-column-name',
+                null,
+                sfCommandOption::PARAMETER_REQUIRED,
+                'Name of the ID column in the source CSV file (default: "legacyId")'
+            ),
+        ]);
+
+        $this->namespace = 'csv';
+        $this->name = 'audit-import';
+        $this->briefDescription = 'Audit CSV import.';
+        $this->detailedDescription = <<<'EOF'
+Audit CSV import by checking to make sure a keymap has been created for each
+row.
+EOF;
+    }
+
+    protected function setAuditOptions($options)
+    {
+        $opts = [];
+
+        $keymap = [
+            'id-column-name' => 'idColumnName',
+        ];
+
+        foreach ($keymap as $oldkey => $newkey) {
+            if (empty($options[$oldkey])) {
+                continue;
+            }
+
+            $opts[$newkey] = $options[$oldkey];
+        }
+
+        return $opts;
+    }
+}

--- a/test/mock/QubitKeymap.php
+++ b/test/mock/QubitKeymap.php
@@ -26,8 +26,20 @@ class QubitKeymap
     public $targetId;
     public $targetName;
 
-    public function save($dbcon = null)
+    public static function getTargetId($sourceName, $sourceId, $targetName = 'information_object')
     {
-        return \QubitQuery::create();
+        $keymap = [
+            'information_object' => [
+                'test_import' => ['123' => '567', '125' => '568'],
+            ],
+        ];
+
+        if (
+          isset($keymap[$targetName], $keymap[$targetName][$sourceName], $keymap[$targetName][$sourceName][$sourceId])
+      ) {
+            return $keymap[$sourceName][$sourceId];
+        }
+
+        return false;
     }
 }

--- a/test/phpunit/CsvImportAuditerTest.php
+++ b/test/phpunit/CsvImportAuditerTest.php
@@ -1,0 +1,368 @@
+<?php
+
+use org\bovigo\vfs\vfsStream;
+
+/**
+ * @internal
+ * @covers \CsvImportAuditer
+ */
+class CsvImportAuditerTest extends \PHPUnit\Framework\TestCase
+{
+    protected $csvHeader;
+    protected $csvData;
+    protected $ormClasses;
+    protected $vfs; // virtual filesystem
+
+    // Fixtures
+
+    public function setUp(): void
+    {
+        $this->ormClasses = [
+            'keymap' => \AccessToMemory\test\mock\QubitKeymap::class,
+        ];
+
+        $this->csvHeader = 'legacyId';
+
+        $this->csvData = [
+            // Note: leading and trailing whitespace in first row is intentional
+            '"123 "',
+            '"124"',
+            '"125"',
+        ];
+
+        // Define virtual file system
+        $directory = [
+            'test.csv' => $this->csvHeader."\n".implode("\n", $this->csvData),
+            'noheader.csv' => implode("\n", $this->csvData)."\n",
+            'unreadable.csv' => $this->csvData[0],
+            'error.log' => '',
+        ];
+
+        // Set up and cache the virtual file system
+        $this->vfs = vfsStream::setup('root', null, $directory);
+
+        // Make 'unreadable.csv' owned and readable only by root user
+        $file = $this->vfs->getChild('root/unreadable.csv');
+        $file->chmod('0400');
+        $file->chown(vfsStream::OWNER_USER_1);
+    }
+
+    public function getCsvRowAsAssocArray($row = 0): array
+    {
+        return array_combine(
+            explode(',', $this->csvHeader),
+            str_getcsv($this->csvData[$row])
+        );
+    }
+
+    // Data providers
+
+    public function setOptionsProvider(): array
+    {
+        $defaultOptions = [
+            'quiet' => false,
+            'errorLog' => null,
+            'progressFrequency' => 1,
+            'idColumnName' => 'legacyId',
+        ];
+
+        $inputs = [
+            null,
+            [],
+            [
+                'progressFrequency' => 2,
+            ],
+        ];
+
+        $outputs = [
+            $defaultOptions,
+            $defaultOptions,
+            [
+                'quiet' => false,
+                'errorLog' => null,
+                'progressFrequency' => 2,
+                'idColumnName' => 'legacyId',
+            ],
+        ];
+
+        return [
+            [$inputs[0], $outputs[0]],
+            [$inputs[1], $outputs[1]],
+            [$inputs[2], $outputs[2]],
+        ];
+    }
+
+    public function processRowProvider(): array
+    {
+        $inputs = [
+            [
+                'source' => 'test_import',
+                'row' => [
+                    'legacyId' => '123',
+                    'title' => 'Row with no issues',
+                ],
+            ],
+            [
+                'source' => 'test_import',
+                'row' => [
+                    'legacyId' => '124',
+                    'title' => 'Row with new source ID',
+                ],
+            ],
+            [
+                'source' => 'bad_source',
+                'row' => [
+                    'legacyId' => '123',
+                    'title' => 'Row with bad source name',
+                ],
+            ],
+        ];
+
+        $expectedResults = [
+            [
+                'missing' => [],
+            ],
+            [
+                'missing' => [124 => 1],
+            ],
+            [
+                'missing' => [123 => 1],
+            ],
+        ];
+
+        return [
+            [$inputs[0], $expectedResults[0]],
+            [$inputs[1], $expectedResults[1]],
+            [$inputs[2], $expectedResults[2]],
+        ];
+    }
+
+    // Tests
+
+    public function testSetAndGetSourceName(): void
+    {
+        $auditer = new CsvImportAuditer();
+
+        $auditer->setSourceName('some_import');
+        $this->assertSame('some_import', $auditer->getSourceName());
+    }
+
+    public function testSetAndGetTargetName(): void
+    {
+        $auditer = new CsvImportAuditer();
+
+        $auditer->setTargetName('some_target_name');
+        $this->assertSame('some_target_name', $auditer->getTargetName());
+    }
+
+    public function testSetAndGetFilename()
+    {
+        $auditer = new CsvImportAuditer();
+
+        $auditer->setFileName($this->vfs->url().'/test.csv');
+        $this->assertSame($this->vfs->url().'/test.csv', $auditer->getFileName());
+    }
+
+    public function testSetFilenameFileNotFoundException(): void
+    {
+        $this->expectException(sfException::class);
+        $auditer = new CsvImportAuditer();
+        $auditer->setFilename('bad_name.csv');
+    }
+
+    public function testSetFilenameFileUnreadableException()
+    {
+        $this->expectException(sfException::class);
+        $auditer = new CsvImportAuditer();
+        $auditer->setFilename($this->vfs->url().'/unreadable.csv');
+    }
+
+    public function testSetFilenameSuccess()
+    {
+        $importer = new CsvImportAuditer();
+        $importer->setFilename($this->vfs->url().'/test.csv');
+        $this->assertSame(
+            $this->vfs->url().'/test.csv',
+            $importer->getFilename()
+        );
+    }
+
+    /**
+     * @dataProvider setOptionsProvider
+     *
+     * @param mixed $options
+     * @param mixed $expected
+     */
+    public function testSetOptions($options, $expected): void
+    {
+        $importer = new CsvImportAuditer();
+        $importer->setOptions($options);
+        $this->assertSame($expected, $importer->getOptions());
+    }
+
+    public function testSetOptionsThrowsTypeError(): void
+    {
+        $this->expectException(TypeError::class);
+
+        $auditer = new CsvImportAuditer();
+        $auditer->setOptions(new stdClass());
+    }
+
+    public function testSetAndGetIdColumnName(): void
+    {
+        $auditer = new CsvImportAuditer();
+
+        $auditer->setOption('idColumnName', 'some_column');
+        $this->assertSame('some_column', $auditer->getOption('idColumnName'));
+    }
+
+    public function testSetOptionFromOptions(): void
+    {
+        $auditer = new CsvImportAuditer();
+        $auditer->setOptions([
+            'progressFrequency' => 5,
+            'idColumnName' => 'some_column',
+        ]);
+
+        $this->assertSame(5, $auditer->getOption('progressFrequency'));
+        $this->assertSame('some_column', $auditer->getOption('idColumnName'));
+    }
+
+    public function testSourceNameDefaultsToFilename()
+    {
+        $filename = $this->vfs->url().'/test.csv';
+        $importer = new CsvImportAuditer();
+        $importer->setFilename($filename);
+
+        $this->assertSame(basename($filename), $importer->getSourceName());
+    }
+
+    public function testDoAuditNoFilenameException(): void
+    {
+        $this->expectException(sfException::class);
+
+        $auditer = new CsvImportAuditer();
+        $auditer->doAudit();
+    }
+
+    public function testImportRowsWithDefaultTargetName(): void
+    {
+        $auditer = new CsvImportAuditer(['quiet' => true]);
+        $auditer->setFilename($this->vfs->url().'/test.csv');
+
+        $auditer->setOrmClasses($this->ormClasses);
+        $auditer->setSourceName('test_import');
+
+        $auditer->doAudit();
+
+        $this->assertSame($auditer->getMissingIds(), [124 => 2]);
+    }
+
+    public function testImportRowsWithExplicitTargetName(): void
+    {
+        $auditer = new CsvImportAuditer(['quiet' => true]);
+        $auditer->setFilename($this->vfs->url().'/test.csv');
+
+        $auditer->setOrmClasses($this->ormClasses);
+        $auditer->setSourceName('test_import');
+        $auditer->setTargetName('information_object');
+
+        $auditer->doAudit();
+
+        $this->assertSame($auditer->getMissingIds(), [124 => 2]);
+    }
+
+    public function testImportRowsWithBadTargetName(): void
+    {
+        $auditer = new CsvImportAuditer(['quiet' => true]);
+        $auditer->setFilename($this->vfs->url().'/test.csv');
+
+        $auditer->setOrmClasses($this->ormClasses);
+        $auditer->setSourceName('test_import');
+        $auditer->setTargetName('bad_target_name');
+
+        $auditer->doAudit();
+
+        // All IDs should be missing
+        $this->assertSame($auditer->getMissingIds(), [123 => 1, 124 => 2, 125 => 3]);
+    }
+
+    /**
+     * @dataProvider processRowProvider
+     *
+     * @param mixed $data
+     * @param mixed $expectedResult
+     */
+    public function testProcessRow($data, $expectedResult): void
+    {
+        $auditer = new CsvImportAuditer();
+        $auditer->setOrmClasses($this->ormClasses);
+        $auditer->setSourceName($data['source']);
+
+        $result = $auditer->processRow($data['row']);
+
+        $this->assertSame($auditer->getMissingIds(), $expectedResult['missing']);
+    }
+
+    public function testProcessRowThrowsExceptionIfBadLegacyIdColumn(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+
+        // Row with mis-named ID column
+        $row = [
+            'id' => '123',
+        ];
+
+        $auditer = new CsvImportAuditer();
+        $auditer->setOrmClasses($this->ormClasses);
+        $auditer->setSourceName('test_import');
+
+        $result = $auditer->processRow($row);
+    }
+
+    public function testProcessRowCustomIdColumn(): void
+    {
+        $row = [
+            'id' => '123',
+        ];
+
+        $auditer = new CsvImportAuditer(['idColumnName' => 'id']);
+        $auditer->setOrmClasses($this->ormClasses);
+        $auditer->setSourceName('test_import');
+
+        $result = $auditer->processRow($row);
+
+        $this->assertSame($auditer->getMissingIds(), []);
+    }
+
+    public function testProcessRowThrowsExceptionIfNoIdColumn(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+
+        $auditer = new CsvImportAuditer();
+
+        $auditer->processRow([]);
+    }
+
+    public function testProgressUpdateFreqOne(): void
+    {
+        $auditer = new CsvImportAuditer();
+        $auditer->setOption('progressFrequency', 1);
+
+        $this->assertSame(
+            'Row [0/0] audited',
+            $auditer->progressUpdate(0)
+        );
+    }
+
+    public function testProgressUpdateFreqTwo(): void
+    {
+        $auditer = new CsvImportAuditer();
+        $auditer->setOption('progressFrequency', 2);
+
+        $this->assertSame(
+            'Audited 2 of 0 rows...',
+            $auditer->progressUpdate(2)
+        );
+    }
+}


### PR DESCRIPTION
Adds CLI task to check legacy ID values from a CSV import file and list any that haven't been imported yet (creating the list by checking keymap data).