### PR TITLE
Fix settings culture discrepencies, refs #13607

### DIFF
--- a/apps/qubit/modules/settings/actions/editAction.class.php
+++ b/apps/qubit/modules/settings/actions/editAction.class.php
@@ -70,7 +70,7 @@ class SettingsEditAction extends DefaultEditAction
         $settingDefault = (isset($this->settingDefaults[$name])) ? $this->settingDefaults[$name] : '';
 
         // Default setting value in form will be current setting value or, if none exists, settings default
-        $settingGetOptions = (in_array($name, $this::$I18N)) ? ['culture' => $this->culture] : ['cultureFallback' => true];
+        $settingGetOptions = (in_array($name, $this::$I18N)) ? [] : ['sourceCulture' => true];
 
         // Use setting default if setting hasn't been saved yet
         $settingValue = (null !== $this->settings[$name]->id) ? $this->settings[$name]->getValue($settingGetOptions) : $settingDefault;
@@ -88,6 +88,7 @@ class SettingsEditAction extends DefaultEditAction
         if (in_array($name, $this::$NAMES)) {
             if (null === $this->settings[$name]->id) {
                 $this->settings[$name]->name = $name;
+                $this->settings[$name]->sourceCulture = $this->culture;
                 $this->settings[$name]->culture = $this->culture;
             }
 

--- a/apps/qubit/modules/settings/actions/inventoryAction.class.php
+++ b/apps/qubit/modules/settings/actions/inventoryAction.class.php
@@ -61,7 +61,10 @@ class SettingsInventoryAction extends DefaultEditAction
     {
         switch ($name) {
             case 'levels':
-                $value = unserialize($this->settingLevels->getValue());
+                $value = unserialize(
+                    $this->settingLevels->getValue(['sourceCulture' => true])
+                );
+
                 if (false !== $value) {
                     foreach ($value as $key => $item) {
                         if (null === QubitTerm::getById($item)) {
@@ -85,7 +88,13 @@ class SettingsInventoryAction extends DefaultEditAction
                     $size = 4;
                 }
 
-                $this->form->setWidget('levels', new sfWidgetFormSelect(['choices' => $choices, 'multiple' => true], ['size' => $size]));
+                $this->form->setWidget(
+                    'levels',
+                    new sfWidgetFormSelect(
+                        ['choices' => $choices, 'multiple' => true],
+                        ['size' => $size]
+                    )
+                );
 
                 break;
         }
@@ -95,11 +104,12 @@ class SettingsInventoryAction extends DefaultEditAction
     {
         switch ($field->getName()) {
             case 'levels':
-                $levels = $this->form->getValue('levels');
-                if (empty($levels)) {
-                    $levels = [];
-                }
-                $this->settingLevels->value = serialize($levels);
+                $levels = $this->form->getValue('levels') ?? [];
+
+                $this->settingLevels->setValue(
+                    serialize($levels),
+                    ['sourceCulture' => true]
+                );
 
                 break;
         }

--- a/apps/qubit/modules/settings/actions/pageElementsAction.class.php
+++ b/apps/qubit/modules/settings/actions/pageElementsAction.class.php
@@ -44,15 +44,34 @@ class SettingsPageElementsAction extends sfAction
 
         // Take note if a Google Maps API key has been set
         $googleMapsApiKeySetting = QubitSetting::getByName('google_maps_api_key');
-        $this->googleMapsApiKeySet = !empty($googleMapsApiKeySetting->value);
+
+        $this->googleMapsApiKeySet = isset($googleMapsApiKeySetting)
+            && !empty(
+                $googleMapsApiKeySetting->getValue(['sourceCulture' => true])
+            );
 
         // Take note of whether digital object map is enabled
         $toggleDigitalObjectMapSetting = QubitSetting::getByName('toggleDigitalObjectMap');
 
         foreach ($this::$NAMES as $name) {
             // Disable checkbox to show digital object maps if it's not currently enabled and no Google Maps API key is defined
-            if ('toggleDigitalObjectMap' == $name && empty($toggleDigitalObjectMapSetting->value) && empty($googleMapsApiKeySetting->value)) {
-                $this->form->setWidget($name, new sfWidgetFormInputCheckbox([], ['class' => 'disabled', 'disabled' => true]));
+            if (
+                'toggleDigitalObjectMap' == $name
+                && isset($toggleDigitalObjectMapSetting)
+                && empty(
+                    $toggleDigitalObjectMapSetting->getValue(
+                        ['sourceCulture' => true]
+                    )
+                )
+                && !$this->googleMapsApiKeySet
+            ) {
+                $this->form->setWidget(
+                    $name,
+                    new sfWidgetFormInputCheckbox(
+                        [],
+                        ['class' => 'disabled', 'disabled' => true],
+                    )
+                );
             } else {
                 $this->form->setWidget($name, new sfWidgetFormInputCheckbox());
             }
@@ -63,6 +82,7 @@ class SettingsPageElementsAction extends sfAction
                 $this->form->setDefault($name, filter_var($settings[$name]->__get('value', ['sourceCulture' => true]), FILTER_VALIDATE_BOOLEAN));
             }
         }
+
         if ($request->isMethod('post')) {
             $this->form->bind($request->getPostParameters());
 

--- a/apps/qubit/modules/settings/actions/siteInformationAction.class.php
+++ b/apps/qubit/modules/settings/actions/siteInformationAction.class.php
@@ -35,7 +35,6 @@ class SettingsSiteInformationAction extends SettingsEditAction
     public static $I18N = [
         'siteTitle',
         'siteDescription',
-        'siteBaseUrl',
     ];
 
     public function earlyExecute()

--- a/apps/qubit/modules/settings/actions/treeviewAction.class.php
+++ b/apps/qubit/modules/settings/actions/treeviewAction.class.php
@@ -224,10 +224,11 @@ class SettingsTreeviewAction extends DefaultEditAction
         if (!isset($setting)) {
             $setting = new QubitSetting();
             $setting->name = $name;
-            $setting->sourceCulture = 'en';
+            $setting->sourceCulture = sfConfig::get('sf_default_culture');
+            $setting->culture = sfConfig::get('sf_default_culture');
         }
 
-        $setting->setValue($value, ['culture' => 'en']);
+        $setting->setValue($value, ['sourceCulture' => true]);
         $setting->save();
     }
 }

--- a/apps/qubit/modules/settings/templates/siteInformationSuccess.php
+++ b/apps/qubit/modules/settings/templates/siteInformationSuccess.php
@@ -60,17 +60,17 @@
           </tr>
           <tr>
             <td>
-              <?php echo $form->siteBaseUrl->renderLabel(
-                           'Site base URL (used in MODS and EAD exports)',
-                           ['title' => 'Used to create absolute URLs, pointing to resources, in XML exports']); ?>
+              <?php
+                echo $form->siteBaseUrl->renderLabel(
+                  'Site base URL (used in MODS and EAD exports)',
+                  [
+                      'title' => 'Used to create absolute URLs, pointing to ' +
+                      'resources, in XML exports',
+                  ]
+                ); ?>
             </td>
             <td>
-              <?php echo get_partial('settings/i18n_form_field',
-                [
-                    'name' => 'siteBaseUrl',
-                    'label' => null,
-                    'settings' => $settings,
-                    'form' => $form, ]); ?>
+              <?php echo $form->siteBaseUrl->render(); ?>
             </td>
           </tr>
         </tbody>

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -1,3 +1,12 @@
+# Translatable settings (e.g. "informationobject" [UI label])
+# - MUST use "source_culture: en"
+# - MUST use "value" language codes, e.g.
+#   value:
+#     fr: foo
+#
+# Non-translatable settings (e.g. hits_per_page)
+# - MUST NOT use "source_culture"
+# - MUST NOT use "value" language codes, e.g. "value: foo"
 QubitSetting:
   version:
     name: version
@@ -915,7 +924,6 @@ QubitSetting:
     scope: oai
     editable: 1
     deleteable: 0
-    source_culture: en
     value: ''
   QubitSetting_oai_additional_sets_enabled:
     name: oai_additional_sets_enabled
@@ -939,19 +947,15 @@ QubitSetting:
     value: 0
   toggleIoSlider:
     name: toggleIoSlider
-    source_culture: en
     value: 1
   toggleLanguageMenu:
     name: toggleLanguageMenu
-    source_culture: en
     value: 1
   toggleCopyrightFilter:
     name: toggleCopyrightFilter
-    source_culture: en
     value: 1
   toggleMaterialFilter:
     name: toggleMaterialFilter
-    source_culture: en
     value: 1
   QubitSetting_checkForUpdates:
     name: check_for_updates
@@ -1336,16 +1340,12 @@ QubitSetting:
     name: findingAidFormat
     editable: 1
     deleteable: 0
-    source_culture: en
-    value:
-      en: pdf
+    value: pdf
   Qubit_Settings_findingAidModel:
     name: findingAidModel
     editable: 1
     deleteable: 0
-    source_culture: en
-    value:
-      en: inventory-summary
+    value: inventory-summary
   Qubit_Settings_publicFindingAid:
     name: publicFindingAid
     editable: 1
@@ -1362,140 +1362,103 @@ QubitSetting:
     value: table
   Qubit_Settings_digitalObjectDerivativesPdfPageNumber:
     name: digital_object_derivatives_pdf_page_number
-    value:
-      en: 1
+    value: 1
   Qubit_Settings_treeviewType:
     name: treeview_type
     editable: 1
     deleteable: 0
-    source_culture: en
-    value:
-      en: sidebar
+    value: sidebar
   Qubit_Settings_stripExtensions:
     name: stripExtensions
     editable: 1
     deleteable: 0
-    source_culture: en
-    value:
-      en: 0
+    value: 0
   Qubit_Settings_slugBasisInformationObject:
     name: slug_basis_informationobject
-    source_culture: en
-    value:
-      en: 0
+    value: 0
   Qubit_Settings_permissiveSlugCreation:
     name: permissive_slug_creation
     editable: 1
-    source_culture: en
-    value:
-      en: 0
+    value: 0
   Qubit_Settings_generateReportsAsPubUser:
     name: generate_reports_as_pub_user
     editable: 1
     deleteable: 0
-    source_culture: en
-    value:
-      en: 0
+    value: 0
   Qubit_Settings_identifierMask:
     name: identifier_mask
     editable: 1
     deleteable: 0
-    source_culture: en
-    value:
-      en: '%Y-%m-%d/#i'
+    value: '%Y-%m-%d/#i'
   Qubit_Settings_identifierCounter:
     name: identifier_counter
     editable: 1
     deleteable: 0
-    source_culture: en
-    value:
-      en: 0
+    value: 0
   Qubit_Settings_identifierMaskEnabled:
     name: identifier_mask_enabled
     editable: 1
     deleteable: 0
-    source_culture: en
-    value:
-      en: 0
+    value: 0
   Qubit_Settings_menu_locking_info:
     name: menu_locking_info
     editable: 0
     deleteable: 0
-    source_culture: en
-    value:
-      en: 'a:2:{s:6:"byName";a:15:{i:0;s:10:"accessions";i:1;s:17:"browseInstitution";i:2;s:9:"clipboard";i:3;s:13:"globalReplace";i:4;s:6:"groups";i:5;s:10:"importSkos";i:6;s:4:"jobs";i:7;s:5:"login";i:8;s:6:"logout";i:9;s:9:"myProfile";i:10;s:7:"plugins";i:12;s:8:"settings";i:13;s:15:"staticPagesMenu";i:14;s:10:"taxonomies";i:15;s:5:"users";}s:4:"byId";a:8:{i:0;i:1;i:1;i:4;i:2;i:7;i:3;i:2;i:4;i:10;i:5;i:3;i:6;i:5;i:7;i:9;}}'
+    value: 'a:2:{s:6:"byName";a:15:{i:0;s:10:"accessions";i:1;s:17:"browseInstitution";i:2;s:9:"clipboard";i:3;s:13:"globalReplace";i:4;s:6:"groups";i:5;s:10:"importSkos";i:6;s:4:"jobs";i:7;s:5:"login";i:8;s:6:"logout";i:9;s:9:"myProfile";i:10;s:7:"plugins";i:12;s:8:"settings";i:13;s:15:"staticPagesMenu";i:14;s:10:"taxonomies";i:15;s:5:"users";}s:4:"byId";a:8:{i:0;i:1;i:1;i:4;i:2;i:7;i:3;i:2;i:4;i:10;i:5;i:3;i:6;i:5;i:7;i:9;}}'
   Qubit_Settings_visibleElements_DacsPhysicalAccess:
     name: dacs_physical_access
     scope: element_visibility
     editable: 1
     deleteable: 0
-    source_culture: en
-    value:
-      en: 1
+    value: 1
   Qubit_Settings_visibleElements_DacsIdentityArea:
     name: dacs_identity_area
     scope: element_visibility
     editable: 1
     deleteable: 0
-    source_culture: en
-    value:
-      en: 1
+    value: 1
   Qubit_Settings_visibleElements_DacsContentArea:
     name: dacs_content_area
     scope: element_visibility
     editable: 1
     deleteable: 0
-    source_culture: en
-    value:
-      en: 1
+    value: 1
   Qubit_Settings_visibleElements_DacsConditionsOfAccessArea:
     name: dacs_conditions_of_access_area
     scope: element_visibility
     editable: 1
     deleteable: 0
-    source_culture: en
-    value:
-      en: 1
+    value: 1
   Qubit_Settings_visibleElements_DacsAcquisitionArea:
     name: dacs_acquisition_area
     scope: element_visibility
     editable: 1
     deleteable: 0
-    source_culture: en
-    value:
-      en: 1
+    value: 1
   Qubit_Settings_visibleElements_DacsMaterialsArea:
     name: dacs_materials_area
     scope: element_visibility
     editable: 1
     deleteable: 0
-    source_culture: en
-    value:
-      en: 1
+    value: 1
   Qubit_Settings_visibleElements_DacsNotesArea:
     name: dacs_notes_area
     scope: element_visibility
     editable: 1
     deleteable: 0
-    source_culture: en
-    value:
-      en: 1
+    value: 1
   Qubit_Settings_visibleElements_DacsControlArea:
     name: dacs_control_area
     scope: element_visibility
     editable: 1
     deleteable: 0
-    source_culture: en
-    value:
-      en: 1
+    value: 1
   Qubit_Settings_visibleElements_DacsAccessPointsArea:
     name: dacs_access_points_area
     scope: element_visibility
     editable: 1
     deleteable: 0
-    source_culture: en
-    value:
-      en: 1
+    value: 1
   Qubit_Settings_csvValidatorDefaultImportBehaviour:
     name: csv_validator_default_import_behaviour
     value: 0

--- a/lib/arInstall.class.php
+++ b/lib/arInstall.class.php
@@ -411,11 +411,9 @@ class arInstall
         QubitSearch::getInstance()->populate();
     }
 
-    public static function createSetting($name, $value)
+    public static function createSetting($name, $value, $options = [])
     {
-        $setting = new QubitSetting();
-        $setting->name = $name;
-        $setting->value = $value;
+        $setting = QubitSetting::createNewSetting($name, $value, $options);
         $setting->save();
     }
 }

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -479,7 +479,7 @@ class QubitInformationObject extends BaseInformationObject
 
     public function getMediaTypes()
     {
-        //TO DO: get via linked digital objects & physical objects
+        // TO DO: get via linked digital objects & physical objects
     }
 
     public function getRepositoryCountry()
@@ -2462,7 +2462,7 @@ class QubitInformationObject extends BaseInformationObject
 
     public static function addTreeViewSortCriteria($criteria)
     {
-        switch (sfConfig::get('app_sort_treeview_informationobject')) {
+        switch (sfConfig::get('app_sort_treeview_informationobject__source')) {
             case 'identifierTitle':
                 $criteria = QubitCultureFallback::addFallbackCriteria($criteria, 'QubitInformationObject');
                 $criteria->addAscendingOrderByColumn('identifier');

--- a/lib/task/tools/purgeTask.class.php
+++ b/lib/task/tools/purgeTask.class.php
@@ -32,80 +32,24 @@ class purgeTask extends installTask
      */
     public function execute($arguments = [], $options = [])
     {
-        if (!$options['demo'] && !function_exists('readline')) {
-            $needed = ['title', 'description', 'url', 'email', 'username', 'password'];
-            if (!array_key_exists($needed, $options)) {
-                throw new Exception(
-                    'At least one of the following command line '
-                    .'options is missing: title, description, url, email, username '
-                    .'and/or password.'
-                );
-            }
-        }
+        $this->createSfContext();
+        $this->validateOptions($options);
 
         if ($options['demo']) {
-            $options['no-confirmation'] = true;
-            $options['title'] = 'Demo site';
-            $options['description'] = 'Demo site';
-            $options['email'] = 'demo@example.com';
-            $options['username'] = 'demo';
-            $options['password'] = 'demo';
-            $options['url'] = 'http://127.0.0.1';
+            $this->setDemoOptions($options);
         }
 
         if ($options['use-gitconfig']) {
-            // attempt to provide default user admin name and email
-            if ($_SERVER['HOME']) {
-                $gitConfigFile = $_SERVER['HOME'].'/.gitconfig';
-                if (file_exists($gitConfigFile)) {
-                    $gitConfig = parse_ini_file($gitConfigFile);
-
-                    $defaultUser = strtolower(strtok($gitConfig['name'], ' '));
-                    $defaultEmail = $gitConfig['email'];
-                }
-            }
+            $this->getGitConfigData($options);
         }
-
-        $siteTitle = (isset($options['title'])) ? $options['title'] : '';
-        if (!$siteTitle) {
-            $siteTitle = readline('Site title [Qubit]: ');
-            $siteTitle = (!empty($siteTitle)) ? $siteTitle : 'Qubit';
-        }
-
-        $siteDescription = (isset($options['description'])) ? $options['description'] : '';
-        if (!$siteDescription) {
-            $siteDescription = readline('Site description [Test site]: ');
-            $siteDescription = (!empty($siteDescription)) ? $siteDescription : 'Test site';
-        }
-
-        $siteBaseUrl = (isset($options['url'])) ? $options['url'] : '';
-        if (!$siteBaseUrl) {
-            $siteBaseUrl = readline('Site base URL [http://127.0.0.1]: ');
-            $siteBaseUrl = (!empty($siteBaseUrl)) ? $siteBaseUrl : 'http://127.0.0.1';
-        }
-
-        $validator = new sfValidatorUrl(['protocols' => ['http', 'https']]);
-        $validator->clean($siteBaseUrl);
-
-        sfConfig::set('app_avoid_routing_propel_exceptions', true);
-        $this->configuration = ProjectConfiguration::getApplicationConfiguration(
-            'qubit',
-            'cli',
-            false
-        );
-        sfContext::createInstance($this->configuration);
 
         $this->initializeDbAndEs($options);
 
         $this->logSection($this->name, 'Adding site configuration');
-
-        arInstall::createSetting('siteTitle', $siteTitle);
-        arInstall::createSetting('siteDescription', $siteDescription);
-        arInstall::createSetting('siteBaseUrl', $siteBaseUrl);
+        $this->addSiteConfiguration($options);
 
         $this->logSection($this->name, 'Creating admin user');
-
-        addSuperuserTask::addSuperUser($options['username'], $options);
+        $this->addAdminUser($options);
 
         $this->logSection($this->name, 'Purge completed');
     }
@@ -131,6 +75,12 @@ class purgeTask extends installTask
             new sfCommandOption('password', null, sfCommandOption::PARAMETER_OPTIONAL, 'Desired admin password'),
             new sfCommandOption('no-confirmation', null, sfCommandOption::PARAMETER_NONE, 'Do not ask for confirmation'),
             new sfCommandOption('demo', null, sfCommandOption::PARAMETER_NONE, 'Use default demo values, do not ask for confirmation'),
+            new sfCommandOption(
+                'culture',
+                null,
+                sfCommandOption::PARAMETER_OPTIONAL,
+                'Desired culture (e.g. "fr") for site title and description',
+            ),
         ]);
 
         $this->namespace = 'tools';
@@ -140,5 +90,123 @@ class purgeTask extends installTask
         $this->detailedDescription = <<<'EOF'
 Purge all data.
 EOF;
+    }
+
+    protected function createSfContext()
+    {
+        sfConfig::set('app_avoid_routing_propel_exceptions', true);
+
+        $this->configuration = ProjectConfiguration::getApplicationConfiguration(
+            'qubit',
+            'cli',
+            false
+        );
+
+        $this->context = sfContext::createInstance($this->configuration);
+    }
+
+    protected function validateOptions($options)
+    {
+        if (!$options['demo'] && !function_exists('readline')) {
+            $needed = ['title', 'description', 'url', 'email', 'username', 'password'];
+            if (!array_key_exists($needed, $options)) {
+                throw new Exception(
+                    'At least one of the following command line '
+                    .'options is missing: title, description, url, email, username '
+                    .'and/or password.'
+                );
+            }
+        }
+    }
+
+    protected function setDemoOptions(&$options)
+    {
+        $options['no-confirmation'] = true;
+        $options['title'] = 'Demo site';
+        $options['description'] = 'Demo site';
+        $options['email'] = 'demo@example.com';
+        $options['username'] = 'demo';
+        $options['password'] = 'demo';
+        $options['url'] = 'http://127.0.0.1';
+        $options['culture'] = 'en';
+    }
+
+    /**
+     * TODO: Fix me!
+     */
+    protected function getGitConfigData()
+    {
+        // attempt to provide default user admin name and email
+        if ($_SERVER['HOME']) {
+            $gitConfigFile = $_SERVER['HOME'].'/.gitconfig';
+
+            if (file_exists($gitConfigFile)) {
+                $gitConfig = parse_ini_file($gitConfigFile);
+
+                $defaultUser = strtolower(strtok($gitConfig['name'], ' '));
+                $defaultEmail = $gitConfig['email'];
+            }
+        }
+    }
+
+    protected function addSiteConfiguration($options)
+    {
+        $siteTitle = $this->getConfigValue(
+            $options['title'],
+            sprintf('(%s) Site title', $this->getCulture($options)),
+            'AtoM'
+        );
+
+        $siteDescription = $this->getConfigValue(
+            $options['description'],
+            sprintf('(%s) Site description', $this->getCulture($options)),
+            'Test site'
+        );
+
+        $siteBaseUrl = $this->getConfigValue(
+            $options['url'], 'Site base URL', 'http://127.0.0.1'
+        );
+
+        arInstall::createSetting(
+            'siteTitle', $siteTitle, $this->getCultureOptions($options)
+        );
+
+        arInstall::createSetting(
+            'siteDescription',
+            $siteDescription,
+            $this->getCultureOptions($options)
+        );
+
+        $validator = new sfValidatorUrl(['protocols' => ['http', 'https']]);
+        $validator->clean($siteBaseUrl);
+        arInstall::createSetting('siteBaseUrl', $siteBaseUrl);
+    }
+
+    protected function getConfigValue($value, $prompt, $default)
+    {
+        if (!empty($value)) {
+            return $value;
+        }
+
+        $response = readline(sprintf('%s [%s]: ', $prompt, $default));
+
+        return !empty($response) ? $response : $default;
+    }
+
+    protected function addAdminUser($options)
+    {
+        addSuperuserTask::addSuperUser($options['username'], $options);
+    }
+
+    protected function getCulture($options)
+    {
+        return $options['culture'] ?? sfConfig::get('sf_default_culture');
+    }
+
+    protected function getCultureOptions($options)
+    {
+        $culture = $this->getCulture($options);
+
+        return ['sourceCulture' => $culture, 'culture' => $culture];
     }
 }


### PR DESCRIPTION
Always use source_culture value for non-translatable settings (e.g.
'hits_per_page') so value doesn't change with the current UI language.

Settings modified to be non-translatable:
- Digital object derivatives > PDF page number for image derivative
- Inventory > Levels of description
- Site information > Base URL
- Treeview settings > Sidebar > Sort (information object)

Also:

Use source_culture value when checking whether to disable the 
"Settings > Default page elements > Digital object map" checkbox.

Update the `tools:purge` task to set the culture of the site title and
description as follows:
- Use the settings.yml `default_culture` by default,
- Use the `--culture` option to override the default culture,
- For the demo data (`--demo`) always use 'en' because the demo strings
  are English