### PR TITLE
Add text helper to related people page, ref #13643

### DIFF
--- a/apps/qubit/modules/term/templates/relatedAuthoritiesSuccess.php
+++ b/apps/qubit/modules/term/templates/relatedAuthoritiesSuccess.php
@@ -1,5 +1,6 @@
 <?php decorate_with('layout_3col'); ?> 
 <?php use_helper('Date'); ?>
+<?php use_helper('Text'); ?>
 
 <?php slot('sidebar'); ?>
 


### PR DESCRIPTION
Error log: `NOTICE: PHP message: PHP Fatal error: Uncaught Error: Call to undefined function truncate_text() in /atom/src/apps/qubit/modules/term/templates/_fields.php:10`

The relatedAuthoritiesSuccess page is missing an include for the text helper which breaks this page for places that need to show a google map image [in _fields.php](https://github.com/artefactual/atom/blob/53612518b49241002d84d274b69c3fe00e39debd/apps/qubit/modules/term/templates/_fields.php#L10). Adding the include to fix this.