### PR TITLE
Add a composer test coverage report script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     },
     "scripts": {
         "test": "phpunit",
+        "test-cov": "@php -dpcov.enabled=1 ./vendor/composer/bin/phpunit --coverage-html=.coverage/html",
         "php-cs-fixer": "php-cs-fixer"
     }
 }


### PR DESCRIPTION
Add a `composer test-cov` script that generates a phpunit text format
coverage report (using pcov) and sends it to STDOUT.