### PR TITLE
Fix levels option for CSV export, ref #13659

### DIFF
--- a/lib/job/arInformationObjectCsvExportJob.class.php
+++ b/lib/job/arInformationObjectCsvExportJob.class.php
@@ -58,7 +58,7 @@ class arInformationObjectCsvExportJob extends arInformationObjectExportJob
 
         // Export descendants if option was selected
         if (!$this->params['current-level-only']) {
-            foreach ($resource->getDescendantsForExport($options) as $item) {
+            foreach ($resource->getDescendantsForExport($this->params) as $item) {
                 $this->exportDataAndDigitalObject($item, $path);
             }
         }


### PR DESCRIPTION
CSV information object was not respecting the levels of description options that were selected during export since the options variable used is null. Using params instead fixes this.