### PR TITLE
Add IO pub. status update via REST API. (#1624)

### DIFF
--- a/plugins/arRestApiPlugin/modules/api/actions/informationobjectsUpdateAction.class.php
+++ b/plugins/arRestApiPlugin/modules/api/actions/informationobjectsUpdateAction.class.php
@@ -240,6 +240,16 @@ class ApiInformationObjectsUpdateAction extends QubitApiAction
                 }
 
                 break;
+
+            case 'published':
+                $publicationStatus = 'Draft';
+                if ($value) {
+                    $publicationStatus = 'Published';
+                }
+
+                $this->io->setPublicationStatusByName($publicationStatus);
+
+                break;
         }
     }
 


### PR DESCRIPTION
Added functionality to the information object update REST API endpoint to allow an information object's publication status to be changed.