### PR TITLE
Fix upgrade task issue for AtoM 2.5 db, ref #13641

### DIFF
--- a/lib/task/migrate/arUpgradeSqlTask.class.php
+++ b/lib/task/migrate/arUpgradeSqlTask.class.php
@@ -211,7 +211,8 @@ EOF;
                 $version,
                 sfConfig::get('sf_lib_dir').'/task/migrate/migrations',
                 $previousMilestone,
-                $currentMilestone
+                $currentMilestone,
+                $options['verbose']
             );
         }
 
@@ -534,10 +535,11 @@ EOF;
      * @param string $migrationsDirectory Directory with migrations in it
      * @param int    $previousMilestone   Previous milestone
      * @param int    $currentMilestone    Current milestone
+     * @param bool   $verboseMode         Verbose mode setting
      *
      * @return int Version of schema after running migrations in this directory
      */
-    private function runMigrationsInDirectory($version, $migrationsDirectory, $previousMilestone, $currentMilestone)
+    private function runMigrationsInDirectory($version, $migrationsDirectory, $previousMilestone, $currentMilestone, $verboseMode)
     {
         foreach (
             sfFinder::type('file')
@@ -565,6 +567,9 @@ EOF;
             else {
                 // Apply unless we are deadling with a 1.x user staying in 1.x
                 if (1 != $previousMilestone || 1 != $currentMilestone) {
+                    if ($verboseMode) {
+                        $this->logSection('upgrade-sql', sprintf('Applying %s', $className));
+                    }
                     // Run migration
                     if (true !== $class->up($this->configuration)) {
                         throw new sfException('Failed to apply upgrade '.get_class($class));

--- a/lib/task/migrate/migrations/arMigration0175.class.php
+++ b/lib/task/migrate/migrations/arMigration0175.class.php
@@ -41,10 +41,11 @@ class arMigration0175
         $sql = 'ALTER TABLE `user` CHANGE COLUMN `sha1_password` `password_hash` VARCHAR(255) DEFAULT NULL';
         QubitPdo::modify($sql);
 
+        $updateHashSql = 'UPDATE `user` SET `password_hash`=? WHERE id=?';
         // Cycle through each user and re-hash stored SHA-1 hash (and salt)
         foreach (QubitUser::getAll() as $user) {
-            $user->passwordHash = QubitUser::generatePasswordHash($user->passwordHash);
-            $user->save();
+            $passwordHash = QubitUser::generatePasswordHash($user->passwordHash);
+            QubitPdo::prepareAndExecute($updateHashSql, [$passwordHash, $user->id]);
         }
 
         return true;


### PR DESCRIPTION
Update migration 175 to use raw SQL query to update user's password hash only since the ORM tries to save the users in a DB where digital object language column doesn't exist yet. Also add a log statement that will print the migration being currently applied when the verbose option is used, to make it easier to find migration issues.