### PR TITLE
Fix integration test repos

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -30,7 +30,7 @@ jobs:
         extensions: apcu, opcache
     - name: Setup PHP-FPM
       run: |
-        sudo apt install php-fpm
+        sudo apt update && sudo apt install php-fpm
         sudo service php8.3-fpm start
     - name: Cache Composer dependencies
       uses: actions/cache@v4


### PR DESCRIPTION
Update integration test workflow to run apt update first before attempting to install packages.