### PR TITLE
Use Path::delete() to delete temp dir, refs #13598

### DIFF
--- a/lib/job/arZipFileDownload.class.php
+++ b/lib/job/arZipFileDownload.class.php
@@ -17,6 +17,8 @@
  * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
  */
 
+use AccessToMemory\Path;
+
 /**
  * Class containing functions needed for creating a downloadable zip file.
  *
@@ -81,8 +83,9 @@ class arZipFileDownload
                 sprintf('Deleting temporary job directory %s', $this->tempDir)
             );
 
-            sfToolkit::clearDirectory($this->tempDir);
-            rmdir($this->tempDir);
+            // Recursively delete $this->tempDir
+            $path = new Path($this->tempDir);
+            $path->delete(true);
         }
     }
 


### PR DESCRIPTION
`sfToolkit::clearDirectory()` will not delete `CVS` or `.svn` sub-directories, which can prevent the target directory from being deleted. 