### PR TITLE
Enable sorting for all treeviews, refs #13644

### DIFF
--- a/apps/qubit/modules/informationobject/actions/fullWidthTreeViewAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/fullWidthTreeViewAction.class.php
@@ -54,6 +54,7 @@ class InformationObjectFullWidthTreeViewAction extends DefaultFullTreeViewAction
         $options = [
             'skip' => $request->skip,
             'limit' => $request->nodeLimit,
+            'memorySort' => true,
         ];
 
         // On first load, retrieve the ancestors of the selected resource, the

--- a/apps/qubit/modules/settings/templates/treeviewSuccess.php
+++ b/apps/qubit/modules/settings/templates/treeviewSuccess.php
@@ -51,16 +51,12 @@
               ->renderRow(); ?>
         </p>
 
-      </fieldset>
-
-      <fieldset class="collapsible">
-
-        <legend><?php echo __('Sidebar'); ?></legend>
-
+        <p>
         <?php echo $form->ioSort
             ->label(__('Sort (information object)'))
             ->help(__('Determines whether to sort siblings in the information object treeview control and, if so, what sort criteria to use'))
             ->renderRow(); ?>
+        </p>
 
       </fieldset>
 


### PR DESCRIPTION
Sorting features are already available to the sidebar. Now we have sorting enabled for full width treeview.

Updates were also made to the appropriate settings template to reflect that the sorting feature is no longer exclusive to the sidebar. Sorting is moved to the general treeview section and the sidebar section is removed.

![before_template_change](https://user-images.githubusercontent.com/17188244/225990630-e2cb4a04-f7aa-4916-8156-5dd23ae7345c.png)
![after_template_change](https://user-images.githubusercontent.com/17188244/225990681-459b57af-b841-4a58-a37e-26f909dde3bb.png)

