### PR TITLE
Add check for existing username in add super user task, ref #13643

### DIFF
--- a/lib/task/tools/addSuperuserTask.class.php
+++ b/lib/task/tools/addSuperuserTask.class.php
@@ -46,8 +46,6 @@ class addSuperuserTask extends sfBaseTask
         }
 
         sfContext::createInstance($this->configuration);
-        $databaseManager = new sfDatabaseManager($this->configuration);
-        $conn = $databaseManager->getDatabase('propel')->getConnection();
 
         self::addSuperUser($arguments['username'], $options);
     }
@@ -62,6 +60,13 @@ class addSuperuserTask extends sfBaseTask
             $usernamePrompt .= ': ';
             $username = readline($usernamePrompt);
             $username = ($username) ? $username : $defaultUser;
+        }
+
+        // Verify that this user doesn't already exist
+        $criteria = new Criteria();
+        $criteria->add(QubitUser::USERNAME, $username);
+        if (null !== QubitUser::getOne($criteria)) {
+            throw new Exception('This username already exists. Please choose a different username.');
         }
 
         $email = ($options['email']) ? $options['email'] : '';


### PR DESCRIPTION
The CLI task to create users allows the creation of duplicate users.

`php symfony tools:add-superuser --email=email@domain.tld --password=password dupe_user_name`

Adding a check to prevent creating a user if one already exists.
