### PR TITLE
Hide locations info from CSV reports, ref #13646

### DIFF
--- a/lib/job/arGenerateReportJob.class.php
+++ b/lib/job/arGenerateReportJob.class.php
@@ -187,7 +187,7 @@ class arGenerateReportJob extends arBaseJob
             $parentTitle = QubitInformationObject::getStandardsBasedInstance($item->parent)->__toString();
             $creationDates = $this->getCreationDates($item);
 
-            $results[$parentFile][] = [
+            $columns = [
                 'resource' => $item,
                 'referenceCode' => QubitInformationObject::getStandardsBasedInstance($item)->referenceCode,
                 'title' => $item->getTitle(['cultureFallback' => true]),
@@ -198,8 +198,13 @@ class arGenerateReportJob extends arBaseJob
                 ) : '',
                 'startDate' => isset($creationDates) ? $creationDates->startDate : null,
                 'accessConditions' => $item->getAccessConditions(['cultureFallback' => true]),
-                'locations' => $this->getLocationString($item),
             ];
+
+            if (0 == sfConfig::get('app_generate_reports_as_pub_user', 1)) {
+                $columns['locations'] = $this->getLocationString($item);
+            }
+
+            $results[$parentFile][] = $columns;
         }
 
         // Sort items by selected criteria


### PR DESCRIPTION
When generating reports, location information should be hidden unless the generate report as public user is set to false. We have a condition check for this in our PHP template but adding in this condition check for the entire job so that it affects generated CSVs as well.