### PR TITLE
Fix identifier mask POST param for edit (#1653)

### DIFF
--- a/apps/qubit/modules/informationobject/actions/editAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/editAction.class.php
@@ -59,6 +59,9 @@ class InformationObjectEditAction extends DefaultEditAction
         $this->publicationStatusId = QubitTerm::PUBLICATION_STATUS_DRAFT_ID;
         $this->unpublishing = false;
 
+        // To track if identifier mask is enabled
+        $this->mask = sfConfig::get('app_identifier_mask_enabled', 0);
+
         // Edit
         if (isset($this->getRoute()->resource)) {
             $this->resource = $this->getRoute()->resource;
@@ -713,7 +716,7 @@ class InformationObjectEditAction extends DefaultEditAction
     {
         // Pass if we're using mask or not to template, fill in identifier with generated
         // identifier if so.
-        if ($this->mask = sfConfig::get('app_identifier_mask_enabled', 0)) {
+        if ($this->mask) {
             $this->resource->identifier = QubitInformationObject::generateIdentiferFromMask();
         }
     }


### PR DESCRIPTION
Identifier mask should to be set for both create and edit actions since an identifier might be generated during either of those actions. Since we're only calling the `handleIdentifierMask` function during `create`, this is never set for the `edit` action, which leads to the count being wrong if a user generates a new identifier during an edit action.