### PR TITLE
Clear template cache when authenticating OIDC usr

### DIFF
--- a/plugins/arOidcPlugin/lib/oidcUser.class.php
+++ b/plugins/arOidcPlugin/lib/oidcUser.class.php
@@ -183,6 +183,11 @@ class oidcUser extends myUser implements Zend_Acl_Role_Interface
             }
 
             $authenticated = true;
+
+            // Clear template cache.
+            $cacheClear = new sfCacheClearTask(sfContext::getInstance()->getEventDispatcher(), new sfFormatter());
+            $cacheClear->run([], ['type' => 'template']);
+
             // Refresh user so new groups and credentials are immediately available on signIn().
             $this->signIn(QubitUser::getById($user->id));
         }


### PR DESCRIPTION
Address issue where cached menu templates are not refreshed on login when user groups are updated in the identity provider.