### PR TITLE
Fix search-box autocomplete, refs #13274

### DIFF
--- a/apps/qubit/modules/search/actions/autocompleteAction.class.php
+++ b/apps/qubit/modules/search/actions/autocompleteAction.class.php
@@ -39,7 +39,7 @@ class SearchAutocompleteAction extends sfAction
         $culture = $this->context->user->getCulture();
 
         $client = QubitSearch::getInstance()->client;
-        $index = QubitSearch::getInstance()->index;
+        $index = QubitSearch::getInstance()->index->getInstance();
 
         // Multisearch object
         $mSearch = new \Elastica\Multi\Search($client);

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchIndexDecorator.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchIndexDecorator.class.php
@@ -52,6 +52,11 @@ class arElasticSearchIndexDecorator
         return $this->_instance->{$key} = $val;
     }
 
+    public function getInstance()
+    {
+        return $this->_instance;
+    }
+
     /**
      * Update entries in the db based on a query.
      *


### PR DESCRIPTION
Pass the actual ES index instance to `\Elastica\Multi\Search` instead of
the new `arElasticSearchIndexDecorator`.