### PR TITLE
Show link to DIP upload target, refs #13504

### DIFF
--- a/plugins/qtSwordPlugin/lib/qtSwordPluginWorker.class.php
+++ b/plugins/qtSwordPlugin/lib/qtSwordPluginWorker.class.php
@@ -22,7 +22,7 @@ class qtSwordPluginWorker extends arBaseJob
     /**
      * @see arBaseJob::$requiredParameters
      */
-    protected $extraRequiredParameters = ['information_object_id'];
+    protected $extraRequiredParameters = ['objectId'];
 
     public function runJob($package)
     {
@@ -35,7 +35,7 @@ class qtSwordPluginWorker extends arBaseJob
 
         $this->info('Processing...');
 
-        $resource = QubitInformationObject::getById($package['information_object_id']);
+        $resource = QubitInformationObject::getById($package['objectId']);
 
         $this->info(sprintf('Object slug: %s', $resource->slug));
 

--- a/plugins/qtSwordPlugin/modules/qtSwordPlugin/actions/depositAction.class.php
+++ b/plugins/qtSwordPlugin/modules/qtSwordPlugin/actions/depositAction.class.php
@@ -83,7 +83,7 @@ class qtSwordPluginDepositAction extends sfAction
 
         $this->informationObject = $this->resource;
 
-        $data = $this->package + ['information_object_id' => $this->informationObject->id];
+        $data = $this->package + ['objectId' => $this->informationObject->id];
 
         QubitJob::runJob('qtSwordPluginWorker', $data);
 


### PR DESCRIPTION
Use `objectId` job parameter for qtSwordPluginWorker so a link to the
target archival description is show on the "Manage jobs" page.