### PR TITLE
Fix clipboard for empty browser cache (#1783)

### DIFF
--- a/js/clipboard.js
+++ b/js/clipboard.js
@@ -12,19 +12,8 @@
     this.storage = localStorage;
     this.types = ['informationObject', 'actor', 'repository'];
     this.initialItems = {'informationObject': [], 'actor': [], 'repository': []};
-    this.items = JSON.parse(this.storage.getItem('clipboard'));
-    this.exportTokens = JSON.parse(this.storage.getItem('exportTokens'));
-
-    if (!this.items)
-    {
-      this.items = this.initialItems;
-    }
-
-    if (!this.exportTokens)
-    {
-      this.exportTokens = [];
-    }
-
+    this.items = JSON.parse(this.storage.getItem('clipboard')) || this.initialItems;
+    this.exportTokens = JSON.parse(this.storage.getItem('exportTokens')) || [];
     this.init();
   };
 
@@ -344,7 +333,7 @@
 
       // Load items from local storage in case activity
       // in another tab has changed the content
-      this.items = JSON.parse(this.storage.getItem("clipboard"));
+      this.items = JSON.parse(this.storage.getItem("clipboard")) || this.initialItems;
 
       var type = $button.data('clipboard-type');
       var slug = $button.data('clipboard-slug');

--- a/plugins/arDominionB5Plugin/js/clipboard.js
+++ b/plugins/arDominionB5Plugin/js/clipboard.js
@@ -11,21 +11,11 @@ import Tooltip from "bootstrap/js/dist/tooltip";
 
       this.storage = localStorage;
       this.types = ["informationObject", "actor", "repository"];
-      this.initialItems = JSON.stringify({
-        informationObject: [],
-        actor: [],
-        repository: [],
-      });
-      this.items = JSON.parse(this.storage.getItem("clipboard"));
-      this.exportTokens = JSON.parse(this.storage.getItem("exportTokens"));
-
-      if (!this.items) {
-        this.items = JSON.parse(this.initialItems);
-      }
-
-      if (!this.exportTokens) {
-        this.exportTokens = [];
-      }
+      this.initialItems = { informationObject: [], actor: [], repository: [] };
+      this.items =
+        JSON.parse(this.storage.getItem("clipboard")) || this.initialItems;
+      this.exportTokens =
+        JSON.parse(this.storage.getItem("exportTokens")) || [];
 
       this.init();
     }
@@ -335,7 +325,8 @@ import Tooltip from "bootstrap/js/dist/tooltip";
 
       // Load items from local storage in case activity
       // in another tab has changed the content
-      this.items = JSON.parse(this.storage.getItem("clipboard"));
+      this.items =
+        JSON.parse(this.storage.getItem("clipboard")) || this.initialItems;
 
       var $button = $(event.target).closest("button");
       var type = $button.data("clipboard-type");
@@ -375,7 +366,7 @@ import Tooltip from "bootstrap/js/dist/tooltip";
       if (type && this.types.includes(type)) {
         this.items[type] = [];
       } else {
-        this.items = JSON.parse(this.initialItems);
+        this.items = this.initialItems;
       }
 
       this.storage.setItem("clipboard", JSON.stringify(this.items));


### PR DESCRIPTION
Set browser local storage values for clipboard if their corresponding variables are null on load, which happens if the browser storage is cleared.