### PR TITLE
Fix overflowing images in BS5 themes, #1610

### DIFF
--- a/plugins/arDominionB5Plugin/scss/_layout.scss
+++ b/plugins/arDominionB5Plugin/scss/_layout.scss
@@ -1,5 +1,11 @@
 body {
   overflow-x: hidden;
+
+  &.staticpage {
+    img {
+      max-width: 100%;
+    }
+  }
 }
 
 header i.fa-2x {


### PR DESCRIPTION
Add css styles to fix overflowing images in static pages with large width.