### PR TITLE
Prevent CSP use with REST API responses

### DIFF
--- a/lib/filter/QubitCSPFilter.php
+++ b/lib/filter/QubitCSPFilter.php
@@ -69,7 +69,7 @@ class QubitCSP extends sfFilter
 
         $filterChain->execute();
 
-        if (false !== strpos($context->response->getContentType(), 'text/xml')) {
+        if (preg_match('~(text/xml|application/json)~', $context->response->getContentType())) {
             return;
         }
 

--- a/plugins/arRestApiPlugin/modules/api/config/filters.yml
+++ b/plugins/arRestApiPlugin/modules/api/config/filters.yml
@@ -13,5 +13,9 @@ restApiFilter:
   class: arRestApiPluginFilter
 
 QubitTransaction: ~
+
+QubitCSP:
+  enable: false
+
 cache: ~
 execution: ~


### PR DESCRIPTION
Do not send CSP headers with AtoM REST API responses.