### PR TITLE
Fix DO images in the edit DO page (#1915)

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/showComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/showComponent.class.php
@@ -74,12 +74,20 @@ class DigitalObjectShowComponent extends sfComponent
      */
     private function checkShowGenericIcon()
     {
+        $resourceObject = $this->resource->object;
+
+        // Get the parent resouce (IO or Actor) for Acl check
+        // if resource->object is empty and parent exists
+        if (!$resourceObject && $this->resouce->parent) {
+            $resourceObject = $this->resource->parent->object;
+        }
+
         switch ($this->usageType) {
             case QubitTerm::REFERENCE_ID:
-                return !QubitAcl::check($this->resource->object, 'readReference');
+                return !QubitAcl::check($resourceObject, 'readReference');
 
             case QubitTerm::THUMBNAIL_ID:
-                return !QubitAcl::check($this->resource->object, 'readThumbnail');
+                return !QubitAcl::check($resourceObject, 'readThumbnail');
         }
     }
 

--- a/plugins/arDominionB5Plugin/modules/digitalobject/templates/editSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/digitalobject/templates/editSuccess.php
@@ -23,9 +23,9 @@
 
     <?php echo $form->renderHiddenFields(); ?>
 
-    <section id="content" class="border-bottom-0 rounded-0 rounded-top">
+    <div class="border border-bottom-0 rounded-0 rounded-top bg-white">
       <?php echo get_component('digitalobject', 'show', ['resource' => $resource, 'usageType' => QubitTerm::REFERENCE_ID]); ?>
-    </section>
+    </div>
 
     <div class="accordion mb-3">
       <div class="accordion-item rounded-0">


### PR DESCRIPTION
Using a div with appropriate styling classes instead of a section for the image in the edit DO page header since blank.js filters/removes any sections that do not have content meant for sections.

Also updating the resource sent to the QubitAcl check in DO's `editAction` to point to the parents' object instead of the resources' object (similar to [viewAction](https://github.com/artefactual/atom/blob/qa/2.x/apps/qubit/modules/digitalobject/actions/viewAction.class.php#L97-L125)) in the scenario when that object is empty.  In PHP 7.4 the Acl check succeeds despite `$this->resource->object` being empty since it isn't strictly `null` (QubitAcl tests `null !== $resource` but doesn't test if it is empty. `$this->resource->object` is empty in PHP 7.4 and null in PHP 8.x), which ends up being a problem in PHP 8.x and the Acl check failing.

