### PR TITLE
Use URL web root for Access Copies links. (#1744)

### DIFF
--- a/apps/qubit/modules/digitalobject/templates/_metadata.php
+++ b/apps/qubit/modules/digitalobject/templates/_metadata.php
@@ -133,7 +133,7 @@
 
           <?php if ($showMasterFileName) { ?>
             <?php if ($canAccessMasterFile) { ?>
-              <?php echo render_show(__('Filename'), link_to($resource->name, $resource->object->getDigitalObjectUrl(), ['target' => '_blank']), ['fieldLabel' => 'filename']); ?>
+              <?php echo render_show(__('Filename'), link_to($resource->name, $resource->object->getDigitalObjectPublicUrl(), ['target' => '_blank']), ['fieldLabel' => 'filename']); ?>
             <?php } else { ?>
               <?php echo render_show(__('Filename'), $resource->name, ['fieldLabel' => 'filename']); ?>
             <?php } ?>

--- a/plugins/arDominionB5Plugin/modules/digitalobject/templates/_metadata.php
+++ b/plugins/arDominionB5Plugin/modules/digitalobject/templates/_metadata.php
@@ -161,7 +161,7 @@
 
                     <?php if ($showMasterFileName) { ?>
                       <?php if ($canAccessMasterFile) { ?>
-                        <?php echo render_show(__('Filename'), link_to($resource->name, $resource->object->getDigitalObjectUrl(), ['target' => '_blank']), ['fieldLabel' => 'filename', 'isSubField' => true]); ?>
+                        <?php echo render_show(__('Filename'), link_to($resource->name, $resource->object->getDigitalObjectPublicUrl(), ['target' => '_blank']), ['fieldLabel' => 'filename', 'isSubField' => true]); ?>
                       <?php } else { ?>
                         <?php echo render_show(__('Filename'), $resource->name, ['fieldLabel' => 'filename', 'isSubField' => true]); ?>
                       <?php } ?>


### PR DESCRIPTION
Addresses derivative links not working as expected when site is hosted on path instead of a domain. (Ex. Home page at https://www.example.com/atom/)