### PR TITLE
Update Bootstrap 5 dependency to current version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@uppy/core": "^2.0.3",
         "@uppy/dashboard": "^2.0.3",
         "@uppy/xhr-upload": "^2.0.3",
-        "bootstrap": "~5.1.1",
+        "bootstrap": "^5.3.0",
         "bootstrap-autocomplete": "^2.3.7",
         "imagesloaded": "^4.1.4",
         "jquery": "^3.6.0",
@@ -179,9 +179,9 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.4.tgz",
-      "integrity": "sha512-q/ytXxO5NKvyT37pmisQAItCFqA7FD/vNb8dgaJy3/630Fsc+Mz9/9f2SziBoIZ30TJooXyTwZmhi1zjXmObYg==",
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "peer": true,
       "funding": {
         "type": "opencollective",
@@ -885,15 +885,21 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
-      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bootstrap"
-      },
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
       "peerDependencies": {
-        "@popperjs/core": "^2.10.2"
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/bootstrap-autocomplete": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@uppy/core": "^2.0.3",
     "@uppy/dashboard": "^2.0.3",
     "@uppy/xhr-upload": "^2.0.3",
-    "bootstrap": "~5.1.1",
+    "bootstrap": "^5.3.0",
     "bootstrap-autocomplete": "^2.3.7",
     "imagesloaded": "^4.1.4",
     "jquery": "^3.6.0",

--- a/plugins/arDominionB5Plugin/scss/_buttonsandlinks.scss
+++ b/plugins/arDominionB5Plugin/scss/_buttonsandlinks.scss
@@ -116,3 +116,13 @@
   font-weight: 700;
   text-decoration: underline;
 }
+
+a {
+  &.h1,
+  &.h2,
+  &.h3,
+  &.h4,
+  &.h5 {
+    color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 1));
+  }
+}

--- a/plugins/arDominionB5Plugin/scss/_layout.scss
+++ b/plugins/arDominionB5Plugin/scss/_layout.scss
@@ -149,3 +149,11 @@ body > iframe,
     }
   }
 }
+
+.card {
+  --bs-card-bg: var(--bs-white);
+}
+
+.list-group-item {
+  --bs-list-group-bg: var(--bs-white);
+}

--- a/plugins/arDominionB5Plugin/scss/main.scss
+++ b/plugins/arDominionB5Plugin/scss/main.scss
@@ -5,6 +5,7 @@
 @import "bootstrap/scss/functions";
 @import "bootstrap/scss/variables";
 @import "bootstrap/scss/mixins";
+@import "bootstrap/scss/maps";
 @import "bootstrap/scss/utilities";
 
 // Custom utilities


### PR DESCRIPTION
Unpinned Bootstrap 5 and updated it to the current version. Due to breaking changes introduced by Bootstrap in v5.2.0 and v5.3.0, and additional import for maps was needed, updating links using the heading class to use the default link colour was needed to be set, and updating the default background colour variable for cards and list group items needed to be set.