### PR TITLE
Fix GA4 tracking for fullwidth treeview. (#1606)

### DIFF
--- a/js/fullWidthTreeView.js
+++ b/js/fullWidthTreeView.js
@@ -187,6 +187,12 @@
         // Insert new content into page
         $('#main-column h1').first().replaceWith($(response.find('#main-column h1').first()));
 
+        // Get new document title for G4 Tracking
+        var doctitle = $('#main-column h1').first();
+
+        // Extract the text content without HTML tags and set title
+        document.title = doctitle[0].textContent;
+
         // Add empty breadcrumb section if current page has none, but response does
         if (!$('#main-column .breadcrumb').length && $(response.find('#main-column .breadcrumb').length))
         {
@@ -269,7 +275,7 @@
       }
     };
 
-    // On node open: remove tooltip after a node is selected, the 
+    // On node open: remove tooltip after a node is selected, the
     // node is reloaded and the first tooltip is never removed
     var openNodeListener = function (e, data)
     {

--- a/plugins/arDominionB5Plugin/js/fullWidthTreeView.js
+++ b/plugins/arDominionB5Plugin/js/fullWidthTreeView.js
@@ -288,6 +288,12 @@
           .first()
           .replaceWith($(response.find("#main-column h1").first()));
 
+        // Get new document title for G4 Tracking
+        var doctitle = $("#main-column h1").first();
+
+        // Extract the text content without HTML tags and set title
+        document.title = doctitle[0].textContent;
+
         // Add empty breadcrumb section if current page has none, but response does
         if (
           !$("#breadcrumb").length &&


### PR DESCRIPTION
With BS5's new fullwidth treeview, GA4 is not tracking any page views triggered via the treeview. We want to add a gtag event to send a page view to GA so that when a user views records using the fullwidth treeview, it can be tracked.