### PR TITLE
Add OIDC 'unauthorized' failure message

### DIFF
--- a/plugins/arOidcPlugin/modules/oidc/actions/loginAction.class.php
+++ b/plugins/arOidcPlugin/modules/oidc/actions/loginAction.class.php
@@ -39,7 +39,12 @@ class OidcLoginAction extends sfAction
                 $this->context->user->validateProviderId($providerId, true);
             }
 
-            $this->context->user->authenticate();
+            $result = $this->context->user->authenticate();
+            if (false == $result) {
+                $this->context->user->logout(false);
+
+                $this->redirect('admin/secure');
+            }
         }
 
         // Redirect to module/action the user was trying to reach before being redirected

--- a/plugins/arOidcPlugin/modules/oidc/actions/logoutAction.class.php
+++ b/plugins/arOidcPlugin/modules/oidc/actions/logoutAction.class.php
@@ -21,7 +21,7 @@ class OidcLogoutAction extends sfAction
 {
     public function execute($request)
     {
-        $this->getUser()->logout();
+        $this->getUser()->logout($this->getUser()->getProviderConfigValue('send_oidc_logout', false));
         $this->redirect('@homepage');
     }
 }


### PR DESCRIPTION
If an error occurs in AtoM after successful authentication with the OIDC endpoint, end the AtoM session and redirect to the standard AtoM 'Unauthorized' message template.

Previously, errors that occurred in AtoM after successful authentication with the OIDC endpoint would fail silently redirecting the user to the AtoM home page in an unauthenticated state.