### PR TITLE
Fix clipboard exports with hidden visible element headers. (#1896)

### DIFF
--- a/lib/flatfile/QubitFlatfileExport.class.php
+++ b/lib/flatfile/QubitFlatfileExport.class.php
@@ -357,6 +357,7 @@ class QubitFlatfileExport
                 if (
                     (false !== strpos($setting, 'app_element_visibility_'.$template))
                     && (!strpos($setting, '__source'))
+                    && str_ends_with('_area', $setting) // Ignore hidden element headers
                     && (0 == sfConfig::get($setting))
                 ) {
                     array_push($nonVisibleElements, $setting);


### PR DESCRIPTION
Hiding visible element headers should not affect description exports in any way. Exclude visible element headers from `getHiddenVisibleElementCsvHeaders()` by excluding settings values ending in `_area`.