### PR TITLE
Remove tests asserting PDO class type

### DIFF
--- a/test/phpunit/PhysicalobjectCsvImporterTest.php
+++ b/test/phpunit/PhysicalobjectCsvImporterTest.php
@@ -228,13 +228,6 @@ class PhysicalObjectCsvImporterTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(sfContext::class, get_class($importer->context));
     }
 
-    public function testConstructorWithNoDbconPassed()
-    {
-        $importer = new PhysicalObjectCsvImporter($this->context, null);
-
-        $this->assertSame(DebugPDO::class, get_class($importer->dbcon));
-    }
-
     public function testMagicGetInvalidPropertyException()
     {
         $this->expectException(sfException::class);

--- a/test/phpunit/arOidcPlugin/lib/oidcUserTest.php
+++ b/test/phpunit/arOidcPlugin/lib/oidcUserTest.php
@@ -76,7 +76,6 @@ class OidcUserTest extends TestCase
      */
     public function testAuthenticateSuccess($redirectUrl, $providerId, $providers, $expected)
     {
-        // $client = $this->getMockBuilder(OpenIDConnectClient::class)->setMethods(['authenticate', 'requestUserInfo', 'getIdToken', 'getVerifiedClaims'])->getMock();
         $oidcClientMock = $this->getMockBuilder(OpenIDConnectClient::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/test/phpunit/csvImportValidator/CsvValidatorTest.php
+++ b/test/phpunit/csvImportValidator/CsvValidatorTest.php
@@ -23,13 +23,6 @@ class CsvValidatorTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(sfContext::class, get_class($csvValidator->getContext()));
     }
 
-    public function testConstructorWithNoDbconPassed()
-    {
-        $csvValidator = new CsvImportValidator($this->context, null, null);
-
-        $this->assertSame(DebugPDO::class, get_class($csvValidator->getDbCon()));
-    }
-
     public function testSetInvalidOptionsException()
     {
         $this->expectException(UnexpectedValueException::class);


### PR DESCRIPTION
Removed two tests that made assertions that the class type should be type 'DebugPDO'. This is not a good assertion to make as it prevents this class type from changing.

Also removed a commented out line.