### PR TITLE
Fix double escaped donor name, refs #13616

### DIFF
--- a/plugins/qtAccessionPlugin/modules/accession/templates/indexSuccess.php
+++ b/plugins/qtAccessionPlugin/modules/accession/templates/indexSuccess.php
@@ -47,7 +47,7 @@
 
   <?php foreach (QubitRelation::getRelationsBySubjectId($resource->id, ['typeId' => QubitTerm::DONOR_ID]) as $item) { ?>
 
-    <?php echo render_show(__('Related donor'), link_to(esc_specialchars(render_title($item->object)), [$item->object, 'module' => 'donor'])); ?>
+    <?php echo render_show(__('Related donor'), link_to(render_title($item->object), [$item->object, 'module' => 'donor'])); ?>
 
     <?php foreach ($item->object->contactInformations as $contactItem) { ?>
       <?php echo get_partial('contactinformation/contactInformation', ['contactInformation' => $contactItem]); ?>


### PR DESCRIPTION
Fixed issue where donor names, when viewed in accession pages, where getting double escaped.