### PR TITLE
Add no-cache header to 404, 403 responses

### DIFF
--- a/apps/qubit/modules/admin/actions/error404Action.class.php
+++ b/apps/qubit/modules/admin/actions/error404Action.class.php
@@ -21,5 +21,6 @@ class AdminError404Action extends sfAction
 {
     public function execute($request)
     {
+        $this->getResponse()->setHttpHeader('Cache-Control', 'no-cache, no-store', false);
     }
 }

--- a/apps/qubit/modules/admin/actions/secureAction.class.php
+++ b/apps/qubit/modules/admin/actions/secureAction.class.php
@@ -22,5 +22,6 @@ class AdminSecureAction extends sfAction
     public function execute($request)
     {
         $this->getResponse()->setStatusCode(403);
+        $this->getResponse()->setHttpHeader('Cache-Control', 'no-cache, no-store', false);
     }
 }


### PR DESCRIPTION
Set `Cache-Control: no-cache, no-store` on 404 and 403 responses.