### PR TITLE
Fix repeated build-nested-set warning (#1634)

### DIFF
--- a/lib/task/propel/propelBuildNestedSetTask.class.php
+++ b/lib/task/propel/propelBuildNestedSetTask.class.php
@@ -95,6 +95,13 @@ class propelBuildNestedSetTask extends arBaseTask
             $this->conn->commit();
         }
 
+        if (!$options['index']) {
+            $this->logSection(
+                'propel',
+                'Note: you will need to rebuild your search index for updates to show up properly in search results.'
+            );
+        }
+
         $this->logSection('propel', 'Done!');
     }
 
@@ -157,11 +164,6 @@ EOF;
             if ($node['id'] != $classname::ROOT_ID) {
                 $this->reindexLft($classname, $node['id'], $node['lft']);
             }
-        } else {
-            $this->logSection(
-                'propel',
-                'Note: you will need to rebuild your search index for updates to show up properly in search results.'
-            );
         }
 
         return $width;


### PR DESCRIPTION
Removes "Note: you will need to rebuild your search index for updates to show up properly in search results." out of recursivelyUpdateTree() function