### PR TITLE
Re-encode AV Files Only when Necessary

### DIFF
--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -2721,23 +2721,19 @@ class QubitDigitalObject extends BaseDigitalObject
 
         foreach($ffProbeInfo['streams'] as $stream) {
             // Read only the first video and audio streams
-            if (!empty($format['video']) && !empty($format['audio']))
-            {
+            if (!empty($format['video']) && !empty($format['audio'])) {
                 break;
             }
 
             $codecType = strtolower($stream['codec_type']);
 
-            if ($codecType === 'video' && empty($format['video']))
-            {
+            if ($codecType === 'video' && empty($format['video'])) {
                 $format['video'] = [];
                 $format['video']['codec_name'] = $stream['codec_name'];
                 $format['video']['pix_fmt']    = $stream['pix_fmt'] ?? null;
                 $format['video']['width']      = (int) $stream['width'];
                 $format['video']['height']     = (int) $stream['height'];
-            }
-            else if ($codecType === 'audio' && empty($format['audio']))
-            {
+            } else if ($codecType === 'audio' && empty($format['audio'])) {
                 $format['audio'] = [];
                 $format['audio']['codec_name'] = $stream['codec_name'];
                 $format['audio']['sample_rate'] = (int) $stream['sample_rate'];
@@ -2747,17 +2743,18 @@ class QubitDigitalObject extends BaseDigitalObject
         return $format;
     }
 
-
     /**
      * Check if the video file's moov atom is at the front of the file.
      *
+     * This is used to check whether an h264 video file is fast started.
+     *
      * @param string $filePath path to the video file
      *
-     * @return bool true if moov atom is at the front, false otherwise or if moov atom does not exist, which means the
-     * file is not a valid MP4 file
+     * @return bool true if moov atom is at the front, false otherwise or if
+     * moov atom does not exist, which means the file is not a valid MP4 file
      */
     public static function isFastStarted($filePath)
-    {   
+    {
         $command = "ffprobe -v trace " . escapeshellarg($filePath) . " 2>&1";
         exec($command, $output, $status);
 
@@ -2803,17 +2800,18 @@ class QubitDigitalObject extends BaseDigitalObject
         // Read stream information
         $format = self::readStreamInformation($originalPath);
 
-        $videoCodec = isset($format['video']['codec_name']) ? $format['video']['codec_name'] : null;
-        $pixelFormat = isset($format['video']['pix_fmt']) ? $format['video']['pix_fmt'] : null;
-        $audioCodec = isset($format['audio']['codec_name']) ? $format['audio']['codec_name'] : null;
-        $sampleRate = isset($format['audio']['sample_rate']) ? $format['audio']['sample_rate'] : null;
-        $format_name = isset($format['format_name']) ? $format['format_name'] : null;
+        $videoCodec = $format['video']['codec_name'] ?? null;
+        $pixelFormat = $format['video']['pix_fmt'] ?? null;
+        $audioCodec = $format['audio']['codec_name'] ?? null;
+        $sampleRate = $format['audio']['sample_rate'] ?? null;
+        $format_name = $format['format_name'] ?? null;
 
-        $reencodeVideo = ($videoCodec !== 'h264' || $pixelFormat !== 'yuv420p');
-        $reencodeAudio = ($audioCodec !== 'aac' || $sampleRate !== 44100);
-        $reformatFile = strpos($format_name, 'mp4') === false || strtolower(pathinfo($originalPath, PATHINFO_EXTENSION)) !== 'mp4';
+        $reencodeVideo = $videoCodec !== 'h264' || $pixelFormat !== 'yuv420p';
+        $reencodeAudio = $audioCodec !== 'aac' || $sampleRate !== 44100;
+        $reformatFile = strpos($format_name, 'mp4') === false ||
+                        strtolower(pathinfo($originalPath, PATHINFO_EXTENSION)) !== 'mp4';
 
-        $needFastStart = !self::isFastStarted($originalPath);        
+        $needFastStart = !self::isFastStarted($originalPath);
 
         $codecOptions = '';
 
@@ -2830,10 +2828,10 @@ class QubitDigitalObject extends BaseDigitalObject
         }
 
         if ($codecOptions && $needFastStart) {
-            $codecOptions = $codecOptions . ' -movflags +faststart';
+            $codecOptions .= ' -movflags +faststart';
         } elseif (!$codecOptions && $needFastStart) {
             // Even if we don't need to reencode or reformat, we still need ffmpeg to faststart the file
-            $codecOptions = '-c copy' . ' -movflags +faststart';
+            $codecOptions = '-c copy -movflags +faststart';
         }
 
         if ($codecOptions) {
@@ -2847,7 +2845,7 @@ class QubitDigitalObject extends BaseDigitalObject
         } else {
             // No reencoding, reformatting, or fast-starting needed
             copy($originalPath, $newPath);
-        }   
+        }
 
         chmod($newPath, 0644);
 

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -2676,6 +2676,67 @@ class QubitDigitalObject extends BaseDigitalObject
     }
 
     /**
+     * Get stream information for an audio or video file from ffprobe.
+     *
+     * Only reads information about the first audio stream and the first video
+     * stream.
+     *
+     * @param string  $filePath  path to the audio or video file
+     *
+     * @return array codec and format information for the first video and
+     * audio streams, or an empty array if the file does not have audio or
+     * video. The video or audio key may be missing if the file does not
+     * have audio or video.
+     */
+    public static function readStreamInformation(string $filePath): array
+    {
+        if (!self::hasFfprobe())
+        {
+            return [];
+        }
+
+        $command = sprintf(
+            'ffprobe -v quiet -show_streams -print_format json %s',
+            escapeshellarg($filePath)
+        );
+        $output = shell_exec($command);
+        $ffProbeInfo = json_decode($output, true);
+
+        $format = [
+            'video' => [],
+            'audio' => [],
+        ];
+
+        foreach($ffProbeInfo['streams'] as $stream)
+        {
+            // Read only the first video and audio streams
+            if (array_key_exists('video', $format) && array_key_exists('audio', $format))
+            {
+                break;
+            }
+
+            $codecType = strtolower($stream['codec_type']);
+
+            if ($codecType === 'video' && !array_key_exists('video', $format))
+            {
+                $format['video'] = [];
+                $format['video']['codec_name'] = $stream['codec_name'];
+                $format['video']['pix_fmt']    = $stream['pix_fmt'];
+                $format['video']['width']      = (int) $stream['width'];
+                $format['video']['height']     = (int) $stream['height'];
+            }
+            else if ($codecType === 'audio' && !array_key_exists('audio', $format))
+            {
+                $format['audio'] = [];
+                $format['audio']['codec_name']  = $stream['codec_name'];
+                $format['audio']['sample_rate'] = (int) $stream['sample_rate'];
+            }
+        }
+
+        return $format;
+    }
+
+    /**
      * Create a mp4 video derivative using the FFmpeg library.
      *
      * @param string     $originalPath path to original video

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -2663,6 +2663,19 @@ class QubitDigitalObject extends BaseDigitalObject
     }
 
     /**
+     * Test if FFprobe is installed. FFprobe is typically installed with FFmpeg.
+     *
+     * @return boolean  true if FFprobe exists, false otherwise
+     */
+    public static function hasFfprobe()
+    {
+        $command = 'ffprobe -version 2>&1';
+        exec($command, $output, $status);
+
+        return 0 < count($output) && false !== strpos(strtolower($output[0]), 'ffprobe');
+    }
+
+    /**
      * Create a mp4 video derivative using the FFmpeg library.
      *
      * @param string     $originalPath path to original video

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -2721,19 +2721,23 @@ class QubitDigitalObject extends BaseDigitalObject
 
         foreach($ffProbeInfo['streams'] as $stream) {
             // Read only the first video and audio streams
-            if (isset($format['video']) && isset($format['audio'])) {
+            if (!empty($format['video']) && !empty($format['audio']))
+            {
                 break;
             }
 
             $codecType = strtolower($stream['codec_type']);
 
-            if ($codecType === 'video' && empty($format['video'])) {
+            if ($codecType === 'video' && empty($format['video']))
+            {
                 $format['video'] = [];
                 $format['video']['codec_name'] = $stream['codec_name'];
-                $format['video']['pix_fmt'] = $stream['pix_fmt'];
-                $format['video']['width'] = (int) $stream['width'];
-                $format['video']['height'] = (int) $stream['height'];
-            } elseif ($codecType === 'audio' && empty($format['audio'])) {
+                $format['video']['pix_fmt']    = $stream['pix_fmt'] ?? null;
+                $format['video']['width']      = (int) $stream['width'];
+                $format['video']['height']     = (int) $stream['height'];
+            }
+            else if ($codecType === 'audio' && empty($format['audio']))
+            {
                 $format['audio'] = [];
                 $format['audio']['codec_name'] = $stream['codec_name'];
                 $format['audio']['sample_rate'] = (int) $stream['sample_rate'];
@@ -2741,6 +2745,38 @@ class QubitDigitalObject extends BaseDigitalObject
         }
 
         return $format;
+    }
+
+
+    /**
+     * Check if the video file's moov atom is at the front of the file.
+     *
+     * @param string $filePath path to the video file
+     *
+     * @return bool true if moov atom is at the front, false otherwise or if moov atom does not exist, which means the
+     * file is not a valid MP4 file
+     */
+    public static function isFastStarted($filePath)
+    {   
+        $command = "ffprobe -v trace " . escapeshellarg($filePath) . " 2>&1";
+        exec($command, $output, $status);
+
+        if ($status !== 0) {
+            return false;
+        }
+
+        $moovFound = false;
+        foreach ($output as $line) {
+            if (strpos($line, "type:'moov'") !== false) {
+                $moovFound = true;
+            }
+            // If we find the 'mdat' atom before we find the 'moov' atom, then the 'moov' atom is not at the front
+            elseif (strpos($line, "type:'mdat'") !== false) {
+                return $moovFound;
+            }
+        }
+
+        return $moovFound;
     }
 
     /**
@@ -2764,8 +2800,54 @@ class QubitDigitalObject extends BaseDigitalObject
             return false;
         }
 
-        $command = 'ffmpeg -y -i '.$originalPath.' -ar 44100 -c:v libx264 -pix_fmt yuv420p -c:a aac -movflags +faststart '.$newPath.' 2>&1';
-        exec($command, $output, $status);
+        // Read stream information
+        $format = self::readStreamInformation($originalPath);
+
+        $videoCodec = isset($format['video']['codec_name']) ? $format['video']['codec_name'] : null;
+        $pixelFormat = isset($format['video']['pix_fmt']) ? $format['video']['pix_fmt'] : null;
+        $audioCodec = isset($format['audio']['codec_name']) ? $format['audio']['codec_name'] : null;
+        $sampleRate = isset($format['audio']['sample_rate']) ? $format['audio']['sample_rate'] : null;
+        $format_name = isset($format['format_name']) ? $format['format_name'] : null;
+
+        $reencodeVideo = ($videoCodec !== 'h264' || $pixelFormat !== 'yuv420p');
+        $reencodeAudio = ($audioCodec !== 'aac' || $sampleRate !== 44100);
+        $reformatFile = strpos($format_name, 'mp4') === false || strtolower(pathinfo($originalPath, PATHINFO_EXTENSION)) !== 'mp4';
+
+        $needFastStart = !self::isFastStarted($originalPath);        
+
+        $codecOptions = '';
+
+        // Determine the appropriate ffmpeg command
+        if ($reencodeVideo && $reencodeAudio) {
+            $codecOptions = '-c:v libx264 -pix_fmt yuv420p -c:a aac -ar 44100';
+        } elseif ($reencodeAudio) {
+            $codecOptions = '-c:v copy -c:a aac -ar 44100';
+        } elseif ($reencodeVideo) {
+            $codecOptions = '-c:v libx264 -pix_fmt yuv420p -c:a copy';
+        } elseif ($reformatFile) {
+            // All the above options also reformat the file
+            $codecOptions = '-c copy';
+        }
+
+        if ($codecOptions && $needFastStart) {
+            $codecOptions = $codecOptions . ' -movflags +faststart';
+        } elseif (!$codecOptions && $needFastStart) {
+            // Even if we don't need to reencode or reformat, we still need ffmpeg to faststart the file
+            $codecOptions = '-c copy' . ' -movflags +faststart';
+        }
+
+        if ($codecOptions) {
+            $command = sprintf(
+                'ffmpeg -y -i %s %s %s 2>&1',
+                escapeshellarg($originalPath),
+                $codecOptions,
+                escapeshellarg($newPath),
+            );
+            exec($command, $output, $status);
+        } else {
+            // No reencoding, reformatting, or fast-starting needed
+            copy($originalPath, $newPath);
+        }   
 
         chmod($newPath, 0644);
 

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -2686,49 +2686,56 @@ class QubitDigitalObject extends BaseDigitalObject
      * @return array codec and format information for the first video and
      * audio streams, or an empty array if the file does not have audio or
      * video. The video or audio key may be missing if the file does not
-     * have audio or video.
+     * have audio or video. Also contains a format_name key if the format
+     * could be read with ffprobe.
      */
     public static function readStreamInformation(string $filePath): array
     {
-        if (!self::hasFfprobe())
-        {
+        if (!self::hasFfprobe()) {
             return [];
         }
 
         $command = sprintf(
-            'ffprobe -v quiet -show_streams -print_format json %s',
+            'ffprobe -v quiet -show_entries format=format_name -show_streams -print_format json %s 2>&1',
             escapeshellarg($filePath)
         );
-        $output = shell_exec($command);
-        $ffProbeInfo = json_decode($output, true);
 
-        $format = [
-            'video' => [],
-            'audio' => [],
-        ];
+        exec($command, $output, $status);
 
-        foreach($ffProbeInfo['streams'] as $stream)
-        {
+        if ($status !== 0) {
+            return [];
+        }
+
+        $ffProbeInfo = json_decode(implode($output), true);
+
+        // json decoding may fail - don't try to use the data if so
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            return [];
+        }
+
+        $format = [];
+
+        if (!empty($ffProbeInfo['format']) && !empty($ffProbeInfo['format']['format_name'])) {
+            $format['format_name'] = $ffProbeInfo['format']['format_name'];
+        }
+
+        foreach($ffProbeInfo['streams'] as $stream) {
             // Read only the first video and audio streams
-            if (array_key_exists('video', $format) && array_key_exists('audio', $format))
-            {
+            if (isset($format['video']) && isset($format['audio'])) {
                 break;
             }
 
             $codecType = strtolower($stream['codec_type']);
 
-            if ($codecType === 'video' && !array_key_exists('video', $format))
-            {
+            if ($codecType === 'video' && empty($format['video'])) {
                 $format['video'] = [];
                 $format['video']['codec_name'] = $stream['codec_name'];
-                $format['video']['pix_fmt']    = $stream['pix_fmt'];
-                $format['video']['width']      = (int) $stream['width'];
-                $format['video']['height']     = (int) $stream['height'];
-            }
-            else if ($codecType === 'audio' && !array_key_exists('audio', $format))
-            {
+                $format['video']['pix_fmt'] = $stream['pix_fmt'];
+                $format['video']['width'] = (int) $stream['width'];
+                $format['video']['height'] = (int) $stream['height'];
+            } elseif ($codecType === 'audio' && empty($format['audio'])) {
                 $format['audio'] = [];
-                $format['audio']['codec_name']  = $stream['codec_name'];
+                $format['audio']['codec_name'] = $stream['codec_name'];
                 $format['audio']['sample_rate'] = (int) $stream['sample_rate'];
             }
         }

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -2555,6 +2555,16 @@ class QubitDigitalObject extends BaseDigitalObject
         }
     }
 
+    /**
+     * Convert an audio file to mp3 using ffmpeg.
+     *
+     * Uses ffmpeg's default mp3 audio encoder (typically libmp3lame). Makes a
+     * copy of the file if it's already an mp3 file.
+     *
+     * @param string $originalPath Path to the original audio file
+     * @param string $newPath Path to the new mp3 file
+     * @return bool true if successful, false otherwise
+     */
     public static function convertAudioToMp3($originalPath, $newPath)
     {
         // Test for FFmpeg library
@@ -2579,7 +2589,7 @@ class QubitDigitalObject extends BaseDigitalObject
 
         if ($status !== 0 && !file_exists($newPath)) {
             return false;
-        }  
+        }
 
         chmod($newPath, 0644);
 
@@ -2693,7 +2703,7 @@ class QubitDigitalObject extends BaseDigitalObject
      * have audio or video. Also contains a format_name key if the format
      * could be read with ffprobe.
      */
-    public static function readStreamInformation(string $filePath): array
+    public static function readStreamInformation($filePath)
     {
         if (!self::hasFfprobe()) {
             return [];
@@ -2783,6 +2793,10 @@ class QubitDigitalObject extends BaseDigitalObject
     /**
      * Create a mp4 video derivative using the FFmpeg library.
      *
+     * If the output video file is already in the proper format, a copy of the
+     * file is made. Otherwise, a minimal ffmpeg command is constructed to do
+     * the least amount of work to convert the video to the proper format.
+     *
      * @param string     $originalPath path to original video
      * @param string     $newPath      path to derivative video
      * @param int        $maxwidth     derivative video maximum width
@@ -2838,6 +2852,7 @@ class QubitDigitalObject extends BaseDigitalObject
             $codecOptions = '-c copy -movflags +faststart';
         }
 
+        $status = null;
         if ($codecOptions) {
             $command = sprintf(
                 'ffmpeg -y -i %s %s %s 2>&1',
@@ -2848,7 +2863,11 @@ class QubitDigitalObject extends BaseDigitalObject
             exec($command, $output, $status);
         } else {
             // No reencoding, reformatting, or fast-starting needed
-            copy($originalPath, $newPath);
+            $status = copy($originalPath, $newPath) ? 0 : 1;
+        }
+
+        if ($status !== 0 && !file_exists($newPath)) {
+            return false;
         }
 
         chmod($newPath, 0644);

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -2562,7 +2562,8 @@ class QubitDigitalObject extends BaseDigitalObject
      * copy of the file if it's already an mp3 file.
      *
      * @param string $originalPath Path to the original audio file
-     * @param string $newPath Path to the new mp3 file
+     * @param string $newPath      Path to the new mp3 file
+     *
      * @return bool true if successful, false otherwise
      */
     public static function convertAudioToMp3($originalPath, $newPath)
@@ -2576,8 +2577,8 @@ class QubitDigitalObject extends BaseDigitalObject
 
         $formatName = $format['format_name'] ?? null;
 
-        $reformatFile = $formatName !== 'mp3' ||
-                        strtolower(pathinfo($originalPath, PATHINFO_EXTENSION)) !== 'mp3';
+        $reformatFile = 'mp3' !== $formatName
+                        || 'mp3' !== strtolower(pathinfo($originalPath, PATHINFO_EXTENSION));
 
         $status = null;
         if ($reformatFile) {
@@ -2587,7 +2588,7 @@ class QubitDigitalObject extends BaseDigitalObject
             $status = copy($originalPath, $newPath) ? 0 : 1;
         }
 
-        if ($status !== 0 && !file_exists($newPath)) {
+        if (0 !== $status && !file_exists($newPath)) {
             return false;
         }
 
@@ -2679,7 +2680,7 @@ class QubitDigitalObject extends BaseDigitalObject
     /**
      * Test if FFprobe is installed. FFprobe is typically installed with FFmpeg.
      *
-     * @return boolean  true if FFprobe exists, false otherwise
+     * @return bool true if FFprobe exists, false otherwise
      */
     public static function hasFfprobe()
     {
@@ -2695,13 +2696,13 @@ class QubitDigitalObject extends BaseDigitalObject
      * Only reads information about the first audio stream and the first video
      * stream.
      *
-     * @param string  $filePath  path to the audio or video file
+     * @param string $filePath path to the audio or video file
      *
      * @return array codec and format information for the first video and
-     * audio streams, or an empty array if the file does not have audio or
-     * video. The video or audio key may be missing if the file does not
-     * have audio or video. Also contains a format_name key if the format
-     * could be read with ffprobe.
+     *               audio streams, or an empty array if the file does not have audio or
+     *               video. The video or audio key may be missing if the file does not
+     *               have audio or video. Also contains a format_name key if the format
+     *               could be read with ffprobe.
      */
     public static function readStreamInformation($filePath)
     {
@@ -2716,7 +2717,7 @@ class QubitDigitalObject extends BaseDigitalObject
 
         exec($command, $output, $status);
 
-        if ($status !== 0) {
+        if (0 !== $status) {
             return [];
         }
 
@@ -2733,7 +2734,7 @@ class QubitDigitalObject extends BaseDigitalObject
             $format['format_name'] = $ffProbeInfo['format']['format_name'];
         }
 
-        foreach($ffProbeInfo['streams'] as $stream) {
+        foreach ($ffProbeInfo['streams'] as $stream) {
             // Read only the first video and audio streams
             if (!empty($format['video']) && !empty($format['audio'])) {
                 break;
@@ -2741,13 +2742,13 @@ class QubitDigitalObject extends BaseDigitalObject
 
             $codecType = strtolower($stream['codec_type']);
 
-            if ($codecType === 'video' && empty($format['video'])) {
+            if ('video' === $codecType && empty($format['video'])) {
                 $format['video'] = [];
                 $format['video']['codec_name'] = $stream['codec_name'];
-                $format['video']['pix_fmt']    = $stream['pix_fmt'] ?? null;
-                $format['video']['width']      = (int) $stream['width'];
-                $format['video']['height']     = (int) $stream['height'];
-            } else if ($codecType === 'audio' && empty($format['audio'])) {
+                $format['video']['pix_fmt'] = $stream['pix_fmt'] ?? null;
+                $format['video']['width'] = (int) $stream['width'];
+                $format['video']['height'] = (int) $stream['height'];
+            } elseif ('audio' === $codecType && empty($format['audio'])) {
                 $format['audio'] = [];
                 $format['audio']['codec_name'] = $stream['codec_name'];
                 $format['audio']['sample_rate'] = (int) $stream['sample_rate'];
@@ -2765,24 +2766,24 @@ class QubitDigitalObject extends BaseDigitalObject
      * @param string $filePath path to the video file
      *
      * @return bool true if moov atom is at the front, false otherwise or if
-     * moov atom does not exist, which means the file is not a valid MP4 file
+     *              moov atom does not exist, which means the file is not a valid MP4 file
      */
     public static function isFastStarted($filePath)
     {
-        $command = "ffprobe -v trace " . escapeshellarg($filePath) . " 2>&1";
+        $command = 'ffprobe -v trace '.escapeshellarg($filePath).' 2>&1';
         exec($command, $output, $status);
 
-        if ($status !== 0) {
+        if (0 !== $status) {
             return false;
         }
 
         $moovFound = false;
         foreach ($output as $line) {
-            if (strpos($line, "type:'moov'") !== false) {
+            if (false !== strpos($line, "type:'moov'")) {
                 $moovFound = true;
             }
             // If we find the 'mdat' atom before we find the 'moov' atom, then the 'moov' atom is not at the front
-            elseif (strpos($line, "type:'mdat'") !== false) {
+            elseif (false !== strpos($line, "type:'mdat'")) {
                 return $moovFound;
             }
         }
@@ -2824,10 +2825,10 @@ class QubitDigitalObject extends BaseDigitalObject
         $sampleRate = $format['audio']['sample_rate'] ?? null;
         $formatName = $format['format_name'] ?? null;
 
-        $reencodeVideo = $videoCodec !== 'h264' || $pixelFormat !== 'yuv420p';
-        $reencodeAudio = $audioCodec !== 'aac' || $sampleRate !== 44100;
-        $reformatFile = strpos($formatName, 'mp4') === false ||
-                        strtolower(pathinfo($originalPath, PATHINFO_EXTENSION)) !== 'mp4';
+        $reencodeVideo = 'h264' !== $videoCodec || 'yuv420p' !== $pixelFormat;
+        $reencodeAudio = 'aac' !== $audioCodec || 44100 !== $sampleRate;
+        $reformatFile = false === strpos($formatName, 'mp4')
+                        || 'mp4' !== strtolower(pathinfo($originalPath, PATHINFO_EXTENSION));
 
         $needFastStart = !self::isFastStarted($originalPath);
 
@@ -2866,7 +2867,7 @@ class QubitDigitalObject extends BaseDigitalObject
             $status = copy($originalPath, $newPath) ? 0 : 1;
         }
 
-        if ($status !== 0 && !file_exists($newPath)) {
+        if (0 !== $status && !file_exists($newPath)) {
             return false;
         }
 

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -2562,20 +2562,24 @@ class QubitDigitalObject extends BaseDigitalObject
             return false;
         }
 
-        $command = 'ffmpeg -y -i '.$originalPath.' '.$newPath.' 2>&1';
-        exec($command, $output, $status);
+        $format = self::readStreamInformation($originalPath);
 
-        if ($status) {
-            $error = true;
+        $formatName = $format['format_name'] ?? null;
 
-            for ($i = count($output) - 1; $i >= 0; --$i) {
-                if (strpos($output[$i], 'output buffer too small')) {
-                    $error = false;
+        $reformatFile = $formatName !== 'mp3' ||
+                        strtolower(pathinfo($originalPath, PATHINFO_EXTENSION)) !== 'mp3';
 
-                    break;
-                }
-            }
+        $status = null;
+        if ($reformatFile) {
+            $command = sprintf('ffmpeg -y -i %s %s 2>&1', escapeshellarg($originalPath), escapeshellarg($newPath));
+            exec($command, $output, $status);
+        } else {
+            $status = copy($originalPath, $newPath) ? 0 : 1;
         }
+
+        if ($status !== 0 && !file_exists($newPath)) {
+            return false;
+        }  
 
         chmod($newPath, 0644);
 
@@ -2804,11 +2808,11 @@ class QubitDigitalObject extends BaseDigitalObject
         $pixelFormat = $format['video']['pix_fmt'] ?? null;
         $audioCodec = $format['audio']['codec_name'] ?? null;
         $sampleRate = $format['audio']['sample_rate'] ?? null;
-        $format_name = $format['format_name'] ?? null;
+        $formatName = $format['format_name'] ?? null;
 
         $reencodeVideo = $videoCodec !== 'h264' || $pixelFormat !== 'yuv420p';
         $reencodeAudio = $audioCodec !== 'aac' || $sampleRate !== 44100;
-        $reformatFile = strpos($format_name, 'mp4') === false ||
+        $reformatFile = strpos($formatName, 'mp4') === false ||
                         strtolower(pathinfo($originalPath, PATHINFO_EXTENSION)) !== 'mp4';
 
         $needFastStart = !self::isFastStarted($originalPath);


### PR DESCRIPTION
Addresses https://github.com/artefactual/atom/issues/1912

These changes concern the creation of digital object reference derivatives for audio and video (AV) files. The changes here are authored by myself and @yenaing-oo.

We have optimized the `ffmpeg` commands used to generate audio and video derivatives by analyzing the master files with `ffprobe` before encoding. Based on a file's parameters, a minimal FFmpeg command is generated to make only those changes that are required to create the reference file.

For example, if only the audio needs to be re-encoded in a video file, then the video stream is copied and the audio is re-encoded to bring it in line with the expected audio encoding and sample rate.

The purpose of this change is to make importing audio and video objects quicker, especially when files are already in the correct format. If an AV file is in the right format already, it is simply `copy()`-ed, rather than processed with FFmpeg.

---

We created a test package of audio and video files that this change can be tested against:  [issue-1912-test-files-import.zip](https://github.com/user-attachments/files/18774430/issue-1912-test-files-import.zip)

Assuming AtoM is being run in Docker, extract them to the root of the repository, and run the following to import them:

```shell
php symfony csv:import issue-1912-test-files-import.csv --index
```

We saw an improvement in import time using the changes included in this PR:

- With the new changes, importing the test package took on average 11.39s (over three runs)
- *Without* these changes, importing the test package took on average 15.05s (over three runs)

To run the timing tests, we used this command to avoid including nested-set build time and search indexing time:

```shell
php symfony cc && time php symfony csv:import issue-1912-test-files-import.csv --skip-nested-set-build
```

This is a modest timing improvement, but since a lot of the test files do require re-encoding we'd expect to see a greater timing improvement for files that don't require any re-encoding.