### PR TITLE
Fix static page quicklinks, ref #13663

### DIFF
--- a/apps/qubit/modules/menu/actions/quickLinksMenuComponent.class.php
+++ b/apps/qubit/modules/menu/actions/quickLinksMenuComponent.class.php
@@ -37,7 +37,7 @@ class menuQuickLinksMenuComponent extends sfComponent
         $this->quickLinks = [];
 
         foreach ($quickLinksMenu->getChildren() as $child) {
-            $url = $child->getPath(['getUrl' => true, 'resolveAlias' => true]);
+            $url = $child->getPath(['getUrl' => true, 'resolveAlias' => true, 'removeIndex' => true]);
             $urlParsed = parse_url($url);
 
             if (isset($urlParsed['scheme']) || QubitObject::actionExistsForUrl($url)) {

--- a/lib/model/QubitMenu.php
+++ b/lib/model/QubitMenu.php
@@ -46,9 +46,11 @@ class QubitMenu extends BaseMenu
     }
 
     /**
-     * Wrapper for BaseMenu::getPath() call to allow additional functionality
-     *  option 'resolveAlias' - resolve aliases into full path
-     *  option 'getUrl' - resolve path to internal or external URL.
+     * Wrapper for BaseMenu::getPath() call to allow additional functionality.
+     *
+     * option 'resolveAlias' - resolve aliases into full path
+     * option 'getUrl' - resolve path to internal or external URL
+     * option 'removeIndex' - trim index.php from the start of path name
      *
      * @param array $options Optional parameters
      *
@@ -101,6 +103,11 @@ class QubitMenu extends BaseMenu
             }
 
             $path = $url;
+        }
+
+        if (isset($options['removeIndex']) && true === $options['removeIndex']) {
+            $regexForIndex = '/\A(\/(index|qubit_dev).php)/';
+            $path = preg_replace($regexForIndex, '', $path);
         }
 
         return $path;


### PR DESCRIPTION
Update Quicklinks menu logic to strip index.php from the start of the url before testing if an action exists for it as Quicklinks would be hidden in AtoM if the config is set to show index.php in the path name.