### PR TITLE
Add OIDC plugin activation control

### DIFF
--- a/config/ProjectConfiguration.class.php
+++ b/config/ProjectConfiguration.class.php
@@ -48,6 +48,12 @@ class ProjectConfiguration extends sfProjectConfiguration
             'sfPluginAdminPlugin',
         ];
 
+        // Check if the OIDC plugin should be enabled.
+        $filePath = 'activate-oidc-plugin';
+        if (file_exists($filePath) && 0 === filesize($filePath)) {
+            $plugins[] = 'arOidcPlugin';
+        }
+
         $this->enablePlugins($plugins);
 
         $this->dispatcher->connect(


### PR DESCRIPTION
Add the ability for an admin to activate the OIDC plugin in a way that does not require updating the ProjectConfiguration class file, or using the plugin admin interface.

If the empty file 'activate-oidc-plugin' is present in the root of the AtoM installation, the OIDC plugin will be enabled.

At this point in Symfony's startup, in ProjectConfiguration::setup() config files like app.yml are not yet loaded which is why the presence of an OS file is being used.