### PR TITLE
Restore missing french translations

### DIFF
--- a/plugins/qtAccessionPlugin/i18n/fr/messages.xml
+++ b/plugins/qtAccessionPlugin/i18n/fr/messages.xml
@@ -1,64 +1,64 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE xliff PUBLIC "-//XLIFF//DTD XLIFF//EN" "http://www.oasis-open.org/committees/xliff/documents/xliff.dtd">
 <xliff version="1.0">
-  <file source-language="en" target-language="fr" datatype="plaintext" original="messages" date="2023-05-25T18:37:42Z" product-name="messages">
+  <file source-language="en" target-language="fr" datatype="plaintext" original="messages" date="2023-06-27T18:48:31Z" product-name="messages">
     <header/>
     <body>
       <trans-unit id="1">
         <source>Untitled</source>
-        <target/>
+        <target>Sans titre</target>
       </trans-unit>
       <trans-unit id="2">
         <source>Authorized form of name - This is a mandatory element.</source>
-        <target/>
+        <target>Forme autorisée du nom - Cet élément est obligatoire.</target>
       </trans-unit>
       <trans-unit id="3">
         <source>Add new donor</source>
-        <target/>
+        <target>Ajouter un donateur</target>
       </trans-unit>
       <trans-unit id="4">
         <source>Edit %1%</source>
-        <target/>
+        <target>Modifier %1%</target>
       </trans-unit>
       <trans-unit id="5">
         <source>Are you sure you want to delete %1%?</source>
-        <target/>
+        <target>Êtes-vous sûr de vouloir supprimer %1% ?</target>
       </trans-unit>
       <trans-unit id="6">
         <source>Cancel</source>
-        <target/>
+        <target>Annuler</target>
       </trans-unit>
       <trans-unit id="7">
         <source>Delete</source>
-        <target/>
+        <target>Supprimer</target>
       </trans-unit>
       <trans-unit id="8">
         <source>Edit donor</source>
-        <target/>
+        <target>Modifier le donateur</target>
       </trans-unit>
       <trans-unit id="9">
         <source>Identity area</source>
-        <target/>
+        <target>Zone d'identification</target>
       </trans-unit>
       <trans-unit id="10">
         <source>Authorized form of name</source>
-        <target/>
+        <target>Forme autorisée du nom</target>
       </trans-unit>
       <trans-unit id="11">
         <source>This is a mandatory element.</source>
-        <target/>
+        <target>Cet élément est obligatoire.</target>
       </trans-unit>
       <trans-unit id="12">
         <source>Contact area</source>
-        <target/>
+        <target>Zone du contact</target>
       </trans-unit>
       <trans-unit id="13">
         <source>Save</source>
-        <target/>
+        <target>Sauvegarder</target>
       </trans-unit>
       <trans-unit id="14">
         <source>Create</source>
-        <target/>
+        <target>Ajouter</target>
       </trans-unit>
       <trans-unit id="15">
         <source>Browse donors</source>
@@ -70,147 +70,147 @@
       </trans-unit>
       <trans-unit id="17">
         <source>Donor</source>
-        <target/>
+        <target>Donateur</target>
       </trans-unit>
       <trans-unit id="18">
         <source>Name</source>
-        <target/>
+        <target>Nom</target>
       </trans-unit>
       <trans-unit id="19">
         <source>Date modified</source>
-        <target/>
+        <target>Date modifiée</target>
       </trans-unit>
       <trans-unit id="20">
         <source>Identifier</source>
-        <target/>
+        <target>Identifiant</target>
       </trans-unit>
       <trans-unit id="21">
         <source>Updated</source>
-        <target/>
+        <target>Mis à jour</target>
       </trans-unit>
       <trans-unit id="22">
         <source>Add new</source>
-        <target/>
+        <target>Ajouter</target>
       </trans-unit>
       <trans-unit id="23">
         <source>List donor</source>
-        <target/>
+        <target>Liste des donateurs</target>
       </trans-unit>
       <trans-unit id="24">
         <source>Search donor</source>
-        <target/>
+        <target>Rechercher un donateur</target>
       </trans-unit>
       <trans-unit id="25">
         <source>View donor</source>
-        <target/>
+        <target>Afficher la notice du donateur</target>
       </trans-unit>
       <trans-unit id="26">
         <source>Accession area</source>
-        <target/>
+        <target>Zone des entrées</target>
       </trans-unit>
       <trans-unit id="27">
         <source>Related accession(s)</source>
-        <target/>
+        <target>Entrée(s) associée(s)</target>
       </trans-unit>
       <trans-unit id="28">
         <source>Edit</source>
-        <target/>
+        <target>Modifier</target>
       </trans-unit>
       <trans-unit id="29">
         <source>Identifier - This is a mandatory element.</source>
-        <target/>
+        <target>Identifiant - Cet élément est obligatoire.</target>
       </trans-unit>
       <trans-unit id="30">
         <source>Date of acquisition - This is a mandatory element.</source>
-        <target/>
+        <target>Date d'acquisition - Cet élément est obligatoire.</target>
       </trans-unit>
       <trans-unit id="31">
         <source>Scope - This is a mandatory element.</source>
-        <target/>
+        <target>Présentation du contenu - Cet élément est obligatoire.</target>
       </trans-unit>
       <trans-unit id="32">
         <source>Description - This is a mandatory element.</source>
-        <target/>
+        <target>Description - Cet élément est obligatoire.</target>
       </trans-unit>
       <trans-unit id="33">
         <source>Add new deaccession record</source>
-        <target/>
+        <target>Ajouter une nouvelle sortie définitive</target>
       </trans-unit>
       <trans-unit id="34">
         <source>Edit deaccession record</source>
-        <target/>
+        <target>Modifier les informations sur la sortie définitive</target>
       </trans-unit>
       <trans-unit id="35">
         <source>Deaccession area</source>
-        <target/>
+        <target>Zone de sortie définitive</target>
       </trans-unit>
       <trans-unit id="36">
         <source>Deaccession number</source>
-        <target/>
+        <target>Numéro de sortie définitive</target>
       </trans-unit>
       <trans-unit id="37">
         <source>Identify if the whole accession is being deaccessioned or if only a part of the accession is being deaccessioned.</source>
-        <target/>
+        <target>Déterminer si le fonds entré sort dans son intégralité ou seulement partiellement.</target>
       </trans-unit>
       <trans-unit id="38">
         <source>Scope</source>
-        <target/>
+        <target>Présentation du contenu</target>
       </trans-unit>
       <trans-unit id="39">
         <source>Date of deaccession</source>
-        <target/>
+        <target>Date de sortie</target>
       </trans-unit>
       <trans-unit id="40">
         <source>Date</source>
-        <target/>
+        <target>Date</target>
       </trans-unit>
       <trans-unit id="41">
         <source>Identify what materials are being deaccessioned.</source>
-        <target/>
+        <target>Identifier quels documents sont en cours de sortie.</target>
       </trans-unit>
       <trans-unit id="42">
         <source>Description</source>
-        <target/>
+        <target>Description</target>
       </trans-unit>
       <trans-unit id="43">
         <source>The number of units as a whole number and the measurement of the records to be deaccessioned.</source>
-        <target/>
+        <target>Nombre d'unités (entier) et importance matérielle du volume de documents destinés à la sortie.</target>
       </trans-unit>
       <trans-unit id="44">
         <source>Provide a reason why the records are being deaccessioned.</source>
-        <target/>
+        <target>Fournir le motif de la sortie des documents.</target>
       </trans-unit>
       <trans-unit id="45">
         <source>View deaccession record</source>
-        <target/>
+        <target>Afficher la notice de sortie définitive</target>
       </trans-unit>
       <trans-unit id="46">
         <source>Extent</source>
-        <target/>
+        <target>Importance matérielle</target>
       </trans-unit>
       <trans-unit id="47">
         <source>Reason</source>
-        <target/>
+        <target>Motif</target>
       </trans-unit>
       <trans-unit id="48">
         <source>Identifier available.</source>
-        <target/>
+        <target>Identifiant disponible.</target>
       </trans-unit>
       <trans-unit id="49">
         <source>Identifier unavailable.</source>
-        <target/>
+        <target>Identifiant indisponible.</target>
       </trans-unit>
       <trans-unit id="50">
         <source>Acquisition date - This is a mandatory element.</source>
-        <target/>
+        <target>Date d'acquisition - Cet élément est obligatoire.</target>
       </trans-unit>
       <trans-unit id="51">
         <source>Source of acquisition - This is a mandatory element.</source>
-        <target/>
+        <target>Source d'acquisition - Cet élément est obligatoire.</target>
       </trans-unit>
       <trans-unit id="52">
         <source>Location information - This is a mandatory element.</source>
-        <target/>
+        <target>Information de localisation - Cet élément est obligatoire.</target>
       </trans-unit>
       <trans-unit id="53">
         <source>We've redirected you to the first page of results.</source>
@@ -218,47 +218,47 @@
       </trans-unit>
       <trans-unit id="54">
         <source>Accession number</source>
-        <target/>
+        <target>Numéro d'entrée</target>
       </trans-unit>
       <trans-unit id="55">
         <source>Title</source>
-        <target/>
+        <target>Titre</target>
       </trans-unit>
       <trans-unit id="56">
         <source>Acquisition date</source>
-        <target/>
+        <target>Date d'acquisition</target>
       </trans-unit>
       <trans-unit id="57">
         <source>Relevance</source>
-        <target/>
+        <target>Pertinence</target>
       </trans-unit>
       <trans-unit id="58">
         <source>Notes</source>
-        <target/>
+        <target>Notes</target>
       </trans-unit>
       <trans-unit id="59">
         <source>Add new accession record</source>
-        <target/>
+        <target>Ajouter une nouvelle entrée</target>
       </trans-unit>
       <trans-unit id="60">
         <source>It has %1% deaccessions that will also be deleted:</source>
-        <target/>
+        <target>L'entité a %1% sorties définitives qui seront également supprimées :</target>
       </trans-unit>
       <trans-unit id="61">
         <source>It has %1% accruals. They will not be deleted.</source>
-        <target/>
+        <target>L'entité a %1% accroissements qui ne seront pas supprimés.</target>
       </trans-unit>
       <trans-unit id="62">
         <source>Event(s)</source>
-        <target/>
+        <target>événement(s)</target>
       </trans-unit>
       <trans-unit id="63">
         <source>Type</source>
-        <target/>
+        <target>Type</target>
       </trans-unit>
       <trans-unit id="64">
         <source>Agent</source>
-        <target/>
+        <target>Agent</target>
       </trans-unit>
       <trans-unit id="65">
         <source>%1%Type:%2% Select the type of the event.%3%</source>
@@ -266,7 +266,7 @@
       </trans-unit>
       <trans-unit id="66">
         <source>%1%Date:%2% Enter the date of the event.%3%</source>
-        <target/>
+        <target>%1%Date:%2% Saisir la date de l'événement.%3%</target>
       </trans-unit>
       <trans-unit id="67">
         <source>%1%Agent:%2% Enter the agent associated with the event.%3%</source>
@@ -278,135 +278,135 @@
       </trans-unit>
       <trans-unit id="69">
         <source>Edit accession record</source>
-        <target/>
+        <target>Modifier les informations d'entrée</target>
       </trans-unit>
       <trans-unit id="70">
         <source>You are creating an accrual to accession %1%</source>
-        <target/>
+        <target>Vous êtes en train de créer un supplément à l'entrée %1%</target>
       </trans-unit>
       <trans-unit id="71">
         <source>Basic info</source>
-        <target/>
+        <target>Informations essentielles</target>
       </trans-unit>
       <trans-unit id="72">
         <source>Loading...</source>
-        <target/>
+        <target>Chargement … </target>
       </trans-unit>
       <trans-unit id="73">
         <source>Accession number should be a combination of values recorded in the field and should be a unique accession number for the repository</source>
-        <target/>
+        <target>Le numéro d'entrée devrait être une combinaison de valeurs enregistrées dans ce champ et devrait correspondre à un numéro unique pour l'institution de conservation</target>
       </trans-unit>
       <trans-unit id="74">
         <source>Server error while checking identifer availability.</source>
-        <target/>
+        <target>Erreur serveur lors de la vérification de la disponibilité de l'identifiant.</target>
       </trans-unit>
       <trans-unit id="75">
         <source>Accession date represents the date of receipt of the materials and is added during the donation process.</source>
-        <target/>
+        <target>La date d'acquisition représente la date de réception des documents et est ajoutée durant de le processus de versement.</target>
       </trans-unit>
       <trans-unit id="76">
         <source>Identify immediate source of acquisition or transfer, and date and method of acquisition IF the information is NOT confidential.</source>
-        <target/>
+        <target>Identifier la source immédiate de l'acquisition ou du versement, ainsi que la date et la méthode d'acquisition SI cette information N'EST PAS confidentielle.</target>
       </trans-unit>
       <trans-unit id="77">
         <source>Immediate source of acquisition</source>
-        <target/>
+        <target>Source immédiate d'acquisition</target>
       </trans-unit>
       <trans-unit id="78">
         <source>A description of the physical location in the repository where the accession can be found.</source>
-        <target/>
+        <target>Décrire la localisation physique dans le dépôt permettant de retrouver le versement.</target>
       </trans-unit>
       <trans-unit id="79">
         <source>Location information</source>
-        <target/>
+        <target>Informations de localisation</target>
       </trans-unit>
       <trans-unit id="80">
         <source>Donor/Transferring body area</source>
-        <target/>
+        <target>Zone du donateur/service versant</target>
       </trans-unit>
       <trans-unit id="81">
         <source>Administrative area</source>
-        <target/>
+        <target>Zone des informations administratives</target>
       </trans-unit>
       <trans-unit id="82">
         <source>Term describing the type of accession transaction and referring to the way in which the accession was acquired.</source>
-        <target/>
+        <target>Terme décrivant le type d'entrée et faisant référence à la façon dont l'entrée a été acquise.</target>
       </trans-unit>
       <trans-unit id="83">
         <source>Select the type of resource represented in the accession, either public or private.</source>
-        <target/>
+        <target>Sélectionner le statut des ressources entrées, archives publiques ou archives privées.</target>
       </trans-unit>
       <trans-unit id="84">
         <source>The title of the accession, usually the creator name and term describing the format of the accession materials.</source>
-        <target/>
+        <target>Intitulé du versement, généralement le nom du producteur et un terme décrivant le format des documents entrants.</target>
       </trans-unit>
       <trans-unit id="85">
         <source>Creators</source>
-        <target/>
+        <target>Producteurs</target>
       </trans-unit>
       <trans-unit id="86">
         <source>The name of the creator of the accession or the name of the department that created the accession.</source>
-        <target/>
+        <target>Nom du producteur lié à l'entrée ou nom de l'entité à l'origine de l'entrée.</target>
       </trans-unit>
       <trans-unit id="87">
         <source>"Identify and record the date(s) of the unit of description. Identify the type of date given. Record as a single date or a range of dates as appropriate.” (ISAD 3.1.3). The Date display field can be used to enter free-text date information, including typographical marks to express approximation, uncertainty, or qualification. Use the start and end fields to make the dates searchable. Do not use any qualifiers or typographical symbols to express uncertainty. Acceptable date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM, YYYY.</source>
-        <target/>
+        <target>"Identifier et donner la (les) date(s) de l'unité de description. Indiquer une seule date ou plusieurs dates selon le cas." (ISAD 3.1.3). Le champ d'affichage de la date peut être utilisé pour entrer des informations sur les dates en texte libre, y compris des signes typographiques pour exprimer une date approximative, une date incertaine ou un qualificatif. Utiliser les champs de début et de fin pour rendre les dates interrogeables. Ne pas utiliser de qualificatifs ou de symboles typographiques pour exprimer l'incertitude. Formats de date acceptables : AAAAMMJJ AAAA-MM-JJ, AAAA-MM, AAAA.</target>
       </trans-unit>
       <trans-unit id="88">
         <source>Information on the history of the accession. When the accession is acquired directly from the creator, do not record an archival history but record the information as the Immediate Source of Acquisition.</source>
-        <target/>
+        <target>Informations sur l'historique de l'entrée. Quand l'entrée est acquise directement auprès du producteur, ne pas renseigner l'histoire archivistique mais enregistrer cette information comme la "Source d'acquisition" immédiate.</target>
       </trans-unit>
       <trans-unit id="89">
         <source>Archival/Custodial history</source>
-        <target/>
+        <target>Historique de la conservation</target>
       </trans-unit>
       <trans-unit id="90">
         <source>A description of the intellectual content and document types represented in the accession.</source>
-        <target/>
+        <target>Décrire le contenu intellectuel et les types de documents présents dans le versement.</target>
       </trans-unit>
       <trans-unit id="91">
         <source>Record appraisal, destruction and scheduling actions taken on or planned for the unit of description, especially if they may affect the interpretation of the material.</source>
-        <target/>
+        <target>Mentionner toute opération de tri et d'élimination effectuée ou programmée sur l'unité de description, surtout si elle est susceptible de modifier l'interprétation des documents.</target>
       </trans-unit>
       <trans-unit id="92">
         <source>Appraisal, destruction and scheduling</source>
-        <target/>
+        <target>Évaluation, élimination et calendrier de conservation</target>
       </trans-unit>
       <trans-unit id="93">
         <source>A description of the physical condition of the accession and if any preservation or special handling is required.</source>
-        <target/>
+        <target>Décrire l'état physique du versement et indiquer si des traitements préventifs ou des interventions particulières sont nécessaires.</target>
       </trans-unit>
       <trans-unit id="94">
         <source>Physical condition</source>
-        <target/>
+        <target>État de conservation</target>
       </trans-unit>
       <trans-unit id="95">
         <source>The number of units as a whole number and the measurement of the received volume of records in the accession.</source>
-        <target/>
+        <target>Nombre d'unités (entier) et importance matérielle du volume de documents reçus lors du versement.</target>
       </trans-unit>
       <trans-unit id="96">
         <source>Received extent units</source>
-        <target/>
+        <target>Volumétrie reçue</target>
       </trans-unit>
       <trans-unit id="97">
         <source>An indicator of the accessioning process.</source>
-        <target/>
+        <target>Indicateur du processus d'entrée.</target>
       </trans-unit>
       <trans-unit id="98">
         <source>Indicates the priority the repository assigns to completing the processing of the accession.</source>
-        <target/>
+        <target>Indique la priorité de l'institution de conservation pour achever le processus d'entrée.</target>
       </trans-unit>
       <trans-unit id="99">
         <source>Notes about the processing plan, describing what needs to be done for the accession to be processed completely.</source>
-        <target/>
+        <target>Remarques sur le projet en cours, décrivant ce qu'il reste à faire pour que le processus d'entrée soit complet.</target>
       </trans-unit>
       <trans-unit id="100">
         <source>%1% area</source>
-        <target/>
+        <target>%1% zone</target>
       </trans-unit>
       <trans-unit id="101">
         <source>Alternative identifier(s)</source>
-        <target/>
+        <target>Identifiant(s) alternatif(s)</target>
       </trans-unit>
       <trans-unit id="102">
         <source>Browse accessions</source>
@@ -418,15 +418,15 @@
       </trans-unit>
       <trans-unit id="104">
         <source>Accession</source>
-        <target/>
+        <target>Acquisition</target>
       </trans-unit>
       <trans-unit id="105">
         <source>Related donors</source>
-        <target/>
+        <target>Donateurs associés</target>
       </trans-unit>
       <trans-unit id="106">
         <source>Related donor record</source>
-        <target/>
+        <target>Notice du donateur associé</target>
       </trans-unit>
       <trans-unit id="107">
         <source>Please complete all required fields.</source>
@@ -442,135 +442,135 @@
       </trans-unit>
       <trans-unit id="109">
         <source>Primary contact information</source>
-        <target/>
+        <target>Principales informations pratiques</target>
       </trans-unit>
       <trans-unit id="110">
         <source>Main</source>
-        <target/>
+        <target>Principal</target>
       </trans-unit>
       <trans-unit id="111">
         <source>Physical location</source>
-        <target/>
+        <target>Localisation physique</target>
       </trans-unit>
       <trans-unit id="112">
         <source>Other details</source>
-        <target/>
+        <target>Autres informations</target>
       </trans-unit>
       <trans-unit id="113">
         <source>URL</source>
-        <target/>
+        <target>URL</target>
       </trans-unit>
       <trans-unit id="114">
         <source>Region/province</source>
-        <target/>
+        <target>Région/province</target>
       </trans-unit>
       <trans-unit id="115">
         <source>Country</source>
-        <target/>
+        <target>Pays</target>
       </trans-unit>
       <trans-unit id="116">
         <source>Name of creator</source>
-        <target/>
+        <target>Nom du producteur</target>
       </trans-unit>
       <trans-unit id="117">
         <source>Administrative history</source>
-        <target/>
+        <target>Histoire administrative</target>
       </trans-unit>
       <trans-unit id="118">
         <source>Biographical history</source>
-        <target/>
+        <target>Notice biographique</target>
       </trans-unit>
       <trans-unit id="119">
         <source>View accession record</source>
-        <target/>
+        <target>Afficher la notice d'entrée</target>
       </trans-unit>
       <trans-unit id="120">
         <source>Edit donor/transferring body area</source>
-        <target/>
+        <target>Modifier la zone du donateur/du service versant</target>
       </trans-unit>
       <trans-unit id="121">
         <source>Related donor</source>
-        <target/>
+        <target>Donateur associé</target>
       </trans-unit>
       <trans-unit id="122">
         <source>Edit administrative area</source>
-        <target/>
+        <target>Modifier la zone administrative</target>
       </trans-unit>
       <trans-unit id="123">
         <source>Acquisition type</source>
-        <target/>
+        <target>Type d'acquisition</target>
       </trans-unit>
       <trans-unit id="124">
         <source>Resource type</source>
-        <target/>
+        <target>Type de ressource</target>
       </trans-unit>
       <trans-unit id="125">
         <source>Date(s)</source>
-        <target/>
+        <target>Date(s)</target>
       </trans-unit>
       <trans-unit id="126">
         <source>Scope and content</source>
-        <target/>
+        <target>Portée et contenu</target>
       </trans-unit>
       <trans-unit id="127">
         <source>Processing status</source>
-        <target/>
+        <target>État du processus</target>
       </trans-unit>
       <trans-unit id="128">
         <source>Processing priority</source>
-        <target/>
+        <target>Priorité du processus</target>
       </trans-unit>
       <trans-unit id="129">
         <source>Processing notes</source>
-        <target/>
+        <target>Notes sur le traitement</target>
       </trans-unit>
       <trans-unit id="130">
         <source>Accruals</source>
-        <target/>
+        <target>Accroissements</target>
       </trans-unit>
       <trans-unit id="131">
         <source>Accrual to</source>
-        <target/>
+        <target>Accroissement de</target>
       </trans-unit>
       <trans-unit id="132">
         <source>Rights area</source>
-        <target/>
+        <target>Zone des droits</target>
       </trans-unit>
       <trans-unit id="133">
         <source>Edit rights area</source>
-        <target/>
+        <target>Modifier la zone des droits</target>
       </trans-unit>
       <trans-unit id="134">
         <source>Deaccession</source>
-        <target/>
+        <target>Sortie définitive</target>
       </trans-unit>
       <trans-unit id="135">
         <source>Add accrual</source>
-        <target/>
+        <target>Ajouter l'accroissement</target>
       </trans-unit>
       <trans-unit id="136">
         <source>Create %1%</source>
-        <target/>
+        <target>Ajouter %1%</target>
       </trans-unit>
       <trans-unit id="137">
         <source>More</source>
-        <target/>
+        <target>Plus</target>
       </trans-unit>
       <trans-unit id="138">
         <source>Create new rights</source>
-        <target/>
+        <target>Ajouter des droits</target>
       </trans-unit>
       <trans-unit id="139">
         <source>Link physical storage</source>
-        <target/>
+        <target>Lier à une localisation physique</target>
       </trans-unit>
       <trans-unit id="140">
         <source>&lt;strong&gt;Type:&lt;/strong&gt; Enter a name for the alternative identifier field that indicates its purpose and usage.&lt;br/&gt;&lt;strong&gt;Identifier:&lt;/strong&gt; Enter a legacy reference code, alternative identifier, or any other alpha-numeric string associated with the record.</source>
-        <target/>
+        <target>&lt;strong&gt;Type:&lt;/strong&gt; Entrez un nom pour le champ d'identifiant alternatif qui indique son but et son utilisation.&lt;br/&gt;&lt;strong&gt;Identifiant:&lt;/strong&gt; Saisissez un code de référence hérité, un autre identifiant ou toute autre chaîne alphanumérique associée à l'enregistrement.</target>
       </trans-unit>
       <trans-unit id="141">
         <source>This identifer is already in use.</source>
-        <target/>
+        <target>Cet identifiant est déjà utilisé.</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
Restoring french translations that were dropped during the 2.7.0 release. Running the weblate import task wipes these translations so this is only meant as a temporary fix for the release.