### PR TITLE
Fix missing institution edit button, ref #13662

### DIFF
--- a/plugins/arDominionB5Plugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
@@ -268,7 +268,7 @@
   <?php slot('after-content'); ?>
 
     <ul class="actions mb-3 nav gap-2">
-      <?php if (QubitAcl::check($resource, 'update')) { ?>
+      <?php if (QubitAcl::check($resource, 'update') || (QubitAcl::check($resource, 'translate'))) { ?>
         <li><?php echo link_to(__('Edit'), [$resource, 'module' => 'repository', 'action' => 'edit'], ['class' => 'btn atom-btn-outline-light']); ?></li>
       <?php } ?>
       <?php if (QubitAcl::check($resource, 'delete')) { ?>
@@ -280,7 +280,7 @@
       <?php if (QubitAcl::check(QubitInformationObject, 'create')) { ?>
         <li><?php echo link_to(__('Add description'), ['module' => 'informationobject', 'action' => 'add', 'repository' => $resource->id], ['class' => 'btn atom-btn-outline-light']); ?></li>
       <?php } ?>
-      <?php if (QubitAcl::check($resource, 'update')) { ?>
+      <?php if (QubitAcl::check($resource, 'update') || (QubitAcl::check($resource, 'translate'))) { ?>
         <li><?php echo link_to(__('Edit theme'), [$resource, 'module' => 'repository', 'action' => 'editTheme'], ['class' => 'btn atom-btn-outline-light']); ?></li>
       <?php } ?>
     </ul>

--- a/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
+++ b/plugins/sfIsdiahPlugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
@@ -247,7 +247,7 @@
 
     <section class="actions">
       <ul>
-        <?php if (QubitAcl::check($resource, 'update')) { ?>
+        <?php if (QubitAcl::check($resource, 'update') || (QubitAcl::check($resource, 'translate'))) { ?>
           <li><?php echo link_to(__('Edit'), [$resource, 'module' => 'repository', 'action' => 'edit'], ['class' => 'c-btn', 'title' => __('Edit')]); ?></li>
         <?php } ?>
         <?php if (QubitAcl::check($resource, 'delete')) { ?>
@@ -260,7 +260,7 @@
           <li><?php echo link_to(__('Add description'), ['module' => 'informationobject', 'action' => 'add', 'repository' => $resource->id], ['class' => 'c-btn', 'title' => __('Add description')]); ?></li>
         <?php } ?>
         <li class="divider"></li>
-        <?php if (QubitAcl::check($resource, 'update')) { ?>
+        <?php if (QubitAcl::check($resource, 'update') || (QubitAcl::check($resource, 'translate'))) { ?>
           <li><?php echo link_to(__('Edit theme'), [$resource, 'module' => 'repository', 'action' => 'editTheme'], ['class' => 'c-btn', 'title' => 'Edit theme']); ?></li>
         <?php } ?>
       </ul>


### PR DESCRIPTION
Update the permissions for archival institutions to have the edit button show up even after language is changed. This change mirrors the permissions from qubit/modules/informationobject/templates/_actions.php.