### PR TITLE
Provide informative csrf attack message. (#1678)

### DIFF
--- a/vendor/symfony/lib/validator/sfValidatorCSRFToken.class.php
+++ b/vendor/symfony/lib/validator/sfValidatorCSRFToken.class.php
@@ -27,7 +27,7 @@ class sfValidatorCSRFToken extends sfValidatorBase
 
     $this->setOption('required', true);
 
-    $this->addMessage('csrf_attack', 'CSRF attack detected.');
+    $this->addMessage('csrf_attack', 'CSRF Token Expired. Please refresh the page and log in again.');
   }
 
   /**


### PR DESCRIPTION
Provide a more informative message for resolving Symfony's csrf token message. 

Currently, if a user stays logged into AtoM for a long period of time, their csrf token expires. If they try to re-login without refreshing the browser, they get a scary message saying "CSRF attack detected". The token is usually not actually attacked, but expired, so providing a more informative message on how to resolve the issue will address any concerns related to the message.