### PR TITLE
Add RAD template actor visibility, refs #13424

### DIFF
--- a/apps/qubit/modules/informationobject/templates/_dates.php
+++ b/apps/qubit/modules/informationobject/templates/_dates.php
@@ -14,7 +14,7 @@
             <dl>
               <?php if (isset($item->actor) && null !== $item->type->getRole()) { ?>
                 <dt><?php echo render_value_inline($item->type->getRole()); ?></dt>
-                <dd><?php echo render_title($item->actor); ?></dd>
+                <dd><?php echo link_to(render_title($item->actor), [$item->actor, 'module' => 'actor', 'action' => 'index']); ?></dd>
               <?php } ?>
               <?php if (null !== $item->getPlace()) { ?>
                 <dt><?php echo __('Place'); ?></dt>

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
@@ -312,7 +312,7 @@
   </div>
 
   <div class="nameAccessPoints">
-    <?php echo get_partial('informationobject/nameAccessPoints', ['resource' => $resource]); ?>
+    <?php echo get_partial('informationobject/nameAccessPoints', ['resource' => $resource, 'showActorEvents' => true]); ?>
   </div>
 
   <div class="genreAccessPoints">


### PR DESCRIPTION
Improve visibility of non-creation actors in the RAD template by:

1) Making the related actor name in the Dates area a hyperlink to the
   authority record for any actor relation

2) Displaying the related actor name for non-creation events in the
   Name Access Points area