### PR TITLE
Fix B5 template actor search field, refs #13645

### DIFF
--- a/plugins/arDominionB5Plugin/modules/actor/templates/_advancedSearch.php
+++ b/plugins/arDominionB5Plugin/modules/actor/templates/_advancedSearch.php
@@ -124,7 +124,7 @@
           <div class="criteria row mb-2">
 
             <div class="col-md-4">
-              <?php echo render_field($form->relatedType->label(__('%1% available', ['%1%' => sfConfig::get('app_ui_label_digitalobject')]))); ?>
+              <?php echo render_field($form->hasDigitalObject->label(__('%1% available', ['%1%' => sfConfig::get('app_ui_label_digitalobject')]))); ?>
             </div>
 
             <div class="col-md-4">


### PR DESCRIPTION
I've corrected the field name for 'Digital object available' field on the Authority search page.
'hasDigitalObject' looks to be the correct field name, instead of 'relatedType'.