### PR TITLE
Remove OIDC dependency require statement

### DIFF
--- a/plugins/arOidcPlugin/lib/arOidc.class.php
+++ b/plugins/arOidcPlugin/lib/arOidc.class.php
@@ -19,8 +19,6 @@ use Jumbojett\OpenIDConnectClient;
  * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
  */
 
-require_once sfConfig::get('sf_root_dir').'/vendor/composer/jumbojett/openid-connect-php/src/OpenIDConnectClient.php';
-
 class arOidc
 {
     protected static $oidcIsInitialized = false;


### PR DESCRIPTION
Remove redundant require_once statement because Composer's autoload file will be loaded in config/ProjectConfiguration.class.php and take care of loading the OIDC dependency automatically.