### PR TITLE
Related material improvements

### DIFF
--- a/apps/qubit/modules/informationobject/actions/editAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/editAction.class.php
@@ -312,7 +312,23 @@ class InformationObjectEditAction extends DefaultEditAction
                         $criteria->add(QubitRelation::TYPE_ID, QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID);
 
                         foreach ($this->relatedMaterialDescriptions = QubitRelation::get($criteria) as $item) {
-                            $choices[$value[] = $this->context->routing->generate(null, [$item->object, 'module' => 'informationobject'])] = $item->object;
+                            $itemTitle = $item->object->__toString();
+
+                            if (isset($item->object->levelOfDescription) || isset($item->object->identifier)) {
+                                $itemTitle = "- {$itemTitle}";
+                                if (isset($item->object->identifier)) {
+                                    $itemTitle = "{$item->object->referenceCode} {$itemTitle}";
+                                }
+                                if (isset($item->object->levelOfDescription)) {
+                                    $itemTitle = "{$item->object->levelOfDescription} {$itemTitle}";
+                                }
+                            }
+
+                            if (QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $item->object->getPublicationStatus()->statusId) {
+                              $itemTitle .= " ({$item->object->getPublicationStatus()})";
+                            }
+
+                            $choices[$value[] = $this->context->routing->generate(null, [$item->object, 'module' => 'informationobject'])] = $itemTitle;
                         }
 
                         // Add also relations where it's the object
@@ -322,7 +338,24 @@ class InformationObjectEditAction extends DefaultEditAction
 
                         foreach (QubitRelation::get($criteria) as $item) {
                             $this->relatedMaterialDescriptions[] = $item;
-                            $choices[$value[] = $this->context->routing->generate(null, [$item->subject, 'module' => 'informationobject'])] = $item->subject;
+
+                            $itemTitle = $item->subject->__toString();
+
+                            if (isset($item->subject->levelOfDescription) || isset($item->subject->identifier)) {
+                                $itemTitle = "- {$itemTitle}";
+                                if (isset($item->subject->identifier)) {
+                                    $itemTitle = "{$item->subject->referenceCode} {$itemTitle}";
+                                }
+                                if (isset($item->subject->levelOfDescription)) {
+                                    $itemTitle = "{$item->subject->levelOfDescription} {$itemTitle}";
+                                }
+                            }
+
+                            if (QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $item->subject->getPublicationStatus()->statusId) {
+                              $itemTitle .= " ({$item->subject->getPublicationStatus()})";
+                            }
+
+                            $choices[$value[] = $this->context->routing->generate(null, [$item->subject, 'module' => 'informationobject'])] = $itemTitle;
                         }
 
                         break;

--- a/apps/qubit/modules/informationobject/templates/_relatedMaterialDescriptions.php
+++ b/apps/qubit/modules/informationobject/templates/_relatedMaterialDescriptions.php
@@ -9,13 +9,17 @@
   <div>
     <ul>
       <?php foreach ($resource->relationsRelatedBysubjectId as $item) { ?>
-        <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
-          <li><?php echo link_to(render_title($item->object), [$item->object, 'module' => 'informationobject']); ?></li>
+        <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->object->getPublicationStatus()->statusId) { ?>
+          <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
+            <li><?php echo link_to(render_title($item->object), [$item->object, 'module' => 'informationobject']); ?></li>
+          <?php } ?>
         <?php } ?>
       <?php } ?>
       <?php foreach ($resource->relationsRelatedByobjectId as $item) { ?>
-        <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
-          <li><?php echo link_to(render_title($item->subject), [$item->subject, 'module' => 'informationobject']); ?></li>
+        <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->subject->getPublicationStatus()->statusId) { ?>
+          <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
+            <li><?php echo link_to(render_title($item->subject), [$item->subject, 'module' => 'informationobject']); ?></li>
+          <?php } ?>
         <?php } ?>
       <?php } ?>
     </ul>

--- a/apps/qubit/modules/informationobject/templates/_relatedMaterialDescriptions.php
+++ b/apps/qubit/modules/informationobject/templates/_relatedMaterialDescriptions.php
@@ -10,15 +10,48 @@
     <ul>
       <?php foreach ($resource->relationsRelatedBysubjectId as $item) { ?>
         <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->object->getPublicationStatus()->statusId) { ?>
+          <?php $itemTitle = $item->object->__toString(); ?>
+
+          <?php if (isset($item->object->levelOfDescription) || isset($item->object->identifier)) { ?>
+            <?php $itemTitle = "- {$itemTitle}"; ?>
+              <?php if (isset($item->object->identifier)) { ?>
+                <?php $itemTitle = "{$item->object->referenceCode} {$itemTitle}"; ?>
+              <?php } ?>
+              <?php if (isset($item->object->levelOfDescription)) { ?>
+                <?php $itemTitle = "{$item->object->levelOfDescription} {$itemTitle}"; ?>
+              <?php } ?>
+          <?php } ?>
+
+          <?php if (QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $item->object->getPublicationStatus()->statusId) { ?>
+            <?php $itemTitle .= " ({$item->object->getPublicationStatus()})"; ?>
+          <?php } ?>
+
           <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
-            <li><?php echo link_to(render_title($item->object), [$item->object, 'module' => 'informationobject']); ?></li>
+            <li><?php echo link_to($itemTitle, [$item->object, 'module' => 'informationobject']); ?></li>
           <?php } ?>
         <?php } ?>
       <?php } ?>
+
       <?php foreach ($resource->relationsRelatedByobjectId as $item) { ?>
         <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->subject->getPublicationStatus()->statusId) { ?>
+          <?php $itemTitle = $item->subject->__toString(); ?>
+
+          <?php if (isset($item->subject->levelOfDescription) || isset($item->subject->identifier)) { ?>
+            <?php $itemTitle = "- {$itemTitle}"; ?>
+              <?php if (isset($item->subject->identifier)) { ?>
+                <?php $itemTitle = "{$item->subject->referenceCode} {$itemTitle}"; ?>
+              <?php } ?>
+              <?php if (isset($item->subject->levelOfDescription)) { ?>
+                <?php $itemTitle = "{$item->subject->levelOfDescription} {$itemTitle}"; ?>
+              <?php } ?>
+          <?php } ?>
+
+          <?php if (QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $item->subject->getPublicationStatus()->statusId) { ?>
+            <?php $itemTitle .= " ({$item->subject->getPublicationStatus()})"; ?>
+          <?php } ?>
+
           <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
-            <li><?php echo link_to(render_title($item->subject), [$item->subject, 'module' => 'informationobject']); ?></li>
+            <li><?php echo link_to($itemTitle, [$item->subject, 'module' => 'informationobject']); ?></li>
           <?php } ?>
         <?php } ?>
       <?php } ?>

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_relatedMaterialDescriptions.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_relatedMaterialDescriptions.php
@@ -9,13 +9,17 @@
   <div class="<?php echo render_b5_show_value_css_classes(); ?>">
     <ul class="<?php echo render_b5_show_list_css_classes(); ?>">
       <?php foreach ($resource->relationsRelatedBysubjectId as $item) { ?>
-        <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
-          <li><?php echo link_to(render_title($item->object), [$item->object, 'module' => 'informationobject']); ?></li>
+        <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->object->getPublicationStatus()->statusId) { ?>
+          <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
+            <li><?php echo link_to(render_title($item->object), [$item->object, 'module' => 'informationobject']); ?></li>
+          <?php } ?>
         <?php } ?>
       <?php } ?>
       <?php foreach ($resource->relationsRelatedByobjectId as $item) { ?>
-        <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
-          <li><?php echo link_to(render_title($item->subject), [$item->subject, 'module' => 'informationobject']); ?></li>
+        <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->subject->getPublicationStatus()->statusId) { ?>
+          <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
+            <li><?php echo link_to(render_title($item->subject), [$item->subject, 'module' => 'informationobject']); ?></li>
+          <?php } ?>
         <?php } ?>
       <?php } ?>
     </ul>

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_relatedMaterialDescriptions.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_relatedMaterialDescriptions.php
@@ -10,15 +10,48 @@
     <ul class="<?php echo render_b5_show_list_css_classes(); ?>">
       <?php foreach ($resource->relationsRelatedBysubjectId as $item) { ?>
         <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->object->getPublicationStatus()->statusId) { ?>
+          <?php $itemTitle = $item->object->__toString(); ?>
+
+          <?php if (isset($item->object->levelOfDescription) || isset($item->object->identifier)) { ?>
+            <?php $itemTitle = "- {$itemTitle}"; ?>
+              <?php if (isset($item->object->identifier)) { ?>
+                <?php $itemTitle = "{$item->object->referenceCode} {$itemTitle}"; ?>
+              <?php } ?>
+              <?php if (isset($item->object->levelOfDescription)) { ?>
+                <?php $itemTitle = "{$item->object->levelOfDescription} {$itemTitle}"; ?>
+              <?php } ?>
+          <?php } ?>
+
+          <?php if (QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $item->object->getPublicationStatus()->statusId) { ?>
+            <?php $itemTitle .= " ({$item->object->getPublicationStatus()})"; ?>
+          <?php } ?>
+
           <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
-            <li><?php echo link_to(render_title($item->object), [$item->object, 'module' => 'informationobject']); ?></li>
+            <li><?php echo link_to($itemTitle, [$item->object, 'module' => 'informationobject']); ?></li>
           <?php } ?>
         <?php } ?>
       <?php } ?>
+
       <?php foreach ($resource->relationsRelatedByobjectId as $item) { ?>
         <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->subject->getPublicationStatus()->statusId) { ?>
+          <?php $itemTitle = $item->subject->__toString(); ?>
+
+          <?php if (isset($item->subject->levelOfDescription) || isset($item->subject->identifier)) { ?>
+            <?php $itemTitle = "- {$itemTitle}"; ?>
+              <?php if (isset($item->subject->identifier)) { ?>
+                <?php $itemTitle = "{$item->subject->referenceCode} {$itemTitle}"; ?>
+              <?php } ?>
+              <?php if (isset($item->subject->levelOfDescription)) { ?>
+                <?php $itemTitle = "{$item->subject->levelOfDescription} {$itemTitle}"; ?>
+              <?php } ?>
+          <?php } ?>
+
+          <?php if (QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $item->subject->getPublicationStatus()->statusId) { ?>
+            <?php $itemTitle .= " ({$item->subject->getPublicationStatus()})"; ?>
+          <?php } ?>
+
           <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
-            <li><?php echo link_to(render_title($item->subject), [$item->subject, 'module' => 'informationobject']); ?></li>
+            <li><?php echo link_to($itemTitle, [$item->subject, 'module' => 'informationobject']); ?></li>
           <?php } ?>
         <?php } ?>
       <?php } ?>


### PR DESCRIPTION
PR adds some small improvements to how related materials are listed in descriptions and in relevant edit forms:

1. If draft descriptions are linked, these will now only be visible to authenticated users. [bug fix]
2. The title of linked descriptions now include the level of description and reference code for descriptions with such values, as well as the draft status when relevant. Both BS2 & BS5 themes are covered.

With regards to the second point, given that titles can be fairly generic in an archival context, just having the title alone ends up being really unclear and unhelpful at times. At BC Archives we have been avoiding using the 'Related materials' field because of how it displays. We've just been using the 'Associated materials' field instead, which technically isn't what it's intended for. Hopefully this can help get us using the appropriate field in the future and benefit from having reciprocal links. I imagine there are others who might be avoiding it or finding it not as clear as it could be for users for similar reasons.