### PR TITLE
Fix mode option name in data integrity CLI (#1844)

### DIFF
--- a/lib/task/tools/dataIntegrityRepairTask.class.php
+++ b/lib/task/tools/dataIntegrityRepairTask.class.php
@@ -178,7 +178,7 @@ EOF;
 
             $this->report($filename, $affectedIosById, $affectedIosAndDescendantIds);
 
-            switch ($options['fix']) {
+            switch ($options['mode']) {
                 case 'fix':
                     $this->fix($affectedIosById);
 


### PR DESCRIPTION
Change the mode option to use the name 'mode' instead of 'fix' so that it is not ignored.