### PR TITLE
Add authority record warnings in BS5, ref #13652

### DIFF
--- a/plugins/arDominionB5Plugin/modules/sfIsaarPlugin/templates/editSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfIsaarPlugin/templates/editSuccess.php
@@ -24,6 +24,17 @@
 
     <?php echo $form->renderHiddenFields(); ?>
 
+    <?php if (!$form->isValid() && $form->hasErrors()) { ?>
+      <div class="alert alert-danger" role="alert">
+        <ul class="<?php echo render_b5_show_list_css_classes(); ?>">
+          <?php foreach ($form->getErrorSchema() as $error) { ?>
+            <?php $error = sfOutputEscaper::unescape($error); ?>
+            <li><?php echo $error->getMessage(); ?></li>
+          <?php } ?>
+        </ul>
+      </div>
+    <?php } ?>
+
     <div class="accordion mb-3">
       <div class="accordion-item">
         <h2 class="accordion-header" id="identity-heading">


### PR DESCRIPTION
Add a warning section to edit authority record BS5 template since these warnings are not easy to find when submitting the form, and don't auto expand the accordion section in BS5 like they do in BS2 themes.