### PR TITLE
Allow selection of secondary OIDC provider

### DIFF
--- a/plugins/arOidcPlugin/config/app.yml
+++ b/plugins/arOidcPlugin/config/app.yml
@@ -1,13 +1,46 @@
 ## OIDC Plugin configuration.
 all:
   oidc:
+    # 'providers' is a list of one or many oidc providers. The provider identified in 
+    # 'primary_provider_name' setting will be selected when authenticating using the "Log in
+    # with SSO" button in AtoM. Additional providers can be selected by adding a query param
+    # to the URL before selecting "Log in with SSO". See 'provider_query_param_name' setting
+    # for more info.
+    #
+    # Any number of secondary providers can be configured in this list. Provider names must be
+    # unique.
+    #
     # OIDC provider endpoint settings:
     #   Default for Dex: 'http://dex:5556/dex'
-    #   Default for Keycloak direct using https: 'https://keycloak:8443/realms/artefactual'
-    # NOTE: Always configure using SSL in production.
-    provider_url: 'https://keycloak:8443/realms/artefactual'
-    client_id: 'artefactual-atom'
-    client_secret: 'example-secret'
+    #   Default for Keycloak direct using https: 'https://keycloak:8443/realms/client'
+    # NOTE: Always configure url using SSL in production.
+    providers:
+      primary:
+        url: 'https://keycloak:8443/realms/artefactual'
+        client_id: 'artefactual-atom'
+        client_secret: 'example-secret'
+
+      #sample_provider:
+        #url: 'https://keycloak:8443/realms/sample'
+        #client_id: 'sample-atom'
+        #client_secret: 'example-secret'
+
+    # Identifies the primary OIDC provider and corresponds to an entry in 'providers' above.
+    # The default provider name is 'primary'. If this setting is not defined, AtoM will default
+    # to the provider named "primary".
+    #
+    # primary_provider_name: primary
+
+    # This setting enables the use of additional providers and identifies the name of the query
+    # param that can be added to the refering URL when selecting "Log in with SSO" button in AtoM. 
+    # To use: append the query param and the provider name to the URL before selecting 
+    # "Log in with SSO". Must be uncommented to activate use of secondary providers.
+    #
+    # E.g. Use the 'sample_provider' provider by modifying the URL before pressing "Log in with SSO":
+    # http://127.0.0.1:63001/index.php?secondary=sample_provider
+    #
+    # provider_query_param_name: secondary
+
     # Localhost port 63001 (127.0.0.1:63001) is used as a placeholder and
     # should be replaced with your AtoM site's public IP and port.
     # NOTE: Always configure using SSL in production.
@@ -43,43 +76,43 @@ all:
     server_cert: false
 
     scopes:
-        - 'openid'
-        # Use with Dex
-        # - 'offline_access'
-        - 'profile'
-        - 'email'
-        # Use with Dex
-        # - 'groups'
+      - 'openid'
+      # Use with Dex
+      # - 'offline_access'
+      - 'profile'
+      - 'email'
+      # Use with Dex
+      # - 'groups'
 
     # Settings for parsing OIDC groups into AtoM group membership.
     # Set set_groups_from_attributes to true to enable.
     set_groups_from_attributes: true
     user_groups:
-        administrator:
-            attribute_value: 'atom-admin'
-            group_id: 100
-        editor:
-            attribute_value: 'atom-editor'
-            group_id: 101
-        contributor:
-            attribute_value: 'atom-contributor'
-            group_id: 102
-        translator:
-            attribute_value: 'atom-translator'
-            group_id: 103
+      administrator:
+        attribute_value: 'atom-admin'
+        group_id: 100
+      editor:
+        attribute_value: 'atom-editor'
+        group_id: 101
+      contributor:
+        attribute_value: 'atom-contributor'
+        group_id: 102
+      translator:
+        attribute_value: 'atom-translator'
+        group_id: 103
 
     # Identify token which contains role claims. Options are 'access-token',
     # 'id-token', 'verified-claims', or 'user-info'.
     # 'set_groups_from_attributes' must be 'true' to enable.
-    roles_source: access-token
+    roles_source: 'access-token'
 
     # Identify the location of role claims within the token identified in
     # `roles_source` above. This is an array containing the node path to
     # locate the roles array in the OIDC token. By default this is found
     # in Keycloak's access token under 'realm_access'/'roles'.
     roles_path:
-        - realm_access
-        - roles
+      - 'realm_access'
+      - 'roles'
 
     # Identify how IAM users are matched to users in AtoM. Two values are allowed:
     #   user_matching_source: oidc-email
@@ -89,7 +122,7 @@ all:
     # Using oidc-email requires the 'email' scope to be set above in the
     # 'scopes' setting. 'email' is an optional user setup field in Keycloak but
     # MUST be set if matching to pre-existing AtoM user accounts is going to work.
-    user_matching_source: oidc-email
+    user_matching_source: 'oidc-email'
 
     # Activate or disable the automatic creation of AtoM user records from OIDC
     # endpoint details. Allowed settings are:

--- a/plugins/arOidcPlugin/lib/arOidc.class.php
+++ b/plugins/arOidcPlugin/lib/arOidc.class.php
@@ -37,20 +37,7 @@ class arOidc
             return;
         }
 
-        $provider_url = sfConfig::get('app_oidc_provider_url', '');
-        if (empty($provider_url)) {
-            throw new Exception('Invalid OIDC provider URL. Please review the app_oidc_provider_url parameter in plugin app.yml.');
-        }
-        $client_id = sfConfig::get('app_oidc_client_id', '');
-        if (empty($client_id)) {
-            throw new Exception('Invalid OIDC client id. Please review the app_oidc_client_id parameter in plugin app.yml.');
-        }
-        $client_secret = sfConfig::get('app_oidc_client_secret', '');
-        if (empty($client_secret)) {
-            throw new Exception('Invalid OIDC client secret. Please review the app_oidc_client_secret parameter in plugin app.yml.');
-        }
-
-        $oidc = new OpenIDConnectClient($provider_url, $client_id, $client_secret);
+        $oidc = new OpenIDConnectClient();
 
         // Validate requested scopes.
         $scopesArray = sfConfig::get('app_oidc_scopes', []);
@@ -65,7 +52,7 @@ class arOidc
         // Validate redirect URL.
         $redirectUrl = sfConfig::get('app_oidc_redirect_url', '');
         if (empty($redirectUrl)) {
-            throw new Exception('Invalid OIDC redirect URL. Please review the app_oidc_provider_url parameter in plugin app.yml.');
+            throw new Exception('Invalid OIDC redirect URL. Please review the app_oidc_redirect_url parameter in plugin app.yml.');
         }
         $oidc->setRedirectURL($redirectUrl);
 

--- a/plugins/arOidcPlugin/modules/oidc/actions/loginAction.class.php
+++ b/plugins/arOidcPlugin/modules/oidc/actions/loginAction.class.php
@@ -31,18 +31,22 @@ class OidcLoginAction extends sfAction
         // user/list (for example) if the user was attempting to access a secure resource. When redirected
         // back from the OIDC endpoint, the referrer will be empty.
         if ($request->isMethod('post') && !empty($request->getReferer())) {
-            $this->context->user->setAttribute('atom-login-referrer', $request->getReferer());
+            $this->context->user->setAttribute('atom-login-referer', $request->getReferer());
         }
 
         if ($request->isMethod('post') || isset($_REQUEST['code'])) {
-            $this->getUser()->authenticate();
+            if (null !== $providerId = $this->context->user->parseProviderIdFromUrl($this->context->user->getAttribute('atom-login-referer', null))) {
+                $this->context->user->validateProviderId($providerId, true);
+            }
+
+            $this->context->user->authenticate();
         }
 
         // Redirect to module/action the user was trying to reach before being redirected
         // to the OIDC IAM system for authentication. We prefer a redirect to a forward so that the ticket
         // parameter is not accidentally exposed in the user's browser.
         if (null !== $redirectUrl = $this->context->user->getAttribute('atom-login-referrer', null)) {
-            $this->context->user->setAttribute('atom-login-referrer', null);
+            $this->context->user->setAttribute('atom-login-referer', null);
             $this->redirect($redirectUrl);
         }
 


### PR DESCRIPTION
Add the ability to define a secondary OIDC provider for authentication and select it using a query param on the request URL.

E.g. Use the 'sample_provider' provider by modifying the AtoM URL before pressing "Log in with SSO":

http://127.0.0.1:63001/index.php?secondary=sample_provider