### PR TITLE
Fix object for Acl check in showComponent (#1915)

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/showComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/showComponent.class.php
@@ -74,20 +74,14 @@ class DigitalObjectShowComponent extends sfComponent
      */
     private function checkShowGenericIcon()
     {
-        $resourceObject = $this->resource->object;
-
-        // Get the parent resouce (IO or Actor) for Acl check
-        // if resource->object is empty and parent exists
-        if (!$resourceObject && $this->resouce->parent) {
-            $resourceObject = $this->resource->parent->object;
-        }
-
         switch ($this->usageType) {
             case QubitTerm::REFERENCE_ID:
-                return !QubitAcl::check($resourceObject, 'readReference');
+                // Use the parent resource (IO or Actor) for Acl check
+                return !QubitAcl::check($this->resource->parent->object, 'readReference');
 
             case QubitTerm::THUMBNAIL_ID:
-                return !QubitAcl::check($resourceObject, 'readThumbnail');
+                // Use the parent resource (IO or Actor) for Acl check
+                return !QubitAcl::check($this->resource->parent->object, 'readThumbnail');
         }
     }
 


### PR DESCRIPTION
Fix typo and update showComponent to always use parent object for Acl check.