### PR TITLE
Update Diacritics mapping config path. (#1735)

### DIFF
--- a/apps/qubit/modules/settings/actions/diacriticsAction.class.php
+++ b/apps/qubit/modules/settings/actions/diacriticsAction.class.php
@@ -71,7 +71,7 @@ class SettingsDiacriticsAction extends SettingsEditAction
             case 'mappings':
                 $file = $this->form->getValue('mappings');
 
-                $diacriticsMappingPath = sfConfig::get('sf_config_dir').DIRECTORY_SEPARATOR.'diacritics_mapping.yml';
+                $diacriticsMappingPath = sfConfig::get('sf_upload_dir').DIRECTORY_SEPARATOR.'diacritics_mapping.yml';
 
                 if (null !== $file) {
                     try {

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPlugin.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPlugin.class.php
@@ -143,8 +143,7 @@ class arElasticSearchPlugin extends QubitSearchEngine
         $diacriticsFinder = sfFinder::type('file')->name('diacritics_mapping.yml');
         $diacriticsFiles = array_unique(
             array_merge(
-                $diacriticsFinder->in(sfConfig::get('sf_config_dir')),
-                $diacriticsFinder->in(ProjectConfiguration::getActive()->getPluginSubPaths('/config'))
+                $diacriticsFinder->in(sfConfig::get('sf_upload_dir')),
             )
         );
 


### PR DESCRIPTION
Store `diacritics_mapping.yml` config file in `uploads` directory instead of `conifg` so that it will be copied during internal site upgrades and replications.