### PR TITLE
Add deprecation notice for BS2 theme (#1642)

### DIFF
--- a/apps/qubit/modules/default/actions/bs2DeprecationMessageComponent.class.php
+++ b/apps/qubit/modules/default/actions/bs2DeprecationMessageComponent.class.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Display bootstrap 2 theme deprecation message component.
+ *
+ * @author Anvit Srivastav <asrivastav@artefactual.com>
+ */
+class DefaultBS2DeprecationMessageComponent extends sfComponent
+{
+    public function execute($request)
+    {
+        $hasTranslateOrEditAccess = $this->context->user->isAdministrator()
+            || $this->getUser()->hasGroup(QubitAclGroup::TRANSLATOR_ID)
+            || $this->getUser()->hasGroup(QubitAclGroup::EDITOR_ID);
+
+        // Only display this banner to editors, translators, and admins and
+        // do not display if the theme uses BS5 if it has previously been dismissed
+        if (!$hasTranslateOrEditAccess || sfConfig::get('app_b5_theme', false)
+            || null !== $this->context->user->getAttribute('bs2_deprecation_message_dismissed')
+        ) {
+            return sfView::NONE;
+        }
+    }
+}

--- a/apps/qubit/modules/default/actions/bs2DeprecationMessageDismissAction.class.php
+++ b/apps/qubit/modules/default/actions/bs2DeprecationMessageDismissAction.class.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class DefaultBS2DeprecationMessageDismissAction extends sfAction
+{
+    public function execute($request)
+    {
+        $this->context->user->setAttribute('bs2_deprecation_message_dismissed', true);
+
+        return sfView::NONE;
+    }
+}

--- a/apps/qubit/modules/default/templates/_bs2DeprecationMessage.php
+++ b/apps/qubit/modules/default/templates/_bs2DeprecationMessage.php
@@ -1,0 +1,10 @@
+<?php echo javascript_include_tag('bs2DeprecationMessage'); ?>
+
+<div class="animateNicely" id="bs2-deprecation-message">
+    <div class="alert alert-danger alert-banner">
+        <div id="bs2-deprecation-message-content">
+            <?php echo __('Bootstrap 2 themes have been deprecated and will be removed in a future release. Please consider switching to a Bootstrap 5 theme. %1%More info.%2%', ['%1%' => '<a href="https://www.accesstomemory.org/en/docs/latest/admin-manual/customization/theming/#bs2-update" target="_blank">', '%2%' => '</a>']); ?>
+        </div>
+        <button type="button" class="close">&times;</button>
+    </div>
+</div>

--- a/apps/qubit/templates/_header.php
+++ b/apps/qubit/templates/_header.php
@@ -1,3 +1,5 @@
+<?php echo get_component('default', 'bs2DeprecationMessage'); ?>
+
 <?php echo get_component('default', 'updateCheck'); ?>
 
 <?php echo get_component('default', 'privacyMessage'); ?>

--- a/js/bs2DeprecationMessage.js
+++ b/js/bs2DeprecationMessage.js
@@ -1,0 +1,31 @@
+(function ($) {
+
+  "use strict";
+
+  class Bs2DeprecationMessage {
+    constructor(element) {
+      this.$block = $(element);
+      this.$button = this.$block.find('button');
+      this.listen();
+    }
+
+    listen() {
+      this.$button.on('click', $.proxy(this.onBs2DeprecationMessageButton, this));
+    }
+
+    onBs2DeprecationMessageButton() {
+      this.$block.slideUp(100);
+      $.get('/default/bs2DeprecationMessageDismiss');
+    }
+  }
+
+  $(function ()
+  {
+    let $node = $('#bs2-deprecation-message');
+    if (0 < $node.length)
+    {
+      new Bs2DeprecationMessage($node.get(0));
+    }
+  });
+
+})(window.jQuery);

--- a/plugins/arArchivesCanadaPlugin/templates/_header.php
+++ b/plugins/arArchivesCanadaPlugin/templates/_header.php
@@ -1,5 +1,7 @@
 <?php echo get_component_slot('header'); ?>
 
+<?php echo get_component('default', 'bs2DeprecationMessage'); ?>
+
 <?php echo get_component('default', 'updateCheck'); ?>
 
 <?php echo get_component('default', 'privacyMessage'); ?>

--- a/plugins/arDominionPlugin/css/less/scaffolding.less
+++ b/plugins/arDominionPlugin/css/less/scaffolding.less
@@ -1668,6 +1668,51 @@ body.login #content {
   }
 }
 
+// Bootstrap 2 theme deprecation notice
+@media (max-width: 767px) {
+  #bs2-deprecation-message {
+    margin-left: -20px;
+    margin-right: -20px;
+  }
+}
+
+#bs2-deprecation-message {
+  text-align: center;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+
+  .alert-banner {
+    margin: 0 auto;
+    display: flex;
+    justify-content: space-between;
+    border: 0;
+    border-radius: 0;
+  }
+
+  button {
+    font-size: 1.75rem;
+    right: 0;
+    top: 0;
+    transform: translateX(-100%);
+  }
+
+  #bs2-deprecation-message-content {
+    padding: 8px 0;
+    color: @red;
+    position: relative;
+    left: 50%;
+    transform: translateX(-50%);
+    margin-right: 65px;
+    font-size: 0.85rem;
+
+    a:not(.btn) {
+      text-shadow: none;
+      text-decoration: underline;
+    }
+  }
+}
+
 // GDPR Privacy Message banner
 @media (max-width: 767px) {
   #privacy-message {


### PR DESCRIPTION
Add deprecation notice that informs users that Bootstrap 2 themes are deprecated and will not be supported in future releases.