### PR TITLE
Add destructor to clean up temp dir, refs #13598

### DIFF
--- a/lib/job/arExportJob.class.php
+++ b/lib/job/arExportJob.class.php
@@ -37,7 +37,11 @@ class arExportJob extends arBaseJob
     {
         $this->params = $parameters;
 
-        $this->zipFileDownload = new arZipFileDownload($this->job->id, $this->downloadFileExtension);
+        $this->zipFileDownload = new arZipFileDownload(
+            $this->job->id,
+            $this->downloadFileExtension,
+            $this->logger,
+        );
 
         $tempPath = $this->zipFileDownload->createJobTempDir();
 
@@ -82,10 +86,6 @@ class arExportJob extends arBaseJob
 
         $this->job->setStatusCompleted();
         $this->job->save();
-
-        // Delete temp directory contents and directory
-        sfToolkit::clearDirectory($tempPath);
-        rmdir($tempPath);
     }
 
     /**

--- a/lib/job/arFileImportJob.class.php
+++ b/lib/job/arFileImportJob.class.php
@@ -133,7 +133,11 @@ class arFileImportJob extends arBaseJob
     protected function createZipFileDownload()
     {
         // Attempt export of verbose report.
-        $zipFileDownload = new arZipFileDownload($this->job->id, $this->downloadFileExtension);
+        $zipFileDownload = new arZipFileDownload(
+            $this->job->id,
+            $this->downloadFileExtension,
+            $this->logger,
+        );
         $tempPath = $zipFileDownload->createJobTempDir();
 
         // Write verbose report contents to tempPath.

--- a/lib/job/arPhysicalObjectCsvHoldingsReportJob.class.php
+++ b/lib/job/arPhysicalObjectCsvHoldingsReportJob.class.php
@@ -45,7 +45,11 @@ class arPhysicalObjectCsvHoldingsReportJob extends arExportJob
         }
 
         // Attempt export
-        $this->zipFileDownload = new arZipFileDownload($this->job->id, $this->downloadFileExtension);
+        $this->zipFileDownload = new arZipFileDownload(
+            $this->job->id,
+            $this->downloadFileExtension,
+            $this->logger,
+        );
         $tempPath = $this->zipFileDownload->createJobTempDir();
 
         $exportFile = $tempPath.DIRECTORY_SEPARATOR.'holdings.csv';

--- a/lib/job/arRepositoryCsvExportJob.class.php
+++ b/lib/job/arRepositoryCsvExportJob.class.php
@@ -38,7 +38,11 @@ class arRepositoryCsvExportJob extends arExportJob
         $this->search = new arElasticSearchPluginQuery(arElasticSearchPluginUtil::SCROLL_SIZE);
         $this->search->queryBool->addMust(new \Elastica\Query\Terms('slug', $this->params['params']['slugs']));
 
-        $this->zipFileDownload = new arZipFileDownload($this->job->id, $this->downloadFileExtension);
+        $this->zipFileDownload = new arZipFileDownload(
+            $this->job->id,
+            $this->downloadFileExtension,
+            $this->logger,
+        );
         $tempPath = $this->zipFileDownload->createJobTempDir();
 
         // Export CSV to temp directory

--- a/lib/job/arValidateCsvJob.class.php
+++ b/lib/job/arValidateCsvJob.class.php
@@ -47,7 +47,11 @@ class arValidateCsvJob extends arBaseJob
         $this->info($validationResultString);
 
         // Attempt export of verbose report.
-        $this->zipFileDownload = new arZipFileDownload($this->job->id, $this->downloadFileExtension);
+        $this->zipFileDownload = new arZipFileDownload(
+            $this->job->id,
+            $this->downloadFileExtension,
+            $this->logger,
+        );
         $tempPath = $this->zipFileDownload->createJobTempDir();
 
         // Write verbose report contents to tempPath.


### PR DESCRIPTION
- Add arZipFileDownload destructor to automatically clean up the
  temporary job directory when the script completes or fails
- Pass the job `logger` object to arZipFileDownload to log deletion of
  temp job directory
- Use `create_date()` to get a valid DateTime object to pass to
  `date_timestamp_get()` in arZipFileDownload