### PR TITLE
Add IO pub. status update via REST API. (#1624)

### DIFF
--- a/plugins/arRestApiPlugin/modules/api/actions/informationobjectsUpdateAction.class.php
+++ b/plugins/arRestApiPlugin/modules/api/actions/informationobjectsUpdateAction.class.php
@@ -240,6 +240,17 @@ class ApiInformationObjectsUpdateAction extends QubitApiAction
                 }
 
                 break;
+
+        case 'published':
+                if ($value) {
+                    $publicationStatus = 'Published';
+                } else {
+                    $publicationStatus = 'Draft';
+                }
+
+                $this->io->setPublicationStatusByName($publicationStatus);
+
+                break;
         }
     }
 


### PR DESCRIPTION
Added functionality to the information object update REST API endpoint to allow an information object's publication status to be changed.