### PR TITLE
Update pcov unit test coverage config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "scripts": {
         "test": "phpunit",
-        "test-cov": "@php -dpcov.enabled=1 ./vendor/composer/bin/phpunit --coverage-html=.coverage/html",
+        "test-cov": "@php -dpcov.enabled=1 -dpcov.directory=. ./vendor/composer/bin/phpunit --coverage-html=.coverage/html",
         "php-cs-fixer": "php-cs-fixer"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,7 @@
       <directory suffix=".php">cache</directory>
       <directory suffix=".php">test</directory>
       <directory suffix=".php">vendor</directory>
+      <directory suffix=".php">docker</directory>
     </exclude>
   </coverage>
 </phpunit>


### PR DESCRIPTION
Exclude AtoM's docker directory from pcov unit test coverage report. Add pcov option to ensure all folders are scanned for unit test coverage (plugin folder tests were not being discovered).