### PR TITLE
Bump gh actions/cache to v4

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,7 +33,7 @@ jobs:
         sudo apt install php7.4-fpm
         sudo service php7.4-fpm start
     - name: Cache Composer dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.composer/cache/files
         key: 20.04-7.4-composer-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/syntax-checks.yml
+++ b/.github/workflows/syntax-checks.yml
@@ -18,7 +18,7 @@ jobs:
         php-version: 7.4
         coverage: none
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.composer/cache/files
         key: syntax-checks-${{ hashFiles('composer.lock') }}
@@ -33,7 +33,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.npm

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
         coverage: none
         extensions: apcu
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.composer/cache/files
         key: 20.04-7.4-composer-${{ hashFiles('composer.lock') }}


### PR DESCRIPTION
Upgrading actions/cache to v4 since v2 is deprecated.