### PR TITLE
Ensure check for `pdftotext` works on all environments.

### DIFF
--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -2790,7 +2790,7 @@ class QubitDigitalObject extends BaseDigitalObject
 
     public static function hasPdfToText()
     {
-        exec('which pdftotext', $output, $status);
+        exec('command -v pdftotext', $output, $status);
 
         return 0 == $status && 0 < count($output);
     }


### PR DESCRIPTION
Some environments (especially restricted hosting environments, such as Rocky9) do not allow `which` to be executed inside `exec()`.