### PR TITLE
Fix PDF page image rendering issues (#1792)

### DIFF
--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -2024,7 +2024,7 @@ class QubitDigitalObject extends BaseDigitalObject
 
             $filenameMinusExtension = preg_replace('/\.[a-zA-Z]{2,3}$/', '', $path);
 
-            $command = 'convert -quality 100 ';
+            $command = 'convert -density 300 -alpha remove -quality 100 ';
             $command .= $path;
             $command .= ' '.$filenameMinusExtension.'_%02d.'.self::THUMB_EXTENSION;
             exec($command, $output, $status);


### PR DESCRIPTION
Added new CLI options to command used to extract images of PDF pages. Added "-density 300" to increase image detail and "-alpha remove" to fix issue where the alpha channel is rendered as black and causes images to be illegible.