### PR TITLE
Remove click trigger on BS5 textarea, issue #13661

### DIFF
--- a/plugins/arDominionB5Plugin/js/multiRow.js
+++ b/plugins/arDominionB5Plugin/js/multiRow.js
@@ -84,7 +84,7 @@
       });
 
       // If user press enter, add new row
-      $table.on("keydown", "input, select, textarea", function (event) {
+      $table.on("keydown", "input, select", function (event) {
         if (event.key == "Enter" && 0 == $table.find(":animated").length) {
           $table.find(".multi-row-add").trigger("click");
           return false;


### PR DESCRIPTION
Remove the click trigger for multi row text areas in BS5 themes as this prevents adding carriage returns.