### PR TITLE
Fix JSON in digitalobject browse API, refs #13621

### DIFF
--- a/plugins/arRestApiPlugin/modules/api/actions/digitalobjectsBrowseAction.class.php
+++ b/plugins/arRestApiPlugin/modules/api/actions/digitalobjectsBrowseAction.class.php
@@ -49,6 +49,7 @@ class ApiDigitalObjectsBrowseAction extends QubitApiAction
         $results = [];
         foreach ($resultSet as $do) {
             $fields = [
+                'id' => $do->id,
                 'name' => $do->name,
                 'path' => $do->path,
                 'byte_size' => intval($do->byteSize),
@@ -81,7 +82,7 @@ class ApiDigitalObjectsBrowseAction extends QubitApiAction
                 }
             }
 
-            $results[$do->id] = $fields;
+            $results[] = $fields;
         }
 
         return [


### PR DESCRIPTION
Make digitalobject id a property of JSON object, rather than an array
key. JSON does not allow keyed arrays.