### PR TITLE
Fix add function page for PHP 8.x (#1947)

### DIFF
--- a/apps/qubit/modules/function/actions/editAction.class.php
+++ b/apps/qubit/modules/function/actions/editAction.class.php
@@ -61,7 +61,7 @@ class FunctionEditAction extends DefaultEditAction
             $this->form->setWidget('serialNumber', new sfWidgetFormInputHidden());
         } else {
             // Check authorization
-            if (!QubitAcl::check($this->parent, 'create')) {
+            if (!QubitAcl::check($this->resource, 'create')) {
                 QubitAcl::forwardUnauthorized();
             }
         }


### PR DESCRIPTION
Fix editAction for function to use resource instead of $this->parent which is always null. $resource needs to be valid in QubitAcl since get_class will not accept null values in PHP 8.x and expects a valid object.