### PR TITLE
Fix missing rad and dacs fields, ref #1596

### DIFF
--- a/lib/helper/QubitHelper.php
+++ b/lib/helper/QubitHelper.php
@@ -44,8 +44,13 @@ function render_field($field, $resource = null, array $options = [])
         }
 
         try {
-            $source = $resourceRaw->__get($options['name'], ['sourceCulture' => true]);
-            $fallback = $resourceRaw->__get($options['name']);
+            if ($resourceRaw instanceof sfRadPlugin || $resourceRaw instanceof arDacsPlugin) {
+                $source = $resourceRaw->getProperty($options['name'], ['sourceCulture' => true]);
+                $fallback = $resourceRaw->getProperty($options['name']);
+            } else {
+                $source = $resourceRaw->__get($options['name'], ['sourceCulture' => true]);
+                $fallback = $resourceRaw->__get($options['name']);
+            }
         } catch (Exception $e) {
             if ('Unknown record property' !== substr($e->getMessage(), 0, 23)) {
                 throw $e;

--- a/plugins/arDacsPlugin/lib/arDacsPlugin.class.php
+++ b/plugins/arDacsPlugin/lib/arDacsPlugin.class.php
@@ -22,15 +22,8 @@ class arDacsPlugin extends sfIsadPlugin
     // sfIsadPlugin is not using properties
     protected $property;
 
-    public function __get($name)
+    public function getProperty($name, $options = [])
     {
-        $args = func_get_args();
-
-        $options = [];
-        if (1 < count($args)) {
-            $options = $args[1];
-        }
-
         switch ($name) {
             case 'technicalAccess':
                 return $this->property('technicalAccess')->__get('value', $options);
@@ -42,7 +35,7 @@ class arDacsPlugin extends sfIsadPlugin
         }
     }
 
-    public function __set($name, $value)
+    public function setProperty($name, $value)
     {
         switch ($name) {
             case 'technicalAccess':

--- a/plugins/arDacsPlugin/modules/arDacsPlugin/actions/editAction.class.php
+++ b/plugins/arDacsPlugin/modules/arDacsPlugin/actions/editAction.class.php
@@ -128,7 +128,7 @@ class arDacsPluginEditAction extends InformationObjectEditAction
 
             case 'languageNotes':
             case 'technicalAccess':
-                $this->form->setDefault($name, $this->dacs[$name]);
+                $this->form->setDefault($name, $this->dacs->getProperty($name));
                 $this->form->setValidator($name, new sfValidatorString());
                 $this->form->setWidget($name, new sfWidgetFormTextarea());
 
@@ -172,7 +172,7 @@ class arDacsPluginEditAction extends InformationObjectEditAction
 
             case 'languageNotes':
             case 'technicalAccess':
-                $this->dacs[$field->getName()] = $this->form->getValue($field->getName());
+                $this->dacs->setProperty($field->getName(), $this->form->getValue($field->getName()));
 
                 break;
 

--- a/plugins/arDacsPlugin/modules/arDacsPlugin/templates/indexSuccess.php
+++ b/plugins/arDacsPlugin/modules/arDacsPlugin/templates/indexSuccess.php
@@ -61,7 +61,7 @@
     <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Identity elements').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'identityArea', 'title' => __('Edit identity elements')]); ?>
   <?php } ?>
 
-  <?php echo render_show(__('Reference code'), $dacs->referenceCode); ?>
+  <?php echo render_show(__('Reference code'), $dacs->getProperty('referenceCode')); ?>
 
   <?php echo render_show_repository(__('Name and location of repository'), $resource); ?>
 
@@ -123,7 +123,7 @@
     <?php echo render_show(__('Physical access'), render_value($resource->getPhysicalCharacteristics(['cultureFallback' => true]))); ?>
   <?php } ?>
 
-  <?php echo render_show(__('Technical access'), render_value($dacs->__get('technicalAccess', ['cultureFallback' => true]))); ?>
+  <?php echo render_show(__('Technical access'), render_value($dacs->getProperty('technicalAccess', ['cultureFallback' => true]))); ?>
 
   <?php echo render_show(__('Conditions governing reproduction'), render_value($resource->getReproductionConditions(['cultureFallback' => true]))); ?>
 
@@ -149,7 +149,7 @@
     </div>
   </div>
 
-  <?php echo render_show(__('Language and script notes'), render_value($dacs->languageNotes)); ?>
+  <?php echo render_show(__('Language and script notes'), render_value($dacs->getProperty('languageNotes'))); ?>
 
   <?php echo render_show(__('Finding aids'), render_value($resource->getFindingAids(['cultureFallback' => true]))); ?>
 

--- a/plugins/arDominionB5Plugin/modules/arDacsPlugin/templates/indexSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/arDacsPlugin/templates/indexSuccess.php
@@ -79,7 +79,7 @@
     ); ?>
   <?php } ?>
 
-  <?php echo render_show(__('Reference code'), $dacs->referenceCode); ?>
+  <?php echo render_show(__('Reference code'), $dacs->getProperty('referenceCode')); ?>
 
   <?php echo render_show_repository(__('Name and location of repository'), $resource); ?>
 
@@ -148,7 +148,7 @@
     <?php echo render_show(__('Physical access'), render_value($resource->getPhysicalCharacteristics(['cultureFallback' => true]))); ?>
   <?php } ?>
 
-  <?php echo render_show(__('Technical access'), render_value($dacs->__get('technicalAccess', ['cultureFallback' => true]))); ?>
+  <?php echo render_show(__('Technical access'), render_value($dacs->getProperty('technicalAccess', ['cultureFallback' => true]))); ?>
 
   <?php echo render_show(__('Conditions governing reproduction'), render_value($resource->getReproductionConditions(['cultureFallback' => true]))); ?>
 
@@ -168,7 +168,7 @@
       echo render_show(__('Scripts of the material'), $scripts);
   ?>
 
-  <?php echo render_show(__('Language and script notes'), render_value($dacs->languageNotes)); ?>
+  <?php echo render_show(__('Language and script notes'), render_value($dacs->getProperty('languageNotes'))); ?>
 
   <?php echo render_show(__('Finding aids'), render_value($resource->getFindingAids(['cultureFallback' => true]))); ?>
 

--- a/plugins/arDominionB5Plugin/modules/sfRadPlugin/templates/editSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfRadPlugin/templates/editSuccess.php
@@ -98,13 +98,13 @@
                 ['mask' => $mask] + $sf_data->getRaw('alternativeIdentifiersComponent')->getVarHolder()->getAll()
             ); ?>
 
-            <?php if ($rad->referenceCode) { ?>
+            <?php if ($rad->getProperty('referenceCode')) { ?>
               <div class="mb-3">
                 <h3 class="fs-6 mb-2">
                   <?php echo __('Reference code'); ?>
                 </h3>
                 <span class="text-muted">
-                  <?php echo render_value_inline($rad->referenceCode); ?>
+                  <?php echo render_value_inline($rad->getProperty('referenceCode')); ?>
                 </span>
               </div>
             <?php } ?>

--- a/plugins/arDominionB5Plugin/modules/sfRadPlugin/templates/indexSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfRadPlugin/templates/indexSuccess.php
@@ -91,9 +91,9 @@
 
   <?php echo render_show(__('Parallel title'), render_value_inline($resource->getAlternateTitle(['cultureFallback' => true])), ['fieldLabel' => 'parallelTitle']); ?>
 
-  <?php echo render_show(__('Other title information'), render_value_inline($rad->__get('otherTitleInformation', ['cultureFallback' => true])), ['fieldLabel' => 'otherTitleInformation']); ?>
+  <?php echo render_show(__('Other title information'), render_value_inline($rad->getProperty('otherTitleInformation', ['cultureFallback' => true])), ['fieldLabel' => 'otherTitleInformation']); ?>
 
-  <?php echo render_show(__('Title statements of responsibility'), render_value_inline($rad->__get('titleStatementOfResponsibility', ['cultureFallback' => true])), ['fieldLabel' => 'titleStatementsOfResponsibility']); ?>
+  <?php echo render_show(__('Title statements of responsibility'), render_value_inline($rad->getProperty('titleStatementOfResponsibility', ['cultureFallback' => true])), ['fieldLabel' => 'titleStatementsOfResponsibility']); ?>
 
   <div class="field <?php echo render_b5_show_field_css_classes(); ?>">
     <?php echo render_b5_show_label(__('Title notes')); ?>
@@ -112,7 +112,7 @@
     <?php echo render_show_repository(__('Repository'), $resource); ?>
   </div>
 
-  <?php echo render_show(__('Reference code'), $rad->__get('referenceCode', ['cultureFallback' => true]), ['fieldLabel' => 'referenceCode']); ?>
+  <?php echo render_show(__('Reference code'), $rad->getProperty('referenceCode', ['cultureFallback' => true]), ['fieldLabel' => 'referenceCode']); ?>
 
 </section> <!-- /section#titleAndStatementOfResponsibilityArea -->
 
@@ -129,7 +129,7 @@
 
   <?php echo render_show(__('Edition statement'), render_value_inline($resource->getEdition(['cultureFallback' => true])), ['fieldLabel' => 'editionStatement']); ?>
 
-  <?php echo render_show(__('Edition statement of responsibility'), render_value_inline($rad->__get('editionStatementOfResponsibility', ['cultureFallback' => true])), ['fieldLabel' => 'editionStatementOfResponsibility']); ?>
+  <?php echo render_show(__('Edition statement of responsibility'), render_value_inline($rad->getProperty('editionStatementOfResponsibility', ['cultureFallback' => true])), ['fieldLabel' => 'editionStatementOfResponsibility']); ?>
 
 </section> <!-- /section#editionArea -->
 
@@ -145,15 +145,15 @@
   <?php } ?>
 
 
-  <?php echo render_show(__('Statement of scale (cartographic)'), render_value_inline($rad->__get('statementOfScaleCartographic', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfScale']); ?>
+  <?php echo render_show(__('Statement of scale (cartographic)'), render_value_inline($rad->getProperty('statementOfScaleCartographic', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfScale']); ?>
 
-  <?php echo render_show(__('Statement of projection (cartographic)'), render_value_inline($rad->__get('statementOfProjection', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfProjection']); ?>
+  <?php echo render_show(__('Statement of projection (cartographic)'), render_value_inline($rad->getProperty('statementOfProjection', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfProjection']); ?>
 
-  <?php echo render_show(__('Statement of coordinates (cartographic)'), render_value_inline($rad->__get('statementOfCoordinates', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfCoordinates']); ?>
+  <?php echo render_show(__('Statement of coordinates (cartographic)'), render_value_inline($rad->getProperty('statementOfCoordinates', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfCoordinates']); ?>
 
-  <?php echo render_show(__('Statement of scale (architectural)'), render_value_inline($rad->__get('statementOfScaleArchitectural', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfScale']); ?>
+  <?php echo render_show(__('Statement of scale (architectural)'), render_value_inline($rad->getProperty('statementOfScaleArchitectural', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfScale']); ?>
 
-  <?php echo render_show(__('Issuing jurisdiction and denomination (philatelic)'), render_value_inline($rad->__get('issuingJurisdictionAndDenomination', ['cultureFallback' => true])), ['fieldLabel' => 'issuingJurisdictionAndDenomination']); ?>
+  <?php echo render_show(__('Issuing jurisdiction and denomination (philatelic)'), render_value_inline($rad->getProperty('issuingJurisdictionAndDenomination', ['cultureFallback' => true])), ['fieldLabel' => 'issuingJurisdictionAndDenomination']); ?>
 </section> <!-- /section#classOfMaterialSpecificDetailsArea -->
 
 <section class="section border-bottom" id="datesOfCreationArea">
@@ -199,17 +199,17 @@
     ); ?>
   <?php } ?>
 
-  <?php echo render_show(__('Title proper of publisher\'s series'), render_value_inline($rad->__get('titleProperOfPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'titleProperOfPublishersSeries']); ?>
+  <?php echo render_show(__('Title proper of publisher\'s series'), render_value_inline($rad->getProperty('titleProperOfPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'titleProperOfPublishersSeries']); ?>
 
-  <?php echo render_show(__('Parallel titles of publisher\'s series'), render_value_inline($rad->__get('parallelTitleOfPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'parallelTitleOfPublishersSeries']); ?>
+  <?php echo render_show(__('Parallel titles of publisher\'s series'), render_value_inline($rad->getProperty('parallelTitleOfPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'parallelTitleOfPublishersSeries']); ?>
 
-  <?php echo render_show(__('Other title information of publisher\'s series'), render_value_inline($rad->__get('otherTitleInformationOfPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'otherTitleInformationOfPublishersSeries']); ?>
+  <?php echo render_show(__('Other title information of publisher\'s series'), render_value_inline($rad->getProperty('otherTitleInformationOfPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'otherTitleInformationOfPublishersSeries']); ?>
 
-  <?php echo render_show(__('Statement of responsibility relating to publisher\'s series'), render_value_inline($rad->__get('statementOfResponsibilityRelatingToPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfResponsibilityRelatingToPublishersSeries']); ?>
+  <?php echo render_show(__('Statement of responsibility relating to publisher\'s series'), render_value_inline($rad->getProperty('statementOfResponsibilityRelatingToPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfResponsibilityRelatingToPublishersSeries']); ?>
 
-  <?php echo render_show(__('Numbering within publisher\'s series'), render_value_inline($rad->__get('numberingWithinPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'numberingWithinPublishersSeries']); ?>
+  <?php echo render_show(__('Numbering within publisher\'s series'), render_value_inline($rad->getProperty('numberingWithinPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'numberingWithinPublishersSeries']); ?>
 
-  <?php echo render_show(__('Note on publisher\'s series'), render_value_inline($rad->__get('noteOnPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'noteOnPublishersSeries']); ?>
+  <?php echo render_show(__('Note on publisher\'s series'), render_value_inline($rad->getProperty('noteOnPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'noteOnPublishersSeries']); ?>
 
 </section> <!-- /section#publishersSeriesArea -->
 
@@ -339,7 +339,7 @@
     ); ?>
   <?php } ?>
 
-  <?php echo render_show(__('Standard number'), render_value_inline($rad->__get('standardNumber', ['cultureFallback' => true])), ['fieldLabel' => 'standardNumber']); ?>
+  <?php echo render_show(__('Standard number'), render_value_inline($rad->getProperty('standardNumber', ['cultureFallback' => true])), ['fieldLabel' => 'standardNumber']); ?>
 
 </section> <!-- /section#standardNumberArea -->
 

--- a/plugins/sfRadPlugin/lib/sfRadPlugin.class.php
+++ b/plugins/sfRadPlugin/lib/sfRadPlugin.class.php
@@ -23,7 +23,7 @@
  *
  * @author     Peter Van Garderen <peter@artefactual.com>
  */
-class sfRadPlugin implements ArrayAccess
+class sfRadPlugin
 {
     protected $resource;
     protected $property;
@@ -50,15 +50,8 @@ class sfRadPlugin implements ArrayAccess
         return $string;
     }
 
-    public function __get($name)
+    public function getProperty($name, $options = [])
     {
-        $args = func_get_args();
-
-        $options = [];
-        if (1 < count($args)) {
-            $options = $args[1];
-        }
-
         switch ($name) {
             case 'editionStatementOfResponsibility':
             case 'issuingJurisdictionAndDenomination':
@@ -88,7 +81,7 @@ class sfRadPlugin implements ArrayAccess
         }
     }
 
-    public function __set($name, $value)
+    public function setProperty($name, $value)
     {
         switch ($name) {
             case 'editionStatementOfResponsibility':
@@ -135,34 +128,6 @@ class sfRadPlugin implements ArrayAccess
 
                 return $this;
         }
-    }
-
-    public function offsetExists($offset)
-    {
-        $args = func_get_args();
-
-        return call_user_func_array([$this, '__isset'], $args);
-    }
-
-    public function offsetGet($offset)
-    {
-        $args = func_get_args();
-
-        return call_user_func_array([$this, '__get'], $args);
-    }
-
-    public function offsetSet($offset, $value)
-    {
-        $args = func_get_args();
-
-        return call_user_func_array([$this, '__set'], $args);
-    }
-
-    public function offsetUnset($offset)
-    {
-        $args = func_get_args();
-
-        return call_user_func_array([$this, '__unset'], $args);
     }
 
     protected function property($name)

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/actions/editAction.class.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/actions/editAction.class.php
@@ -152,14 +152,14 @@ class sfRadPluginEditAction extends InformationObjectEditAction
             case 'statementOfScaleCartographic':
             case 'titleStatementOfResponsibility':
             case 'titleProperOfPublishersSeries':
-                $this->form->setDefault($name, $this->rad[$name]);
+                $this->form->setDefault($name, $this->rad->getProperty($name));
                 $this->form->setValidator($name, new sfValidatorString());
                 $this->form->setWidget($name, new sfWidgetFormInput());
 
                 break;
 
             case 'languageNotes':
-                $this->form->setDefault($name, $this->rad[$name]);
+                $this->form->setDefault($name, $this->rad->getProperty($name));
                 $this->form->setValidator($name, new sfValidatorString());
                 $this->form->setWidget($name, new sfWidgetFormTextarea());
 
@@ -212,7 +212,7 @@ class sfRadPluginEditAction extends InformationObjectEditAction
             case 'statementOfScaleCartographic':
             case 'titleProperOfPublishersSeries':
             case 'titleStatementOfResponsibility':
-                $this->rad[$field->getName()] = $this->form->getValue($field->getName());
+                $this->rad->setProperty($field->getName(), $this->form->getValue($field->getName()));
 
                 break;
 

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/actions/indexAction.class.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/actions/indexAction.class.php
@@ -94,7 +94,7 @@ class sfRadPluginIndexAction extends InformationObjectIndexAction
                             ['required' => true],
                             ['required' => $this->context->i18n->__('Statement of scale (architectural) - This is a mandatory element for architectural drawing.')]
                         );
-                        $values['statementOfScaleArchitectural'] = $this->rad->statementOfScaleArchitectural;
+                        $values['statementOfScaleArchitectural'] = $this->rad->getProperty('statementOfScaleArchitectural');
 
                         break;
 
@@ -103,19 +103,19 @@ class sfRadPluginIndexAction extends InformationObjectIndexAction
                             ['required' => true],
                             ['required' => $this->context->i18n->__('Statement of coordinates (cartographic) - This is a mandatory element for cartographic material.')]
                         );
-                        $values['statementOfCoordinates'] = $this->rad->statementOfCoordinates;
+                        $values['statementOfCoordinates'] = $this->rad->getProperty('statementOfCoordinates');
 
                         $validatorSchema->statementOfProjection = new sfValidatorString(
                             ['required' => true],
                             ['required' => $this->context->i18n->__('Statement of projection (cartographic) - This is a mandatory element for cartographic material.')]
                         );
-                        $values['statementOfProjection'] = $this->rad->statementOfProjection;
+                        $values['statementOfProjection'] = $this->rad->getProperty('statementOfProjection');
 
                         $validatorSchema->statementOfScaleCartographic = new sfValidatorString(
                             ['required' => true],
                             ['required' => $this->context->i18n->__('Statement of scale (cartographic) - This is a mandatory element for cartographic material.')]
                         );
-                        $values['statementOfScaleCartographic'] = $this->rad->statementOfScaleCartographic;
+                        $values['statementOfScaleCartographic'] = $this->rad->getProperty('statementOfScaleCartographic');
 
                         break;
 
@@ -124,7 +124,7 @@ class sfRadPluginIndexAction extends InformationObjectIndexAction
                             ['required' => true],
                             ['required' => $this->context->i18n->__('Issuing jurisdiction and denomination (philatelic) - This is a mandatory element for philatelic record.')]
                         );
-                        $values['issuingJurisdictionAndDenomination'] = $this->rad->issuingJurisdictionAndDenomination;
+                        $values['issuingJurisdictionAndDenomination'] = $this->rad->getProperty('issuingJurisdictionAndDenomination');
 
                         break;
                 }

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/templates/editSuccess.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/templates/editSuccess.php
@@ -84,7 +84,7 @@
         <?php echo get_partial('informationobject/identifierOptions', ['mask' => $mask]); ?>
         <?php echo get_partial('informationobject/alternativeIdentifiers', $sf_data->getRaw('alternativeIdentifiersComponent')->getVarHolder()->getAll()); ?>
 
-        <?php echo render_show(__('Reference code'), $rad->referenceCode); ?>
+        <?php echo render_show(__('Reference code'), $rad->getProperty('referenceCode')); ?>
 
       </fieldset> <!-- #titleAndStatementOfResponsibilityArea -->
 

--- a/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
+++ b/plugins/sfRadPlugin/modules/sfRadPlugin/templates/indexSuccess.php
@@ -77,9 +77,9 @@
 
   <?php echo render_show(__('Parallel title'), render_value($resource->getAlternateTitle(['cultureFallback' => true])), ['fieldLabel' => 'parallelTitle']); ?>
 
-  <?php echo render_show(__('Other title information'), render_value($rad->__get('otherTitleInformation', ['cultureFallback' => true])), ['fieldLabel' => 'otherTitleInformation']); ?>
+  <?php echo render_show(__('Other title information'), render_value($rad->getProperty('otherTitleInformation', ['cultureFallback' => true])), ['fieldLabel' => 'otherTitleInformation']); ?>
 
-  <?php echo render_show(__('Title statements of responsibility'), render_value($rad->__get('titleStatementOfResponsibility', ['cultureFallback' => true])), ['fieldLabel' => 'titleStatementsOfResponsibility']); ?>
+  <?php echo render_show(__('Title statements of responsibility'), render_value($rad->getProperty('titleStatementOfResponsibility', ['cultureFallback' => true])), ['fieldLabel' => 'titleStatementsOfResponsibility']); ?>
 
   <div class="field">
     <h3><?php echo __('Title notes'); ?></h3>
@@ -98,7 +98,7 @@
     <?php echo render_show_repository(__('Repository'), $resource); ?>
   </div>
 
-  <?php echo render_show(__('Reference code'), $rad->__get('referenceCode', ['cultureFallback' => true]), ['fieldLabel' => 'referenceCode']); ?>
+  <?php echo render_show(__('Reference code'), $rad->getProperty('referenceCode', ['cultureFallback' => true]), ['fieldLabel' => 'referenceCode']); ?>
 
 </section> <!-- /section#titleAndStatementOfResponsibilityArea -->
 
@@ -110,7 +110,7 @@
 
   <?php echo render_show(__('Edition statement'), render_value($resource->getEdition(['cultureFallback' => true])), ['fieldLabel' => 'editionStatement']); ?>
 
-  <?php echo render_show(__('Edition statement of responsibility'), render_value($rad->__get('editionStatementOfResponsibility', ['cultureFallback' => true])), ['fieldLabel' => 'editionStatementOfResponsibility']); ?>
+  <?php echo render_show(__('Edition statement of responsibility'), render_value($rad->getProperty('editionStatementOfResponsibility', ['cultureFallback' => true])), ['fieldLabel' => 'editionStatementOfResponsibility']); ?>
 
 </section> <!-- /section#editionArea -->
 
@@ -121,15 +121,15 @@
   <?php } ?>
 
 
-  <?php echo render_show(__('Statement of scale (cartographic)'), render_value($rad->__get('statementOfScaleCartographic', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfScale']); ?>
+  <?php echo render_show(__('Statement of scale (cartographic)'), render_value($rad->getProperty('statementOfScaleCartographic', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfScale']); ?>
 
-  <?php echo render_show(__('Statement of projection (cartographic)'), render_value($rad->__get('statementOfProjection', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfProjection']); ?>
+  <?php echo render_show(__('Statement of projection (cartographic)'), render_value($rad->getProperty('statementOfProjection', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfProjection']); ?>
 
-  <?php echo render_show(__('Statement of coordinates (cartographic)'), render_value($rad->__get('statementOfCoordinates', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfCoordinates']); ?>
+  <?php echo render_show(__('Statement of coordinates (cartographic)'), render_value($rad->getProperty('statementOfCoordinates', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfCoordinates']); ?>
 
-  <?php echo render_show(__('Statement of scale (architectural)'), render_value($rad->__get('statementOfScaleArchitectural', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfScale']); ?>
+  <?php echo render_show(__('Statement of scale (architectural)'), render_value($rad->getProperty('statementOfScaleArchitectural', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfScale']); ?>
 
-  <?php echo render_show(__('Issuing jurisdiction and denomination (philatelic)'), render_value($rad->__get('issuingJurisdictionAndDenomination', ['cultureFallback' => true])), ['fieldLabel' => 'issuingJurisdictionAndDenomination']); ?>
+  <?php echo render_show(__('Issuing jurisdiction and denomination (philatelic)'), render_value($rad->getProperty('issuingJurisdictionAndDenomination', ['cultureFallback' => true])), ['fieldLabel' => 'issuingJurisdictionAndDenomination']); ?>
 </section> <!-- /section#classOfMaterialSpecificDetailsArea -->
 
 <section class="section" id="datesOfCreationArea">
@@ -160,17 +160,17 @@
     <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Publisher\'s series area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'publishersSeriesArea', 'title' => __('Edit publisher\'s series area')]); ?>
   <?php } ?>
 
-  <?php echo render_show(__('Title proper of publisher\'s series'), render_value($rad->__get('titleProperOfPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'titleProperOfPublishersSeries']); ?>
+  <?php echo render_show(__('Title proper of publisher\'s series'), render_value($rad->getProperty('titleProperOfPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'titleProperOfPublishersSeries']); ?>
 
-  <?php echo render_show(__('Parallel titles of publisher\'s series'), render_value($rad->__get('parallelTitleOfPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'parallelTitleOfPublishersSeries']); ?>
+  <?php echo render_show(__('Parallel titles of publisher\'s series'), render_value($rad->getProperty('parallelTitleOfPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'parallelTitleOfPublishersSeries']); ?>
 
-  <?php echo render_show(__('Other title information of publisher\'s series'), render_value($rad->__get('otherTitleInformationOfPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'otherTitleInformationOfPublishersSeries']); ?>
+  <?php echo render_show(__('Other title information of publisher\'s series'), render_value($rad->getProperty('otherTitleInformationOfPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'otherTitleInformationOfPublishersSeries']); ?>
 
-  <?php echo render_show(__('Statement of responsibility relating to publisher\'s series'), render_value($rad->__get('statementOfResponsibilityRelatingToPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfResponsibilityRelatingToPublishersSeries']); ?>
+  <?php echo render_show(__('Statement of responsibility relating to publisher\'s series'), render_value($rad->getProperty('statementOfResponsibilityRelatingToPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'statementOfResponsibilityRelatingToPublishersSeries']); ?>
 
-  <?php echo render_show(__('Numbering within publisher\'s series'), render_value($rad->__get('numberingWithinPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'numberingWithinPublishersSeries']); ?>
+  <?php echo render_show(__('Numbering within publisher\'s series'), render_value($rad->getProperty('numberingWithinPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'numberingWithinPublishersSeries']); ?>
 
-  <?php echo render_show(__('Note on publisher\'s series'), render_value($rad->__get('noteOnPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'noteOnPublishersSeries']); ?>
+  <?php echo render_show(__('Note on publisher\'s series'), render_value($rad->getProperty('noteOnPublishersSeries', ['cultureFallback' => true])), ['fieldLabel' => 'noteOnPublishersSeries']); ?>
 
 </section> <!-- /section#publishersSeriesArea -->
 
@@ -291,7 +291,7 @@
     <?php echo link_to_if(SecurityPrivileges::editCredentials($sf_user, 'informationObject'), '<h2>'.__('Standard number area').'</h2>', [$resource, 'module' => 'informationobject', 'action' => 'edit'], ['anchor' => 'standardNumberArea', 'title' => __('Edit standard number area')]); ?>
   <?php } ?>
 
-  <?php echo render_show(__('Standard number'), render_value($rad->__get('standardNumber', ['cultureFallback' => true])), ['fieldLabel' => 'standardNumber']); ?>
+  <?php echo render_show(__('Standard number'), render_value($rad->getProperty('standardNumber', ['cultureFallback' => true])), ['fieldLabel' => 'standardNumber']); ?>
 
 </section> <!-- /section#standardNumberArea -->
 


### PR DESCRIPTION
Changing the overridden `__get` magic method to a new function definition that expects an `$options` array as a second parameter for both RAD and DACS classes since the `__get` method does not expect additional arguments and will ignore them unless the function call passing them is from inside the class itself.