### PR TITLE
Update Clipboard send to use form submit (#1701)

### DIFF
--- a/js/clipboard.js
+++ b/js/clipboard.js
@@ -182,39 +182,56 @@
         return;
       }
 
+      let $form = $("<form />", {
+        "id": "sendForm",
+        "action": $sendButton.data("url"),
+        "method": $sendButton.data("method"),
+      });
+
       // Generate clipboard send data
-      var data = {base_url: $sendButton.data('site-base-url')};
+      let $baseUrl = $("<input />", {
+        "type": "hidden",
+        "name": "base_url",
+        "value": $sendButton.data('site-base-url')
+      });
+
+      $form.append($baseUrl);
 
       if (this.items['informationObject'].length !== 0)
       {
-        data.informationobject_slugs = JSON.stringify(this.items['informationObject']);
+        let $informationobjectSlugs = $("<input />", {
+          "type": "hidden",
+          "name": "information_object_slugs",
+          "value": JSON.stringify(this.items['informationObject'])
+        });
+        $form.append($informationobjectSlugs);
       }
-  
+
       if (this.items['actor'].length !== 0)
       {
-        data.actor_slugs = JSON.stringify(this.items['actor']);
+        let $actorSlugs = $("<input />", {
+          "type": "hidden",
+          "name": "actor_slugs",
+          "value": JSON.stringify(this.items['actor'])
+        });
+        $form.append($actorSlugs);
       }
-  
+
       if (this.items['repository'].length !== 0)
       {
-        data.repository_slugs = JSON.stringify(this.items['repository']);
+        let $repositorySlugs = $("<input />", {
+          "type": "hidden",
+          "name": "repository_slugs",
+          "value": JSON.stringify(this.items['repository'])
+        });
+        $form.append($repositorySlugs);
       }
 
       // Show sending alert and assign it to a variable
       var $sendingAlert = this.showAlert($sendButton.data('message'), 'alert-info');
 
-      $.ajax({
-        url: $sendButton.data('url'),
-        type: $sendButton.data('method'),
-        cache: false,
-        data: data,
-        context: this,
-        complete: function()
-        {
-          // Remove alert on error and success
-          $sendingAlert.remove();
-        }
-      });
+      $form.appendTo(document.body);
+      $form.submit();
     },
     export: function(event)
     {

--- a/plugins/arDominionB5Plugin/js/clipboard.js
+++ b/plugins/arDominionB5Plugin/js/clipboard.js
@@ -181,21 +181,46 @@ import Tooltip from "bootstrap/js/dist/tooltip";
         return;
       }
 
+      let $form = $("<form />", {
+        id: "sendForm",
+        action: $sendButton.data("url"),
+        method: $sendButton.data("method"),
+      });
+
       // Generate clipboard send data
-      var data = { base_url: $sendButton.data("site-base-url") };
+      let $baseUrl = $("<input />", {
+        type: "hidden",
+        name: "base_url",
+        value: $sendButton.data("site-base-url"),
+      });
+
+      $form.append($baseUrl);
 
       if (this.items["informationObject"].length !== 0) {
-        data.informationobject_slugs = JSON.stringify(
-          this.items["informationObject"]
-        );
+        let $informationobjectSlugs = $("<input />", {
+          type: "hidden",
+          name: "information_object_slugs",
+          value: JSON.stringify(this.items["informationObject"]),
+        });
+        $form.append($informationobjectSlugs);
       }
 
       if (this.items["actor"].length !== 0) {
-        data.actor_slugs = JSON.stringify(this.items["actor"]);
+        let $actorSlugs = $("<input />", {
+          type: "hidden",
+          name: "actor_slugs",
+          value: JSON.stringify(this.items["actor"]),
+        });
+        $form.append($actorSlugs);
       }
 
       if (this.items["repository"].length !== 0) {
-        data.repository_slugs = JSON.stringify(this.items["repository"]);
+        let $repositorySlugs = $("<input />", {
+          type: "hidden",
+          name: "repository_slugs",
+          value: JSON.stringify(this.items["repository"]),
+        });
+        $form.append($repositorySlugs);
       }
 
       // Show sending alert and assign it to a variable
@@ -204,17 +229,8 @@ import Tooltip from "bootstrap/js/dist/tooltip";
         "alert-info"
       );
 
-      $.ajax({
-        url: $sendButton.data("url"),
-        type: $sendButton.data("method"),
-        cache: false,
-        data: data,
-        context: this,
-        complete: function () {
-          // Remove alert on error and success
-          $sendingAlert.remove();
-        },
-      });
+      $form.appendTo(document.body);
+      $form.submit();
     }
 
     export(event) {


### PR DESCRIPTION
Remove the ajax request, and udate the clipboard send feature to send the information through a form submit instead. This allows the Send button to redirect to the intended URL like the documentation suggests.