### PR TITLE
Fix D.O. path CSV column check tool, refs #13588

### DIFF
--- a/lib/task/import/csvDigitalObjectPathsCheckTask.class.php
+++ b/lib/task/import/csvDigitalObjectPathsCheckTask.class.php
@@ -66,7 +66,7 @@ Compare digital object-related files in a directory to data in a CSV file's
 column (digitalObjectPath by default) and display a report.
 
 Determines which files aren't referenced in the CSV data, which are referenced
-in CSV data but missing, and which files are references more than once.
+in CSV data but missing, and which files are referenced more than once.
 EOF;
     }
 
@@ -113,7 +113,8 @@ EOF;
         }
 
         while ($row = fgetcsv($fh, 60000)) {
-            array_push($values, $row[$imageColumnIndex]);
+            // Remove absolute path leading to image file
+            array_push($values, basename($row[$imageColumnIndex]));
         }
 
         return $values;


### PR DESCRIPTION
Fixed issue with the digital object path CSV column check tool where checks for absolute digital object paths weren't working correctly.

Fix was suggested by Scott Breeden.