### PR TITLE
Update default CSP directive

### DIFF
--- a/config/app.yml
+++ b/config/app.yml
@@ -68,13 +68,14 @@ all:
       response_header: Content-Security-Policy-Report-Only
       # Configure CSP response directives.
       directives: >
-        default-src 'self'; 
-        font-src 'self' https://fonts.gstatic.com; 
-        img-src 'self' https://*.googleapis.com https://*.gstatic.com *.google.com  *.googleusercontent.com data: https://www.gravatar.com/avatar/ https://*.google-analytics.com https://*.googletagmanager.com blob:; 
-        script-src 'self' https://*.googletagmanager.com 'nonce' https://*.googleapis.com https://*.gstatic.com *.google.com https://*.ggpht.com *.googleusercontent.com blob:; 
-        style-src 'self' 'nonce' https://fonts.googleapis.com; 
-        worker-src 'self' blob:; 
-        connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.googleapis.com *.google.com https://*.gstatic.com  data: blob:; 
+        default-src 'self';
+        font-src 'self' https://fonts.gstatic.com;
+        form-action 'self';
+        img-src 'self' https://*.googleapis.com https://*.gstatic.com *.google.com  *.googleusercontent.com data: https://www.gravatar.com/avatar/ https://*.google-analytics.com https://*.googletagmanager.com blob:;
+        script-src 'self' https://*.googletagmanager.com 'nonce' https://*.googleapis.com https://*.gstatic.com *.google.com https://*.ggpht.com *.googleusercontent.com blob:;
+        style-src 'self' 'nonce' https://fonts.googleapis.com;
+        worker-src 'self' blob:;
+        connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.googleapis.com *.google.com https://*.gstatic.com  data: blob:;
         frame-ancestors 'self';
 
   ldap:

--- a/docker/bootstrap.php
+++ b/docker/bootstrap.php
@@ -105,7 +105,7 @@ all:
   read_only: false
   htmlpurifier_enabled: false
   csp:
-    response_header: Content-Security-Policy-Report-Only
+    response_header: Content-Security-Policy
     directives: >
       default-src 'self';
       font-src 'self' https://fonts.gstatic.com;

--- a/docker/bootstrap.php
+++ b/docker/bootstrap.php
@@ -108,13 +108,13 @@ all:
     response_header: Content-Security-Policy-Report-Only
     directives: >
       default-src 'self';
-      font-src 'self';
+      font-src 'self' https://fonts.gstatic.com;
       form-action 'self';
-      img-src 'self' https://www.gravatar.com/avatar/ https://*.google-analytics.com https://*.googletagmanager.com blob:;
-      script-src 'self' https://*.googletagmanager.com 'nonce';
-      style-src 'self' 'nonce';
+      img-src 'self' https://*.googleapis.com https://*.gstatic.com *.google.com  *.googleusercontent.com data: https://www.gravatar.com/avatar/ https://*.google-analytics.com https://*.googletagmanager.com blob:;
+      script-src 'self' https://*.googletagmanager.com 'nonce' https://*.googleapis.com https://*.gstatic.com *.google.com https://*.ggpht.com *.googleusercontent.com blob:;
+      style-src 'self' 'nonce' https://fonts.googleapis.com;
       worker-src 'self' blob:;
-      connect-src https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com;
+      connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.googleapis.com *.google.com https://*.gstatic.com  data: blob:;
       frame-ancestors 'self';
 
 EOT;

--- a/docker/bootstrap.php
+++ b/docker/bootstrap.php
@@ -106,7 +106,17 @@ all:
   htmlpurifier_enabled: false
   csp:
     response_header: Content-Security-Policy-Report-Only
-    directives: "default-src 'self'; font-src 'self'; img-src 'self' https://www.gravatar.com/avatar/ https://*.google-analytics.com https://*.googletagmanager.com blob:; script-src 'self' https://*.googletagmanager.com 'nonce'; style-src 'self' 'nonce'; worker-src 'self' blob:; connect-src https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; frame-ancestors 'self';"
+    directives: >
+      default-src 'self';
+      font-src 'self';
+      form-action 'self';
+      img-src 'self' https://www.gravatar.com/avatar/ https://*.google-analytics.com https://*.googletagmanager.com blob:;
+      script-src 'self' https://*.googletagmanager.com 'nonce';
+      style-src 'self' 'nonce';
+      worker-src 'self' blob:;
+      connect-src https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com;
+      frame-ancestors 'self';
+
 EOT;
 
     file_put_contents(_ATOM_DIR.'/apps/qubit/config/app.yml', $app_yml);


### PR DESCRIPTION
Add form-action directive to default CSP header. Limit form target to 'self'.