### PR TITLE
remove markdown rendering on DO files, refs #13503

### DIFF
--- a/apps/qubit/modules/digitalobject/templates/_metadata.php
+++ b/apps/qubit/modules/digitalobject/templates/_metadata.php
@@ -133,9 +133,9 @@
 
           <?php if ($showMasterFileName) { ?>
             <?php if ($canAccessMasterFile) { ?>
-              <?php echo render_show(__('Filename'), link_to(render_value_inline($resource->name), $resource->object->getDigitalObjectUrl(), ['target' => '_blank']), ['fieldLabel' => 'filename']); ?>
+              <?php echo render_show(__('Filename'), link_to($resource->name, $resource->object->getDigitalObjectUrl(), ['target' => '_blank']), ['fieldLabel' => 'filename']); ?>
             <?php } else { ?>
-              <?php echo render_show(__('Filename'), render_value($resource->name), ['fieldLabel' => 'filename']); ?>
+              <?php echo render_show(__('Filename'), $resource->name, ['fieldLabel' => 'filename']); ?>
             <?php } ?>
           <?php } ?>
 
@@ -172,9 +172,9 @@
         <div class="digital-object-metadata-body">
           <?php if ($showReferenceCopyFileName) { ?>
             <?php if ($canAccessReferenceCopy && $sf_user->isAuthenticated()) { ?>
-              <?php echo render_show(__('Filename'), link_to(render_value_inline($referenceCopy->name), $referenceCopy->getFullPath(), ['target' => '_blank']), ['fieldLabel' => 'referenceCopyFileName']); ?>
+              <?php echo render_show(__('Filename'), link_to($referenceCopy->name, $referenceCopy->getFullPath(), ['target' => '_blank']), ['fieldLabel' => 'referenceCopyFileName']); ?>
             <?php } else { ?>
-              <?php echo render_show(__('Filename'), render_value($referenceCopy->name), ['fieldLabel' => 'referenceCopyFileName']); ?>
+              <?php echo render_show(__('Filename'), $referenceCopy->name, ['fieldLabel' => 'referenceCopyFileName']); ?>
             <?php } ?>
           <?php } ?>
 
@@ -211,9 +211,9 @@
         <div class="digital-object-metadata-body">
           <?php if ($showThumbnailCopyFileName) { ?>
             <?php if ($canAccessThumbnailCopy) { ?>
-              <?php echo render_show(__('Filename'), link_to(render_value_inline($thumbnailCopy->name), $thumbnailCopy->getFullPath(), ['target' => '_blank']), ['fieldLabel' => 'thumbnailCopyFileName']); ?>
+              <?php echo render_show(__('Filename'), link_to($thumbnailCopy->name, $thumbnailCopy->getFullPath(), ['target' => '_blank']), ['fieldLabel' => 'thumbnailCopyFileName']); ?>
             <?php } else { ?>
-              <?php echo render_show(__('Filename'), render_value($thumbnailCopy->name), ['fieldLabel' => 'thumbnailCopyFileName']); ?>
+              <?php echo render_show(__('Filename'), $thumbnailCopy->name, ['fieldLabel' => 'thumbnailCopyFileName']); ?>
             <?php } ?>
           <?php } ?>
 

--- a/plugins/arDominionB5Plugin/modules/digitalobject/templates/_metadata.php
+++ b/plugins/arDominionB5Plugin/modules/digitalobject/templates/_metadata.php
@@ -160,9 +160,9 @@
 
                     <?php if ($showMasterFileName) { ?>
                       <?php if ($canAccessMasterFile) { ?>
-                        <?php echo render_show(__('Filename'), link_to(render_value_inline($resource->name), $resource->object->getDigitalObjectUrl(), ['target' => '_blank']), ['fieldLabel' => 'filename', 'isSubField' => true]); ?>
+                        <?php echo render_show(__('Filename'), link_to($resource->name, $resource->object->getDigitalObjectUrl(), ['target' => '_blank']), ['fieldLabel' => 'filename', 'isSubField' => true]); ?>
                       <?php } else { ?>
-                        <?php echo render_show(__('Filename'), render_value_inline($resource->name), ['fieldLabel' => 'filename', 'isSubField' => true]); ?>
+                        <?php echo render_show(__('Filename'), $resource->name, ['fieldLabel' => 'filename', 'isSubField' => true]); ?>
                       <?php } ?>
                     <?php } ?>
 
@@ -200,9 +200,9 @@
                   <div class="digital-object-metadata-body <?php echo render_b5_show_value_css_classes(); ?>">
                     <?php if ($showReferenceCopyFileName) { ?>
                       <?php if ($canAccessReferenceCopy && $sf_user->isAuthenticated()) { ?>
-                        <?php echo render_show(__('Filename'), link_to(render_value_inline($referenceCopy->name), $referenceCopy->getFullPath(), ['target' => '_blank']), ['fieldLabel' => 'referenceCopyFileName', 'isSubField' => true]); ?>
+                        <?php echo render_show(__('Filename'), link_to($referenceCopy->name, $referenceCopy->getFullPath(), ['target' => '_blank']), ['fieldLabel' => 'referenceCopyFileName', 'isSubField' => true]); ?>
                       <?php } else { ?>
-                        <?php echo render_show(__('Filename'), render_value_inline($referenceCopy->name), ['fieldLabel' => 'referenceCopyFileName', 'isSubField' => true]); ?>
+                        <?php echo render_show(__('Filename'), $referenceCopy->name, ['fieldLabel' => 'referenceCopyFileName', 'isSubField' => true]); ?>
                       <?php } ?>
                     <?php } ?>
 
@@ -240,9 +240,9 @@
                   <div class="digital-object-metadata-body <?php echo render_b5_show_value_css_classes(); ?>">
                     <?php if ($showThumbnailCopyFileName) { ?>
                       <?php if ($canAccessThumbnailCopy) { ?>
-                        <?php echo render_show(__('Filename'), link_to(render_value_inline($thumbnailCopy->name), $thumbnailCopy->getFullPath(), ['target' => '_blank']), ['fieldLabel' => 'thumbnailCopyFileName', 'isSubField' => true]); ?>
+                        <?php echo render_show(__('Filename'), link_to($thumbnailCopy->name, $thumbnailCopy->getFullPath(), ['target' => '_blank']), ['fieldLabel' => 'thumbnailCopyFileName', 'isSubField' => true]); ?>
                       <?php } else { ?>
-                        <?php echo render_show(__('Filename'), render_value_inline($thumbnailCopy->name), ['fieldLabel' => 'thumbnailCopyFileName', 'isSubField' => true]); ?>
+                        <?php echo render_show(__('Filename'), $thumbnailCopy->name, ['fieldLabel' => 'thumbnailCopyFileName', 'isSubField' => true]); ?>
                       <?php } ?>
                     <?php } ?>
 


### PR DESCRIPTION
Remove function calls with render_value and render_value_inline on digital object files, preventing markdown elements to break the file names.