### PR TITLE
Allow independent OIDC provider config

### DIFF
--- a/plugins/arDominionB5Plugin/modules/user/templates/_showActions.mod_ext_auth.php
+++ b/plugins/arDominionB5Plugin/modules/user/templates/_showActions.mod_ext_auth.php
@@ -9,7 +9,7 @@
       <li><?php echo link_to(__('Delete'), [$resource, 'module' => 'user', 'action' => 'delete'], ['class' => 'btn atom-btn-outline-danger']); ?></li>
     <?php } ?>
 
-    <?php if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) { ?>
+    <?php if (false === sfContext::getinstance()->user->getProviderConfigValue('auto_create_atom_user', true)) { ?>
       <?php if (QubitAcl::check($resource, 'create')) { ?>
         <li><?php echo link_to(__('Add new'), ['module' => 'user', 'action' => 'add'], ['class' => 'btn atom-btn-outline-light']); ?></li>
       <?php } ?>

--- a/plugins/arDominionB5Plugin/modules/user/templates/editSuccess.mod_ext_auth.php
+++ b/plugins/arDominionB5Plugin/modules/user/templates/editSuccess.mod_ext_auth.php
@@ -27,7 +27,7 @@
           <div id="basic-collapse" class="accordion-collapse collapse show" aria-labelledby="basic-heading">
             <div class="accordion-body">
 
-              <?php if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) { ?>
+              <?php if (false === sfContext::getinstance()->user->getProviderConfigValue('auto_create_atom_user', true)) { ?>
                 <?php echo render_field($form->username); ?>
                 <?php echo render_field($form->email, null, ['type' => 'email']); ?>
               <?php } ?>
@@ -79,7 +79,7 @@
         <li><input class="btn atom-btn-outline-success" type="submit" value="<?php echo __('Save'); ?>"></li>
       <?php } else { ?>
         <li><?php echo link_to(__('Cancel'), ['module' => 'user', 'action' => 'list'], ['class' => 'btn atom-btn-outline-light', 'role' => 'button']); ?></li>
-        <?php if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) { ?>
+        <?php if (false === sfContext::getinstance()->user->getProviderConfigValue('auto_create_atom_user', true)) { ?>
           <li><input class="btn atom-btn-outline-success" type="submit" value="<?php echo __('Create'); ?>"></li>
         <?php } ?>
       <?php } ?>

--- a/plugins/arDominionB5Plugin/modules/user/templates/listSuccess.mod_ext_auth.php
+++ b/plugins/arDominionB5Plugin/modules/user/templates/listSuccess.mod_ext_auth.php
@@ -80,7 +80,7 @@
 
 <?php echo get_partial('default/pager', ['pager' => $pager]); ?>
 
-<?php if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) { ?>
+<?php if (false === sfContext::getinstance()->user->getProviderConfigValue('auto_create_atom_user', true)) { ?>
   <section class="actions mb-3">
     <?php echo link_to(__('Add new'), ['module' => 'user', 'action' => 'add'], ['class' => 'btn atom-btn-outline-light']); ?>
   </section>

--- a/plugins/arOidcPlugin/config/app.yml
+++ b/plugins/arOidcPlugin/config/app.yml
@@ -20,10 +20,118 @@ all:
         client_id: 'artefactual-atom'
         client_secret: 'example-secret'
 
+        # Set to true if OIDC endpoint supports logout.
+        # Setting examples for tested OpenID providers:
+        # --------
+        # Keycloak via Dex:
+        #   send_oidc_logout: false
+        # Keycloak direct:
+        #   send_oidc_logout: true
+        send_oidc_logout: true
+
+        # Set to true if OIDC endpoint is configured to send refresh tokens.
+        enable_refresh_token_use: true
+
+        # OIDC server SSL certificate location for server validation.
+        # Accepts a filepath or false (to disable, e.g. for development).
+        # Examples
+        # --------
+        # Relative path to sf_root_dir:    'data/oidc/cert/mycert.pem'
+        # Absolute path:                   '/usr/var/certif/xxx.pem'
+        # Disable server validation:       false
+        server_cert: false
+
+        # Settings for parsing OIDC groups into AtoM group membership.
+        # Set set_groups_from_attributes to true to enable.
+        set_groups_from_attributes: true
+        user_groups:
+          administrator:
+            attribute_value: 'atom-admin'
+            group_id: 100
+          editor:
+            attribute_value: 'atom-editor'
+            group_id: 101
+          contributor:
+            attribute_value: 'atom-contributor'
+            group_id: 102
+          translator:
+            attribute_value: 'atom-translator'
+            group_id: 103
+
+        scopes:
+          - 'openid'
+          # Use with Dex
+          # - 'offline_access'
+          - 'profile'
+          - 'email'
+          # Use with Dex
+          # - 'groups'
+
+        # Identify token which contains role claims. Options are 'access-token',
+        # 'id-token', 'verified-claims', or 'user-info'.
+        # 'set_groups_from_attributes' must be 'true' to enable.
+        roles_source: 'access-token'
+
+        # Identify the location of role claims within the token identified in
+        # `roles_source` above. This is an array containing the node path to
+        # locate the roles array in the OIDC token. By default this is found
+        # in Keycloak's access token under 'realm_access'/'roles'.
+        roles_path:
+          - 'realm_access'
+          - 'roles'
+
+        # Identify how IAM users are matched to users in AtoM. Two values are allowed:
+        #   user_matching_source: oidc-email
+        #   user_matching_source: oidc-username
+        # Using oidc-username will work without additional scopes being requested.
+        #
+        # Using oidc-email requires the 'email' scope to be set above in the
+        # 'scopes' setting. 'email' is an optional user setup field in Keycloak but
+        # MUST be set if matching to pre-existing AtoM user accounts is going to work.
+        user_matching_source: 'oidc-email'
+
+        # Activate or disable the automatic creation of AtoM user records from OIDC
+        # endpoint details. Allowed settings are:
+        #
+        # true (default): AtoM will automatically create a user record on first login.
+        #
+        # false: AtoM will not automatically create a user record on first login - AtoM
+        #        user must be created in advance to successfully authenticate in AtoM.
+        auto_create_atom_user: true
+
+      # The following is an example secondary provider called 'sample_provider'. If
+      # uncommented, a second OIDC provider in the 'sample' Keycloak realm will be available.
       #sample_provider:
         #url: 'https://keycloak:8443/realms/sample'
         #client_id: 'sample-atom'
         #client_secret: 'example-secret'
+        #send_oidc_logout: true
+        #enable_refresh_token_use: true
+        #server_cert: false
+        #set_groups_from_attributes: true
+        #user_groups:
+        #  administrator:
+        #    attribute_value: 'atom-admin'
+        #    group_id: 100
+        #  editor:
+        #    attribute_value: 'atom-editor'
+        #    group_id: 101
+        #  contributor:
+        #    attribute_value: 'atom-contributor'
+        #    group_id: 102
+        #  translator:
+        #    attribute_value: 'atom-translator'
+        #    group_id: 103
+        #scopes:
+        #  - 'openid'
+        #  - 'profile'
+        #  - 'email'
+        #roles_source: 'access-token'
+        #roles_path:
+        #  - 'realm_access'
+        #  - 'roles'
+        #user_matching_source: 'oidc-email'
+        #auto_create_atom_user: true
 
     # Identifies the primary OIDC provider and corresponds to an entry in 'providers' above.
     # The default provider name is 'primary'. If this setting is not defined, AtoM will default
@@ -46,15 +154,6 @@ all:
     # NOTE: Always configure using SSL in production.
     redirect_url: 'http://127.0.0.1:63001/index.php/oidc/login'
 
-    # Set to true if OIDC endpoint supports logout.
-    # Setting examples for tested OpenID providers:
-    # --------
-    # Keycloak via Dex:
-    #   send_oidc_logout: false
-    # Keycloak direct:
-    #   send_oidc_logout: true
-    send_oidc_logout: true
-
     # OIDC logout requires a URL to redirect to. Use this setting to
     # specify a page to redirect the user to on logout when
     # 'send_oidc_logout' is 'true'. Localhost port 63001 (127.0.0.1:63001)
@@ -62,73 +161,3 @@ all:
     # public IP and port.
     # NOTE: Always configure using SSL in production.
     logout_redirect_url: 'http://127.0.0.1:63001'
-
-    # Set to true if OIDC endpoint is configured to send refresh tokens.
-    enable_refresh_token_use: true
-
-    # OIDC server SSL certificate location for server validation.
-    # Accepts a filepath or false (to disable, e.g. for development).
-    # Examples
-    # --------
-    # Relative path to sf_root_dir:    'data/oidc/cert/mycert.pem'
-    # Absolute path:                   '/usr/var/certif/xxx.pem'
-    # Disable server validation:       false
-    server_cert: false
-
-    scopes:
-      - 'openid'
-      # Use with Dex
-      # - 'offline_access'
-      - 'profile'
-      - 'email'
-      # Use with Dex
-      # - 'groups'
-
-    # Settings for parsing OIDC groups into AtoM group membership.
-    # Set set_groups_from_attributes to true to enable.
-    set_groups_from_attributes: true
-    user_groups:
-      administrator:
-        attribute_value: 'atom-admin'
-        group_id: 100
-      editor:
-        attribute_value: 'atom-editor'
-        group_id: 101
-      contributor:
-        attribute_value: 'atom-contributor'
-        group_id: 102
-      translator:
-        attribute_value: 'atom-translator'
-        group_id: 103
-
-    # Identify token which contains role claims. Options are 'access-token',
-    # 'id-token', 'verified-claims', or 'user-info'.
-    # 'set_groups_from_attributes' must be 'true' to enable.
-    roles_source: 'access-token'
-
-    # Identify the location of role claims within the token identified in
-    # `roles_source` above. This is an array containing the node path to
-    # locate the roles array in the OIDC token. By default this is found
-    # in Keycloak's access token under 'realm_access'/'roles'.
-    roles_path:
-      - 'realm_access'
-      - 'roles'
-
-    # Identify how IAM users are matched to users in AtoM. Two values are allowed:
-    #   user_matching_source: oidc-email
-    #   user_matching_source: oidc-username
-    # Using oidc-username will work without additional scopes being requested.
-    #
-    # Using oidc-email requires the 'email' scope to be set above in the
-    # 'scopes' setting. 'email' is an optional user setup field in Keycloak but
-    # MUST be set if matching to pre-existing AtoM user accounts is going to work.
-    user_matching_source: 'oidc-email'
-
-    # Activate or disable the automatic creation of AtoM user records from OIDC
-    # endpoint details. Allowed settings are:
-    #
-    # true (default): AtoM will automatically create a user record on first login.
-    #
-    # false: AtoM will not automatically create a user record on first login - AtoM
-    #        user must be created in advance to successfully authenticate in AtoM.
-    auto_create_atom_user: true

--- a/plugins/arOidcPlugin/lib/arOidc.class.php
+++ b/plugins/arOidcPlugin/lib/arOidc.class.php
@@ -39,36 +39,12 @@ class arOidc
 
         $oidc = new OpenIDConnectClient();
 
-        // Validate requested scopes.
-        $scopesArray = sfConfig::get('app_oidc_scopes', []);
-        $validScopes = self::validateScopes($scopesArray);
-        // Add scopes only if the array is not empty
-        if (!empty($validScopes)) {
-            $oidc->addScope($validScopes);
-        } else {
-            throw new Exception('No valid scopes found in app_oidc_scopes.');
-        }
-
         // Validate redirect URL.
         $redirectUrl = sfConfig::get('app_oidc_redirect_url', '');
         if (empty($redirectUrl)) {
             throw new Exception('Invalid OIDC redirect URL. Please review the app_oidc_redirect_url parameter in plugin app.yml.');
         }
         $oidc->setRedirectURL($redirectUrl);
-
-        // Validate the server SSL certificate according to configuration.
-        $certPath = sfConfig::get('app_oidc_server_cert', false);
-        if (0 === !strpos($certPath, '/')) {
-            $certPath = sfConfig::get('sf_root_dir').DIRECTORY_SEPARATOR.$certPath;
-        }
-
-        if (file_exists($certPath)) {
-            $oidc->setCertPath($certPath);
-        } elseif (false === $certPath) {
-            // OIDC server SSL certificate disabled.
-        } else {
-            throw new Exception('Invalid SSL certificate settings. Please review the app_oidc_server_cert parameter in plugin app.yml.');
-        }
 
         self::$oidcIsInitialized = true;
 

--- a/plugins/arOidcPlugin/modules/user/actions/editAction.class.php
+++ b/plugins/arOidcPlugin/modules/user/actions/editAction.class.php
@@ -104,7 +104,7 @@ class UserEditAction extends DefaultEditAction
     {
         $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
 
-        if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) {
+        if (false === sfContext::getinstance()->user->getProviderConfigValue('auto_create_atom_user', true)) {
             $this->form->getValidatorSchema()->setPostValidator(
                 new sfValidatorCallback(['callback' => [$this, 'exists']])
             );
@@ -136,7 +136,7 @@ class UserEditAction extends DefaultEditAction
     {
         switch ($name) {
             case 'username':
-                if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) {
+                if (false === sfContext::getinstance()->user->getProviderConfigValue('auto_create_atom_user', true)) {
                     $this->form->setDefault('username', $this->resource->username);
                     $this->form->setValidator('username', new sfValidatorString(['required' => true]));
                     $this->form->setWidget('username', new sfWidgetFormInput());
@@ -145,7 +145,7 @@ class UserEditAction extends DefaultEditAction
                 break;
 
             case 'email':
-                if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) {
+                if (false === sfContext::getinstance()->user->getProviderConfigValue('auto_create_atom_user', true)) {
                     $this->form->setDefault('email', $this->resource->email);
                     $this->form->setValidator('email', new sfValidatorEmail(['required' => true]));
                     $this->form->setWidget('email', new sfWidgetFormInput());
@@ -315,7 +315,7 @@ class UserEditAction extends DefaultEditAction
 
             case 'username':
             case 'email':
-                if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) {
+                if (false === sfContext::getinstance()->user->getProviderConfigValue('auto_create_atom_user', true)) {
                     $this->resource[$name] = $this->form->getValue($name);
                 }
 

--- a/plugins/arOidcPlugin/modules/user/templates/_showActions.php
+++ b/plugins/arOidcPlugin/modules/user/templates/_showActions.php
@@ -10,7 +10,7 @@
       <li><?php echo link_to(__('Delete'), [$resource, 'module' => 'user', 'action' => 'delete'], ['class' => 'c-btn c-btn-delete']); ?></li>
     <?php } ?>
     
-    <?php if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) { ?>
+    <?php if (false === sfContext::getinstance()->user->getProviderConfigValue('auto_create_atom_user', true)) { ?>
       <?php if (QubitAcl::check($resource, 'create')) { ?>
         <li><?php echo link_to(__('Add new'), ['module' => 'user', 'action' => 'add'], ['class' => 'c-btn']); ?></li>
       <?php } ?>

--- a/plugins/arOidcPlugin/modules/user/templates/editSuccess.php
+++ b/plugins/arOidcPlugin/modules/user/templates/editSuccess.php
@@ -24,7 +24,7 @@
 
           <legend><?php echo __('Basic info'); ?></legend>
 
-          <?php if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) { ?>
+          <?php if (false === sfContext::getinstance()->user->getProviderConfigValue('auto_create_atom_user', true)) { ?>
             <?php echo $form->username->renderRow(); ?>
             <?php echo $form->email->renderRow(); ?>
           <?php } ?>
@@ -71,7 +71,7 @@
           <li><input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Save'); ?>"/></li>
         <?php } else { ?>
           <li><?php echo link_to(__('Cancel'), ['module' => 'user', 'action' => 'list'], ['class' => 'c-btn']); ?></li>
-          <?php if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) { ?>
+          <?php if (false === sfContext::getinstance()->user->getProviderConfigValue('auto_create_atom_user', true)) { ?>
             <li><input class="c-btn c-btn-submit" type="submit" value="<?php echo __('Create'); ?>"/></li>
           <?php } ?>
         <?php } ?>

--- a/plugins/arOidcPlugin/modules/user/templates/listSuccess.php
+++ b/plugins/arOidcPlugin/modules/user/templates/listSuccess.php
@@ -54,7 +54,7 @@
 
 <?php echo get_partial('default/pager', ['pager' => $pager]); ?>
 
-<?php if (false === sfConfig::get('app_oidc_auto_create_atom_user', true)) { ?>
+<?php if (false === sfContext::getinstance()->user->getProviderConfigValue('auto_create_atom_user', true)) { ?>
   <section class="actions">
     <ul>
       <li><?php echo link_to(__('Add new'), ['module' => 'user', 'action' => 'add'], ['class' => 'c-btn']); ?></li>


### PR DESCRIPTION
Allow provider specific config values to be set independently for each
provider instead of these settings applying to every configured OIDC
provider.