### PR TITLE
Add lang & script to csv:authority-export. (#1726)

### DIFF
--- a/lib/flatfile/config/QubitActor.yml
+++ b/lib/flatfile/config/QubitActor.yml
@@ -30,6 +30,8 @@ columnNames:
   - placeAccessPoints
   - digitalObjectURI
   - digitalObjectChecksum
+  - language
+  - script
 
 direct:
   - culture
@@ -47,6 +49,8 @@ direct:
   - rules
   - revisionHistory
   - sources
+  - language
+  - script
 
 map:
   id:                                legacyId


### PR DESCRIPTION
Add languages and scripts to be included in the authority record csv export template.