### PR TITLE
Update GitHub dependencies in workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,7 +17,7 @@ jobs:
       COMPOSE_FILE: ${{ github.workspace }}/docker/docker-compose.dev.yml
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Start containerized services
       run: |
         sudo sysctl -w vm.max_map_count=262144
@@ -33,14 +33,14 @@ jobs:
         sudo apt install php7.4-fpm
         sudo service php7.4-fpm start
     - name: Cache Composer dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.composer/cache/files
         key: 20.04-7.4-composer-${{ hashFiles('composer.lock') }}
     - name: Install Composer dependencies
       run: composer install
     - name: Cache NPM dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.npm

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,7 +13,7 @@ jobs:
       COMPOSE_FILE: ${{ github.workspace }}/docker/docker-compose.dev.yml
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Start containerized services
       run: |
         sudo sysctl -w vm.max_map_count=262144
@@ -25,7 +25,7 @@ jobs:
         coverage: none
         extensions: apcu
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.composer/cache/files
         key: 20.04-7.4-composer-${{ hashFiles('composer.lock') }}


### PR DESCRIPTION
Update outdated actions in GitHub workflow since they use an older version of node which was leading to deprecation warnings.