### PR TITLE
Revert fix for showComponent and fix typo (#1915)

### DIFF
--- a/apps/qubit/modules/digitalobject/actions/showComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/showComponent.class.php
@@ -74,20 +74,14 @@ class DigitalObjectShowComponent extends sfComponent
      */
     private function checkShowGenericIcon()
     {
-        $resourceObject = $this->resource->object;
-
-        // Get the parent resouce (IO or Actor) for Acl check
-        // if resource->object is empty and parent exists
-        if (!$resourceObject && $this->resource->parent) {
-            $resourceObject = $this->resource->parent->object;
-        }
-
         switch ($this->usageType) {
             case QubitTerm::REFERENCE_ID:
-                return !QubitAcl::check($resourceObject, 'readReference');
+                // Use the parent resource (IO or Actor) for Acl check
+                return !QubitAcl::check($this->resource->object, 'readReference');
 
             case QubitTerm::THUMBNAIL_ID:
-                return !QubitAcl::check($resourceObject, 'readThumbnail');
+                // Use the parent resource (IO or Actor) for Acl check
+                return !QubitAcl::check($this->resource->object, 'readThumbnail');
         }
     }
 

--- a/apps/qubit/modules/digitalobject/actions/showComponent.class.php
+++ b/apps/qubit/modules/digitalobject/actions/showComponent.class.php
@@ -74,14 +74,20 @@ class DigitalObjectShowComponent extends sfComponent
      */
     private function checkShowGenericIcon()
     {
+        $resourceObject = $this->resource->object;
+
+        // Get the parent resouce (IO or Actor) for Acl check
+        // if resource->object is empty and parent exists
+        if (!$resourceObject && $this->resource->parent) {
+            $resourceObject = $this->resource->parent->object;
+        }
+
         switch ($this->usageType) {
             case QubitTerm::REFERENCE_ID:
-                // Use the parent resource (IO or Actor) for Acl check
-                return !QubitAcl::check($this->resource->parent->object, 'readReference');
+                return !QubitAcl::check($resourceObject, 'readReference');
 
             case QubitTerm::THUMBNAIL_ID:
-                // Use the parent resource (IO or Actor) for Acl check
-                return !QubitAcl::check($this->resource->parent->object, 'readThumbnail');
+                return !QubitAcl::check($resourceObject, 'readThumbnail');
         }
     }
 

--- a/apps/qubit/modules/digitalobject/templates/_editRepresentation.php
+++ b/apps/qubit/modules/digitalobject/templates/_editRepresentation.php
@@ -9,7 +9,7 @@
       <?php echo get_component('digitalobject', 'show', [
           'iconOnly' => true,
           'link' => public_path($representation->getFullPath()),
-          'resource' => $representation,
+          'resource' => $resource,
           'usageType' => QubitTerm::THUMBNAIL_ID, ]); ?>
 
     <?php } ?>

--- a/plugins/arDominionB5Plugin/modules/digitalobject/templates/_editRepresentation.php
+++ b/plugins/arDominionB5Plugin/modules/digitalobject/templates/_editRepresentation.php
@@ -46,7 +46,7 @@
       <?php echo get_component('digitalobject', 'show', [
           'iconOnly' => true,
           'link' => public_path($representation->getFullPath()),
-          'resource' => $representation,
+          'resource' => $resource,
           'usageType' => QubitTerm::THUMBNAIL_ID,
           'editForm' => true,
       ]); ?>


### PR DESCRIPTION
Revert the change to showComponent that was changing the showComponent to always use the parent object for reference and thumbnail since this broke description page with attatched digital objects. Updating the last fix to showComponent with the typo fixed resolves this bug since it uses the parent object only when it is not null.