### PR TITLE
Update REST API ACL checks, refs #13445

### DIFF
--- a/lib/myUser.class.php
+++ b/lib/myUser.class.php
@@ -24,6 +24,15 @@ class myUser extends sfBasicSecurityUser implements Zend_Acl_Role_Interface
     // Module-specific permissions get temporarily stored here for access checks
     protected $security = [];
 
+    public function __toString()
+    {
+        if (isset($this->user)) {
+            return $this->user->username;
+        }
+
+        return 'NULL';
+    }
+
     /**
      * Required for Zend_Acl_Role_Interface.
      */

--- a/plugins/arRestApiPlugin/config/arRestApiPluginConfiguration.class.php
+++ b/plugins/arRestApiPlugin/config/arRestApiPluginConfiguration.class.php
@@ -67,10 +67,10 @@ class arRestApiPluginConfiguration extends sfPluginConfiguration
             'params' => ['slug' => '['.QubitSlug::getValidSlugChars().']+'],
         ]);
 
-        $this->addRoute('GET', '/api/informationobjects/tree/:parent_slug', [
+        $this->addRoute('GET', '/api/informationobjects/tree/:slug', [
             'module' => 'api',
             'action' => 'informationobjectsTree',
-            'params' => ['parent_slug' => '['.QubitSlug::getValidSlugChars().']+'],
+            'params' => ['slug' => '['.QubitSlug::getValidSlugChars().']+'],
         ]);
 
         $this->addRoute('PUT', '/api/informationobjects/:slug', [

--- a/plugins/arRestApiPlugin/modules/api/actions/digitalobjectsBrowseAction.class.php
+++ b/plugins/arRestApiPlugin/modules/api/actions/digitalobjectsBrowseAction.class.php
@@ -21,6 +21,11 @@ class ApiDigitalObjectsBrowseAction extends QubitApiAction
 {
     protected function get($request)
     {
+        // Require system-wide "readMaster" authorization to use this endpoint
+        if (!QubitAcl::check(QubitInformationObject::getRoot(), 'readMaster')) {
+            throw new QubitApiNotAuthorizedException();
+        }
+
         $data = [];
 
         $results = $this->getResults($request);

--- a/plugins/arRestApiPlugin/modules/api/actions/informationobjectsUpdateAction.class.php
+++ b/plugins/arRestApiPlugin/modules/api/actions/informationobjectsUpdateAction.class.php
@@ -31,6 +31,10 @@ class ApiInformationObjectsUpdateAction extends QubitApiAction
             throw new QubitApiForbiddenException();
         }
 
+        if (!QubitAcl::check($this->io, 'update')) {
+            throw new QubitApiNotAuthorizedException();
+        }
+
         foreach ($payload as $field => $value) {
             $this->processField($field, $value);
         }

--- a/plugins/qbAclPlugin/lib/QubitAcl.class.php
+++ b/plugins/qbAclPlugin/lib/QubitAcl.class.php
@@ -174,7 +174,14 @@ class QubitAcl
 
         self::getInstance()->buildAcl($resource, $options);
 
-        return self::getInstance()->acl->isAllowed($role, $resource, $action);
+        $allowed = self::getInstance()->acl->isAllowed(
+            $role, $resource, $action
+        );
+
+        // Log ACL check
+        self::log($allowed, $role, $resource, $action);
+
+        return $allowed;
     }
 
     /**
@@ -722,6 +729,28 @@ class QubitAcl
         }
 
         return $this;
+    }
+
+    /**
+     * Log access request.
+     *
+     * @param bool   $allowed  whether access was granted
+     * @param myUser $role     subject of access request
+     * @param mixed  $resource object of access request
+     * @param string $action   action requested
+     */
+    protected static function log($allowed, $role, $resource, $action)
+    {
+        $result = $allowed ? 'ALLOW' : 'DENY';
+        $msg = sprintf(
+            '{QubitAcl} User: "%s", Action: "%s", Resource id:%s, Result: "%s"',
+            $role,
+            $action,
+            $resource->id,
+            $result,
+        );
+
+        sfContext::getInstance()->getLogger()->log($msg, sfLogger::INFO);
     }
 
     /**

--- a/plugins/qbAclPlugin/lib/QubitInformationObjectAcl.class.php
+++ b/plugins/qbAclPlugin/lib/QubitInformationObjectAcl.class.php
@@ -97,10 +97,8 @@ class QubitInformationObjectAcl extends QubitAcl
             QubitTerm::PUBLICATION_STATUS_DRAFT_ID
             == $resource->getPublicationStatus()->statusId
         ) {
-            $instance = self::getInstance()->buildAcl($resource, $options);
-
-            return $instance->acl->isAllowed($user, $resource, 'read')
-                && $instance->acl->isAllowed($user, $resource, 'viewDraft');
+            return parent::isAllowed($user, $resource, 'read')
+                && parent::isAllowed($user, $resource, 'viewDraft');
         }
 
         // Otherwise, just do a "read" ACL check


### PR DESCRIPTION
- Log each ACL check and result to the symfony log file (at "info"
  level) to make debugging easier.
- Add ACL checks to informationobject read (GET) endpoint to include
  digital object URLs (master, reference, and thumbnail)
- Add ACL checks to the informationobject create (POST) endpoint
- Add an ACL check to the informationobject update (PUT) endpoint
- Add ACL checks to the informationobject delete (DELETE) endpoint
- Add ACL checks to the informationobject tree (GET) endpoint
- Change informationobject/tree endpoint "parent_slug" paramater name
  to "slug" to be consistent with other endpoints
- Add an ACL check to the digitalobjects browse (GET) endpoint,
  require system-wide "readMaster" authorization

Add ACL checks to the digitalboject create (POST) endpoint:
- Require digitalobject create (POST) request to include one of:
  information_object_slug, information_object_id, or parent_id
- If using `information_object_slug` require "update" permission on the
  information object to add the digital object
- If using `information_object_id` require "create" permission on the
  information object (a child IO is created for the digital object)
- If using `parent_id` require "update" permission on the parent DO's
  information_object