### PR TITLE
Fix 500 error for empty accession (#1952)

### DIFF
--- a/plugins/qtAccessionPlugin/modules/accession/actions/indexAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/indexAction.class.php
@@ -23,6 +23,10 @@ class AccessionIndexAction extends sfAction
     {
         $this->resource = $this->getRoute()->resource;
 
+        if (!isset($this->resource)) {
+            $this->forward404();
+        }
+
         // Check user authorization
         if (!QubitAcl::check($this->resource, 'read')) {
             QubitAcl::forwardToSecureAction();


### PR DESCRIPTION
Check for resource being set and forwarding to a 404 page if no resource is found in the indexAction for accessions.