### PR TITLE
Standardize BS5 required form elements. (#61)

### DIFF
--- a/plugins/arDominionB5Plugin/scss/_forms.scss
+++ b/plugins/arDominionB5Plugin/scss/_forms.scss
@@ -90,3 +90,7 @@ ul.multiInput,
 .accordion-body > .mb-3:last-child {
   margin-bottom: 0 !important;
 }
+
+.form-required {
+  color: $primary;
+}


### PR DESCRIPTION
The asterisk used to represent required fields in BS5 forms should consistently be orange.