### PR TITLE
Improve the contrast

### DIFF
--- a/plugins/arDominionB5Plugin/scss/_variables.scss
+++ b/plugins/arDominionB5Plugin/scss/_variables.scss
@@ -13,7 +13,7 @@ $gray-700: #495057 !default;
 $gray-800: #343a40 !default;
 $gray-900: #212529 !default;
 $black: #000 !default;
-$orange: #f60 !default;
+$orange: #c44e00 !default;
 $blue: #0a58ca !default;
 $primary: $orange !default;
 $secondary: $gray-700 !default;


### PR DESCRIPTION
As part of https://github.com/artefactual/atom/issues/1509

I chose the colour by using a darker shade of orange: #c44e00 instead of #f60.

We can pick another colour - I only tested on Firefox using the integrated accessibility tools.

If my understanding of SCSS is correct, this should build correctly, given that I am unable to build and access this version to test it locally with Docker, following the instructions in https://www.accesstomemory.org/fr/docs/2.8/dev-manual/env/compose/ ... do these docs needs a review ?