### PR TITLE
Fix update function for 'Language and script notes'. (#13657)

### DIFF
--- a/lib/model/QubitObject.php
+++ b/lib/model/QubitObject.php
@@ -305,6 +305,33 @@ class QubitObject extends BaseObject implements Zend_Acl_Resource_Interface
         return QubitStatus::getOne($criteria);
     }
 
+    /**
+     * Check to see if note is saved in memory (field was updated).
+     *
+     * Used by ISAD, DACS, and RAD templates when duplicating a description,
+     * specifcally for updating the 'Language and script notes' field.
+     *
+     * @return array $notes
+     */
+    public function getMemoryNotesByType(array $options = [])
+    {
+        // Check memory for notes
+        if (!count($this->notes) < 0) {
+            return $this->getNotesByType($options);
+        }
+
+        $noteTypeId = $options['noteTypeId'];
+        $notes = new ArrayObject();
+
+        foreach ($this->notes as $note) {
+            if ($note->typeId == $noteTypeId) {
+                $notes->append($note);
+            }
+        }
+
+        return $notes;
+    }
+
     public function getNotesByType(array $options = [])
     {
         $criteria = new Criteria();

--- a/plugins/sfIsadPlugin/lib/sfIsadPlugin.class.php
+++ b/plugins/sfIsadPlugin/lib/sfIsadPlugin.class.php
@@ -70,12 +70,20 @@ class sfIsadPlugin implements ArrayAccess
     {
         switch ($name) {
             case 'languageNotes':
-                $note = $this->resource->getNotesByType(['noteTypeId' => QubitTerm::LANGUAGE_NOTE_ID])->offsetGet(0);
+                $note = $this->resource->getMemoryNotesByType(['noteTypeId' => QubitTerm::LANGUAGE_NOTE_ID])->offsetGet(0);
+
                 $missingNote = 0 === count($note);
 
                 if (0 == strlen($value)) {
                     // Delete note if it's available
                     if (!$missingNote) {
+                        // Update deleted note on duplication
+                        if (!isset($value)) {
+                            $note->content = $value;
+
+                            break;
+                        }
+
                         $note->delete();
                     }
 

--- a/plugins/sfRadPlugin/lib/sfRadPlugin.class.php
+++ b/plugins/sfRadPlugin/lib/sfRadPlugin.class.php
@@ -104,7 +104,7 @@ class sfRadPlugin
                 return $this;
 
             case 'languageNotes':
-                $note = $this->resource->getNotesByType(['noteTypeId' => QubitTerm::LANGUAGE_NOTE_ID])->offsetGet(0);
+                $note = $this->resource->getMemoryNotesByType(['noteTypeId' => QubitTerm::LANGUAGE_NOTE_ID])->offsetGet(0);
                 $missingNote = 0 === count($note);
 
                 if (0 == strlen($value)) {


### PR DESCRIPTION
Bug was due to the 'Language and script notes' field being specific to the ISAD, DACS, and RAD templates only, so they were handled differently and was not checking to see if the string/field was updated. 

Added a function to check the stored memory to see if notes were updated when duplicating an archival description. This was created specifically for the 'Language and script notes' field, defined by the `QubitTerm::LANGUAGE_NOTE_ID`.