### PR TITLE
Add PDF page D.O. support to regen. task (#1794)

### DIFF
--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -1662,18 +1662,6 @@ class QubitDigitalObject extends BaseDigitalObject
     }
 
     /**
-     * Return true if this is a compound digital object.
-     *
-     * @return bool
-     */
-    public function isCompoundObject()
-    {
-        $isCompoundObjectProp = QubitProperty::getOneByObjectIdAndName($this->id, 'is_compound_object');
-
-        return null !== $isCompoundObjectProp && '1' == $isCompoundObjectProp->getValue(['sourceCulture' => true]);
-    }
-
-    /**
      * Derive file path for a digital object asset.
      *
      * All digital object paths are keyed by object id that is the


### PR DESCRIPTION
Fixed issue with the digital objects regeneration task (digitalobject:regen-derivatives) deleting, but not regenerating, digital objects representing PDF pages.

Removed unneeded and unused digital object class method.