### PR TITLE
Fix CLI CSV import update flag (#1937)

### DIFF
--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -61,6 +61,11 @@ EOF;
     {
         parent::execute($arguments, $options);
 
+        // Make sure QubitSearch is initialized since
+        // QubitActor needs it and is set to disable
+        // indexing by default which results in the
+        // index not being initialized
+        QubitSearch::getInstance();
         $this->validateOptions($options);
 
         if (false === $fh = fopen($arguments['filename'], 'rb')) {


### PR DESCRIPTION
Update csvImportTask to initialize the ElasticSearch index by attempting to get a QubitSearch instance. Since QubitSearch is disabled for the import in QubitFlatfileImport by default, attempts to use search to fetch a document and find its associated actor relations will fail in arUpdateEsActorRelationsJob unless search as been initialized first.