### PR TITLE
Refactor getByTitleIdentifierAndRepo()

### DIFF
--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -2162,34 +2162,59 @@ class QubitInformationObject extends BaseInformationObject
      *
      * @return int InfoObj id
      */
-    public static function getByTitleIdentifierAndRepo($identifier, $title, $repoName)
+    public static function getByTitleIdentifierAndRepo($identifier, $title, $repoName): ?int
     {
+        // Proceed only if both identifier and title are provided.
         if (null !== $identifier && null !== $title) {
-            $sf_user = sfContext::getInstance()->user;
-            $currentCulture = $sf_user->getCulture();
+            // Get the current culture from the user session.
+            $sf_user = sfContext::getInstance()->getUser();
+            $culture = $sf_user->getCulture();
 
-            $queryBool = new \Elastica\Query\BoolQuery();
+            $selectClause = '
+                SELECT io.id
+                FROM information_object io
+                INNER JOIN information_object_i18n io_i18n 
+                    ON io_i18n.id = io.id 
+                AND io_i18n.culture = :culture
+            ';
+            $whereClause = '
+                WHERE io.identifier = :identifier
+                AND io_i18n.title = :title
+            ';
+            // Parameters for the query.
+            $params = [
+                ':identifier' => $identifier,
+                ':title' => $title,
+                ':culture' => $culture,
+            ];
 
-            // Use match query for exact matches.
-            $queryText = new \Elastica\Query\MatchQuery();
-            $queryBool->addMust($queryText->setFieldQuery('identifier', $identifier));
-
-            $queryText = new \Elastica\Query\MatchQuery();
-            $queryBool->addMust($queryText->setFieldQuery(sprintf('i18n.%s.title.untouched', $currentCulture), $title));
-
+            // If a repository name is provided, add joins and condition on the repository authorized name.
             if (null !== $repoName) {
-                $queryText = new \Elastica\Query\MatchQuery();
-                $queryBool->addMust($queryText->setFieldQuery(sprintf('repository.i18n.%s.authorizedFormOfName.untouched', $currentCulture), $repoName));
+                $selectClause .= '
+                    INNER JOIN repository r 
+                        ON r.id = io.repository_id
+                    INNER JOIN actor a 
+                        ON a.id = io.repository_id
+                    INNER JOIN actor_i18n a_i18n 
+                        ON a_i18n.id = a.id 
+                    AND a_i18n.culture = :culture
+                ';
+                $whereClause .= '
+                    AND a_i18n.authorized_form_of_name = :repoName
+                ';
+                $params[':repoName'] = $repoName;
             }
 
-            $query = new \Elastica\Query($queryBool);
-            $query->setSize(1);
-            $resultSet = QubitSearch::getInstance()->index->getIndex('QubitInformationObject')->search($query);
+            $sql = $selectClause.$whereClause.' LIMIT 1';
 
-            if ($resultSet->count()) {
-                return $resultSet[0]->getId();
+            // If a matching record is found, return its ID.
+            if ($row = QubitPdo::fetchOne($sql, $params)) {
+                return $row->id;
             }
         }
+
+        // Return null if no match is found.
+        return null;
     }
 
     // Publication Status

--- a/test/phpunit/QubitInformationObjectTest.php
+++ b/test/phpunit/QubitInformationObjectTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @covers \QubitInformationObject::getByTitleIdentifierAndRepo
+ */
+class QubitInformationObjectTest extends TestCase
+{
+    protected $io;
+    protected $repo;
+
+    /**
+     * @dataProvider dataProviderForGetByTitleIdentifierAndRepo
+     *
+     * @param string      $identifier    the information object identifier
+     * @param string      $title         the information object title
+     * @param null|string $repoName      the repository authorized_form_of_name
+     * @param null|string $expectedTitle expected localized title if a match is found; otherwise, null
+     * @param mixed       $hasLinkedRepo
+     */
+    public function testGetByTitleIdentifierAndRepo($identifier, $title, $repoName, $hasLinkedRepo, $expectedTitle)
+    {
+        if (null !== $this->io) {
+            $io = $this->io;
+        } else {
+            $io = new QubitInformationObject();
+        }
+
+        $io->title = 'TestDescriptionTitle';
+        $io->identifier = 'TestDescriptionIdentifier';
+
+        if (true === $hasLinkedRepo) {
+            if (null !== $this->repo) {
+                $repository = $this->repo;
+            } else {
+                $repository = new QubitRepository();
+            }
+            $repository = new QubitRepository();
+            $repository->indexOnSave = false;
+            $repository->setAuthorizedFormOfName('TestRepository');
+            $repository->save();
+            $io->setRepositoryId($repository->id);
+            $this->repo = $repository;
+        }
+
+        $io->indexOnSave = false;
+        $io->save();
+        $this->io = $io;
+
+        $result = QubitInformationObject::getByTitleIdentifierAndRepo($identifier, $title, $repoName);
+
+        if (null === $expectedTitle) {
+            // No match expected.
+            $this->assertNull($result, 'Expected null when no matching record exists.');
+        } else {
+            // A match is expected.
+            $this->assertNotNull($result, 'Expected a valid integer id when data should match.');
+            $this->assertIsInt($result, 'Expected the returned id to be an integer.');
+        }
+    }
+
+    public function dataProviderForGetByTitleIdentifierAndRepo()
+    {
+        // Order of fields: $identifier, $title, $repoName, $hasLinkedRepo, $expectedTitle
+        return [
+            // Id, title and repository specified but repo not linked: matching fail.
+            ['TestDescriptionIdentifier', 'TestDescriptionTitle', 'TestRepository', false, null],
+            // Id, title specified only and repo is linked: matching success.
+            ['TestDescriptionIdentifier', 'TestDescriptionTitle', null, false, 'exampleTitle1'],
+            // Id, title and repository specified but title not matched and repo missing: matching fail.
+            ['TestDescriptionIdentifier', 'TestDescriptionTitleX', 'TestRepository', false, null],
+            // Id, title and repository specified but id not matched and repo missing: matching fail.
+            ['TestDescriptionIdentifierX', 'TestDescriptionTitle', 'TestRepository', false, null],
+            // Id, title and repository specified in lookup & all exist: matched.
+            ['TestDescriptionIdentifier', 'TestDescriptionTitle', 'TestRepository', true, 'exampleTitle1'],
+            // Id, title specified only & repo not linked: matching success.
+            ['TestDescriptionIdentifier', 'TestDescriptionTitle', null, true, 'exampleTitle1'],
+            // Id, title and repository specified but repo not matched: matching fail.
+            ['TestDescriptionIdentifier', 'TestDescriptionTitle', 'TestRepositoryX', true, null],
+            // Id, title and repository specified but title not matched: matching fail.
+            ['TestDescriptionIdentifier', 'TestDescriptionTitleX', 'TestRepository', true, null],
+            // Id, title and repository specified but id not matched: matching fail.
+            ['TestDescriptionIdentifierX', 'TestDescriptionTitle', 'TestRepository', true, null],
+        ];
+    }
+}

--- a/test/phpunit/QubitInformationObjectTest.php
+++ b/test/phpunit/QubitInformationObjectTest.php
@@ -18,47 +18,50 @@ class QubitInformationObjectTest extends TestCase
      * @param string      $identifier    the information object identifier
      * @param string      $title         the information object title
      * @param null|string $repoName      the repository authorized_form_of_name
+     * @param mixed       $hasLinkedRepo boolean indicating if the information object should have a linked repository
      * @param null|string $expectedTitle expected localized title if a match is found; otherwise, null
-     * @param mixed       $hasLinkedRepo
      */
     public function testGetByTitleIdentifierAndRepo($identifier, $title, $repoName, $hasLinkedRepo, $expectedTitle)
     {
-        if (null !== $this->io) {
-            $io = $this->io;
-        } else {
-            $io = new QubitInformationObject();
-        }
+        $randomString = rand(1000000, 9999999);
 
-        $io->title = 'TestDescriptionTitle';
-        $io->identifier = 'TestDescriptionIdentifier';
+        $io = new QubitInformationObject();
+        $io->title = 'TestDescriptionTitle'.$randomString;
+        $io->identifier = 'TestDescriptionIdentifier'.$randomString;
 
+        // Set up a linked repository if needed for the test.
         if (true === $hasLinkedRepo) {
-            if (null !== $this->repo) {
-                $repository = $this->repo;
-            } else {
-                $repository = new QubitRepository();
-            }
             $repository = new QubitRepository();
             $repository->indexOnSave = false;
-            $repository->setAuthorizedFormOfName('TestRepository');
+            $repository->setAuthorizedFormOfName('TestRepository'.$randomString);
             $repository->save();
             $io->setRepositoryId($repository->id);
-            $this->repo = $repository;
         }
 
         $io->indexOnSave = false;
         $io->save();
-        $this->io = $io;
 
-        $result = QubitInformationObject::getByTitleIdentifierAndRepo($identifier, $title, $repoName);
+        if (null !== $repoName) {
+            $repoName .= $randomString;
+        }
+
+        $result = QubitInformationObject::getByTitleIdentifierAndRepo(
+            $identifier.$randomString,
+            $title.$randomString,
+            $repoName
+        );
 
         if (null === $expectedTitle) {
             // No match expected.
-            $this->assertNull($result, 'Expected null when no matching record exists.');
+            $this->assertNull($result, 'Expected null result when no matching record exists.');
         } else {
             // A match is expected.
             $this->assertNotNull($result, 'Expected a valid integer id when data should match.');
             $this->assertIsInt($result, 'Expected the returned id to be an integer.');
+
+            $resultIo = QubitInformationObject::getById($result);
+            $this->assertNotNull($resultIo, 'Expected a valid information object.');
+            $this->assertEquals($expectedTitle.$randomString, $resultIo->title, 'The information object title does not match expected.');
         }
     }
 
@@ -69,15 +72,15 @@ class QubitInformationObjectTest extends TestCase
             // Id, title and repository specified but repo not linked: matching fail.
             ['TestDescriptionIdentifier', 'TestDescriptionTitle', 'TestRepository', false, null],
             // Id, title specified only and repo is linked: matching success.
-            ['TestDescriptionIdentifier', 'TestDescriptionTitle', null, false, 'exampleTitle1'],
+            ['TestDescriptionIdentifier', 'TestDescriptionTitle', null, false, 'TestDescriptionTitle'],
             // Id, title and repository specified but title not matched and repo missing: matching fail.
             ['TestDescriptionIdentifier', 'TestDescriptionTitleX', 'TestRepository', false, null],
             // Id, title and repository specified but id not matched and repo missing: matching fail.
             ['TestDescriptionIdentifierX', 'TestDescriptionTitle', 'TestRepository', false, null],
             // Id, title and repository specified in lookup & all exist: matched.
-            ['TestDescriptionIdentifier', 'TestDescriptionTitle', 'TestRepository', true, 'exampleTitle1'],
+            ['TestDescriptionIdentifier', 'TestDescriptionTitle', 'TestRepository', true, 'TestDescriptionTitle'],
             // Id, title specified only & repo not linked: matching success.
-            ['TestDescriptionIdentifier', 'TestDescriptionTitle', null, true, 'exampleTitle1'],
+            ['TestDescriptionIdentifier', 'TestDescriptionTitle', null, true, 'TestDescriptionTitle'],
             // Id, title and repository specified but repo not matched: matching fail.
             ['TestDescriptionIdentifier', 'TestDescriptionTitle', 'TestRepositoryX', true, null],
             // Id, title and repository specified but title not matched: matching fail.


### PR DESCRIPTION
Refactor getByTitleIdentifierAndRepo() to use a SQL query instead of looking for a description match in the ES index.

This should make description matching during csv or xml import more successful since it is possible for the AtoM DB and the ES index to get out of sync which can cause matching to fail.