### PR TITLE
Add tab for viewing failed jobs (#1613)

### DIFF
--- a/apps/qubit/modules/jobs/actions/browseAction.class.php
+++ b/apps/qubit/modules/jobs/actions/browseAction.class.php
@@ -57,6 +57,8 @@ class JobsBrowseAction extends DefaultBrowseAction
 
         if ('active' === $this->filter) {
             $criteria->add(QubitJob::STATUS_ID, QubitTerm::JOB_STATUS_IN_PROGRESS_ID);
+        } else if ('failed' === $this->filter) {
+            $criteria->add(QubitJob::STATUS_ID, QubitTerm::JOB_STATUS_ERROR_ID);
         }
 
         $criteria->addJoin(QubitJob::ID, QubitObject::ID);

--- a/apps/qubit/modules/jobs/templates/browseSuccess.php
+++ b/apps/qubit/modules/jobs/templates/browseSuccess.php
@@ -4,6 +4,7 @@
   <ul class="nav nav-tabs" id="job-tabs">
     <li<?php if ('all' === $filter) { ?> class="active"<?php } ?>><?php echo link_to(__('All jobs'), ['filter' => 'all'] + $sf_data->getRaw('sf_request')->getParameterHolder()->getAll()); ?></li>
     <li<?php if ('active' === $filter) { ?> class="active"<?php } ?>><?php echo link_to(__('Active jobs'), ['filter' => 'active'] + $sf_data->getRaw('sf_request')->getParameterHolder()->getAll()); ?></li>
+    <li<?php if ('failed' === $filter) { ?> class="active"<?php } ?>><?php echo link_to(__('Failed jobs'), ['filter' => 'failed'] + $sf_data->getRaw('sf_request')->getParameterHolder()->getAll()); ?></li>
   </ul>
 </div>
 

--- a/plugins/arDominionB5Plugin/modules/jobs/templates/browseSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/jobs/templates/browseSuccess.php
@@ -18,6 +18,14 @@
       <?php } ?>
       <?php echo link_to(__('Active jobs'), ['filter' => 'active'] + $sf_data->getRaw('sf_request')->getParameterHolder()->getAll(), $options); ?>
     </li>
+    <li class="nav-item">
+      <?php $options = ['class' => 'btn atom-btn-white active-primary text-wrap']; ?>
+      <?php if ('failed' === $filter) { ?>
+        <?php $options['class'] .= ' active'; ?>
+        <?php $options['aria-current'] = 'page'; ?>
+      <?php } ?>
+      <?php echo link_to(__('Failed jobs'), ['filter' => 'failed'] + $sf_data->getRaw('sf_request')->getParameterHolder()->getAll(), $options); ?>
+    </li>
   </ul>
 </nav>
 


### PR DESCRIPTION
Add a "Failed Jobs" tab in the Jobs page (Manage > Jobs) to easily filter and and see failed jobs.