### PR TITLE
Fix SKOS import autocomplete list (#1696)

### DIFF
--- a/plugins/arDominionB5Plugin/modules/sfSkosPlugin/templates/importSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfSkosPlugin/templates/importSuccess.php
@@ -57,7 +57,7 @@
                       'class' => 'form-autocomplete',
                       'extraInputs' => '<input class="list" type="hidden" value="'
                           .url_for([
-                              'module' => 'informationobject',
+                              'module' => 'taxonomy',
                               'action' => 'autocomplete',
                           ])
                           .'">',


### PR DESCRIPTION
Fix SKOS import autocomplete to display a list of taxonomies instead of displaying a list of descriptions.