### PR TITLE
Increase PDF indexing limit, ref #13650

### DIFF
--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 192
+    value: 193
   milestone:
     name: milestone
     editable: 0

--- a/data/sql/lib.model.schema.sql
+++ b/data/sql/lib.model.schema.sql
@@ -958,7 +958,7 @@ DROP TABLE IF EXISTS `property_i18n`;
 
 CREATE TABLE `property_i18n`
 (
-	`value` TEXT,
+	`value` MEDIUMTEXT,
 	`id` INTEGER  NOT NULL,
 	`culture` VARCHAR(16)  NOT NULL,
 	PRIMARY KEY (`id`,`culture`),

--- a/lib/QubitFindingAid.class.php
+++ b/lib/QubitFindingAid.class.php
@@ -419,8 +419,8 @@ class QubitFindingAid
      */
     public function saveTranscript(): void
     {
-        // Truncate PDF text to <64KB to fit in `property.value` column
-        $text = mb_strcut($this->getTranscript(), 0, 65535);
+        // Truncate PDF text to <16MB to fit in `property.value` column
+        $text = mb_strcut($this->getTranscript(), 0, 16777215);
 
         $this->logger->info(
             sprintf('Saving transcript (%u bytes)', mb_strlen($text))

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -2871,8 +2871,8 @@ class QubitDigitalObject extends BaseDigitalObject
         if (0 == $status && 0 < count($output)) {
             $text = implode(PHP_EOL, $output);
 
-            // Truncate PDF text to <64KB to fit in `property.value` column
-            $text = mb_strcut($text, 0, 65535);
+            // Truncate PDF text to <16MB to fit in `property.value` column
+            $text = mb_strcut($text, 0, 16777215);
 
             // Update or create 'transcript' property
             $criteria = new Criteria();

--- a/lib/task/migrate/migrations/arMigration0193.class.php
+++ b/lib/task/migrate/migrations/arMigration0193.class.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Modify database for large PDF text support
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0193
+{
+    public const VERSION = 193;
+    public const MIN_MILESTONE = 2;
+
+    public function up($configuration)
+    {
+        $sql = 'ALTER TABLE `property_i18n` MODIFY `value` MEDIUMTEXT;';
+        QubitPdo::modify($sql);
+
+        return true;
+    }
+}


### PR DESCRIPTION
Increase the max amount of PDF text that can be stored from 64KB to 16MB. Also update the upgrade-sql task to set the property value column to use the MEDIUMTEXT type instead of TEXT.