### PR TITLE
Update institution upload limits. (#1864)

### DIFF
--- a/apps/qubit/modules/object/templates/addDigitalObjectSuccess.php
+++ b/apps/qubit/modules/object/templates/addDigitalObjectSuccess.php
@@ -42,7 +42,7 @@
 
           <legend><?php echo __('Upload a %1%', ['%1%' => mb_strtolower(sfConfig::get('app_ui_label_digitalobject'))]); ?></legend>
 
-          <?php if (null == $repository || -1 == $repository->uploadLimit || floatval($repository->getDiskUsage() / pow(10, 9)) < floatval($repository->uploadLimit)) { ?>
+          <?php if (null == $repository || -1 == $repository->uploadLimit || floatval($repository->getDiskUsage() / pow(10, 9)) < floatval($repository->uploadLimit) || -1 == sfConfig::get('app_upload_limit')) { ?>
 
             <?php echo $form->file->renderRow(); ?>
 

--- a/apps/qubit/modules/settings/templates/uploadsSuccess.php
+++ b/apps/qubit/modules/settings/templates/uploadsSuccess.php
@@ -43,7 +43,7 @@
           <?php echo $form
               ->enable_repository_quotas
               ->label(
-                __('%1% upload limits',
+                __('%1% upload limits meter display',
                 [
                     '%1%' => sfConfig::get('app_ui_label_repository'),
                 ]
@@ -65,7 +65,7 @@
               ['%1%' => strtolower(sfConfig::get('app_ui_label_repository'))]
             ))
               ->help(__(
-                'Default %1% upload limit for a new %2%.  A value of &quot;0&quot; (zero) disables file upload.  A value of &quot;-1&quot; allows unlimited uploads',
+                'Default %1% upload limit for a new %2%.  A value of &quot;0&quot; (zero) disables file upload.  A value of &quot;-1&quot; allows unlimited uploads for all %2%s, overriding limit set for individual %2%s.',
                 [
                     '%1%' => strtolower(sfConfig::get('app_ui_label_digitalobject')),
                     '%2%' => strtolower(sfConfig::get('app_ui_label_repository')),

--- a/plugins/arDominionB5Plugin/modules/object/templates/addDigitalObjectSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/object/templates/addDigitalObjectSuccess.php
@@ -43,7 +43,7 @@
           </h2>
           <div id="upload-collapse" class="accordion-collapse collapse show" aria-labelledby="upload-heading">
             <div class="accordion-body">
-              <?php if (null == $repository || -1 == $repository->uploadLimit || floatval($repository->getDiskUsage() / pow(10, 9)) < floatval($repository->uploadLimit)) { ?>
+              <?php if (null == $repository || -1 == $repository->uploadLimit || floatval($repository->getDiskUsage() / pow(10, 9)) < floatval($repository->uploadLimit) || -1 == sfConfig::get('app_upload_limit')) { ?>
 
                 <?php echo render_field($form->file); ?>
 

--- a/plugins/arDominionB5Plugin/modules/settings/templates/uploadsSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/settings/templates/uploadsSuccess.php
@@ -36,7 +36,7 @@
 
             <?php echo render_field($form->enable_repository_quotas
                 ->label(
-                  __('%1% upload limits',
+                  __('%1% upload limits meter display',
                   [
                       '%1%' => sfConfig::get('app_ui_label_repository'),
                   ]
@@ -54,7 +54,7 @@
                     ['%1%' => strtolower(sfConfig::get('app_ui_label_repository'))]
                 ))
                 ->help(__(
-                    'Default %1% upload limit for a new %2%.  A value of &quot;0&quot; (zero) disables file upload.  A value of &quot;-1&quot; allows unlimited uploads',
+                    'Default %1% upload limit for a new %2%.  A value of &quot;0&quot; (zero) disables file upload.  A value of &quot;-1&quot; allows unlimited uploads for all %2%s, overriding limit set for individual %2%s.',
                     [
                         '%1%' => strtolower(sfConfig::get('app_ui_label_digitalobject')),
                         '%2%' => strtolower(sfConfig::get('app_ui_label_repository')),


### PR DESCRIPTION
Clarify that 'Archival Institution upload limits' setting is to enable/disable the meter display. Implement 'Default Archival Institution upload limit' setting of '-1' to enable unlimited uploads for all Archival Institutions.