### PR TITLE
Fix exports for PHP 8.x (#1940)

### DIFF
--- a/lib/job/arExportJob.class.php
+++ b/lib/job/arExportJob.class.php
@@ -55,7 +55,7 @@ class arExportJob extends arBaseJob
 
         $this->doExport($tempPath);
 
-        if (count($this->itemsExported) > 0) {
+        if ($this->itemsExported > 0) {
             $this->info($this->i18n->__(
                 'Exported %1 records.',
                 ['%1' => $this->itemsExported]


### PR DESCRIPTION
Fix condition for counting number of exported items to just use the variable instead of count. This is always an integer that is incremented, not a countable value, and PHP 8.0 only allows countable values as arguments for count.