### PR TITLE
Fix CSV check multi-file output, refs #13561

### DIFF
--- a/lib/task/import/csvCheckImportTask.class.php
+++ b/lib/task/import/csvCheckImportTask.class.php
@@ -169,7 +169,7 @@ EOF;
             $filePath = $directory.DIRECTORY_SEPARATOR.$file;
 
             if (is_file($filePath) && is_readable($filePath)) {
-                $filePaths[] = $filePath;
+                $filePaths[basename($filePath)] = $filePath;
             }
         }
 

--- a/lib/task/import/validate/csvValidatorResultCollection.php
+++ b/lib/task/import/validate/csvValidatorResultCollection.php
@@ -126,11 +126,12 @@ class CsvValidatorResultCollection implements Iterator
 
     public function renderResultsAsText(bool $verbose = false): string
     {
-        $this->resetResultCounterList();
         $outputString = "CSV Results:\n";
 
         foreach ($this->results as $result) {
             if ($filename !== $result->getFilename()) {
+                $this->resetResultCounterList();
+
                 if (!empty($filename)) {
                     $outputString .= "\n";
                 }


### PR DESCRIPTION
Fixes issues with the output of the CSV check task when checking multiple files.

Now shows CSV filename corresponding to results, rather than the count of CSV file.

Also resets counters for errors/warnings when changing which CSV file's results are being shown.