### PR TITLE
Fix search query special chars (#1605)

### DIFF
--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginUtil.class.php
@@ -171,7 +171,7 @@ class arElasticSearchPluginUtil
     /**
      * Generate a query string query.
      *
-     * @param string $query    escaped search term
+     * @param string $query    unescaped search term
      * @param array  $fields   fields to search (including culture if needed)
      * @param string $operator default query operator (AND/OR), default: AND
      *
@@ -180,7 +180,7 @@ class arElasticSearchPluginUtil
     public static function generateQueryString(
         $query, $fields, $operator = 'AND'
     ) {
-        $queryString = new \Elastica\Query\QueryString($query);
+        $queryString = new \Elastica\Query\QueryString(self::escapeTerm($query));
         $queryString->setDefaultOperator($operator);
         $queryString->setFields(self::getBoostedSearchFields($fields));
         $queryString->setAnalyzer(


### PR DESCRIPTION
The search query used in the `generateQueryString` function does not escape special characters specified in the escape_queries setting, and the query provided to it by `arElasticSearchPluginQuery` has not been previously escaped either. 

This seems to have regressed during #1518 and I can't seem to find references to `escapeTerm` being called elsewhere and the search query escaping user provided special characters, so I'm updating this in the generateQueryString function to call escapeTerm to escape the search query so that this setting is respected.

If there's a better place to make this function call to pre-escape the query string, let me know. 