### PR TITLE
Restore finding aid phys. container, refs #13583

### DIFF
--- a/lib/job/arFindingAidJob.class.php
+++ b/lib/job/arFindingAidJob.class.php
@@ -54,6 +54,9 @@ class arFindingAidJob extends arBaseJob
         } else {
             $generator = new QubitFindingAidGenerator($this->resource);
             $generator->setLogger($this->logger);
+            $generator->setAuthLevel(
+                QubitFindingAidGenerator::getPublicSetting()
+            );
             $generator->setFormat(QubitFindingAidGenerator::getFormatSetting());
             $generator->setModel(QubitFindingAidGenerator::getModelSetting());
             $result = $generator->generate();

--- a/lib/task/export/exportBulkBaseTask.class.php
+++ b/lib/task/export/exportBulkBaseTask.class.php
@@ -62,7 +62,7 @@ abstract class exportBulkBaseTask extends sfBaseTask
         switch ($format) {
             case 'ead':
                 $eadLevels = ['class', 'collection', 'file', 'fonds', 'item', 'otherlevel', 'recordgrp', 'series', 'subfonds', 'subgrp', 'subseries'];
-                $ead = new sfEadPlugin($resource);
+                $ead = new sfEadPlugin($resource, $options);
 
                 break;
 

--- a/lib/task/findingAid/findingAidGenerateTask.class.php
+++ b/lib/task/findingAid/findingAidGenerateTask.class.php
@@ -46,7 +46,8 @@ EOL;
             exit(1);
         }
 
-        $options['logger'] = $this->getLogger($options);
+        $this->setLogger($options);
+        $this->setAuthLevel($options);
 
         $generator = new QubitFindingAidGenerator($resource, $options);
         $generator->generate();
@@ -107,10 +108,17 @@ EOL;
                 'Output extra debugging information',
                 null
             ),
+            new sfCommandOption(
+                'private',
+                null,
+                sfCommandOption::PARAMETER_NONE,
+                'Include sensitive data like physical storage locations',
+                null
+            ),
         ]);
     }
 
-    private function getLogger($options)
+    private function setLogger(array &$options): void
     {
         $logger = new sfConsoleLogger($this->dispatcher);
 
@@ -118,6 +126,15 @@ EOL;
             $logger->setLogLevel(sfLogger::DEBUG);
         }
 
-        return $logger;
+        $options['logger'] = $logger;
+    }
+
+    private function setAuthLevel(array &$options): void
+    {
+        // Set authLevel option
+        if ($options['private']) {
+            $options['authLevel'] = 'private';
+            unset($options['private']);
+        }
     }
 }

--- a/lib/task/pdf/helper-functions.xsl
+++ b/lib/task/pdf/helper-functions.xsl
@@ -105,6 +105,7 @@
             <xsl:when test="$tag = 'chronlist'">Chronology list</xsl:when>
             <xsl:when test="$tag = 'accessrestrict'">Restrictions on access</xsl:when>
             <xsl:when test="$tag = 'userestrict'">Conditions governing use</xsl:when>
+            <xsl:when test="$tag = 'container'">Physical storage</xsl:when>
             <xsl:when test="$tag = 'controlaccess'">Access points</xsl:when>
             <xsl:when test="$tag = 'corpname'">Corporate name</xsl:when>
             <xsl:when test="$tag = 'creation'">Creation</xsl:when>
@@ -164,7 +165,6 @@
             <xsl:when test="$tag = 'phystech'">Physical condition</xsl:when>
             <xsl:when test="$tag = 'physdesc'">Physical description</xsl:when>
             <xsl:when test="$tag = 'physfacet'">Physical facet</xsl:when>
-            <xsl:when test="$tag = 'physloc'">Physical location</xsl:when>
             <xsl:when test="$tag = 'ptr'">Pointer</xsl:when>
             <xsl:when test="$tag = 'ptrgrp'">Pointer group</xsl:when>
             <xsl:when test="$tag = 'ptrloc'">Pointer location</xsl:when>
@@ -231,6 +231,12 @@
             </xsl:choose>
         </xsl:variable>
         <xsl:value-of select="concat($month,' ',substring($dateString,9,2),', ',substring($dateString,1,4))"/>
+    </xsl:function>
+    <!-- Uppercase the first letter of a string-->
+    <xsl:function name="local:ucfirst">
+        <xsl:param name="string"/>
+        <xsl:value-of select="upper-case(substring($string,1,1))"/>
+        <xsl:value-of select="substring($string,2)"/>
     </xsl:function>
     <!--
         Prints out full language name from abbreviation.

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/actions/indexAction.class.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/actions/indexAction.class.php
@@ -31,7 +31,10 @@ class sfEadPluginIndexAction extends InformationObjectIndexAction
         // run the core informationObject show action commands
         parent::execute($request);
 
-        $this->ead = new sfEadPlugin($this->resource);
+        $this->ead = new sfEadPlugin(
+            $this->resource,
+            ['public' => !$this->context->user->isAuthenticated()]
+        );
 
         // Determine language(s) used in the export
         $this->exportLanguage = sfContext::getInstance()->user->getCulture();

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
@@ -81,23 +81,18 @@
 
 <archdesc <?php echo $ead->renderLOD($resource, $eadLevels); ?> relatedencoding="<?php echo $ead->getMetadataParameter('relatedencoding'); ?>">
   <?php
+    $resourceVar = 'resource';
+    $creators = ${$resourceVar}->getCreators();
+    $events = ${$resourceVar}->getActorEvents(['eventTypeId' => QubitTerm::CREATION_ID]);
 
-  $resourceVar = 'resource';
-  $counter = 0;
-  $counterVar = 'counter';
+    $topLevelDid = true;
 
-  $creators = ${$resourceVar}->getCreators();
-  $events = ${$resourceVar}->getActorEvents(['eventTypeId' => QubitTerm::CREATION_ID]);
+    include 'indexSuccessBodyDidElement.xml.php';
 
-  $topLevelDid = true;
+    include 'indexSuccessBodyBioghistElement.xml.php';
 
-  include 'indexSuccessBodyDidElement.xml.php';
-
-  include 'indexSuccessBodyBioghistElement.xml.php';
-
-  $topLevelDid = false;
+    $topLevelDid = false;
   ?>
-
   <?php if ($resource->getPublicationStatus()) { ?>
     <odd type="publicationStatus"><p><?php echo escape_dc(esc_specialchars($resource->getPublicationStatus())); ?></p></odd>
   <?php } ?>

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
@@ -1,25 +1,14 @@
 <did>
 
-  <?php if (check_field_visibility('app_element_visibility_physical_storage', $options)) { ?>
-    <?php $objects = ${$resourceVar}->getPhysicalObjects(); ?>
-    <?php foreach ($objects as $object) { ?>
-      <?php if (0 < strlen($location = $object->getLocation(['cultureFallback' => true]))) { ?>
-        <physloc id="<?php echo 'physloc'.str_pad(++${$counterVar}, 4, '0', STR_PAD_LEFT); ?>"><?php echo escape_dc(esc_specialchars($location)); ?></physloc>
-      <?php } ?>
-      <container <?php echo $ead->getEadContainerAttributes($object); ?><?php if (0 < strlen($location)) { ?> parent="<?php echo 'physloc'.str_pad(${$counterVar}, 4, '0', STR_PAD_LEFT); ?>"<?php } ?>>
-        <?php if (0 < strlen($name = $object->getName(['cultureFallback' => true]))) { ?>
-          <?php echo escape_dc(esc_specialchars($name)); ?>
-        <?php } ?>
-      </container>
-    <?php } ?>
-  <?php } ?>
+  <?php include 'indexSuccessBodyPhysloc.xml.php'; ?>
 
-  <?php if (0 < strlen(${$resourceVar}->getPropertyByName('titleProperOfPublishersSeries')->__toString())
+  <?php if (
+    0 < strlen(${$resourceVar}->getPropertyByName('titleProperOfPublishersSeries')->__toString())
     || 0 < strlen(${$resourceVar}->getPropertyByName('parallelTitleOfPublishersSeries')->__toString())
-      || 0 < strlen(${$resourceVar}->getPropertyByName('otherTitleInformationOfPublishersSeries')->__toString())
-        || 0 < strlen(${$resourceVar}->getPropertyByName('statementOfResponsibilityRelatingToPublishersSeries')->__toString())
-          || 0 < strlen(${$resourceVar}->getPropertyByName('numberingWithinPublishersSeries')->__toString())) { ?>
-
+    || 0 < strlen(${$resourceVar}->getPropertyByName('otherTitleInformationOfPublishersSeries')->__toString())
+    || 0 < strlen(${$resourceVar}->getPropertyByName('statementOfResponsibilityRelatingToPublishersSeries')->__toString())
+    || 0 < strlen(${$resourceVar}->getPropertyByName('numberingWithinPublishersSeries')->__toString())
+  ) { ?>
     <unittitle>
       <bibseries>
 

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyPhysloc.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyPhysloc.xml.php
@@ -1,0 +1,13 @@
+<?php foreach ($ead->getPhysicalObjects(${$resourceVar}) as $po) { ?>
+  <?php if (!empty($po['location'])) { ?>
+    <physloc
+      id="<?php echo $po['physlocId']; ?>"
+    ><?php echo $po['location']; ?></physloc>
+  <?php } ?>
+  <container
+    <?php echo $ead->getEadContainerAttributes($po['object']); ?>
+    <?php if (!empty($po['location'])) { ?>
+      <?php echo sprintf(' parent="%s"', $po['physlocId']); ?>
+    <?php }  ?>
+  ><?php echo $po['name']; ?></container>
+<?php } // end foreach()?>

--- a/test/phpunit/QubitFindingAidGeneratorTest.php
+++ b/test/phpunit/QubitFindingAidGeneratorTest.php
@@ -27,6 +27,15 @@ class QubitFindingAidGeneratorTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($resource2, $generator->getResource());
     }
 
+    public function testSetResourceRootException()
+    {
+        $resource = new QubitInformationObject();
+        $resource->id = 1;
+
+        $this->expectException(UnexpectedValueException::class);
+        $generator = new QubitFindingAidGenerator($resource);
+    }
+
     public function testSetResourceTypeError()
     {
         $generator = new QubitFindingAidGenerator(new QubitInformationObject());
@@ -52,6 +61,31 @@ class QubitFindingAidGeneratorTest extends \PHPUnit\Framework\TestCase
         );
 
         $this->assertSame($logger, $generator->getLogger());
+    }
+
+    public function testValidateSetting()
+    {
+        $generator = new QubitFindingAidGenerator(new QubitInformationObject());
+
+        $this->assertTrue(
+            $generator->validateSetting('val1', ['val1', 'val2'])
+        );
+    }
+
+    public function testValidateSettingUnexpectedValue()
+    {
+        $generator = new QubitFindingAidGenerator(new QubitInformationObject());
+        $this->expectException(UnexpectedValueException::class);
+
+        $generator->validateSetting('test', ['val1', 'val2']);
+    }
+
+    public function testSetAuthLevel()
+    {
+        $generator = new QubitFindingAidGenerator(new QubitInformationObject());
+        $generator->setAuthLevel('public');
+
+        $this->assertSame('public', $generator->getAuthLevel());
     }
 
     public function testSetAppRoot()
@@ -101,14 +135,6 @@ class QubitFindingAidGeneratorTest extends \PHPUnit\Framework\TestCase
         $generator->setModel('full-details');
 
         $this->assertSame('full-details', $generator->getModel());
-    }
-
-    public function testSetInvalidModel()
-    {
-        $generator = new QubitFindingAidGenerator(new QubitInformationObject());
-
-        $this->expectException(UnexpectedValueException::class);
-        $generator->setModel('foo');
     }
 
     public function testGetXslFilePath()


### PR DESCRIPTION
- Create a separate EAD physical object template
- Add authorization level to finding aid generator
- Default to showing ead:container data because they are usually
  visible to the public
- Create an XSL key to lookup an ead:physloc element by id
- Conditionally prepend ead:physloc data if present in the EAD
- Update display of ead:container @type and @label attributes
- Change label for phyloc + container data to "Physical storage"
- Add a XSL "ucfirst" function to capitalize the first letter of a
  string
- Remove unused logic for printing origination/persname@role