### PR TITLE
Normalize holdings label usage, refs #13610

### DIFF
--- a/apps/qubit/modules/repository/templates/_holdings.php
+++ b/apps/qubit/modules/repository/templates/_holdings.php
@@ -5,7 +5,7 @@
 <form class="sidebar-search" role="search" aria-label="<?php echo sfConfig::get('app_ui_label_holdings'); ?>" action="<?php echo url_for(['module' => 'informationobject', 'action' => 'browse']); ?>">
   <input type="hidden" name="repos" value="<?php echo $resource->id; ?>">
   <div class="input-prepend input-append">
-    <input type="text" name="query" aria-label="<?php echo __('Search %1%', ['%1%' => sfConfig::get('app_ui_label_holdings')]); ?>" placeholder="<?php echo __('Search %1%', ['%1%' => strtolower(sfConfig::get('app_ui_label_holdings'))]); ?>">
+    <input type="text" name="query" aria-label="<?php echo __('Search'); ?>" placeholder="<?php echo __('Search'); ?>">
     <button class="btn" type="submit" aria-label=<?php echo __('Search'); ?>>
       <i aria-hidden="true" class="fa fa-search"></i>
     </button>

--- a/apps/qubit/modules/repository/templates/_holdingsInstitution.php
+++ b/apps/qubit/modules/repository/templates/_holdingsInstitution.php
@@ -24,7 +24,7 @@
         <?php echo image_tag('loading.small.gif', ['class' => 'hidden', 'id' => 'spinner', 'alt' => __('Loading ...')]); ?>
       </h3>
 
-      <form class="sidebar-search" role="search" aria-label="<?php echo __(sfConfig::get('app_ui_label_informationobject')); ?>" action="<?php echo url_for(['module' => 'informationobject', 'action' => 'browse']); ?>">
+      <form class="sidebar-search" role="search" aria-label="<?php echo __(sfConfig::get('app_ui_label_institutionSearchHoldings')); ?>" action="<?php echo url_for(['module' => 'informationobject', 'action' => 'browse']); ?>">
         <input type="hidden" name="repos" value="<?php echo $resource->id; ?>">
         <div class="input-prepend input-append">
           <input type="text" name="query" aria-label="<?php echo __('Search'); ?>" value="<?php echo $sf_request->query; ?>" placeholder="<?php echo __('Search'); ?>">

--- a/apps/qubit/modules/repository/templates/_holdingsList.php
+++ b/apps/qubit/modules/repository/templates/_holdingsList.php
@@ -5,7 +5,7 @@
   <div class="more">
     <a href="<?php echo url_for(['module' => 'informationobject', 'action' => 'browse', 'repos' => $resource->id]); ?>">
       <i class="fa fa-search"></i>
-      <?php echo __('Browse %1% holdings', ['%1%' => $pager->getNbResults()]); ?>
+      <?php echo __('Browse %1% results', ['%1%' => $pager->getNbResults()]); ?>
     </a>
   </div>
   <ul>


### PR DESCRIPTION
- Use "results" instead of harcoded "holdings" in browse link.
- Use `app_ui_label_institutionSearchHoldings` as form arial-label.
- Use only "Search" as input placeholder and aria-label.