### PR TITLE
Search for terms across all fields, refs #13608

### DIFF
--- a/apps/qubit/modules/default/actions/moveAction.class.php
+++ b/apps/qubit/modules/default/actions/moveAction.class.php
@@ -129,7 +129,9 @@ class DefaultMoveAction extends sfAction
                 sprintf('i18n.%s.title', sfContext::getInstance()->user->getCulture()) => 1,
             ];
             $this->queryBool->addMust(
-                arElasticSearchPluginUtil::generateBoolQueryString($request->query, $fields)
+                arElasticSearchPluginUtil::generateQueryString(
+                    $request->query, $fields
+                )
             );
         } else {
             $query = new \Elastica\Query\Term();

--- a/apps/qubit/modules/informationobject/actions/autocompleteAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/autocompleteAction.class.php
@@ -65,7 +65,9 @@ class InformationObjectAutocompleteAction extends sfAction
             }
 
             $this->queryBool->addMust(
-                arElasticSearchPluginUtil::generateBoolQueryString($request->query, $fields)
+                arElasticSearchPluginUtil::generateQueryString(
+                    $request->query, $fields
+                )
             );
         }
 

--- a/apps/qubit/modules/repository/actions/browseAction.class.php
+++ b/apps/qubit/modules/repository/actions/browseAction.class.php
@@ -86,7 +86,7 @@ class RepositoryBrowseAction extends DefaultBrowseAction
             $this->search->queryBool->addMust(new \Elastica\Query\MatchAll());
         } else {
             $this->search->queryBool->addMust(
-                arElasticSearchPluginUtil::generateBoolQueryString(
+                arElasticSearchPluginUtil::generateQueryString(
                     $request->subquery,
                     arElasticSearchPluginUtil::getAllFields('repository')
                 )

--- a/apps/qubit/modules/search/actions/indexAction.class.php
+++ b/apps/qubit/modules/search/actions/indexAction.class.php
@@ -27,7 +27,7 @@ class SearchIndexAction extends DefaultBrowseAction
         parent::execute($request);
 
         $this->search->queryBool->addMust(
-            arElasticSearchPluginUtil::generateBoolQueryString(
+            arElasticSearchPluginUtil::generateQueryString(
                 $request->query,
                 arElasticSearchPluginUtil::getAllFields('informationObject')
             )

--- a/apps/qubit/modules/taxonomy/actions/indexAction.class.php
+++ b/apps/qubit/modules/taxonomy/actions/indexAction.class.php
@@ -182,7 +182,9 @@ class TaxonomyIndexAction extends sfAction
 
             // Filter results by subquery
             $this->queryBool->addMust(
-                arElasticSearchPluginUtil::generateBoolQueryString($request->subquery, $fields)
+                arElasticSearchPluginUtil::generateQueryString(
+                    $request->subquery, $fields
+                )
             );
         }
 

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchMapping.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchMapping.class.php
@@ -176,6 +176,16 @@ class arElasticSearchMapping
         return $fields;
     }
 
+    public static function getAnalyzer($culture)
+    {
+        if (isset(self::$analyzers[$culture])) {
+            return self::$analyzers[$culture];
+        }
+
+        // Default to standard analyzer
+        return 'standard';
+    }
+
     /**
      * Camelize field names by creating and unsetting array items recursively.
      * Only properties are camelized, other attributes are ignored.
@@ -445,9 +455,7 @@ class arElasticSearchMapping
             // std_french in search.yml) based in the language being used. The default
             // analyzer is standard, which does not provide a stopwords list.
             foreach ($nestedI18nFields as $fn => &$fv) {
-                $analyzer = isset(self::$analyzers[$culture]) ? self::$analyzers[$culture] : 'standard';
-
-                $fv['analyzer'] = $analyzer;
+                $fv['analyzer'] = self::getAnalyzer($culture);
             }
             unset($fv);
 

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginQuery.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginQuery.class.php
@@ -428,7 +428,7 @@ class arElasticSearchPluginQuery
                 break;
         }
 
-        return arElasticSearchPluginUtil::generateBoolQueryString(
+        return arElasticSearchPluginUtil::generateQueryString(
             $query, $fields
         );
     }

--- a/plugins/qtAccessionPlugin/modules/accession/actions/browseAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/browseAction.class.php
@@ -111,7 +111,9 @@ class AccessionBrowseAction extends sfAction
             ];
 
             $this->queryBool->addMust(
-                arElasticSearchPluginUtil::generateBoolQueryString($request->subquery, $fields)
+                arElasticSearchPluginUtil::generateQueryString(
+                    $request->subquery, $fields
+                )
             );
 
             $this->sortOptions['relevance'] = $this->context->i18n->__('Relevance');


### PR DESCRIPTION
Instead of adding one "should" clause for each search field use a
single "query string" that searches all relevant fields.  This change
allows multiple search terms (e.g. "foo bar") to match "foo" in one
field and "bar" in a different field.  This makes
arElasticSearchPluginUtil::generateBoolQueryString()
unnecessary, so I've replace calls to it with generateBoolQueryString().

Thank you to https://gist.github.com/bardocuteam for submitting the
initial suggestion to remove the multiple "should" search clauses.

Unfortantely this change reintroduced bug #12186: "Searching for titles
with stop words will not give results". To get stop words working again
requires two additional changes:

- use the stop word analyzer for the current user culture in the
  Elastica QueryString object
- remove "keyword" fields from the "_all" search field list - query
  string searches don't filter stop words when keyword fields are
  included in the search fields

The three keyword fields removed from the general search are: slug,
referenceCodeWithoutCountryAndRepo, and digitalObject.thumbnailPath.