### PR TITLE
Drop version property in compose files

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,6 +1,4 @@
 ---
-version: "2.1"
-
 volumes:
   elasticsearch_data:
   percona_data:

--- a/docker/docker-compose.pmm.yml
+++ b/docker/docker-compose.pmm.yml
@@ -1,6 +1,4 @@
 ---
-version: "2.1"
-
 volumes:
   pmm_prometheus_data:
   pmm_consul_data:

--- a/docker/docker-compose.varnish.yml
+++ b/docker/docker-compose.varnish.yml
@@ -1,6 +1,4 @@
 ---
-version: "2.1"
-
 services:
 
   varnish:


### PR DESCRIPTION
Removing version property in docker compose files since this is [obsolete and has been informative only](https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements) with no impact on docker compose functionality. 