### PR TITLE
Fix missing dc:format field in DC XML, ref #13651

### DIFF
--- a/plugins/sfDcPlugin/modules/sfDcPlugin/templates/_dc.xml.php
+++ b/plugins/sfDcPlugin/modules/sfDcPlugin/templates/_dc.xml.php
@@ -37,8 +37,8 @@
     <dc:type><?php echo esc_specialchars(strval($item)); ?></dc:type>
   <?php } ?>
 
-  <?php foreach ($dc->format as $item) { ?>
-    <dc:format><?php echo esc_specialchars(strval($item)); ?></dc:format>
+  <?php if ($dc->format) { ?>
+    <dc:format><?php echo esc_specialchars(strval($dc->format)); ?></dc:format>
   <?php } ?>
 
   <dc:identifier><?php echo esc_specialchars(sfConfig::get('app_siteBaseUrl').'/'.$resource->slug); ?></dc:identifier>


### PR DESCRIPTION
Update the DC XML template to correctly display dc:format field and remove `foreach` since `$dc->format` is a string instead of an array after the changes to the DC template in #13600.