### PR TITLE
Fix clipboard storage behaviour (#1749)

### DIFF
--- a/js/clipboard.js
+++ b/js/clipboard.js
@@ -342,6 +342,10 @@
         $button.tooltip('hide');
       }
 
+      // Load items from local storage in case activity
+      // in another tab has changed the content
+      this.items = JSON.parse(this.storage.getItem("clipboard"));
+
       var type = $button.data('clipboard-type');
       var slug = $button.data('clipboard-slug');
       var index = this.items[type].indexOf(slug);
@@ -420,7 +424,7 @@
       var actorsCount = this.items['actor'].length;
       var reposCount = this.items['repository'].length;
       var totalCount = iosCount + actorsCount + reposCount;
-      
+
       // Menu button count
       var $buttonSpan = this.$menuButton.find('> span');
       if (!$buttonSpan.length && totalCount > 0)

--- a/plugins/arDominionB5Plugin/js/clipboard.js
+++ b/plugins/arDominionB5Plugin/js/clipboard.js
@@ -333,6 +333,10 @@ import Tooltip from "bootstrap/js/dist/tooltip";
         event.preventDefault();
       }
 
+      // Load items from local storage in case activity
+      // in another tab has changed the content
+      this.items = JSON.parse(this.storage.getItem("clipboard"));
+
       var $button = $(event.target).closest("button");
       var type = $button.data("clipboard-type");
       var slug = $button.data("clipboard-slug");


### PR DESCRIPTION
Clipboard behaviour changed to always load from browser storage before updating content when toggle button is pressed to avoid overwriting data from another tab.