### PR TITLE
Add diacritics setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /config/config.php
 /config/databases.yml
 /config/propel.ini
+/config/diacritics_mapping.yml
 
 # Internal use
 /cache/

--- a/apps/qubit/modules/settings/actions/diacriticsAction.class.php
+++ b/apps/qubit/modules/settings/actions/diacriticsAction.class.php
@@ -1,0 +1,103 @@
+<?php
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class SettingsDiacriticsAction extends SettingsEditAction
+{
+    // Arrays not allowed in class constants
+    public static $NAMES = [
+        'diacritics',
+        'mappings',
+    ];
+
+    public function earlyExecute()
+    {
+        parent::earlyExecute();
+
+        $this->updateMessage = $this->i18n->__('Diacritics settings saved.');
+
+        $this->settingDefaults = [
+            'diacritics' => 0,
+        ];
+    }
+
+    public function processForm()
+    {
+        foreach ($this->form as $field) {
+            $this->processField($field);
+        }
+    }
+
+    protected function addField($name)
+    {
+        switch ($name) {
+            case 'diacritics':
+                $this->form->setDefault($name, $this->settingDefaults[$name]);
+                $this->form->setWidget($name, new sfWidgetFormSelectRadio(['choices' => [0 => $this->i18n->__('Disabled'), 1 => $this->i18n->__('Enabled')]], ['class' => 'radio']));
+                $this->form->setValidator($name, new sfValidatorChoice(['choices' => [1, 0]]));
+
+                break;
+
+            case 'mappings':
+                $this->form->setWidget($name, new sfWidgetFormInputFile([], ['accept' => '.yml,.yaml']));
+                $this->form->setValidator($name, new sfValidatorFile(['mime_types' => ['text/plain']]));
+
+                break;
+        }
+    }
+
+    protected function processField($field)
+    {
+        switch ($name = $field->getName()) {
+            case 'diacritics':
+                parent::processField($field);
+
+                break;
+
+            case 'mappings':
+                $file = $this->form->getValue('mappings');
+
+                $diacriticsMappingPath = sfConfig::get('sf_config_dir').DIRECTORY_SEPARATOR.'diacritics_mapping.yml';
+
+                if (null !== $file) {
+                    try {
+                        sfYaml::load($file->getTempName());
+
+                        if (!move_uploaded_file($file->getTempName(), $diacriticsMappingPath)) {
+                            $this->getUser()->setFlash('error', $this->context->i18n->__('Unable to upload diacritics mapping yaml file.'));
+                            unset($this->updateMessage);
+
+                            return;
+                        }
+                    } catch (Exception $e) {
+                        QubitSetting::findAndSave('diacritics', 0, ['sourceCulture' => true]);
+                        unlink($diacriticsMappingPath);
+                        $this->getUser()->setFlash('error', $this->context->i18n->__('Unable to upload diacritis mapping yaml file.'));
+                        unset($this->updateMessage);
+                    }
+                } else {
+                    // Reset diacritics settings when uploading yaml fails
+                    QubitSetting::findAndSave('diacritics', 0, ['sourceCulture' => true]);
+                    unlink($diacriticsMappingPath);
+                    $this->getUser()->setFlash('error', $this->context->i18n->__('Unable to upload diacritis mapping yaml file.'));
+                    unset($this->updateMessage);
+                }
+
+                break;
+        }
+    }
+}

--- a/apps/qubit/modules/settings/actions/editAction.class.php
+++ b/apps/qubit/modules/settings/actions/editAction.class.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * This file is part of the Access to Memory (AtoM) software.
  *
@@ -28,7 +27,7 @@ class SettingsEditAction extends DefaultEditAction
 
         // Handle posted data
         if ($request->isMethod('post')) {
-            $this->form->bind($request->getPostParameters());
+            $this->form->bind($request->getPostParameters(), $request->getFiles());
 
             if ($this->form->isValid()) {
                 $this->processForm();

--- a/apps/qubit/modules/settings/actions/menuComponent.class.php
+++ b/apps/qubit/modules/settings/actions/menuComponent.class.php
@@ -40,6 +40,10 @@ class SettingsMenuComponent extends sfComponent
                 'action' => 'template',
             ],
             [
+                'label' => $i18n->__('Diacritics'),
+                'action' => 'diacritics',
+            ],
+            [
                 'label' => $i18n->__('Digital object derivatives'),
                 'action' => 'digitalObjectDerivatives',
             ],

--- a/apps/qubit/modules/settings/templates/diacriticsSuccess.php
+++ b/apps/qubit/modules/settings/templates/diacriticsSuccess.php
@@ -1,0 +1,66 @@
+<?php decorate_with('layout_2col.php'); ?>
+
+<?php slot('sidebar'); ?>
+
+<?php echo get_component('settings', 'menu'); ?>
+
+<?php end_slot(); ?>
+
+<?php slot('title'); ?>
+
+<h1>
+  <?php echo __('Diacritics'); ?>
+</h1>
+
+<?php end_slot(); ?>
+
+<?php slot('content'); ?>
+<div class="alert alert-info">
+  <p>
+    <?php echo __('Please rebuild the search index after uploading diacritics mappings.'); ?>
+  </p>
+  <pre>$ php symfony search:populate</pre>
+</div>
+
+<div class="alert alert-info">
+  <p>
+    <?php echo __('Example CSV:'); ?>
+  </p>
+  <pre>type: mapping<br/>mappings:<br/>  - À => A<br/>  - Á => A</pre>
+</div>
+
+<?php echo $form->renderGlobalErrors(); ?>
+
+<?php echo $form->renderFormTag(url_for(['module' => 'settings', 'action' => 'diacritics'])); ?>
+
+<?php echo $form->renderHiddenFields(); ?>
+
+<div id="content">
+
+  <fieldset class="collapsible">
+    <legend>
+      <?php echo __('Diacritics settings'); ?>
+    </legend>
+
+    <?php echo $form->diacritics->label(__('Diacritics'))->renderRow(); ?>
+  </fieldset>
+
+  <fieldset class="collapsible">
+    <legend>
+      <?php echo __('CSV Mapping YAML'); ?>
+    </legend>
+
+    <?php echo $form->mappings->label(__('Mappings YAML'))->renderRow(); ?>
+  </fieldset>
+
+</div>
+
+<section class="actions">
+  <ul>
+    <li><input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Save'); ?>" /></li>
+  </ul>
+</section>
+
+</form>
+
+<?php end_slot(); ?>

--- a/plugins/arDominionB5Plugin/modules/settings/templates/diacriticsSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/settings/templates/diacriticsSuccess.php
@@ -1,0 +1,74 @@
+<?php decorate_with('layout_2col.php'); ?>
+
+<?php slot('sidebar'); ?>
+
+<?php echo get_component('settings', 'menu'); ?>
+
+<?php end_slot(); ?>
+
+<?php slot('title'); ?>
+<h1>
+  <?php echo __('Diacritics settings'); ?>
+</h1>
+<?php end_slot(); ?>
+
+<?php slot('content'); ?>
+
+<div class="alert alert-info">
+  <p>
+    <?php echo __('Please rebuild the search index after uploading diacritics mappings.'); ?>
+  </p>
+  <pre>$ php symfony search:populate</pre>
+</div>
+
+<?php echo $form->renderGlobalErrors(); ?>
+
+<?php echo $form->renderFormTag(url_for(['module' => 'settings', 'action' => 'diacritics'])); ?>
+
+<?php echo $form->renderHiddenFields(); ?>
+
+<div class="accordion mb-3">
+  <div class="accordion-item">
+    <h2 class="accordion-header" id="diacritics-heading">
+      <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#diacritics-collapse"
+        aria-expanded="true" aria-controls="diacritics-collapse">
+        <?php echo __('Diacritics Settings'); ?>
+      </button>
+    </h2>
+    <div id="diacritics-collapse" class="accordion-collapse collapse show" aria-labelledby="diacritics-heading">
+      <div class="accordion-body">
+        <?php echo render_field($form->diacritics->label(__('Diacritics'))); ?>
+      </div>
+    </div>
+  </div>
+  <div class="accordion-item">
+    <h2 class="accordion-header" id="mappings-heading">
+      <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#mappings-collapse"
+        aria-expanded="false" aria-controls="mappings-collapse">
+        <?php echo __('CSV Mapping YAML'); ?>
+      </button>
+    </h2>
+
+    <div id="mappings-collapse" class="accordion-collapse collapse show" aria-labelledby="sending-heading">
+
+      <div class="alert alert-info m-3 mb-0">
+        <p>
+          <?php echo __('Example CSV:'); ?>
+        </p>
+        <pre>type: mapping<br/>mappings:<br/>  - À => A<br/>  - Á => A</pre>
+      </div>
+
+      <div class="accordion-body">
+        <?php echo render_field($form->mappings->label(__('Mappings YAML'))); ?>
+      </div>
+    </div>
+  </div>
+</div>
+
+<section class="actions">
+  <input class="btn atom-btn-outline-success" type="submit" value="<?php echo __('Save'); ?>" />
+</section>
+
+</form>
+
+<?php end_slot(); ?>


### PR DESCRIPTION
New setting for users to enable further char_filter mappings for diacritics, assigned to the default, autocomplete, english and french analyzers. Requires a yaml file to enable the setting, example attached to this gist for reference: https://gist.github.com/melaniekung/6014e100767019b1f85637e5a7cdf9df. Commit includes an empty diacritics_mapping.yml (default) which will be replaced with the submitted yaml to map out the required diacritics.