### PR TITLE
[PHP 8.4] Fix: Curl `CURLOPT_BINARYTRANSFER` deprecated

### DIFF
--- a/plugins/sfModsPlugin/lib/sfModsConvertor.class.php
+++ b/plugins/sfModsPlugin/lib/sfModsConvertor.class.php
@@ -332,7 +332,6 @@ class sfModsConvertor extends QubitSaxParser
         // Download/copy URL to temp file
         $curlSession = curl_init();
         curl_setopt($curlSession, CURLOPT_URL, $this->data());
-        curl_setopt($curlSession, CURLOPT_BINARYTRANSFER, true);
         curl_setopt($curlSession, CURLOPT_RETURNTRANSFER, true);
 
         $tempFile = tempnam(sys_get_temp_dir(), 'atomFile');


### PR DESCRIPTION
The `CURLOPT_BINARYTRANSFER` PHP constant from the Curl extension was no-op since PHP 5.1, and is deprecated in PHP 8.4. This removes the constant usage to avoid the deprecation notice in PHP 8.4 and later.

Because this constant was no-op since PHP 5.1 (circa 2005), this change has no impact.

See:

 - [PHP.Watch - PHP 8.4 - Curl: CURLOPT_BINARYTRANSFER deprecated](https://php.watch/versions/8.4/CURLOPT_BINARYTRANSFER-deprecated)
 - [commit](https://github.com/php/php-src/commit/fc16285538e96ecb35d017231051f83dcbd8b55b)