### PR TITLE
Add GA sources to CSP directive

### DIFF
--- a/apps/qubit/modules/default/templates/_tagManager.php
+++ b/apps/qubit/modules/default/templates/_tagManager.php
@@ -1,4 +1,7 @@
 <?php if ('script' === $code) { ?>
+
+<?php if ('' === sfConfig::get('csp_nonce', '')) { ?>
+
 <!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -6,6 +9,20 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','<?php echo $containerId; ?>');</script>
 <!-- End Google Tag Manager -->
+
+<?php } else { ?>
+
+<!-- Google Tag Manager -->
+<script <?php echo __(sfConfig::get('csp_nonce', '')); ?>>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;var n=d.querySelector('[nonce]');
+n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','<?php echo $containerId; ?>');</script>
+<!-- End Google Tag Manager -->
+
+<?php } ?>
+
 <?php } elseif ('noscript' === $code) { ?>
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<?php echo $containerId; ?>"

--- a/apps/qubit/templates/_footer.php
+++ b/apps/qubit/templates/_footer.php
@@ -21,8 +21,8 @@
 
 <?php $gaKey = sfConfig::get('app_google_analytics_api_key', ''); ?>
 <?php if (!empty($gaKey)) { ?>
-  <script async src="https://www.googletagmanager.com/gtag/js?id=<?php echo $gaKey; ?>"></script>
-  <script>
+  <script <?php echo __(sfConfig::get('csp_nonce', '')); ?> async src="https://www.googletagmanager.com/gtag/js?id=<?php echo $gaKey; ?>"></script>
+  <script <?php echo __(sfConfig::get('csp_nonce', '')); ?>>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());

--- a/config/app.yml
+++ b/config/app.yml
@@ -67,4 +67,4 @@ all:
       # 'Content-Security-Policy-Report-Only' or 'Content-Security-Policy'
       response_header: Content-Security-Policy-Report-Only
       # Configure CSP response directives.
-      directives: "default-src 'self'; font-src 'self'; img-src 'self' https://www.gravatar.com/avatar/ blob:; script-src 'self' 'nonce'; style-src 'self' 'nonce'; worker-src 'self' blob:; frame-ancestors 'self';"
+      directives: "default-src 'self'; font-src 'self'; img-src 'self' https://www.gravatar.com/avatar/ https://*.google-analytics.com https://*.googletagmanager.com blob:; script-src 'self' https://*.googletagmanager.com 'nonce'; style-src 'self' 'nonce'; worker-src 'self' blob:; connect-src https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; frame-ancestors 'self';"

--- a/docker/bootstrap.php
+++ b/docker/bootstrap.php
@@ -106,7 +106,7 @@ all:
   htmlpurifier_enabled: false
   csp:
     response_header: Content-Security-Policy-Report-Only
-    directives: "default-src 'self'; font-src 'self'; img-src 'self' https://www.gravatar.com/avatar/ blob:; script-src 'self' 'nonce'; style-src 'self' 'nonce'; worker-src 'self' blob:; frame-ancestors 'self';"
+    directives: "default-src 'self'; font-src 'self'; img-src 'self' https://www.gravatar.com/avatar/ https://*.google-analytics.com https://*.googletagmanager.com blob:; script-src 'self' https://*.googletagmanager.com 'nonce'; style-src 'self' 'nonce'; worker-src 'self' blob:; connect-src https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; frame-ancestors 'self';"
 EOT;
 
     file_put_contents(_ATOM_DIR.'/apps/qubit/config/app.yml', $app_yml);


### PR DESCRIPTION
Add Google Analytics sources to CSP directive.

Address CSP issue with GA inline script in _footer template by adding template to the BS5 theme and inserting CSP nonce value. CSP is not supported in BS2 themes.