### PR TITLE
Resolve duplicate OAI results

### DIFF
--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -437,6 +437,8 @@ class QubitInformationObject extends BaseInformationObject
         }
 
         $criteria->addAscendingOrderByColumn(QubitObject::UPDATED_AT);
+        // Secondarily filter by ID in case UPDATED_AT has duplicate entries.
+        $criteria->addAscendingOrderByColumn(QubitObject::ID);
 
         if (empty($options['offset'])) {
             $options['offset'] = 0;


### PR DESCRIPTION
Resolve duplicate OAI results when updated_at dates are the same. Issue https://github.com/artefactual/atom/issues/1581.