### PR TITLE
Set the default theme to arDominionB5Plugin

### DIFF
--- a/lib/arInstall.class.php
+++ b/lib/arInstall.class.php
@@ -315,7 +315,7 @@ class arInstall
         $object->name = 'plugins';
         $object->value = serialize([
             'sfDcPlugin',
-            'arDominionPlugin',
+            'arDominionB5Plugin',
             'sfEacPlugin',
             'sfEadPlugin',
             'sfIsaarPlugin',


### PR DESCRIPTION
Changes the default theme to be the Bootstrap 5 Dominion theme so that new installs use the BS5 theme.