### PR TITLE
Delete DIP after processing, refs #13396

### DIFF
--- a/config/ProjectConfiguration.class.php
+++ b/config/ProjectConfiguration.class.php
@@ -76,6 +76,7 @@ class ProjectConfiguration extends sfProjectConfiguration
 
         $loader->registerNamespaces([
             'Psr' => $rootDir.DIRECTORY_SEPARATOR.'vendor',
+            'AccessToMemory' => $rootDir.DIRECTORY_SEPARATOR.'lib',
         ]);
 
         $loader->register();

--- a/lib/AccessToMemory/Path.php
+++ b/lib/AccessToMemory/Path.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace AccessToMemory;
+
+/**
+ * Filesystem path abstraction class.
+ */
+class Path
+{
+    public $path;
+
+    public function __construct($path)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * Check if path exists.
+     *
+     * @return bool true if path exists
+     */
+    public function exists()
+    {
+        return file_exists($this->path);
+    }
+
+    /**
+     * Return directory listing as an array.
+     *
+     * @param array $exclude from list
+     *
+     * @return array directory contents
+     */
+    public function ls($exclude = ['.', '..'])
+    {
+        $this->throwExceptionIfNotADir();
+
+        return array_diff(scandir($this->path), $exclude);
+    }
+
+    /**
+     * Remove a directory.
+     *
+     * @param bool $recursive delete a directory and all its contents when true
+     */
+    public function rmdir($recursive = false)
+    {
+        $this->throwExceptionIfNotADir();
+
+        if ($recursive) {
+            foreach ($this->ls() as $node) {
+                $child = new Path($this->path.DIRECTORY_SEPARATOR.$node);
+                $child->delete($recursive);
+            }
+        }
+
+        if (!empty($this->ls())) {
+            throw new \RuntimeException(
+                sprintf(
+                    "Can't delete %s: directory is not empty",
+                    $this->path
+                )
+            );
+        }
+
+        rmdir($this->path);
+    }
+
+    /**
+     * Delete a file.
+     */
+    public function unlink()
+    {
+        $this->throwExceptionIfNotAFile();
+
+        unlink($this->path);
+    }
+
+    /**
+     * Delete a file or a directory.
+     *
+     * @param bool $recursive if true, delete a directory and all its contents
+     */
+    public function delete($recursive = false)
+    {
+        if (is_dir($this->path)) {
+            $this->rmdir($recursive);
+        } else {
+            $this->unlink();
+        }
+    }
+
+    protected function throwExceptionIfFileNotFound()
+    {
+        if (!$this->exists()) {
+            throw new \RuntimeException(
+                sprintf('File not found: %s', $this->path)
+            );
+        }
+    }
+
+    protected function throwExceptionIfNotADir()
+    {
+        $this->throwExceptionIfFileNotFound();
+
+        if (!is_dir($this->path)) {
+            throw new \RuntimeException(
+                sprintf('%s is not a directory', $this->path)
+            );
+        }
+    }
+
+    protected function throwExceptionIfNotAFile()
+    {
+        $this->throwExceptionIfFileNotFound();
+
+        if (is_dir($this->path)) {
+            throw new \RuntimeException(
+                sprintf('%s is not a file', $this->path)
+            );
+        }
+    }
+}

--- a/plugins/qtSwordPlugin/lib/qtPackageExtractorBase.class.php
+++ b/plugins/qtSwordPlugin/lib/qtPackageExtractorBase.class.php
@@ -17,6 +17,8 @@
  * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
  */
 
+use AccessToMemory\Path;
+
 class qtPackageExtractorBase
 {
     public function __construct(array $options = [])
@@ -55,6 +57,10 @@ class qtPackageExtractorBase
         if (isset($options['checksum_md5'])) {
             $this->checksumMd5 = $options['checksum_md5'];
         }
+
+        if (isset($options['logger'])) {
+            $this->logger = $options['logger'];
+        }
     }
 
     public function run()
@@ -62,6 +68,8 @@ class qtPackageExtractorBase
         $this->load();
 
         $this->process();
+
+        $this->clean();
     }
 
     protected function load()
@@ -110,28 +118,29 @@ class qtPackageExtractorBase
     {
     }
 
+    /**
+     * Log an info level message.
+     *
+     * @param string $msg log message
+     */
+    protected function info($msg)
+    {
+        if (isset($this->logger)) {
+            $this->logger->info($msg);
+        }
+    }
+
+    /**
+     * Clean up temporary files.
+     */
     protected function clean()
     {
-        unlink($this->filename);
+        $this->info(
+            sprintf('Processing complete, deleting "%s"', $this->filename)
+        );
 
-        $rrmdir = function ($directory) use (&$rrmdir) {
-            $objects = scandir($directory);
-
-            foreach ($objects as $object) {
-                if ('.' != $object && '..' != $object) {
-                    if ('dir' == filetype($directory.'/'.$object)) {
-                        $rrmdir($directory.'/'.$object);
-                    } else {
-                        unlink($directory.'/'.$object);
-                    }
-                }
-            }
-
-            reset($objects);
-            rmdir($directory);
-        };
-
-        $rrmdir($this->directory);
+        $path = new Path($this->filename);
+        $path->delete(true);
     }
 
     protected function grab()

--- a/plugins/qtSwordPlugin/lib/qtSwordPluginWorker.class.php
+++ b/plugins/qtSwordPlugin/lib/qtSwordPluginWorker.class.php
@@ -41,7 +41,11 @@ class qtSwordPluginWorker extends arBaseJob
 
         $extractor = qtPackageExtractorFactory::build(
             $package['format'],
-            $package + ['resource' => $resource, 'job' => $this->job]
+            $package + [
+                'resource' => $resource,
+                'job' => $this->job,
+                'logger' => $this->logger,
+            ]
         );
 
         $extractor->run();

--- a/test/bootstrap/phpunit.php
+++ b/test/bootstrap/phpunit.php
@@ -14,14 +14,6 @@ $_test_dir = realpath(dirname(__FILE__).'/..');
 require_once dirname(__FILE__).'/../../config/ProjectConfiguration.class.php';
 $configuration = ProjectConfiguration::hasActive() ? ProjectConfiguration::getActive() : new ProjectConfiguration(realpath($_test_dir.'/..'));
 
-// autoloader
-$autoload = sfSimpleAutoload::getInstance(sfConfig::get('sf_cache_dir').'/project_autoload.cache');
-$autoload->loadConfiguration(sfFinder::type('file')->name('autoload.yml')->in([
-    sfConfig::get('sf_symfony_lib_dir').'/config/config',
-    sfConfig::get('sf_config_dir'),
-]));
-$autoload->register();
-
 sfContext::createInstance($configuration->getApplicationConfiguration(
     'qubit',
     'test',

--- a/test/phpunit/PathTest.php
+++ b/test/phpunit/PathTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use AccessToMemory\Path;
+use org\bovigo\vfs\vfsStream;
+
+// require_once 'lib/Path.class.php';
+
+/**
+ * @covers \AccessToMemory\Path
+ *
+ * @internal
+ */
+class PathTest extends \PHPUnit\Framework\TestCase
+{
+    public function setUp(): void
+    {
+        // define virtual file system
+        $directory = [
+            'subdir' => [
+                'foo.txt' => 'foo',
+            ],
+            'empty_dir' => [],
+            'bar.txt' => 'bar',
+        ];
+
+        // setup and cache the virtual file system
+        $this->vfs = vfsStream::setup('root', null, $directory);
+    }
+
+    public function testSetPathFromConstructor()
+    {
+        $path = new Path('testdir');
+        $this->assertSame('testdir', $path->path);
+    }
+
+    public function testExists()
+    {
+        // Directory
+        $path = new Path($this->vfs->url().'/empty_dir');
+        $this->assertTrue($path->exists());
+
+        // File
+        $path = new Path($this->vfs->url().'/bar.txt');
+        $this->assertTrue($path->exists());
+
+        // Should return false for non-existent file
+        $path = new Path($this->vfs->url().'/not_here');
+        $this->assertFalse($path->exists());
+    }
+
+    public function testLs()
+    {
+        // Non-empty dir
+        $path = new Path($this->vfs->url());
+        $this->assertEqualsCanonicalizing(
+            ['subdir', 'empty_dir', 'bar.txt'],
+            $path->ls()
+        );
+
+        // Empty dir
+        $path = new Path($this->vfs->url().'/empty_dir');
+        $this->assertEquals([], $path->ls());
+    }
+
+    public function testRmdirEmpty()
+    {
+        $path = new Path($this->vfs->url().'/empty_dir');
+        $path->rmdir();
+        $this->assertFalse($this->vfs->hasChild('empty_dir'));
+    }
+
+    public function testErrorRmdirNotEmpty()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('directory is not empty');
+
+        $path = new Path($this->vfs->url().'/subdir');
+        $path->rmdir();
+        $this->assertTrue($this->vfs->hasChild('subdir'));
+    }
+
+    public function testRmdirRecursive()
+    {
+        $path = new Path($this->vfs->url().'/subdir');
+        $path->rmdir(true);
+        $this->assertFalse($this->vfs->hasChild('subdir'));
+    }
+
+    public function testErrorRmdirOnFile()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('not a directory');
+
+        $path = new Path($this->vfs->url().'/bar.txt');
+        $path->rmdir();
+        $this->assertTrue($this->vfs->hasChild('bar.txt'));
+    }
+
+    public function testErrorRmdirFileNotFound()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('File not found');
+
+        $path = new Path($this->vfs->url().'/unknown');
+        $path->rmdir();
+    }
+
+    public function testUnlink()
+    {
+        $path = new Path($this->vfs->url().'/bar.txt');
+        $path->unlink();
+        $this->assertFalse($this->vfs->hasChild('bar.txt'));
+    }
+
+    public function testErrorUnlinkOnDir()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('not a file');
+
+        $path = new Path($this->vfs->url().'/empty_dir');
+        $path->unlink();
+        $this->assertTrue($this->vfs->hasChild('empty_dir'));
+    }
+
+    public function testErrorUnlinkFileNotFound()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('File not found');
+
+        $path = new Path($this->vfs->url().'/unknown.txt');
+        $path->unlink();
+    }
+
+    public function testDelete()
+    {
+        // Delete a file
+        $path = new Path($this->vfs->url().'/bar.txt');
+        $path->delete();
+        $this->assertFalse($this->vfs->hasChild('bar.txt'));
+
+        // Delete a dir recursively
+        $path = new Path($this->vfs->url().'/subdir');
+        $path->delete(true);
+        $this->assertFalse($this->vfs->hasChild('subdir'));
+    }
+}


### PR DESCRIPTION
- Add `\AccessToMemory\Path` class and tests
- Call qtPackageExtractorBase::clean() after processing metadata
- Use `Path::delete()` to recursively delete the package directory
- Pass logger to qtPackageExtratorBase to allow logging DIP deletion
- Remove unnecessary autoloader from `test/bootstrap/phpunit.php`