### PR TITLE
Prevent CSP use with SWORD API responses

### DIFF
--- a/plugins/qtSwordPlugin/modules/qtSwordPlugin/config/filters.yml
+++ b/plugins/qtSwordPlugin/modules/qtSwordPlugin/config/filters.yml
@@ -12,5 +12,9 @@ QubitSslRequirement: ~
 QubitMeta: ~
 QubitLimitResults: ~
 QubitTransaction: ~
+
+QubitCSP:
+  enable: false
+
 cache: ~
 execution: ~


### PR DESCRIPTION
Do not send CSP headers with AtoM SWORD API responses.

Closes #1742 