### PR TITLE
Remove user privileges for translator, ref #13647

### DIFF
--- a/apps/qubit/modules/user/config/security.yml
+++ b/apps/qubit/modules/user/config/security.yml
@@ -7,7 +7,7 @@ delete:
   is_secure: true
 
 edit:
-  credentials: [[ administrator, translator ]]
+  credentials: administrator
   is_secure: true
 
 index:


### PR DESCRIPTION
Translator user role should not have the ability to add or edit users so removing this privilege.

To update this policy, clear cache needs to be run after applying this commit `php symfony cc` or `php symfony cache:clear` 