### PR TITLE
Increase default treeview items per page (#1749)

### DIFF
--- a/apps/qubit/modules/browse/actions/hierarchyAction.class.php
+++ b/apps/qubit/modules/browse/actions/hierarchyAction.class.php
@@ -9,6 +9,6 @@ class BrowseHierarchyAction extends sfAction
             QubitAcl::forwardUnauthorized();
         }
 
-        $this->itemsPerPage = sfConfig::get('app_treeview_full_items_per_page', 50);
+        $this->itemsPerPage = sfConfig::get('app_treeview_full_items_per_page', 8000);
     }
 }

--- a/apps/qubit/modules/default/actions/fullTreeViewAction.class.php
+++ b/apps/qubit/modules/default/actions/fullTreeViewAction.class.php
@@ -343,7 +343,7 @@ class DefaultFullTreeViewAction extends sfAction
     protected function getPageLimit($options)
     {
         // Get default limit from config
-        $limit = sfConfig::get('app_treeview_full_items_per_page', 50);
+        $limit = sfConfig::get('app_treeview_full_items_per_page', 8000);
 
         if (isset($options['limit']) && intval($options['limit']) > 0) {
             $limit = intval($options['limit']);

--- a/apps/qubit/modules/informationobject/actions/treeViewComponent.class.php
+++ b/apps/qubit/modules/informationobject/actions/treeViewComponent.class.php
@@ -26,7 +26,7 @@ class InformationObjectTreeViewComponent extends sfComponent
         $this->treeviewType = sfConfig::get('app_treeview_type__source', 'sidebar');
         if ('sidebar' != $this->treeviewType) {
             $this->collapsible = sfConfig::get('app_treeview_allow_full_width_collapse');
-            $this->itemsPerPage = sfConfig::get('app_treeview_full_items_per_page', 50);
+            $this->itemsPerPage = sfConfig::get('app_treeview_full_items_per_page', 8000);
 
             return sfView::SUCCESS;
         }

--- a/apps/qubit/modules/settings/actions/treeviewAction.class.php
+++ b/apps/qubit/modules/settings/actions/treeviewAction.class.php
@@ -147,7 +147,7 @@ class SettingsTreeviewAction extends DefaultEditAction
             case 'fullItemsPerPage':
                 $this->fullItemsPerPageSetting = QubitSetting::getByName('treeview_full_items_per_page');
 
-                $default = 50;
+                $default = 8000;
                 if (isset($this->fullItemsPerPageSetting)) {
                     $default = $this->fullItemsPerPageSetting->getValue(['sourceCulture' => true]);
                 }


### PR DESCRIPTION
Increase the default limit for items per page in treeview to 8000