### PR TITLE
Fix edit Donor typo, refs #13612

### DIFF
--- a/apps/qubit/i18n/ar/messages.xml
+++ b/apps/qubit/i18n/ar/messages.xml
@@ -3466,7 +3466,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target>&#x627;&#x644;&#x639;&#x642;&#x62F; &#x627;&#x644;&#x623;&#x633;&#x627;&#x633;&#x64A;</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ca/messages.xml
+++ b/apps/qubit/i18n/ca/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target>Contracte principal</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ca@valencia/messages.xml
+++ b/apps/qubit/i18n/ca@valencia/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/cs/messages.xml
+++ b/apps/qubit/i18n/cs/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/cy/messages.xml
+++ b/apps/qubit/i18n/cy/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target>Prif gytundeb</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/de/messages.xml
+++ b/apps/qubit/i18n/de/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/de_AT/messages.xml
+++ b/apps/qubit/i18n/de_AT/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/de_CH/messages.xml
+++ b/apps/qubit/i18n/de_CH/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/el/messages.xml
+++ b/apps/qubit/i18n/el/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/es/messages.xml
+++ b/apps/qubit/i18n/es/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/et/messages.xml
+++ b/apps/qubit/i18n/et/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/eu/messages.xml
+++ b/apps/qubit/i18n/eu/messages.xml
@@ -331,7 +331,7 @@
       </trans-unit>
       <trans-unit id="9f780ca0f3cbaf61d43c297030552bdee2a5bf50">
         <source>Add an alpha-numeric code to uniquely identify this particular OAI repository within its network domain to create a unique, OAI-compliant identifier, e.g. oai:foo.org:repositorycode_10001</source>
-        <target>Kode alfanumerikoa gehitu OAI errepositorio zehatz hau identifikatzeko bere sarearen domeinuan bereiztu dadin, OAI-identifikatzailea, adb. 
+        <target>Kode alfanumerikoa gehitu OAI errepositorio zehatz hau identifikatzeko bere sarearen domeinuan bereiztu dadin, OAI-identifikatzailea, adb.
 oai:foo.org:repositorycode_10001</target>
         <note>https://github.com/artefactual/atom/blob/master/lib/form/SettingsOaiRepositoryForm.class.php</note>
       </trans-unit>
@@ -3466,7 +3466,7 @@ oai:foo.org:repositorycode_10001</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/fa/messages.xml
+++ b/apps/qubit/i18n/fa/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/fil/messages.xml
+++ b/apps/qubit/i18n/fil/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/fr/messages.xml
+++ b/apps/qubit/i18n/fr/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target>Contrat principal</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/gl/messages.xml
+++ b/apps/qubit/i18n/gl/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/he/messages.xml
+++ b/apps/qubit/i18n/he/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/hr/messages.xml
+++ b/apps/qubit/i18n/hr/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target>Glavni ugovor</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/hu/messages.xml
+++ b/apps/qubit/i18n/hu/messages.xml
@@ -331,7 +331,7 @@
       </trans-unit>
       <trans-unit id="9f780ca0f3cbaf61d43c297030552bdee2a5bf50">
         <source>Add an alpha-numeric code to uniquely identify this particular OAI repository within its network domain to create a unique, OAI-compliant identifier, e.g. oai:foo.org:repositorycode_10001</source>
-        <target>K&#xE9;sz&#xED;tsen egy egyedi, alfanumerikus azonos&#xED;t&#xF3; k&#xF3;dot ennek a meghat&#xE1;rozott OAI rakt&#xE1;rnak a saj&#xE1;t h&#xE1;l&#xF3;zati tartom&#xE1;ny&#xE1;n bel&#xFC;l! 
+        <target>K&#xE9;sz&#xED;tsen egy egyedi, alfanumerikus azonos&#xED;t&#xF3; k&#xF3;dot ennek a meghat&#xE1;rozott OAI rakt&#xE1;rnak a saj&#xE1;t h&#xE1;l&#xF3;zati tartom&#xE1;ny&#xE1;n bel&#xFC;l!
 P&#xE9;ld&#xE1;ul: oai:foo.org:repositorycode_10001</target>
         <note>https://github.com/artefactual/atom/blob/master/lib/form/SettingsOaiRepositoryForm.class.php</note>
       </trans-unit>
@@ -643,7 +643,7 @@ pl.: bibliogr&#xE1;fiai id&#xE9;z&#xE9;s.</target>
       </trans-unit>
       <trans-unit id="4ffa72ac302c094f8d275fc9d11ab00287903f05">
         <source>Are you sure you want to delete this reference/thumbnail representation?</source>
-        <target>Biztosan t&#xF6;r&#xF6;lni akarja ezt a 
+        <target>Biztosan t&#xF6;r&#xF6;lni akarja ezt a
 reference/thumbnail representation?</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/digitalobject/templates/deleteSuccess.php</note>
       </trans-unit>
@@ -654,7 +654,7 @@ reference/thumbnail representation?</target>
       </trans-unit>
       <trans-unit id="01850f0b38dbc0ccf240926c3bb291e710cdacc0">
         <source>Are you sure you want to replace "%1%" with "%2%" in %3%?</source>
-        <target>Biztosan kicser&#xE9;li 
+        <target>Biztosan kicser&#xE9;li
  "%1%" with "%2%" in %3%?</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/search/actions/globalReplaceAction.class.php</note>
       </trans-unit>
@@ -3474,7 +3474,7 @@ YYYYMMDD, YYYY-MM-DD, YYYY-MM, YYYY.</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target>Els&#x151;dleges szerz&#x151;d&#xE9;s</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/id/messages.xml
+++ b/apps/qubit/i18n/id/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target>Kontrak utama</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/is/messages.xml
+++ b/apps/qubit/i18n/is/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/it/messages.xml
+++ b/apps/qubit/i18n/it/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target>Contratto principale</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ja/messages.xml
+++ b/apps/qubit/i18n/ja/messages.xml
@@ -3467,7 +3467,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ka/messages.xml
+++ b/apps/qubit/i18n/ka/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ko/messages.xml
+++ b/apps/qubit/i18n/ko/messages.xml
@@ -3467,7 +3467,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>
@@ -3609,13 +3609,13 @@
       </trans-unit>
       <trans-unit id="b5ed865bd130aa9047b8cc4b5d512e2ca1ab7d23">
         <source>Record notes on sources consulted in preparing the description and who prepared it. (ISAD 3.7.1)</source>
-        <target>&#xAE30;&#xC220;&#xBB3C;&#xC744; &#xC791;&#xC131;&#xD558;&#xB294;&#xB370; &#xCC38;&#xC870;&#xD55C; &#xC815;&#xBCF4;&#xC6D0;&#xACFC; &#xB204;&#xAC00; &#xADF8;&#xAC83;&#xC744; &#xC791;&#xC131;&#xD588;&#xB294;&#xC9C0;&#xC5D0; &#xB300;&#xD558;&#xC5EC; &#xAE30;&#xC785;&#xD558;&#xB77C;. (ISAD 3.7.1)	
+        <target>&#xAE30;&#xC220;&#xBB3C;&#xC744; &#xC791;&#xC131;&#xD558;&#xB294;&#xB370; &#xCC38;&#xC870;&#xD55C; &#xC815;&#xBCF4;&#xC6D0;&#xACFC; &#xB204;&#xAC00; &#xADF8;&#xAC83;&#xC744; &#xC791;&#xC131;&#xD588;&#xB294;&#xC9C0;&#xC5D0; &#xB300;&#xD558;&#xC5EC; &#xAE30;&#xC785;&#xD558;&#xB77C;. (ISAD 3.7.1)
 </target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/actions/notesComponent.class.php</note>
       </trans-unit>
       <trans-unit id="53acccead279f0e87c4051db5cefa6dbe4ec049f">
         <source>Record specialized or other important information not accommodated by any of the defined elements of description. (ISAD 3.6.1)</source>
-        <target>&#xC815;&#xC758;&#xB41C; &#xC5B4;&#xB5A4; &#xAE30;&#xC220;&#xC694;&#xC18C;&#xC5D0;&#xB3C4; &#xD574;&#xB2F9;&#xB418;&#xC9C0; &#xC54A;&#xB294; &#xC804;&#xBB38;&#xD654;&#xB418;&#xAC70;&#xB098; &#xB2E4;&#xB978; &#xC911;&#xC694;&#xD55C; &#xC815;&#xBCF4;&#xB97C; &#xAE30;&#xB85D;&#xD558;&#xB77C;. (ISAD 3.6.1)	
+        <target>&#xC815;&#xC758;&#xB41C; &#xC5B4;&#xB5A4; &#xAE30;&#xC220;&#xC694;&#xC18C;&#xC5D0;&#xB3C4; &#xD574;&#xB2F9;&#xB418;&#xC9C0; &#xC54A;&#xB294; &#xC804;&#xBB38;&#xD654;&#xB418;&#xAC70;&#xB098; &#xB2E4;&#xB978; &#xC911;&#xC694;&#xD55C; &#xC815;&#xBCF4;&#xB97C; &#xAE30;&#xB85D;&#xD558;&#xB77C;. (ISAD 3.6.1)
 </target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/informationobject/actions/notesComponent.class.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/nb/messages.xml
+++ b/apps/qubit/i18n/nb/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/nl/messages.xml
+++ b/apps/qubit/i18n/nl/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/pl/messages.xml
+++ b/apps/qubit/i18n/pl/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/pt/messages.xml
+++ b/apps/qubit/i18n/pt/messages.xml
@@ -3468,7 +3468,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target>Contrato prim&#xE1;rio</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/pt_BR/messages.xml
+++ b/apps/qubit/i18n/pt_BR/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target>Contrato prim&#xE1;rio</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ro/messages.xml
+++ b/apps/qubit/i18n/ro/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ru/messages.xml
+++ b/apps/qubit/i18n/ru/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ru_RU/messages.xml
+++ b/apps/qubit/i18n/ru_RU/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/sk/messages.xml
+++ b/apps/qubit/i18n/sk/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/sl/messages.xml
+++ b/apps/qubit/i18n/sl/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/sq/messages.xml
+++ b/apps/qubit/i18n/sq/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/sr/messages.xml
+++ b/apps/qubit/i18n/sr/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target>&#x41E;&#x441;&#x43D;&#x43E;&#x432;&#x43D;&#x438; &#x443;&#x433;&#x43E;&#x432;&#x43E;&#x440;</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/sv/messages.xml
+++ b/apps/qubit/i18n/sv/messages.xml
@@ -3466,7 +3466,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target>Huvudkontakt</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ta/messages.xml
+++ b/apps/qubit/i18n/ta/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target>&#xBAE;&#xBC1;&#xBA4;&#xBA9;&#xBCD;&#xBAE;&#xBC8; &#xB92;&#xBAA;&#xBCD;&#xBAA;&#xBA8;&#xBCD;&#xBA4;&#xBAE;&#xBCD;</target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/th/messages.xml
+++ b/apps/qubit/i18n/th/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/tn/messages.xml
+++ b/apps/qubit/i18n/tn/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/tr/messages.xml
+++ b/apps/qubit/i18n/tr/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/uk/messages.xml
+++ b/apps/qubit/i18n/uk/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/ur/messages.xml
+++ b/apps/qubit/i18n/ur/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/uz/messages.xml
+++ b/apps/qubit/i18n/uz/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/vi/messages.xml
+++ b/apps/qubit/i18n/vi/messages.xml
@@ -3123,7 +3123,7 @@ B&#x1EA1;n c&#xF3; ch&#x1EAF;c ch&#x1EAF;n b&#x1EA1;n mu&#x1ED1;n thay th&#x1EBF
       </trans-unit>
       <trans-unit id="1532d65ee8af467a28b22294d88943777e5db47f">
         <source>OAI repository identifier</source>
-        <target>&#x110;&#x1ECB;nh danh OAI repository 
+        <target>&#x110;&#x1ECB;nh danh OAI repository
 </target>
         <note>https://github.com/artefactual/atom/blob/master/lib/form/SettingsOaiRepositoryForm.class.php</note>
       </trans-unit>
@@ -3393,7 +3393,7 @@ Truy c&#x1EAD;p v&#x1EAD;t l&#xFD;
       <trans-unit id="0cd3597453ab504a3dbeec3289e21abe922d223a">
         <source>Places</source>
         <target>
- 
+
 &#x111;&#x1ECB;a &#x111;i&#x1EC3;m </target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/object/templates/_placeAccessPoints.php</note>
       </trans-unit>
@@ -3473,7 +3473,7 @@ Truy c&#x1EAD;p v&#x1EAD;t l&#xFD;
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>
@@ -4339,7 +4339,7 @@ Y&#xEA;u c&#x1EA7;u m&#x1EAD;t kh&#x1EA9;u m&#x1EA1;nh</target>
       </trans-unit>
       <trans-unit id="2eb56be3c2d93cdab0c52e677e3167dfddb30ac5">
         <source>Sources</source>
-        <target>Ngu&#x1ED3;n 
+        <target>Ngu&#x1ED3;n
 </target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/actor/actions/browseAction.class.php</note>
       </trans-unit>
@@ -4410,7 +4410,7 @@ Y&#xEA;u c&#x1EA7;u m&#x1EAD;t kh&#x1EA9;u m&#x1EA1;nh</target>
       </trans-unit>
       <trans-unit id="8d183dbdcea3b29906090bd83fa6fa37923cc8ec">
         <source>Subject</source>
-        <target>T&#x1B0;&#x1EE3;ng 
+        <target>T&#x1B0;&#x1EE3;ng
 </target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/actor/actions/contextMenuComponent.class.php</note>
       </trans-unit>
@@ -4778,7 +4778,7 @@ T&#x1EA3;i l&#xEA;n m&#x1EDB;i %1%</target>
       </trans-unit>
       <trans-unit id="3deb7456519697ecf4eefc455516c969a3681bae">
         <source>Type</source>
-        <target>Lo&#x1EA1;i 
+        <target>Lo&#x1EA1;i
 </target>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>

--- a/apps/qubit/i18n/zh/messages.xml
+++ b/apps/qubit/i18n/zh/messages.xml
@@ -3465,7 +3465,7 @@
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_contactInformation.php</note>
       </trans-unit>
       <trans-unit id="487b19b411631ca1a19742f365becbcac67042ec">
-        <source>Primary contract</source>
+        <source>Primary Contact</source>
         <target/>
         <note>https://github.com/artefactual/atom/blob/master/apps/qubit/modules/contactinformation/templates/_edit.php</note>
       </trans-unit>


### PR DESCRIPTION
Checkbox for Primary Contract should say Primary Contact, instead of Primary Contract, when editing Contact person for a Donor.