### PR TITLE
Prevent addition of incomplete access points. (#1661)

### DIFF
--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -233,6 +233,9 @@
                 // jQuery.toggle() expects a boolean parameter
                 $ul.toggle(!!$ul.children().length);
               });
+
+              // Remove relatedResourceForm from stack
+              relatedResourceForms.remove($input.data('relatedResourceForm'));
             });
 
           $li.appendTo($ul);
@@ -304,7 +307,7 @@
           // Make autocomplete <input/>, copy @class from <select/>, copy @id from <select/>
           // so <label for="..."/> is correct, and copy aria-describedby and disabled attribute.
           var $input = $('<input type="text" class="' + $select.attr('class') + '" id="' + $select.attr('id') + '"/>');
-          
+
           if ($select.attr('aria-describedby')) {
             $input.attr('aria-describedby', $select.attr('aria-describedby'))
           }
@@ -312,7 +315,7 @@
           if ($select.attr('disabled')) {
             $input.attr('disabled', $select.attr('disabled'))
           }
-          
+
           $input.insertAfter(this);
 
           if ($(this).attr('multiple')) {


### PR DESCRIPTION
Currently, if a user starts to type a term, then decide not to add it and delete the bullet point before saving the archival description, the incomplete term is still saved in the taxonomy.

Expected behaviour is that if the bullet point has been deleted prior to saving, the term should not be saved.

