### PR TITLE
Allow manual user creation based on  OIDC setting

### DIFF
--- a/plugins/arDominionB5Plugin/modules/user/templates/_showActions.mod_ext_auth.php
+++ b/plugins/arDominionB5Plugin/modules/user/templates/_showActions.mod_ext_auth.php
@@ -9,6 +9,12 @@
       <li><?php echo link_to(__('Delete'), [$resource, 'module' => 'user', 'action' => 'delete'], ['class' => 'btn atom-btn-outline-danger']); ?></li>
     <?php } ?>
 
+    <?php if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) { ?>
+      <?php if (QubitAcl::check($resource, 'create')) { ?>
+        <li><?php echo link_to(__('Add new'), ['module' => 'user', 'action' => 'add'], ['class' => 'btn atom-btn-outline-light']); ?></li>
+      <?php } ?>
+    <?php } ?>
+
     <?php if (QubitAcl::check($resource, 'list')) { ?>
       <li><?php echo link_to(__('Return to user list'), ['module' => 'user', 'action' => 'list'], ['class' => 'btn atom-btn-outline-light']); ?></li>
     <?php } ?>

--- a/plugins/arDominionB5Plugin/modules/user/templates/editSuccess.mod_ext_auth.php
+++ b/plugins/arDominionB5Plugin/modules/user/templates/editSuccess.mod_ext_auth.php
@@ -26,6 +26,12 @@
           </h2>
           <div id="basic-collapse" class="accordion-collapse collapse show" aria-labelledby="basic-heading">
             <div class="accordion-body">
+
+              <?php if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) { ?>
+                <?php echo render_field($form->username); ?>
+                <?php echo render_field($form->email, null, ['type' => 'email']); ?>
+              <?php } ?>
+
               <?php echo render_field($form->active->label(__('Active'))); ?>
             </div>
           </div>
@@ -73,6 +79,9 @@
         <li><input class="btn atom-btn-outline-success" type="submit" value="<?php echo __('Save'); ?>"></li>
       <?php } else { ?>
         <li><?php echo link_to(__('Cancel'), ['module' => 'user', 'action' => 'list'], ['class' => 'btn atom-btn-outline-light', 'role' => 'button']); ?></li>
+        <?php if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) { ?>
+          <li><input class="btn atom-btn-outline-success" type="submit" value="<?php echo __('Create'); ?>"></li>
+        <?php } ?>
       <?php } ?>
     </ul>
 

--- a/plugins/arDominionB5Plugin/modules/user/templates/listSuccess.mod_ext_auth.php
+++ b/plugins/arDominionB5Plugin/modules/user/templates/listSuccess.mod_ext_auth.php
@@ -79,3 +79,9 @@
 </div>
 
 <?php echo get_partial('default/pager', ['pager' => $pager]); ?>
+
+<?php if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) { ?>
+  <section class="actions mb-3">
+    <?php echo link_to(__('Add new'), ['module' => 'user', 'action' => 'add'], ['class' => 'btn atom-btn-outline-light']); ?>
+  </section>
+<?php } ?>

--- a/plugins/arOidcPlugin/lib/oidcUser.class.php
+++ b/plugins/arOidcPlugin/lib/oidcUser.class.php
@@ -85,6 +85,7 @@ class oidcUser extends myUser implements Zend_Acl_Role_Interface
             $userMatchingSource = sfConfig::get('app_oidc_user_matching_source', '');
             if (!arOidc::validateUserMatchingSource($userMatchingSource)) {
                 $this->logger->err('OIDC user matching source is configured but is not set properly. Unable to match OIDC users to AtoM users.');
+                $this->logout();
 
                 return $authenticated;
             }
@@ -106,6 +107,7 @@ class oidcUser extends myUser implements Zend_Acl_Role_Interface
             $autoCreateUser = sfConfig::get('app_oidc_auto_create_atom_user', true);
             if (!is_bool($autoCreateUser)) {
                 $this->logger->err('OIDC auto_create_atom_user is configured but is not set properly - value should be of type bool. Unable to match OIDC users to AtoM users.');
+                $this->logout();
 
                 return $authenticated;
             }
@@ -121,6 +123,7 @@ class oidcUser extends myUser implements Zend_Acl_Role_Interface
             // If user is null and $autoCreateUser is true, then something failed.
             if (null === $user && $autoCreateUser) {
                 $this->logger->err('OIDC authentication succeeded but unable to find or create user in AtoM.');
+                $this->logout();
 
                 return $authenticated;
             }
@@ -128,6 +131,7 @@ class oidcUser extends myUser implements Zend_Acl_Role_Interface
             // If user is null and $autoCreateUser is false, then user has not been previously created or matching failed.
             if (null === $user && !$autoCreateUser) {
                 $this->logger->err('OIDC authentication succeeded but user not found and auto_create_atom_user is set to false.');
+                $this->logout();
 
                 return $authenticated;
             }
@@ -138,6 +142,7 @@ class oidcUser extends myUser implements Zend_Acl_Role_Interface
             $setGroupsFromClaims = sfConfig::get('app_oidc_set_groups_from_attributes', false);
             if (!is_bool($setGroupsFromClaims)) {
                 $this->logger->err('OIDC set_groups_from_attributes is configured but is not set properly - value should be of type bool. Unable to complete authentication.');
+                $this->logout();
 
                 return $authenticated;
             }

--- a/plugins/arOidcPlugin/modules/menu/templates/_userMenu.php
+++ b/plugins/arOidcPlugin/modules/menu/templates/_userMenu.php
@@ -22,7 +22,7 @@
 
           <?php echo $form->renderHiddenFields(); ?>
 
-          <button type="submit"><?php echo __('SSO'); ?></button>
+          <button type="submit"><?php echo __('Log in with SSO'); ?></button>
 
         </form>
 

--- a/plugins/arOidcPlugin/modules/user/templates/_showActions.php
+++ b/plugins/arOidcPlugin/modules/user/templates/_showActions.php
@@ -10,6 +10,12 @@
       <li><?php echo link_to(__('Delete'), [$resource, 'module' => 'user', 'action' => 'delete'], ['class' => 'c-btn c-btn-delete']); ?></li>
     <?php } ?>
     
+    <?php if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) { ?>
+      <?php if (QubitAcl::check($resource, 'create')) { ?>
+        <li><?php echo link_to(__('Add new'), ['module' => 'user', 'action' => 'add'], ['class' => 'c-btn']); ?></li>
+      <?php } ?>
+    <?php } ?>
+
     <?php if (QubitAcl::check($resource, 'list')) { ?>
       <li><?php echo link_to(__('Return to user list'), ['module' => 'user', 'action' => 'list'], ['class' => 'c-btn']); ?></li>
     <?php } ?>

--- a/plugins/arOidcPlugin/modules/user/templates/editSuccess.php
+++ b/plugins/arOidcPlugin/modules/user/templates/editSuccess.php
@@ -23,10 +23,15 @@
         <fieldset class="collapsible" id="basicInfo">
 
           <legend><?php echo __('Basic info'); ?></legend>
-          
-            <?php echo $form->active
-                ->label(__('Active'))
-                ->renderRow(); ?>
+
+          <?php if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) { ?>
+            <?php echo $form->username->renderRow(); ?>
+            <?php echo $form->email->renderRow(); ?>
+          <?php } ?>
+
+          <?php echo $form->active
+              ->label(__('Active'))
+              ->renderRow(); ?>
 
         </fieldset> <!-- /#basicInfo -->
       <?php } ?>
@@ -66,6 +71,9 @@
           <li><input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Save'); ?>"/></li>
         <?php } else { ?>
           <li><?php echo link_to(__('Cancel'), ['module' => 'user', 'action' => 'list'], ['class' => 'c-btn']); ?></li>
+          <?php if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) { ?>
+            <li><input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Create'); ?>"/></li>
+          <?php } ?>
         <?php } ?>
       </ul>
     </section>

--- a/plugins/arOidcPlugin/modules/user/templates/listSuccess.php
+++ b/plugins/arOidcPlugin/modules/user/templates/listSuccess.php
@@ -53,3 +53,11 @@
 </table>
 
 <?php echo get_partial('default/pager', ['pager' => $pager]); ?>
+
+<?php if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) { ?>
+  <section class="actions">
+    <ul>
+      <li><?php echo link_to(__('Add new'), ['module' => 'user', 'action' => 'add'], ['class' => 'c-btn']); ?></li>
+    </ul>
+  </div>
+<?php } ?>

--- a/plugins/arOidcPlugin/modules/user/templates/loginSuccess.php
+++ b/plugins/arOidcPlugin/modules/user/templates/loginSuccess.php
@@ -21,7 +21,7 @@
 
           <?php echo $form->renderHiddenFields(); ?>
 
-          <button type="submit"><?php echo __('SSO'); ?></button>
+          <button type="submit"><?php echo __('Log in with SSO'); ?></button>
 
         </form>
 


### PR DESCRIPTION
If OIDC Plugin setting auto_create_atom_user is set to false, allow manual creation of AtoM users in the AtoM UI. Passwords will not be able to be set since the authorization will come from the OIDC endpoint.