### PR TITLE
Add error message for XLIFF file load (#1627)

### DIFF
--- a/vendor/symfony/lib/i18n/sfMessageSource_XLIFF.class.php
+++ b/vendor/symfony/lib/i18n/sfMessageSource_XLIFF.class.php
@@ -54,6 +54,16 @@ class sfMessageSource_XLIFF extends sfMessageSource_File
     if (!$xml = simplexml_load_file($filename))
     {
       $error = false;
+      $xmlErrors = libxml_get_errors();
+      $errorMessage = '';
+      foreach ($xmlErrors as $error) {
+        $errorMessage .= sprintf("%s[File]: %s at line %s, column %s\n",
+          $error->message, $error->file, $error->line, $error->column);
+      }
+      if ($errorMessage) {
+        throw new sfException(sprintf("Could not load XML file:\n\n%s",
+          $errorMessage));
+      }
 
       return $error;
     }


### PR DESCRIPTION
Throwing an exception when Symfony runs into issues when loading XLIFF files. This will help with catching broken XML files due to translation errors. Without any error handling, this would lead Symfony to use an empty array as the array of translations when it is unable to read XML files, and would make it delete all existing translations for such a file.