### PR TITLE
Fix identifier matching errors, refs #13582

### DIFF
--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -2171,7 +2171,7 @@ class QubitInformationObject extends BaseInformationObject
 
             // Use match query for exact matches.
             $queryText = new \Elastica\Query\Match();
-            $queryBool->addMust($queryText->setFieldQuery('identifier', $identifier));
+            $queryBool->addMust($queryText->setFieldQuery('identifier.untouched', $identifier));
 
             $queryText = new \Elastica\Query\Match();
             $queryBool->addMust($queryText->setFieldQuery(sprintf('i18n.%s.title.untouched', $currentCulture), $title));


### PR DESCRIPTION
During command line imports with the _match-and-update_ flag set, it is possible for AtoM to false-match to an existing record based on **Title only** if Identifiers contain special characters, and Identifier patterns are 'similar' in the Repository. This causes metadata in matched record to be overwritten, parent id reassigned, and breaks the nested set.  

This seems to be related to the way that Elastic tokenizes special characters.

Problem first noted in Nov 2021, reported by Matthew Addis @ Arkivum (UK). https://projects.artefactual.com/issues/13582 

The proposed code-fix has been used locally in multiple AtoMs and across multiple versions since 2.5+. The modified field/index _identifier.untouched_ is already used in several places in code: https://github.com/search?q=repo%3Aartefactual%2Fatom%20identifier.untouched&type=code  