### PR TITLE
Fix finding aid cosmetic issues, refs #13618

### DIFF
--- a/lib/task/pdf/helper-functions.xsl
+++ b/lib/task/pdf/helper-functions.xsl
@@ -238,6 +238,50 @@
         <xsl:value-of select="upper-case(substring($string,1,1))"/>
         <xsl:value-of select="substring($string,2)"/>
     </xsl:function>
+    <!-- Map @type value to a human-readable string -->
+    <xsl:function name="local:typeLabel">
+        <xsl:param name="node"/>
+        <xsl:choose>
+            <!-- Title (ead:unittitle) type labels-->
+            <xsl:when test="$node[@type='otherInfo']">Other title information</xsl:when>
+            <!-- Note (ead:note) type labels -->
+            <xsl:when test="$node[@type='sourcesDescription']">Sources</xsl:when>
+            <xsl:when test="$node[@type='generalNote']">General</xsl:when>
+            <xsl:otherwise><xsl:value-of select="$node[@type]"/></xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+    <!-- Lookup ead:odd type labels (except RAD title notes) -->
+    <xsl:function name="local:oddLabel">
+        <xsl:param name="node"/>
+        <xsl:choose>
+            <xsl:when test="$node[@type='levelOfDetail']">Level of detail</xsl:when>
+            <xsl:when test="$node[@type='statusDescription']">Status description</xsl:when>
+            <xsl:when test="$node[@type='descriptionIdentifier']">Description identifier</xsl:when>
+            <xsl:when test="$node[@type='institutionIdentifier']">Institution identifier</xsl:when>
+            <xsl:when test="$node[@type='edition']">Edition</xsl:when>
+            <xsl:when test="$node[@type='physDesc']">Physical description</xsl:when>
+            <xsl:when test="$node[@type='conservation']">Conservation</xsl:when>
+            <xsl:when test="$node[@type='material']">Accompanying material</xsl:when>
+            <xsl:when test="$node[@type='alphanumericDesignation']">Alpha-numeric designations</xsl:when>
+            <xsl:when test="$node[@type='bibSeries']">Publisher's series</xsl:when>
+            <xsl:when test="$node[@type='rights']">Rights</xsl:when>
+            <xsl:when test="$node[@type='publicationStatus']">Publication status</xsl:when>
+        </xsl:choose>
+    </xsl:function>
+    <!-- RAD title note (ead:odd) type labels -->
+    <xsl:function name="local:titleNoteLabel">
+        <xsl:param name="node"/>
+        <xsl:choose>
+            <xsl:when test="$node[@type='titleVariation']">Variations in title</xsl:when>
+            <xsl:when test="$node[@type='titleAttributions']">Attributions and conjectures</xsl:when>
+            <xsl:when test="$node[@type='titleContinuation']">Continuation of title</xsl:when>
+            <xsl:when test="$node[@type='titleStatRep']">Statements of responsibility</xsl:when>
+            <xsl:when test="$node[@type='titleParallel']">Parallel titles and other title information</xsl:when>
+            <xsl:when test="$node[@type='titleSource']">Source of title proper</xsl:when>
+            <xsl:otherwise><xsl:value-of select="$node[@type]"/></xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
     <!--
         Prints out full language name from abbreviation.
         List based on the ISO 639-2b three-letter language codes (http://www.loc.gov/standards/iso639-2/php/code_list.php).


### PR DESCRIPTION
General:
- Don't show the field label for "Dates of creation, revision and
  deletion" when there is no content.
- Generalize logic for displaying specialized field labels and values
  (e.g. dates, physical storage)
- Remove admin / bio history "Note" subtitle

Cover page:
- Remove extra line breaks from second line of title
- Remove vertical height setting for logo to avoid extra vertical whitespace
- Add a 1.5cm margin to the top of the page

Improve field type display:
- Move ead:odd type attribute display value lookups to a function
- Use field label lookup function for all field labels
- Add display value lookups for ead:unittitle and ead:note type values

Title notes:
- Don't show "Title Notes" heading when there are no title notes
- Use titleNoteLabel lookup function to display human friendly labels
- Remove the series level call to titleNotes template, as the EAD XML
  only includes title notes data for the top (archdesc) level