### PR TITLE
Add CSP Headers to AtoM Responses

### DIFF
--- a/apps/qubit/config/filters.yml
+++ b/apps/qubit/config/filters.yml
@@ -25,5 +25,8 @@ QubitLimitResults:
 QubitTransaction:
   class: QubitTransactionFilter
 
+QubitCSP:
+  class: QubitCSP
+
 cache: ~
 execution: ~

--- a/apps/qubit/modules/informationobject/templates/_stylesheet.php
+++ b/apps/qubit/modules/informationobject/templates/_stylesheet.php
@@ -1,4 +1,4 @@
-<style type="text/css">
+<style <?php echo __(sfConfig::get('csp_nonce', '')); ?>>
   html, body {
     background-image: none !important;
     background-color: <?php echo $backgroundColor; ?> !important;

--- a/apps/qubit/modules/repository/templates/_stylesheet.php
+++ b/apps/qubit/modules/repository/templates/_stylesheet.php
@@ -1,4 +1,4 @@
-<style type="text/css">
+<style <?php echo __(sfConfig::get('csp_nonce', '')); ?>>
   html, body {
     background-image: none !important;
     background-color: <?php echo $backgroundColor; ?> !important;

--- a/config/app.yml
+++ b/config/app.yml
@@ -59,3 +59,12 @@ all:
 
   # Maximum allowed value for full-width treeview "items per page" setting
   treeview_items_per_page_max: 10000
+
+  # Content Security Policy (CSP) header configuration. CSP settings are used
+  # only when a B5 theme is in use, otherwise these settings will be ignored.
+  csp:
+      # Configure CSP response header to be either
+      # 'Content-Security-Policy-Report-Only' or 'Content-Security-Policy'
+      response_header: Content-Security-Policy
+      # Configure CSP response directives.
+      directives: "default-src 'self'; font-src 'self'; img-src 'self' https://www.gravatar.com/avatar/ blob:; script-src 'self' 'nonce'; style-src 'self' 'nonce'; worker-src 'self' blob:; frame-ancestors 'self';"

--- a/docker/bootstrap.php
+++ b/docker/bootstrap.php
@@ -104,6 +104,9 @@ all:
     persistent: true
   read_only: false
   htmlpurifier_enabled: false
+  csp:
+    response_header: Content-Security-Policy
+    directives: "default-src 'self'; font-src 'self'; img-src 'self' https://www.gravatar.com/avatar/ blob:; script-src 'self' 'nonce'; style-src 'self' 'nonce'; worker-src 'self' blob:; frame-ancestors 'self';"
 EOT;
 
     file_put_contents(_ATOM_DIR.'/apps/qubit/config/app.yml', $app_yml);

--- a/lib/filter/QubitCSPFilter.php
+++ b/lib/filter/QubitCSPFilter.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class QubitCSP extends sfFilter
+{
+    public function execute($filterChain)
+    {
+        // Only use CSP headers if theme is b5.
+        if (!sfConfig::get('app_b5_theme', false)) {
+            $filterChain->execute();
+
+            return;
+        }
+
+        $cspResponseHeader = sfConfig::get('app_csp_response_header', '');
+
+        if (empty($cspResponseHeader)) {
+            // CSP is deactivated.
+            $filterChain->execute();
+
+            return;
+        }
+
+        $context = $this->getContext();
+        if (false === array_search($cspResponseHeader, ['Content-Security-Policy-Report-Only', 'Content-Security-Policy'])) {
+            $context->getLogger()->err(
+                sprintf(
+                    'Setting \'app_csp_response_header\' is not set properly. CSP is not being used.'
+                )
+            );
+
+            $filterChain->execute();
+
+            return;
+        }
+
+        $cspDirectives = sfConfig::get('app_csp_directives', '');
+        if (empty($cspDirectives)) {
+            $context->getLogger()->err(
+                sprintf(
+                    'Setting \'app_csp_directives\' is not set properly. CSP is not being used.'
+                )
+            );
+
+            $filterChain->execute();
+
+            return;
+        }
+
+        // Save nonce for use in templates.
+        $nonce = $this->getRandomNonce();
+        sfConfig::set('csp_nonce', 'nonce='.$nonce);
+
+        $filterChain->execute();
+
+        if (false !== strpos($context->response->getContentType(), 'text/xml')) {
+            return;
+        }
+
+        // Set CSP header on response.
+        $context->response->setHttpHeader(
+            $cspResponseHeader,
+            $cspDirectives = str_replace('nonce', 'nonce-'.$nonce, $cspDirectives)
+        );
+    }
+
+    protected function getRandomNonce($length = 16)
+    {
+        return bin2hex(random_bytes($length));
+    }
+}

--- a/plugins/arDominionB5Plugin/js/imageflow.js
+++ b/plugins/arDominionB5Plugin/js/imageflow.js
@@ -24,11 +24,11 @@
             variableWidth: true,
             centerPadding: "60px",
             nextArrow:
-              '<button class="slick-next slick-arrow" type="button" style=""><span class="slick-next-icon" aria-hidden="true"></span><span class="slick-sr-only">' +
+              '<button class="slick-next slick-arrow" type="button"><span class="slick-next-icon" aria-hidden="true"></span><span class="slick-sr-only">' +
               $(node).data("carousel-next-arrow-button-text") +
               "</span></button>",
             prevArrow:
-              '<button class="slick-prev slick-arrow" type="button" style=""><span class="slick-prev-icon" aria-hidden="true"></span><span class="slick-sr-only">' +
+              '<button class="slick-prev slick-arrow" type="button"><span class="slick-prev-icon" aria-hidden="true"></span><span class="slick-sr-only">' +
               $(node).data("carousel-prev-arrow-button-text") +
               "</span></button>",
           });

--- a/plugins/arDominionB5Plugin/js/main.js
+++ b/plugins/arDominionB5Plugin/js/main.js
@@ -38,3 +38,4 @@ import "./rights";
 import "./fullWidthTreeView";
 import "./deletePhysicalStorage";
 import "./settingsFindingAid";
+import "./refreshJobs";

--- a/plugins/arDominionB5Plugin/js/refreshJobs.js
+++ b/plugins/arDominionB5Plugin/js/refreshJobs.js
@@ -1,0 +1,12 @@
+(($) => {
+  "use strict";
+
+  $(() => {
+    const refreshJobsButton = $("#jobs-refresh-button");
+
+    refreshJobsButton.on("click", (e) => {
+      e.preventDefault(); // Prevent the default behavior of the anchor element
+      window.location.reload();
+    });
+  });
+})(jQuery);

--- a/plugins/arDominionB5Plugin/modules/accession/templates/_alternativeIdentifiers.php
+++ b/plugins/arDominionB5Plugin/modules/accession/templates/_alternativeIdentifiers.php
@@ -22,13 +22,13 @@
     <table class="table table-bordered mb-0 multi-row">
       <thead class="table-light">
         <tr>
-          <th id="alt-identifiers-type-head" style="width: 30%">
+          <th id="alt-identifiers-type-head" class="w-30">
             <?php echo __('Type'); ?>
           </th>
-          <th id="alt-identifiers-identifier-head" style="width: 35%">
+          <th id="alt-identifiers-identifier-head" class="w-35">
             <?php echo __('Identifier'); ?>
           </th>
-          <th id="alt-identifiers-note-head" style="width: 35%">
+          <th id="alt-identifiers-note-head" class="w-35">
             <?php echo __('Notes'); ?>
           </th>
           <th>

--- a/plugins/arDominionB5Plugin/modules/accession/templates/_events.php
+++ b/plugins/arDominionB5Plugin/modules/accession/templates/_events.php
@@ -6,10 +6,10 @@
   <table class="table table-bordered mb-0 multi-row">
     <thead class="table-light">
       <tr>
-        <th id="accession-events-type-head" style="width: 20%">
+        <th id="accession-events-type-head" class="w-20">
           <?php echo __('Type'); ?>
         </th>
-        <th id="accession-events-date-head" style="width: 25%">
+        <th id="accession-events-date-head" class="w-25">
           <?php echo __('Date'); ?>
         </th>
         <th id="accession-events-agent-head">

--- a/plugins/arDominionB5Plugin/modules/accession/templates/_relatedDonor.php
+++ b/plugins/arDominionB5Plugin/modules/accession/templates/_relatedDonor.php
@@ -15,8 +15,8 @@
   <div class="table-responsive">
     <table class="table table-bordered mb-0">
       <thead class="table-light">
-        <tr>
-          <th style="width: 100%">
+	<tr>
+          <th class="w-100">
             <?php echo __('Name'); ?>
           </th>
           <th>

--- a/plugins/arDominionB5Plugin/modules/accession/templates/browseSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/accession/templates/browseSuccess.php
@@ -43,17 +43,17 @@
         <?php foreach ($pager->getResults() as $hit) { ?>
           <?php $doc = $hit->getData(); ?>
           <tr>
-            <td width="20%">
+            <td class="w-20">
               <?php echo link_to($doc['identifier'], ['module' => 'accession', 'slug' => $doc['slug']]); ?>
             </td>
             <td>
               <?php echo link_to(render_title(get_search_i18n($doc, 'title')), ['module' => 'accession', 'slug' => $doc['slug']]); ?>
             </td>
-            <td width="20%">
+            <td class="w-20">
               <?php echo format_date($doc['date'], 'i'); ?>
             </td>
             <?php if ('lastUpdated' == $sf_request->sort) { ?>
-              <td width="20%">
+              <td class="w-20">
                 <?php echo format_date($doc['updatedAt'], 'f'); ?>
               </td>
             <?php } ?>

--- a/plugins/arDominionB5Plugin/modules/actor/templates/_occupations.php
+++ b/plugins/arDominionB5Plugin/modules/actor/templates/_occupations.php
@@ -6,10 +6,10 @@
   <table class="table table-bordered mb-0 multi-row">
     <thead class="table-light">
       <tr>
-        <th id="occupations-occupation-head" style="width: 50%">
+        <th id="occupations-occupation-head" class="w-50">
           <?php echo __('Occupation'); ?>
         </th>
-        <th id="occupations-content-head" style="width: 50%">
+        <th id="occupations-content-head" class="w-50">
           <?php echo __('Note'); ?>
         </th>
         <th>

--- a/plugins/arDominionB5Plugin/modules/actor/templates/renameSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/actor/templates/renameSuccess.php
@@ -22,7 +22,7 @@
           </button>
         </h2>
         <div id="rename-collapse" class="accordion-collapse collapse show" aria-labelledby="rename-heading">
-          <div class="accordion-body">
+	  <div class="accordion-body">
             <p><?php echo __('Use this interface to update the authorized form of name, slug (permalink), and/or %1% filename.', ['%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject'))]); ?></p>
             <hr />
 
@@ -38,7 +38,7 @@
             <p><?php echo __('Original authorized form of name'); ?>: <em><?php echo $resource->authorizedFormOfName; ?></em></p>
             <hr />
 
-            <div id="rename-slug-warning" class="alert alert-danger" role="alert" style="display: none;">
+            <div id="rename-slug-warning" class="alert alert-danger d-none" role="alert">
               <?php echo __('A slug based on this name already exists so a number has been added to pad the slug.'); ?>
             </div>
             <div class="rename-form-field-toggle form-check mb-4">

--- a/plugins/arDominionB5Plugin/modules/contactinformation/templates/_edit.php
+++ b/plugins/arDominionB5Plugin/modules/contactinformation/templates/_edit.php
@@ -16,11 +16,11 @@
   <div class="table-responsive">
     <table class="table table-bordered mb-0">
       <thead class="table-light">
-        <tr>
-          <th style="width: 80%">
+	<tr>
+          <th class="w-80">
             <?php echo __('Contact person'); ?>
           </th>
-          <th style="width: 20%">
+          <th class="w-20">
             <?php echo __('Primary'); ?>
           </th>
           <th>

--- a/plugins/arDominionB5Plugin/modules/digitalobject/templates/_editSubtitles.php
+++ b/plugins/arDominionB5Plugin/modules/digitalobject/templates/_editSubtitles.php
@@ -18,14 +18,14 @@
       <div class="table-responsive mb-3">
         <table class="table table-bordered mb-0">
           <thead class="table-light">
-            <tr>
-              <th style="width: 30%">
+	    <tr>
+              <th class="w-30">
                 <?php echo __('Language'); ?>
               </th>
-              <th style="width: 50%">
+              <th class="w-50">
                 <?php echo __('Filename'); ?>
               </th>
-              <th style="width: 20%">
+              <th class="w-20">
                 <?php echo __('Filesize'); ?>
               </th>
               <th>

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_childLevels.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_childLevels.php
@@ -6,16 +6,16 @@
   <table class="table table-bordered mb-0 multi-row">
     <thead class="table-light">
       <tr>
-        <th id="child-identifier-head" style="width: 20%">
+        <th id="child-identifier-head" class="w-20">
           <?php echo __('Identifier'); ?>
         </th>
-        <th id="child-level-head" style="width: 20%">
+        <th id="child-level-head" class="w-20">
           <?php echo __('Level'); ?>
         </th>
-        <th id="child-title-head" style="width: 40%">
+        <th id="child-title-head" class="w-40">
           <?php echo __('Title'); ?>
         </th>
-        <th id="child-date-head" style="width: 20%">
+        <th id="child-date-head" class="w-20">
           <?php echo __('Date'); ?>
         </th>
         <th>

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_event.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_event.php
@@ -11,17 +11,17 @@
   <div class="table-responsive mb-3">
     <table class="table table-bordered mb-0">
       <thead class="table-light">
-        <tr>
-          <th style="width: 30%">
+	<tr>
+          <th class="w-30">
             <?php echo __('Name'); ?>
           </th>
-          <th style="width: 20%">
+          <th class="w-20">
             <?php echo __('Role/event'); ?>
           </th>
-          <th style="width: 25%">
+          <th class="w-25">
             <?php echo __('Place'); ?>
           </th>
-          <th style="width: 25%">
+          <th class="w-25">
             <?php echo __('Date(s)'); ?>
           </th>
           <th>

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_identifierOptions.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_identifierOptions.php
@@ -47,10 +47,10 @@
       <table class="table table-bordered mb-0 multi-row">
         <thead class="table-light">
           <tr>
-            <th id="alt-identifiers-label-head" style="width: 50%">
+            <th id="alt-identifiers-label-head" class="w-50">
               <?php echo __('Label'); ?>
             </th>
-            <th id="alt-identifiers-identifier-head" style="width: 50%">
+            <th id="alt-identifiers-identifier-head" class="w-50"> 
               <?php echo __('Identifier'); ?>
             </th>
             <th>

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/multiFileUploadSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/multiFileUploadSuccess.php
@@ -81,7 +81,7 @@
 
       <?php echo $form->renderGlobalErrors(); ?>
 
-      <?php echo $form->renderFormTag(url_for([$resource, 'module' => 'informationobject', 'action' => 'multiFileUpload']), ['id' => 'multiFileUploadForm', 'style' => 'inline']); ?>
+      <?php echo $form->renderFormTag(url_for([$resource, 'module' => 'informationobject', 'action' => 'multiFileUpload']), ['id' => 'multiFileUploadForm', 'class' => 'd-inline']); ?>
 
         <?php echo $form->renderHiddenFields(); ?>
 
@@ -93,7 +93,7 @@
               </button>
             </h2>
             <div id="upload-collapse" class="accordion-collapse collapse show" aria-labelledby="upload-heading">
-              <div class="accordion-body">
+	      <div class="accordion-body">
                 <div class="alert alert-info" role="alert">
                   <p><?php echo __('Add your digital objects by dragging and dropping local files into the pane below, or by clicking the browse link to open your local file explorer.'); ?></p>
                   <p><?php echo __('The Title and Level of description values entered on this page will be applied to each child description created for the associated digital objects - \'%dd%\' represents an incrementing 2-value number, so by default descriptions created via this uploader will be named image 01, image 02, etc.'); ?></p>
@@ -115,7 +115,7 @@
 
                 <div id="uploads"></div>
 
-                <div id="uiElements" style="display: inline;">
+                <div id="uiElements" class="d-inline">
                   <div id="uploaderContainer">
                     <div class="uppy-dashboard"></div>
                   </div>

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/renameSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/renameSuccess.php
@@ -28,7 +28,7 @@
           </button>
         </h2>
         <div id="rename-collapse" class="accordion-collapse collapse show" aria-labelledby="rename-heading">
-          <div class="accordion-body">
+	  <div class="accordion-body">
             <p><?php echo __('Use this interface to update the description title, slug (permalink), and/or %1% filename.', ['%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject'))]); ?></p>
             <hr />
 
@@ -44,7 +44,7 @@
             <p><?php echo __('Original title'); ?>: <em><?php echo $resource->title; ?></em></p>
             <hr />
 
-            <div id="rename-slug-warning" class="alert alert-danger" role="alert" style="display: none;">
+            <div id="rename-slug-warning" class="alert alert-danger d-none" role="alert">
               <?php echo __('A slug based on this title already exists so a number has been added to pad the slug.'); ?>
             </div>
             <div class="rename-form-field-toggle form-check mb-4">

--- a/plugins/arDominionB5Plugin/modules/jobs/templates/browseSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/jobs/templates/browseSuccess.php
@@ -33,13 +33,13 @@
   <div class="table-responsive mb-3">
     <table class="table table-bordered mb-0">
       <thead>
-        <tr>
-          <th style="width: 15%"><?php echo __('Start date'); ?></th>
-          <th style="width: 15%"><?php echo __('End date'); ?></th>
-          <th style="width: 20%"><?php echo __('Job name'); ?></th>
-          <th style="width: 10%"><?php echo __('Job status'); ?></th>
-          <th style="width: 30%"><?php echo __('Info'); ?></th>
-          <th style="width: 10%"><?php echo __('User'); ?></th>
+	<tr>
+          <th class="w-15"><?php echo __('Start date'); ?></th>
+          <th class="w-15"><?php echo __('End date'); ?></th>
+          <th class="w-20"><?php echo __('Job name'); ?></th>
+          <th class="w-10"><?php echo __('Job status'); ?></th>
+          <th class="w-30"><?php echo __('Info'); ?></th>
+          <th class="w-10"><?php echo __('User'); ?></th>
         </tr>
       </thead>
 
@@ -127,7 +127,7 @@
 <!-- Action buttons -->
 <ul class="actions mb-3 nav gap-2">
   <li>
-    <a class="btn atom-btn-outline-light" onClick="window.location.reload()" href="#">
+    <a class="btn atom-btn-outline-light" id="jobs-refresh-button" href="#">
       <i class="fas fa-sync-alt me-1" aria-hidden="true"></i>
       <?php echo __('Refresh'); ?>
     </a>
@@ -155,7 +155,7 @@
 
 <!-- Refresh after specified interval if auto-refresh enabled -->
 <?php if ($autoRefresh) { ?>
-  <script>
+  <script <?php echo __(sfConfig::get('csp_nonce', '')); ?>>
     setTimeout(function() {
       window.location.reload(1);
     }, <?php echo $refreshInterval; ?>);

--- a/plugins/arDominionB5Plugin/modules/menu/templates/listSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/menu/templates/listSuccess.php
@@ -25,8 +25,8 @@
       </thead>
       <tbody>
         <?php foreach ($menuTree as $item) { ?>
-          <tr>
-            <td<?php if (QubitMenu::ROOT_ID == $item['parentId']) { ?> style="font-weight: bold"<?php } ?>>
+	  <tr>
+            <td<?php if (QubitMenu::ROOT_ID == $item['parentId']) { ?> class="fw-bold"<?php } ?>>
 
               <?php echo str_repeat('&nbsp;&nbsp;', ($item['depth'] - 1)); ?>
 

--- a/plugins/arDominionB5Plugin/modules/object/templates/_notes.php
+++ b/plugins/arDominionB5Plugin/modules/object/templates/_notes.php
@@ -6,15 +6,15 @@
   <table class="table table-bordered mb-0 multi-row">
     <thead class="table-light">
       <tr>
-        <?php if ($hiddenType) { ?>
-          <th id="<?php echo $arrayName; ?>-content-head" style="width: 100%">
+	<?php if ($hiddenType) { ?>
+          <th id="<?php echo $arrayName; ?>-content-head" class="w-100">
             <?php echo __('Content'); ?>
           </th>
-        <?php } else { ?>
-          <th id="<?php echo $arrayName; ?>-content-head" style="width: 70%">
+	<?php } else { ?>
+          <th id="<?php echo $arrayName; ?>-content-head" class="w-70">
             <?php echo __('Content'); ?>
           </th>
-          <th id="<?php echo $arrayName; ?>-type-head" style="width: 30%">
+          <th id="<?php echo $arrayName; ?>-type-head" class="w-30">
             <?php echo __('Type'); ?>
           </th>
         <?php } ?>

--- a/plugins/arDominionB5Plugin/modules/object/templates/editPhysicalObjectsSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/object/templates/editPhysicalObjectsSuccess.php
@@ -27,8 +27,8 @@
       <div class="table-responsive mb-3">
         <table class="table table-bordered mb-0">
           <thead>
-            <tr>
-              <th style="width: 100%;">
+	    <tr>
+              <th class="w-100">
                 <?php echo __('Containers'); ?>
               </th>
               <th>

--- a/plugins/arDominionB5Plugin/modules/object/templates/importSelectSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/object/templates/importSelectSuccess.php
@@ -88,8 +88,8 @@
                 </div>
               <?php } ?>
 
-              <div class="form-item">
-                <div class="panel panel-default" id="matchingOptions" style="display:none;">
+	      <div class="form-item">
+                <div class="panel panel-default d-none" id="matchingOptions">
                   <div class="panel-body">
                     <div class="mb-3 form-check">
                       <input class="form-check-input" name="skipUnmatched" id="skip-unmatched-input" type="checkbox"/>

--- a/plugins/arDominionB5Plugin/modules/repository/templates/_browseTableView.php
+++ b/plugins/arDominionB5Plugin/modules/repository/templates/_browseTableView.php
@@ -2,7 +2,7 @@
   <table class="table table-bordered mb-0">
     <thead>
       <tr>
-        <th class="sortable" style="width: 40%">
+        <th class="sortable w-40">
           <?php echo link_to(__('Name'), ['sort' => ('nameUp' == $sf_request->sort) ? 'nameDown' : 'nameUp'] +
                             $sf_data->getRaw('sf_request')->getParameterHolder()->getAll(),
                             ['title' => __('Sort'), 'class' => 'sortable']); ?>
@@ -14,7 +14,7 @@
           <?php } ?>
         </th>
 
-        <th class="sortable" style="width: 20%">
+        <th class="sortable w-20">
           <?php echo link_to(__('Region'), ['sort' => ('regionUp' == $sf_request->sort) ? 'regionDown' : 'regionUp'] +
                             $sf_data->getRaw('sf_request')->getParameterHolder()->getAll(),
                             ['title' => __('Sort'), 'class' => 'sortable']); ?>
@@ -26,7 +26,7 @@
           <?php } ?>
         </th>
 
-        <th class="sortable" style="width: 20%">
+        <th class="sortable w-20">
           <?php echo link_to(__('Locality'), ['sort' => ('localityUp' == $sf_request->sort) ? 'localityDown' : 'localityUp'] +
                             $sf_data->getRaw('sf_request')->getParameterHolder()->getAll(),
                             ['title' => __('Sort'), 'class' => 'sortable']); ?>
@@ -38,7 +38,7 @@
           <?php } ?>
         </th>
 
-        <th style="width: 20%">
+        <th class="w-20">
           <?php echo __('Thematic area'); ?>
         </th>
 

--- a/plugins/arDominionB5Plugin/modules/repository/templates/_uploadLimit.php
+++ b/plugins/arDominionB5Plugin/modules/repository/templates/_uploadLimit.php
@@ -18,11 +18,15 @@
   </h5>
 
   <div class="card-body py-2">
+    <style <?php echo __(sfConfig::get('csp_nonce', '')); ?>>
+	#upload-limit-progress-div { height : 25px }
+	#upload-limit-progress-bar-div {width: <?php echo $sf_data->getRaw('diskUsageFloat'); ?>%}
+    </style>
     <?php if ('limited' == $quotaType) { ?>
-      <div class="progress mb-1" style="height: 25px;">
+      <div class="progress mb-1" id="upload-limit-progress-div">
         <div
           class="progress-bar"
-          style="width: <?php echo $sf_data->getRaw('diskUsageFloat'); ?>%;"
+          id="upload-limit-progress-bar-div"
           role="progressbar"
           aria-valuenow="<?php echo $sf_data->getRaw('diskUsageFloat'); ?>"
           aria-valuemin="0"
@@ -67,7 +71,10 @@
 
           <form id="upload-limit-form" method="POST" action="<?php echo url_for([$resource, 'module' => 'repository', 'action' => 'editUploadLimit']); ?>">
             <?php echo $form->renderHiddenFields(); ?>
-            <div>
+	    <div>
+	      <style <?php echo __(sfConfig::get('csp_nonce', '')); ?>>
+                #uploadLimit_value { width: 6em }
+              </style>	
               <label for="uploadLimit_type"><?php echo __('Set the upload limit for this %1%', ['%1%' => strtolower(sfConfig::get('app_ui_label_repository'))]); ?></label>
               <div class="form-check">
                 <input class="form-check-input" type="radio" name="uploadLimit[type]" id="uploadLimit_type_disabled" value="disabled"<?php echo ('disabled' == $quotaType) ? ' checked' : ''; ?>>
@@ -78,7 +85,7 @@
               <div class="form-check">
                 <input class="form-check-input" type="radio" name="uploadLimit[type]" id="uploadLimit_type_limited" value="limited"<?php echo ('limited' == $quotaType) ? ' checked' : ''; ?>>
                 <label class="form-check-label" for="uploadLimit_type_limited">
-                  <?php echo __('Limit uploads to %1% GB', ['%1%' => '<input class="form-control form-control-sm d-inline" id="uploadLimit_value" type="number" step="any" name="uploadLimit[value]" value="'.(($resource->uploadLimit > 0) ? $resource->uploadLimit : '').'" style="width: 6em" />']); ?>
+                  <?php echo __('Limit uploads to %1% GB', ['%1%' => '<input class="form-control form-control-sm d-inline" id="uploadLimit_value" type="number" step="any" name="uploadLimit[value]" value="'.(($resource->uploadLimit > 0) ? $resource->uploadLimit : '').' />']); ?>
                 </label>
               </div>
               <div class="form-check">

--- a/plugins/arDominionB5Plugin/modules/search/templates/descriptionUpdatesSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/search/templates/descriptionUpdatesSuccess.php
@@ -35,19 +35,19 @@
 
       <table class="table table-bordered mb-0">
         <thead>
-          <tr>
-            <th style="width: 40%">
+	  <tr>
+            <th class="w-40">
               <?php echo __('Title'); ?>
             </th>
-            <th style="width: 40%">
+            <th class="w-40">
               <?php echo __('Repository'); ?>
             </th>
             <?php if ('CREATED_AT' != $form->getValue('dateOf')) { ?>
-              <th style="width: 20%">
+              <th class="w-20">
                 <?php echo __('Updated'); ?>
               </th>
             <?php } else { ?>
-              <th style="width: 20%">
+              <th class="w-20">
                 <?php echo __('Created'); ?>
               </th>
             <?php } ?>
@@ -99,35 +99,35 @@
 
       <table class="table table-bordered mb-0">
         <thead>
-          <tr>
+	  <tr>
             <?php if (
                 'QubitInformationObject' == $className
                 && 0 < sfConfig::get('app_multi_repository')
             ) { ?>
-              <th style="width: 40%">
+              <th class="w-40">
                 <?php echo __($nameColumnDisplay); ?>
               </th>
-              <th style="width: 40%">
+              <th class="w-40,">
                 <?php echo __('Repository'); ?>
               </th>
             <?php } elseif ('QubitTerm' == $className) { ?>
-              <th style="width: 40%">
+              <th class="w-40">
                 <?php echo __($nameColumnDisplay); ?>
               </th>
-              <th style="width: 40%">
+              <th class="w-40">
                 <?php echo __('Taxonomy'); ?>
               </th>
             <?php } else { ?>
-              <th style="width: 80%">
+              <th class="w-80">
                 <?php echo __($nameColumnDisplay); ?>
               </th>
             <?php } ?>
             <?php if ('CREATED_AT' != $form->getValue('dateOf')) { ?>
-              <th style="width: 20%">
+              <th class="w-20">
                 <?php echo __('Updated'); ?>
               </th>
             <?php } else { ?>
-              <th style="width: 20%">
+              <th class="w-20">
                 <?php echo __('Created'); ?>
               </th>
             <?php } ?>

--- a/plugins/arDominionB5Plugin/modules/sfDcPlugin/templates/_dcDates.php
+++ b/plugins/arDominionB5Plugin/modules/sfDcPlugin/templates/_dcDates.php
@@ -6,13 +6,13 @@
   <table class="table table-bordered mb-0 multi-row">
     <thead class="table-light">
       <tr>
-        <th id="dc-dates-date-head" style="width: 40%">
+        <th id="dc-dates-date-head" class="w-40">
           <?php echo __('Date'); ?>
         </th>
-        <th id="dc-dates-start-head" style="width: 30%">
+        <th id="dc-dates-start-head" class="w-30">
           <?php echo __('Start'); ?>
         </th>
-        <th id="dc-dates-end-head" style="width: 30%">
+        <th id="dc-dates-end-head" class="w-30">
           <?php echo __('End'); ?>
         </th>
         <th>

--- a/plugins/arDominionB5Plugin/modules/sfDcPlugin/templates/_dcNames.php
+++ b/plugins/arDominionB5Plugin/modules/sfDcPlugin/templates/_dcNames.php
@@ -6,10 +6,10 @@
   <table class="table table-bordered mb-0 multi-row">
     <thead class="table-light">
       <tr>
-        <th id="dc-names-actor-head" style="width: 60%">
+        <th id="dc-names-actor-head" class="w-60">
           <?php echo __('Actor name'); ?>
         </th>
-        <th id="dc-names-type-head" style="width: 40%">
+        <th id="dc-names-type-head" class="w-40">
           <?php echo __('Type'); ?>
         </th>
         <th>

--- a/plugins/arDominionB5Plugin/modules/sfDcPlugin/templates/editSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfDcPlugin/templates/editSuccess.php
@@ -95,11 +95,11 @@
             <div class="table-responsive mb-2">
               <table class="table table-bordered mb-0 multi-row">
                 <thead class="table-light">
-                  <tr>
-                    <th id="child-identifier-head" style="width: 20%">
+		  <tr>
+                    <th id="child-identifier-head" class="w-20">
                       <?php echo __('Identifier'); ?>
                     </th>
-                    <th id="child-title-head" style="width: 80%">
+                    <th id="child-title-head" class="w-80">
                       <?php echo __('Title'); ?>
                     </th>
                     <th>

--- a/plugins/arDominionB5Plugin/modules/sfIsaarPlugin/templates/_event.php
+++ b/plugins/arDominionB5Plugin/modules/sfIsaarPlugin/templates/_event.php
@@ -24,14 +24,14 @@
   <div class="table-responsive">
     <table class="table table-bordered mb-0">
       <thead class="table-light">
-        <tr>
-          <th style="width: 40%">
+	<tr>
+          <th class="w-40">
             <?php echo __('Title'); ?>
           </th>
-          <th style="width: 30%">
+          <th class="w-30">
             <?php echo __('Relationship'); ?>
           </th>
-          <th style="width: 30%">
+          <th class="w-30">
             <?php echo __('Dates'); ?>
           </th>
           <th>

--- a/plugins/arDominionB5Plugin/modules/sfIsaarPlugin/templates/_relatedAuthorityRecord.php
+++ b/plugins/arDominionB5Plugin/modules/sfIsaarPlugin/templates/_relatedAuthorityRecord.php
@@ -16,20 +16,20 @@
   <div class="table-responsive mb-3">
     <table class="table table-bordered mb-0">
       <thead class="table-light">
-        <tr>
-          <th style="width: 25%">
+	<tr>
+          <th class="w-25">
             <?php echo __('Name'); ?>
           </th>
-          <th style="width: 15%">
+          <th class="w-15">
             <?php echo __('Category'); ?>
           </th>
-          <th style="width: 15%">
+          <th class="w-15">
             <?php echo __('Type'); ?>
           </th>
-          <th style="width: 15%">
+          <th class="w-15">
             <?php echo __('Dates'); ?>
           </th>
-          <th style="width: 30%">
+          <th class="w-30">
             <?php echo __('Description'); ?>
           </th>
           <th>

--- a/plugins/arDominionB5Plugin/modules/sfIsadPlugin/templates/_event.php
+++ b/plugins/arDominionB5Plugin/modules/sfIsadPlugin/templates/_event.php
@@ -7,10 +7,10 @@
   <table class="table table-bordered mb-0 multi-row">
     <thead class="table-light">
       <tr>
-        <th id="isad-events-type-head" style="width: 25%">
+        <th id="isad-events-type-head" class="w-25">
           <?php echo __('Type'); ?>
         </th>
-        <th id="isad-events-date-head" style="width: 30%">
+        <th id="isad-events-date-head" class="w-30">
           <?php echo __('Date'); ?>
         </th>
         <th id="isad-events-start-head">

--- a/plugins/arDominionB5Plugin/modules/sfIsdfPlugin/templates/_relatedAuthorityRecord.php
+++ b/plugins/arDominionB5Plugin/modules/sfIsdfPlugin/templates/_relatedAuthorityRecord.php
@@ -15,14 +15,14 @@
   <div class="table-responsive mb-3">
     <table class="table table-bordered mb-0">
       <thead class="table-light">
-        <tr>
-          <th style="width: 30%">
+	<tr>
+          <th class="w-30">
             <?php echo __('Identifier/name'); ?>
           </th>
-          <th style="width: 40%">
+          <th class="w-40">
             <?php echo __('Nature of relationship'); ?>
           </th>
-          <th style="width: 30%">
+          <th class="w-30">
             <?php echo __('Dates'); ?>
           </th>
           <th>

--- a/plugins/arDominionB5Plugin/modules/sfIsdfPlugin/templates/_relatedFunction.php
+++ b/plugins/arDominionB5Plugin/modules/sfIsdfPlugin/templates/_relatedFunction.php
@@ -15,17 +15,17 @@
   <div class="table-responsive mb-3">
     <table class="table table-bordered mb-0">
       <thead class="table-light">
-        <tr>
-          <th style="width: 30%">
+	<tr>
+          <th class="w-30">
             <?php echo __('Name'); ?>
           </th>
-          <th style="width: 20%">
+          <th class="w-20">
             <?php echo __('Category'); ?>
           </th>
-          <th style="width: 30%">
+          <th class="w-30">
             <?php echo __('Description'); ?>
           </th>
-          <th style="width: 20%">
+          <th class="w-20">
             <?php echo __('Dates'); ?>
           </th>
           <th>

--- a/plugins/arDominionB5Plugin/modules/sfIsdfPlugin/templates/_relatedResource.php
+++ b/plugins/arDominionB5Plugin/modules/sfIsdfPlugin/templates/_relatedResource.php
@@ -15,14 +15,14 @@
   <div class="table-responsive">
     <table class="table table-bordered mb-0">
       <thead class="table-light">
-        <tr>
-          <th style="width: 30%">
+	<tr>
+          <th class="w-30">
             <?php echo __('Identifier/title'); ?>
           </th>
-          <th style="width: 40%">
+          <th class="w-40">
             <?php echo __('Nature of relationship'); ?>
           </th>
-          <th style="width: 30%">
+          <th class="w-30">
             <?php echo __('Dates'); ?>
           </th>
           <th>

--- a/plugins/arDominionB5Plugin/modules/sfModsPlugin/templates/editSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfModsPlugin/templates/editSuccess.php
@@ -73,11 +73,11 @@
             <div class="table-responsive mb-2">
               <table class="table table-bordered mb-0 multi-row">
                 <thead class="table-light">
-                  <tr>
-                    <th id="child-identifier-head" style="width: 20%">
+		  <tr>
+                    <th id="child-identifier-head" class="w-20">
                       <?php echo __('Identifier'); ?>
                     </th>
-                    <th id="child-title-head" style="width: 80%">
+                    <th id="child-title-head" class="w-80">
                       <?php echo __('Title'); ?>
                     </th>
                     <th>

--- a/plugins/arDominionB5Plugin/modules/user/templates/editSuccess.mod_standard.php
+++ b/plugins/arDominionB5Plugin/modules/user/templates/editSuccess.mod_standard.php
@@ -57,8 +57,8 @@
               <div class="col-md-6 template" hidden>
                 <div class="mb-3 bg-light p-3 rounded border-start border-4">
                   <label class="form-label"><?php echo __('Password strength:'); ?></label>
-                  <div class="progress mb-3">
-                    <div class="progress-bar" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+		  <div class="progress mb-3">
+                    <div class="progress-bar w-0" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
                   </div>
                 </div>
               </div>

--- a/plugins/arDominionB5Plugin/modules/user/templates/passwordEditSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/user/templates/passwordEditSuccess.php
@@ -45,8 +45,8 @@
               <div class="col-md-6 template" hidden>
                 <div class="mb-3 bg-light p-3 rounded border-start border-4">
                   <label class="form-label"><?php echo __('Password strength:'); ?></label>
-                  <div class="progress mb-3">
-                    <div class="progress-bar" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+		  <div class="progress mb-3">
+                    <div class="progress-bar w-0" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
                   </div>
                 </div>
               </div>

--- a/plugins/arDominionB5Plugin/scss/_utilities.scss
+++ b/plugins/arDominionB5Plugin/scss/_utilities.scss
@@ -1,0 +1,26 @@
+$utilities: map-merge(
+  $utilities,
+  (
+    "width":
+      map-merge(
+        map-get($utilities, "width"),
+        (
+          values:
+            map-merge(
+              map-get(map-get($utilities, "width"), "values"),
+              (
+                0: 0%,
+                15: 15%,
+                20: 20%,
+                30: 30%,
+                35: 35%,
+                40: 40%,
+                60: 60%,
+                70: 70%,
+                80: 80%,
+              )
+            ),
+        )
+      ),
+  )
+);

--- a/plugins/arDominionB5Plugin/scss/main.scss
+++ b/plugins/arDominionB5Plugin/scss/main.scss
@@ -7,6 +7,9 @@
 @import "bootstrap/scss/mixins";
 @import "bootstrap/scss/utilities";
 
+// Custom utilities
+@import "utilities";
+
 // Bootstrap optional
 @import "bootstrap/scss/root";
 @import "bootstrap/scss/reboot";

--- a/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/_stylesheet.php
+++ b/plugins/sfIsadPlugin/modules/sfIsadPlugin/templates/_stylesheet.php
@@ -1,4 +1,4 @@
-<style type="text/css">
+<style <?php echo __(sfConfig::get('csp_nonce', '')); ?>>
   html, body {
     background-image: none !important;
     background-color: <?php echo $backgroundColor; ?> !important;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,7 +79,7 @@ module.exports = {
     filename: "js/[name].bundle.[contenthash].js",
     clean: true,
   },
-  devtool: devMode ? "eval-source-map" : "source-map",
+  devtool: "source-map",
   module: {
     rules: [
       {
@@ -104,6 +104,14 @@ module.exports = {
           "resolve-url-loader",
           { loader: "sass-loader", options: { sourceMap: true } },
         ],
+      },
+      {
+        mimetype: "image/svg+xml",
+        scheme: "data",
+        type: "asset/resource",
+        generator: {
+          filename: "icons/[hash].svg",
+        },
       },
     ],
   },


### PR DESCRIPTION
Add Content Security Policy (CSP) headers to AtoM responses when B5 themes are enabled.

The 'app_csp_reponse_header' setting is used to switch between using 'Content-Security-Policy-Report-Only' or 'Content-Security-Policy' headers. Deleting the setting will disable CSP headers.

The 'app_csp_directives' setting is used to tweak the actual header contents.