### PR TITLE
Handle sourceCulture option for notes, ref#13631

### DIFF
--- a/lib/model/QubitNote.php
+++ b/lib/model/QubitNote.php
@@ -22,6 +22,27 @@ class QubitNote extends BaseNote
     // Flag for updating search index on save or delete
     public $indexOnSave = true;
 
+    public function __get($name)
+    {
+        $args = func_get_args();
+
+        $options = [];
+        if (1 < count($args)) {
+            $options = $args[1];
+        }
+
+        if ('type' === $name && true === $options['sourceCulture']) {
+            $sql = 'SELECT term_i18n.name FROM note
+                JOIN term_i18n ON term_i18n.id = note.type_id
+                WHERE term_i18n.id=?
+                AND note.id=? AND term_i18n.culture=?';
+
+            return QubitPdo::fetchColumn($sql, [$this->typeId, $this->id, $this->sourceCulture]);
+        }
+
+        return call_user_func_array([$this, 'BaseNote::__get'], $args);
+    }
+
     public function __toString()
     {
         if (null === $content = $this->getContent()) {

--- a/plugins/arDominionB5Plugin/modules/sfRadPlugin/templates/indexSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfRadPlugin/templates/indexSuccess.php
@@ -305,13 +305,11 @@
 
   <?php foreach ($resource->getNotesByTaxonomy(['taxonomyId' => QubitTaxonomy::RAD_NOTE_ID]) as $item) { ?>
 
-    <?php $type = $item->getType(['sourceCulture' => true]); ?>
-
-    <?php if ('Conservation' == $type && !check_field_visibility('app_element_visibility_rad_conservation_notes')) { ?>
+    <?php if ($conservationTermID === $item->type->id && !check_field_visibility('app_element_visibility_rad_conservation_notes')) { ?>
       <?php continue; ?>
     <?php } ?>
 
-    <?php if ('Rights' == $type && !check_field_visibility('app_element_visibility_rad_rights_notes')) { ?>
+    <?php if ($rightsTermID === $item->type->id && !check_field_visibility('app_element_visibility_rad_rights_notes')) { ?>
       <?php continue; ?>
     <?php } ?>
 

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/actions/indexAction.class.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/actions/indexAction.class.php
@@ -187,5 +187,20 @@ class sfRadPluginIndexAction extends InformationObjectIndexAction
                 $this->errorSchema = $e;
             }
         }
+
+        // Term ID constants for Rights and Conservation terms
+        $this->rightsTermID = $this->getRADTermID('Rights');
+        $this->conservationTermID = $this->getRADTermID('Conservation');
+    }
+
+    protected function getRADTermID($term)
+    {
+        $sql = "SELECT term.id FROM term
+            JOIN term_i18n ON term_i18n.id = term.id
+            WHERE term.taxonomy_id=?
+            AND term_i18n.culture='en'
+            AND term_i18n.name=?";
+
+        return QubitPdo::fetchColumn($sql, [QubitTaxonomy::RAD_NOTE_ID, $term]);
     }
 }

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
@@ -262,13 +262,11 @@
 
   <?php foreach ($resource->getNotesByTaxonomy(['taxonomyId' => QubitTaxonomy::RAD_NOTE_ID]) as $item) { ?>
 
-    <?php $type = $item->getType(['sourceCulture' => true]); ?>
-
-    <?php if ('Conservation' == $type && !check_field_visibility('app_element_visibility_rad_conservation_notes')) { ?>
+    <?php if ($conservationTermID === $item->type->id && !check_field_visibility('app_element_visibility_rad_conservation_notes')) { ?>
       <?php continue; ?>
     <?php } ?>
 
-    <?php if ('Rights' == $type && !check_field_visibility('app_element_visibility_rad_rights_notes')) { ?>
+    <?php if ($rightsTermID === $item->type->id && !check_field_visibility('app_element_visibility_rad_rights_notes')) { ?>
       <?php continue; ?>
     <?php } ?>
 


### PR DESCRIPTION
Add a __get method to QubitNote to handle sourceCulture option. Currently these calls go to BaseNote which ignores this option, and this leads to hidden fields such as Rights or Conservation showing up when language is changed.

See **line 265-273** in `plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php` for a scenario where the `['sourceCulture' => true]` is passed correctly but would being ignored.