### PR TITLE
Install npm in CI without sudo

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,14 +47,14 @@ jobs:
           ~/.cache/Cypress
         key: npm-${{ hashFiles('package-lock.json') }}
     - name: Install NPM dependencies
-      run: sudo npm install -g npm && npm ci
+      run: npm install -g npm && npm ci
     - name: Modify Gearman config
       run: |
         echo -e "all:\n  servers:\n    default: 127.0.0.1:63005" \
           > apps/qubit/config/gearman.yml
     - name: Build themes
       run: |
-        sudo npm install -g "less@<4.0.0"
+        npm install -g "less@<4.0.0"
         make -C plugins/arDominionPlugin
         make -C plugins/arArchivesCanadaPlugin
         npm run build


### PR DESCRIPTION
For Cypress CI integration-tests do not run 'npm install' with 'sudo'.