### PR TITLE
Fix PHP 8.x deprecation warnings (#1960)

### DIFF
--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -1117,7 +1117,7 @@ class QubitDigitalObject extends BaseDigitalObject
                 return $this->values['reference'];
         }
 
-        return call_user_func_array([$this, 'BaseDigitalObject::__get'], $args);
+        return call_user_func_array('BaseDigitalObject::__get', $args);
     }
 
     public function save($connection = null)

--- a/lib/model/QubitNote.php
+++ b/lib/model/QubitNote.php
@@ -40,7 +40,7 @@ class QubitNote extends BaseNote
             return QubitPdo::fetchColumn($sql, [$this->typeId, $this->id, $this->sourceCulture]);
         }
 
-        return call_user_func_array([$this, 'BaseNote::__get'], $args);
+        return call_user_func_array('BaseNote::__get', $args);
     }
 
     public function __toString()

--- a/lib/model/om/BaseAccessLog.php
+++ b/lib/model/om/BaseAccessLog.php
@@ -182,6 +182,7 @@ abstract class BaseAccessLog implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -223,6 +224,7 @@ abstract class BaseAccessLog implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -277,6 +279,7 @@ abstract class BaseAccessLog implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -308,6 +311,7 @@ abstract class BaseAccessLog implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BaseActor.php
+++ b/lib/model/om/BaseActor.php
@@ -242,7 +242,7 @@ abstract class BaseActor extends QubitObject implements ArrayAccess
 
     try
     {
-      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrentactorI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen($value = call_user_func_array(array($this->getCurrentactorI18n($options), '__get'), $args) ?? '') && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrentactorI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }

--- a/lib/model/om/BaseAuditLog.php
+++ b/lib/model/om/BaseAuditLog.php
@@ -188,6 +188,7 @@ abstract class BaseAuditLog implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -229,6 +230,7 @@ abstract class BaseAuditLog implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -283,6 +285,7 @@ abstract class BaseAuditLog implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -314,6 +317,7 @@ abstract class BaseAuditLog implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BaseClipboardSave.php
+++ b/lib/model/om/BaseClipboardSave.php
@@ -189,6 +189,7 @@ abstract class BaseClipboardSave implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -247,6 +248,7 @@ abstract class BaseClipboardSave implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -301,6 +303,7 @@ abstract class BaseClipboardSave implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -332,6 +335,7 @@ abstract class BaseClipboardSave implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BaseClipboardSaveItem.php
+++ b/lib/model/om/BaseClipboardSaveItem.php
@@ -184,6 +184,7 @@ abstract class BaseClipboardSaveItem implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -225,6 +226,7 @@ abstract class BaseClipboardSaveItem implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -279,6 +281,7 @@ abstract class BaseClipboardSaveItem implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -310,6 +313,7 @@ abstract class BaseClipboardSaveItem implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BaseContactInformationI18n.php
+++ b/lib/model/om/BaseContactInformationI18n.php
@@ -191,6 +191,7 @@ abstract class BaseContactInformationI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -232,6 +233,7 @@ abstract class BaseContactInformationI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -286,6 +288,7 @@ abstract class BaseContactInformationI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -317,6 +320,7 @@ abstract class BaseContactInformationI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BaseDigitalObject.php
+++ b/lib/model/om/BaseDigitalObject.php
@@ -118,7 +118,7 @@ abstract class BaseDigitalObject extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__get'), $args);
+      return call_user_func_array('QubitObject::__get', $args);
     }
     catch (sfException $e)
     {

--- a/lib/model/om/BaseEvent.php
+++ b/lib/model/om/BaseEvent.php
@@ -90,7 +90,7 @@ abstract class BaseEvent extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__isset'), $args);
+      return call_user_func_array('QubitObject::__isset', $args);
     }
     catch (sfException $e)
     {
@@ -129,7 +129,7 @@ abstract class BaseEvent extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__get'), $args);
+      return call_user_func_array('QubitObject::__get', $args);
     }
     catch (sfException $e)
     {

--- a/lib/model/om/BaseEventI18n.php
+++ b/lib/model/om/BaseEventI18n.php
@@ -189,6 +189,7 @@ abstract class BaseEventI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -230,6 +231,7 @@ abstract class BaseEventI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -284,6 +286,7 @@ abstract class BaseEventI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -315,6 +318,7 @@ abstract class BaseEventI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BaseFunctionObjectI18n.php
+++ b/lib/model/om/BaseFunctionObjectI18n.php
@@ -203,6 +203,7 @@ abstract class BaseFunctionObjectI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -244,6 +245,7 @@ abstract class BaseFunctionObjectI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -298,6 +300,7 @@ abstract class BaseFunctionObjectI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -329,6 +332,7 @@ abstract class BaseFunctionObjectI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BaseGrantedRight.php
+++ b/lib/model/om/BaseGrantedRight.php
@@ -192,6 +192,7 @@ abstract class BaseGrantedRight implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -233,6 +234,7 @@ abstract class BaseGrantedRight implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -287,6 +289,7 @@ abstract class BaseGrantedRight implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -318,6 +321,7 @@ abstract class BaseGrantedRight implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BaseKeymap.php
+++ b/lib/model/om/BaseKeymap.php
@@ -188,6 +188,7 @@ abstract class BaseKeymap implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -229,6 +230,7 @@ abstract class BaseKeymap implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -283,6 +285,7 @@ abstract class BaseKeymap implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -314,6 +317,7 @@ abstract class BaseKeymap implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BaseMenu.php
+++ b/lib/model/om/BaseMenu.php
@@ -246,6 +246,7 @@ abstract class BaseMenu implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -374,6 +375,7 @@ abstract class BaseMenu implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -430,6 +432,7 @@ abstract class BaseMenu implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -471,6 +474,7 @@ abstract class BaseMenu implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BaseMenuI18n.php
+++ b/lib/model/om/BaseMenuI18n.php
@@ -187,6 +187,7 @@ abstract class BaseMenuI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -228,6 +229,7 @@ abstract class BaseMenuI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -282,6 +284,7 @@ abstract class BaseMenuI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -313,6 +316,7 @@ abstract class BaseMenuI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BaseNoteI18n.php
+++ b/lib/model/om/BaseNoteI18n.php
@@ -185,6 +185,7 @@ abstract class BaseNoteI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -226,6 +227,7 @@ abstract class BaseNoteI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -280,6 +282,7 @@ abstract class BaseNoteI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -311,6 +314,7 @@ abstract class BaseNoteI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BaseOaiHarvest.php
+++ b/lib/model/om/BaseOaiHarvest.php
@@ -196,6 +196,7 @@ abstract class BaseOaiHarvest implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -237,6 +238,7 @@ abstract class BaseOaiHarvest implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -291,6 +293,7 @@ abstract class BaseOaiHarvest implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -322,6 +325,7 @@ abstract class BaseOaiHarvest implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BaseOaiRepository.php
+++ b/lib/model/om/BaseOaiRepository.php
@@ -197,6 +197,7 @@ abstract class BaseOaiRepository implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -255,6 +256,7 @@ abstract class BaseOaiRepository implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -309,6 +311,7 @@ abstract class BaseOaiRepository implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -340,6 +343,7 @@ abstract class BaseOaiRepository implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BaseOtherNameI18n.php
+++ b/lib/model/om/BaseOtherNameI18n.php
@@ -189,6 +189,7 @@ abstract class BaseOtherNameI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -230,6 +231,7 @@ abstract class BaseOtherNameI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -284,6 +286,7 @@ abstract class BaseOtherNameI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -315,6 +318,7 @@ abstract class BaseOtherNameI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BasePhysicalObject.php
+++ b/lib/model/om/BasePhysicalObject.php
@@ -78,7 +78,7 @@ abstract class BasePhysicalObject extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__isset'), $args);
+      return call_user_func_array('QubitObject::__isset', $args);
     }
     catch (sfException $e)
     {
@@ -117,7 +117,7 @@ abstract class BasePhysicalObject extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__get'), $args);
+      return call_user_func_array('QubitObject::__get', $args);
     }
     catch (sfException $e)
     {

--- a/lib/model/om/BasePhysicalObjectI18n.php
+++ b/lib/model/om/BasePhysicalObjectI18n.php
@@ -189,6 +189,7 @@ abstract class BasePhysicalObjectI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -230,6 +231,7 @@ abstract class BasePhysicalObjectI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -284,6 +286,7 @@ abstract class BasePhysicalObjectI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -315,6 +318,7 @@ abstract class BasePhysicalObjectI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BaseProperty.php
+++ b/lib/model/om/BaseProperty.php
@@ -264,7 +264,7 @@ abstract class BaseProperty implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrentpropertyI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen($value = call_user_func_array(array($this->getCurrentpropertyI18n($options), '__get'), $args) ?? '') && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrentpropertyI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }

--- a/lib/model/om/BasePropertyI18n.php
+++ b/lib/model/om/BasePropertyI18n.php
@@ -185,6 +185,7 @@ abstract class BasePropertyI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -226,6 +227,7 @@ abstract class BasePropertyI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -280,6 +282,7 @@ abstract class BasePropertyI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -311,6 +314,7 @@ abstract class BasePropertyI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BaseRelation.php
+++ b/lib/model/om/BaseRelation.php
@@ -125,7 +125,7 @@ abstract class BaseRelation extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__get'), $args);
+      return call_user_func_array('QubitObject::__get', $args);
     }
     catch (sfException $e)
     {

--- a/lib/model/om/BaseRelationI18n.php
+++ b/lib/model/om/BaseRelationI18n.php
@@ -187,6 +187,7 @@ abstract class BaseRelationI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -228,6 +229,7 @@ abstract class BaseRelationI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -282,6 +284,7 @@ abstract class BaseRelationI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -313,6 +316,7 @@ abstract class BaseRelationI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BaseRightsI18n.php
+++ b/lib/model/om/BaseRightsI18n.php
@@ -201,6 +201,7 @@ abstract class BaseRightsI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -242,6 +243,7 @@ abstract class BaseRightsI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -296,6 +298,7 @@ abstract class BaseRightsI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -327,6 +330,7 @@ abstract class BaseRightsI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BaseStaticPageI18n.php
+++ b/lib/model/om/BaseStaticPageI18n.php
@@ -187,6 +187,7 @@ abstract class BaseStaticPageI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -228,6 +229,7 @@ abstract class BaseStaticPageI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -282,6 +284,7 @@ abstract class BaseStaticPageI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -313,6 +316,7 @@ abstract class BaseStaticPageI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/lib/model/om/BaseTerm.php
+++ b/lib/model/om/BaseTerm.php
@@ -103,7 +103,7 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__isset'), $args);
+      return call_user_func_array('QubitObject::__isset', $args);
     }
     catch (sfException $e)
     {
@@ -337,7 +337,7 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__get'), $args);
+      return call_user_func_array('QubitObject::__get', $args);
     }
     catch (sfException $e)
     {

--- a/lib/model/om/BaseTermI18n.php
+++ b/lib/model/om/BaseTermI18n.php
@@ -185,6 +185,7 @@ abstract class BaseTermI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -226,6 +227,7 @@ abstract class BaseTermI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -280,6 +282,7 @@ abstract class BaseTermI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -311,6 +314,7 @@ abstract class BaseTermI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/plugins/qbAclPlugin/lib/model/om/BaseAclPermission.php
+++ b/plugins/qbAclPlugin/lib/model/om/BaseAclPermission.php
@@ -198,6 +198,7 @@ abstract class BaseAclPermission implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -239,6 +240,7 @@ abstract class BaseAclPermission implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -293,6 +295,7 @@ abstract class BaseAclPermission implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -324,6 +327,7 @@ abstract class BaseAclPermission implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/plugins/qtAccessionPlugin/lib/model/om/BaseAccessionEventI18n.php
+++ b/plugins/qtAccessionPlugin/lib/model/om/BaseAccessionEventI18n.php
@@ -185,6 +185,7 @@ abstract class BaseAccessionEventI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -226,6 +227,7 @@ abstract class BaseAccessionEventI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -280,6 +282,7 @@ abstract class BaseAccessionEventI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -311,6 +314,7 @@ abstract class BaseAccessionEventI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/plugins/qtAccessionPlugin/lib/model/om/BaseAccessionI18n.php
+++ b/plugins/qtAccessionPlugin/lib/model/om/BaseAccessionI18n.php
@@ -201,6 +201,7 @@ abstract class BaseAccessionI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -242,6 +243,7 @@ abstract class BaseAccessionI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -296,6 +298,7 @@ abstract class BaseAccessionI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -327,6 +330,7 @@ abstract class BaseAccessionI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/plugins/qtAccessionPlugin/lib/model/om/BaseDeaccessionI18n.php
+++ b/plugins/qtAccessionPlugin/lib/model/om/BaseDeaccessionI18n.php
@@ -189,6 +189,7 @@ abstract class BaseDeaccessionI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -230,6 +231,7 @@ abstract class BaseDeaccessionI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -284,6 +286,7 @@ abstract class BaseDeaccessionI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -315,6 +318,7 @@ abstract class BaseDeaccessionI18n implements ArrayAccess
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();

--- a/plugins/sfDcPlugin/lib/sfDcPlugin.class.php
+++ b/plugins/sfDcPlugin/lib/sfDcPlugin.class.php
@@ -151,6 +151,7 @@ class sfDcPlugin implements ArrayAccess
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         $args = func_get_args();
@@ -158,6 +159,7 @@ class sfDcPlugin implements ArrayAccess
         return call_user_func_array([$this, '__isset'], $args);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $args = func_get_args();
@@ -165,6 +167,7 @@ class sfDcPlugin implements ArrayAccess
         return call_user_func_array([$this, '__get'], $args);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $args = func_get_args();
@@ -172,6 +175,7 @@ class sfDcPlugin implements ArrayAccess
         return call_user_func_array([$this, '__set'], $args);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $args = func_get_args();

--- a/plugins/sfEacPlugin/lib/sfEacPlugin.class.php
+++ b/plugins/sfEacPlugin/lib/sfEacPlugin.class.php
@@ -431,6 +431,7 @@ return;
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         $args = func_get_args();
@@ -438,6 +439,7 @@ return;
         return call_user_func_array([$this, '__isset'], $args);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $args = func_get_args();
@@ -445,6 +447,7 @@ return;
         return call_user_func_array([$this, '__get'], $args);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $args = func_get_args();
@@ -452,6 +455,7 @@ return;
         return call_user_func_array([$this, '__set'], $args);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $args = func_get_args();

--- a/plugins/sfEadPlugin/lib/sfEadPlugin.class.php
+++ b/plugins/sfEadPlugin/lib/sfEadPlugin.class.php
@@ -25,6 +25,7 @@ class sfEadPlugin
     public $resource;
     public $siteBaseUrl;
     public $options;
+    public $version;
 
     public static $ENCODING_MAP = [
         'isad' => [

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
@@ -3,13 +3,13 @@
   <?php echo $ead->renderEadId(); ?>
   <filedesc>
     <titlestmt>
-      <?php if (0 < strlen($value = $resource->getTitle(['cultureFallback' => true]))) { ?>
+      <?php if (0 < strlen($value = $resource->getTitle(['cultureFallback' => true]) ?? '')) { ?>
         <titleproper encodinganalog="<?php echo $ead->getMetadataParameter('titleproper'); ?>"><?php echo escape_dc(esc_specialchars($value)); ?></titleproper>
       <?php } ?>
     </titlestmt>
     <?php
       // TODO: find out if we need this element as it's not imported by our EAD importer
-      if (0 < strlen($value = $resource->getEdition(['cultureFallback' => true]))) { ?>
+      if (0 < strlen($value = $resource->getEdition(['cultureFallback' => true]) ?? '')) { ?>
       <editionstmt>
         <edition><?php echo escape_dc(esc_specialchars($value)); ?></edition>
       </editionstmt>
@@ -19,31 +19,31 @@
         <publisher encodinganalog="<?php echo $ead->getMetadataParameter('publisher'); ?>"><?php echo escape_dc(esc_specialchars($value->__toString())); ?></publisher>
         <?php if ($address = $value->getPrimaryContact()) { ?>
           <address>
-            <?php if (0 < strlen($addressline = $address->getStreetAddress())) { ?>
+            <?php if (0 < strlen($addressline = $address->getStreetAddress() ?? '')) { ?>
               <addressline><?php echo escape_dc(esc_specialchars($addressline)); ?></addressline>
             <?php } ?>
-            <?php if (0 < strlen($addressline = $address->getCity())) { ?>
+            <?php if (0 < strlen($addressline = $address->getCity() ?? '')) { ?>
               <addressline><?php echo escape_dc(esc_specialchars($addressline)); ?></addressline>
             <?php } ?>
-            <?php if (0 < strlen($addressline = $address->getRegion())) { ?>
+            <?php if (0 < strlen($addressline = $address->getRegion() ?? '')) { ?>
               <addressline><?php echo escape_dc(esc_specialchars($addressline)); ?></addressline>
             <?php } ?>
-            <?php if (0 < strlen($addressline = $resource->getRepositoryCountry())) { ?>
+            <?php if (0 < strlen($addressline = $resource->getRepositoryCountry() ?? '')) { ?>
               <addressline><?php echo escape_dc(esc_specialchars($addressline)); ?></addressline>
             <?php } ?>
-            <?php if (0 < strlen($addressline = $address->getPostalCode())) { ?>
+            <?php if (0 < strlen($addressline = $address->getPostalCode() ?? '')) { ?>
               <addressline><?php echo escape_dc(esc_specialchars($addressline)); ?></addressline>
             <?php } ?>
-            <?php if (0 < strlen($addressline = $address->getTelephone())) { ?>
+            <?php if (0 < strlen($addressline = $address->getTelephone() ?? '')) { ?>
               <addressline><?php echo __('Telephone: ').escape_dc(esc_specialchars($addressline)); ?></addressline>
             <?php } ?>
-            <?php if (0 < strlen($addressline = $address->getFax())) { ?>
+            <?php if (0 < strlen($addressline = $address->getFax() ?? '')) { ?>
               <addressline><?php echo __('Fax: ').escape_dc(esc_specialchars($addressline)); ?></addressline>
             <?php } ?>
-            <?php if (0 < strlen($addressline = $address->getEmail())) { ?>
+            <?php if (0 < strlen($addressline = $address->getEmail() ?? '')) { ?>
               <addressline><?php echo __('Email: ').escape_dc(esc_specialchars($addressline)); ?></addressline>
             <?php } ?>
-            <?php if (0 < strlen($addressline = $address->getWebsite())) { ?>
+            <?php if (0 < strlen($addressline = $address->getWebsite() ?? '')) { ?>
               <addressline><?php echo escape_dc(esc_specialchars($addressline)); ?></addressline>
             <?php } ?>
           </address>
@@ -58,13 +58,13 @@
       <date normal="<?php echo gmdate('o-m-d'); ?>"><?php echo gmdate('o-m-d H:i e'); ?></date>
     </creation>
     <langusage>
-      <language langcode="<?php echo strtolower($iso639convertor->getID2($exportLanguage)); ?>"><?php echo format_language($exportLanguage); ?></language>
-      <?php if (0 < strlen($languageOfDescription = $resource->getPropertyByName('languageOfDescription')->__toString())) { ?>
+      <language langcode="<?php echo strtolower($iso639convertor->getID2($exportLanguage) ?? ''); ?>"><?php echo format_language($exportLanguage); ?></language>
+      <?php if (0 < strlen($languageOfDescription = $resource->getPropertyByName('languageOfDescription')->__toString() ?? '')) { ?>
         <?php $langsOfDesc = unserialize($languageOfDescription); ?>
         <?php if (is_array($langsOfDesc)) { ?>
           <?php foreach ($langsOfDesc as $langcode) { ?>
             <?php if ($langcode != $exportLanguage) { ?>
-              <language langcode="<?php echo strtolower($iso639convertor->getID2($langcode)); ?>"><?php echo format_language($langcode); ?></language>
+              <language langcode="<?php echo strtolower($iso639convertor->getID2($langcode) ?? ''); ?>"><?php echo format_language($langcode); ?></language>
             <?php } ?>
           <?php } ?>
         <?php } ?>
@@ -73,8 +73,8 @@
         <language scriptcode="<?php echo $code; ?>"><?php echo format_script($code); ?></language>
       <?php } ?>
     </langusage>
-    <?php if (0 < strlen($rules = $resource->getRules(['cultureFallback' => true]))) { ?>
-      <descrules <?php if (0 < strlen($encoding = $ead->getMetadataParameter('descrules'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($rules)); ?></descrules>
+    <?php if (0 < strlen($rules = $resource->getRules(['cultureFallback' => true]) ?? '')) { ?>
+      <descrules <?php if (0 < strlen($encoding = $ead->getMetadataParameter('descrules') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($rules)); ?></descrules>
     <?php } ?>
   </profiledesc>
 </eadheader>
@@ -132,7 +132,7 @@
 
       if (0 < count($notes = $resource->getNotesByType(['noteTypeId' => $noteTypeId]))) {
           foreach ($notes as $note) { ?>
-        <odd type="<?php echo $xmlType; ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter($xmlType))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><p><?php echo escape_dc(esc_specialchars($note->getContent(['cultureFallback' => true]))); ?></p></odd>
+        <odd type="<?php echo $xmlType; ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter($xmlType) ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><p><?php echo escape_dc(esc_specialchars($note->getContent(['cultureFallback' => true]))); ?></p></odd>
       <?php }
       }
   }
@@ -152,7 +152,7 @@
 
       if (0 < count($notes = $resource->getNotesByType(['noteTypeId' => $noteTypeId]))) {
           foreach ($notes as $note) { ?>
-        <odd type="<?php echo $xmlType; ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter($xmlType))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><p><?php echo escape_dc(esc_specialchars($note->getContent(['cultureFallback' => true]))); ?></p></odd>
+        <odd type="<?php echo $xmlType; ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter($xmlType) ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><p><?php echo escape_dc(esc_specialchars($note->getContent(['cultureFallback' => true]))); ?></p></odd>
       <?php }
       }
   }
@@ -170,17 +170,17 @@
 
       if (0 < count($notes = $resource->getNotesByType(['noteTypeId' => $noteTypeId]))) {
           foreach ($notes as $note) { ?>
-        <odd type="<?php echo $xmlType; ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter($xmlType))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><p><?php echo escape_dc(esc_specialchars($note->getContent(['cultureFallback' => true]))); ?></p></odd>
+        <odd type="<?php echo $xmlType; ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter($xmlType) ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><p><?php echo escape_dc(esc_specialchars($note->getContent(['cultureFallback' => true]))); ?></p></odd>
       <?php }
       }
   } ?>
 
-  <?php if (0 < strlen($value = $resource->getPropertyByName('noteOnPublishersSeries')->__toString())) { ?>
+  <?php if (0 < strlen($value = $resource->getPropertyByName('noteOnPublishersSeries')->__toString() ?? '')) { ?>
     <odd type='bibSeries'><p><?php echo escape_dc(esc_specialchars($value)); ?></p></odd>
   <?php } ?>
-  <?php if (0 < strlen($value = $resource->getScopeAndContent(['cultureFallback' => true]))) { ?>
+  <?php if (0 < strlen($value = $resource->getScopeAndContent(['cultureFallback' => true]) ?? '')) { ?>
     <scopecontent encodinganalog="<?php echo $ead->getMetadataParameter('scopecontent'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></scopecontent><?php } ?>
-  <?php if (0 < strlen($value = $resource->getArrangement(['cultureFallback' => true]))) { ?>
+  <?php if (0 < strlen($value = $resource->getArrangement(['cultureFallback' => true]) ?? '')) { ?>
     <arrangement encodinganalog="<?php echo $ead->getMetadataParameter('arrangement'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></arrangement><?php } ?>
 
   <?php if ($ead->getControlAccessFields($resource, $materialTypes, $genres, $subjects, $names, $places, $placeEvents)) { ?>
@@ -189,13 +189,13 @@
         <?php if ('Creator' != $event->getType()->getRole()) { ?>
 
         <?php if (QubitTerm::PERSON_ID == $event->getActor()->getEntityTypeId()) { ?>
-          <persname role="<?php echo $event->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $event->id; ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))); ?></persname>
+          <persname role="<?php echo $event->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()) ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $event->id; ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))); ?></persname>
         <?php } elseif (QubitTerm::FAMILY_ID == $event->getActor()->getEntityTypeId()) { ?>
-          <famname role="<?php echo $event->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $event->id; ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))); ?></famname>
+          <famname role="<?php echo $event->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()) ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $event->id; ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))); ?></famname>
         <?php } elseif (QubitTerm::CORPORATE_BODY_ID == $event->getActor()->getEntityTypeId()) { ?>
-          <corpname role="<?php echo $event->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $event->id; ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))); ?></corpname>
+          <corpname role="<?php echo $event->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()) ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $event->id; ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))); ?></corpname>
         <?php } else { ?>
-          <name role="<?php echo $event->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $event->id; ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))); ?></name>
+          <name role="<?php echo $event->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()) ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $event->id; ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor()))); ?></name>
         <?php } ?>
 
         <?php } ?>
@@ -216,7 +216,7 @@
         <?php } ?>
       <?php } ?>
       <?php foreach ($materialTypes as $materialtype) { ?>
-        <genreform source="rad" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('materialType'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(escape_dc(esc_specialchars((string) $materialtype->getTerm()))); ?></genreform>
+        <genreform source="rad" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('materialType') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(escape_dc(esc_specialchars((string) $materialtype->getTerm()))); ?></genreform>
       <?php } ?>
       <?php foreach ($genres as $genre) { ?>
         <genreform><?php echo escape_dc(esc_specialchars((string) $genre->getTerm())); ?></genreform>
@@ -228,28 +228,28 @@
         <geogname><?php echo escape_dc(esc_specialchars((string) $place->getTerm())); ?></geogname>
       <?php } ?>
       <?php foreach ($placeEvents as $place) { ?>
-        <geogname role="<?php echo $place->getObject()->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('geog'.$place->getObject()->getType()->getRole()))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('geogDefault'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $place->objectId; ?>_place"><?php echo escape_dc(esc_specialchars((string) $place->getTerm())); ?></geogname>
+        <geogname role="<?php echo $place->getObject()->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('geog'.$place->getObject()->getType()->getRole()) ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('geogDefault') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $place->objectId; ?>_place"><?php echo escape_dc(esc_specialchars((string) $place->getTerm())); ?></geogname>
       <?php } ?>
     </controlaccess>
   <?php } ?>
-  <?php if (0 < strlen($value = $resource->getPhysicalCharacteristics(['cultureFallback' => true]))) { ?>
+  <?php if (0 < strlen($value = $resource->getPhysicalCharacteristics(['cultureFallback' => true]) ?? '')) { ?>
     <phystech encodinganalog="<?php echo $ead->getMetadataParameter('phystech'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></phystech>
   <?php } ?>
-  <?php if (0 < strlen($value = $resource->getAppraisal(['cultureFallback' => true]))) { ?>
-    <appraisal <?php if (0 < strlen($encoding = $ead->getMetadataParameter('appraisal'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><p><?php echo escape_dc(esc_specialchars($value)); ?></p></appraisal>
+  <?php if (0 < strlen($value = $resource->getAppraisal(['cultureFallback' => true]) ?? '')) { ?>
+    <appraisal <?php if (0 < strlen($encoding = $ead->getMetadataParameter('appraisal') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><p><?php echo escape_dc(esc_specialchars($value)); ?></p></appraisal>
   <?php } ?>
-  <?php if (0 < strlen($value = $resource->getAcquisition(['cultureFallback' => true]))) { ?>
+  <?php if (0 < strlen($value = $resource->getAcquisition(['cultureFallback' => true]) ?? '')) { ?>
     <acqinfo encodinganalog="<?php echo $ead->getMetadataParameter('acqinfo'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></acqinfo>
   <?php } ?>
-  <?php if (0 < strlen($value = $resource->getAccruals(['cultureFallback' => true]))) { ?>
+  <?php if (0 < strlen($value = $resource->getAccruals(['cultureFallback' => true]) ?? '')) { ?>
     <accruals encodinganalog="<?php echo $ead->getMetadataParameter('accruals'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></accruals>
   <?php } ?>
-  <?php if (0 < strlen($value = $resource->getArchivalHistory(['cultureFallback' => true]))) { ?>
+  <?php if (0 < strlen($value = $resource->getArchivalHistory(['cultureFallback' => true]) ?? '')) { ?>
     <custodhist encodinganalog="<?php echo $ead->getMetadataParameter('custodhist'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></custodhist>
   <?php } ?>
 
   <?php $archivistsNotes = $resource->getNotesByType(['noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID]); ?>
-  <?php if (0 < strlen($value = $resource->getRevisionHistory(['cultureFallback' => true])) || 0 < count($archivistsNotes)) { ?>
+  <?php if (0 < strlen($value = $resource->getRevisionHistory(['cultureFallback' => true]) ?? '') || 0 < count($archivistsNotes)) { ?>
 
     <processinfo>
       <?php if ($value) { ?>
@@ -264,27 +264,27 @@
     </processinfo>
   <?php } ?>
 
-  <?php if (0 < strlen($value = $resource->getLocationOfOriginals(['cultureFallback' => true]))) { ?>
+  <?php if (0 < strlen($value = $resource->getLocationOfOriginals(['cultureFallback' => true]) ?? '')) { ?>
     <originalsloc encodinganalog="<?php echo $ead->getMetadataParameter('originalsloc'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></originalsloc>
   <?php } ?>
-  <?php if (0 < strlen($value = $resource->getLocationOfCopies(['cultureFallback' => true]))) { ?>
+  <?php if (0 < strlen($value = $resource->getLocationOfCopies(['cultureFallback' => true]) ?? '')) { ?>
     <altformavail encodinganalog="<?php echo $ead->getMetadataParameter('altformavail'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></altformavail>
   <?php } ?>
-  <?php if (0 < strlen($value = $resource->getRelatedUnitsOfDescription(['cultureFallback' => true]))) { ?>
+  <?php if (0 < strlen($value = $resource->getRelatedUnitsOfDescription(['cultureFallback' => true]) ?? '')) { ?>
     <relatedmaterial encodinganalog="<?php echo $ead->getMetadataParameter('relatedmaterial'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></relatedmaterial>
   <?php } ?>
-  <?php if (0 < strlen($value = $resource->getAccessConditions(['cultureFallback' => true]))) { ?>
+  <?php if (0 < strlen($value = $resource->getAccessConditions(['cultureFallback' => true]) ?? '')) { ?>
     <accessrestrict encodinganalog="<?php echo $ead->getMetadataParameter('accessrestrict'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></accessrestrict>
   <?php } ?>
-  <?php if (0 < strlen($value = $resource->getReproductionConditions(['cultureFallback' => true]))) { ?>
+  <?php if (0 < strlen($value = $resource->getReproductionConditions(['cultureFallback' => true]) ?? '')) { ?>
     <userestrict encodinganalog="<?php echo $ead->getMetadataParameter('userestrict'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></userestrict>
   <?php } ?>
-  <?php if (0 < strlen($value = $resource->getFindingAids(['cultureFallback' => true]))) { ?>
+  <?php if (0 < strlen($value = $resource->getFindingAids(['cultureFallback' => true]) ?? '')) { ?>
     <otherfindaid encodinganalog="<?php echo $ead->getMetadataParameter('otherfindaid'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></otherfindaid>
   <?php } ?>
   <?php if (0 < count($publicationNotes = $resource->getNotesByType(['noteTypeId' => QubitTerm::PUBLICATION_NOTE_ID]))) { ?>
     <?php foreach ($publicationNotes as $note) { ?>
-      <bibliography <?php if (0 < strlen($encoding = $ead->getMetadataParameter('bibliography'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><p><?php echo escape_dc(esc_specialchars($note->getContent(['cultureFallback' => true]))); ?></p></bibliography>
+      <bibliography <?php if (0 < strlen($encoding = $ead->getMetadataParameter('bibliography') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><p><?php echo escape_dc(esc_specialchars($note->getContent(['cultureFallback' => true]))); ?></p></bibliography>
     <?php } ?>
   <?php } ?>
 
@@ -316,11 +316,11 @@
         <odd type="publicationStatus"><p><?php echo escape_dc(esc_specialchars($descendant->getPublicationStatus())); ?></p></odd>
       <?php } ?>
 
-      <?php if (0 < strlen($value = $descendant->getScopeAndContent(['cultureFallback' => true]))) { ?>
+      <?php if (0 < strlen($value = $descendant->getScopeAndContent(['cultureFallback' => true]) ?? '')) { ?>
         <scopecontent encodinganalog="<?php echo $ead->getMetadataParameter('scopecontent'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></scopecontent>
       <?php } ?>
 
-      <?php if (0 < strlen($value = $descendant->getArrangement(['cultureFallback' => true]))) { ?>
+      <?php if (0 < strlen($value = $descendant->getArrangement(['cultureFallback' => true]) ?? '')) { ?>
         <arrangement encodinganalog="<?php echo $ead->getMetadataParameter('arrangement'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></arrangement>
       <?php } ?>
 
@@ -332,13 +332,13 @@
             <?php if ('Creator' != $event->getType()->getRole()) { ?>
 
               <?php if (QubitTerm::PERSON_ID == $event->getActor()->getEntityTypeId()) { ?>
-                <persname role="<?php echo $event->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $event->id; ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor(['cultureFallback' => true])))); ?> </persname>
+                <persname role="<?php echo $event->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()) ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $event->id; ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor(['cultureFallback' => true])))); ?> </persname>
               <?php } elseif (QubitTerm::FAMILY_ID == $event->getActor()->getEntityTypeId()) { ?>
-                <famname role="<?php echo $event->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $event->id; ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor(['cultureFallback' => true])))); ?> </famname>
+                <famname role="<?php echo $event->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()) ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $event->id; ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor(['cultureFallback' => true])))); ?> </famname>
               <?php } elseif (QubitTerm::CORPORATE_BODY_ID == $event->getActor()->getEntityTypeId()) { ?>
-                <corpname role="<?php echo $event->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $event->id; ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor(['cultureFallback' => true])))); ?> </corpname>
+                <corpname role="<?php echo $event->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()) ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $event->id; ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor(['cultureFallback' => true])))); ?> </corpname>
               <?php } else { ?>
-                <name role="<?php echo $event->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $event->id; ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor(['cultureFallback' => true])))); ?> </name>
+                <name role="<?php echo $event->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('name'.$event->getType()->getRole()) ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('nameDefault') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $event->id; ?>_actor"><?php echo escape_dc(esc_specialchars(render_title($event->getActor(['cultureFallback' => true])))); ?> </name>
               <?php } ?>
 
             <?php } ?>
@@ -357,11 +357,11 @@
           <?php } ?>
 
           <?php foreach ($materialTypes as $materialtype) { ?>
-            <genreform source="rad" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('materialType'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars((string) $materialtype->getTerm())); ?></genreform>
+            <genreform source="rad" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('materialType') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars((string) $materialtype->getTerm())); ?></genreform>
           <?php } ?>
 
           <?php foreach ($genres as $genre) { ?>
-            <genreform <?php if (0 < strlen($encoding = $ead->getMetadataParameter('genreform'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(escape_dc(esc_specialchars((string) $genre->getTerm()))); ?></genreform>
+            <genreform <?php if (0 < strlen($encoding = $ead->getMetadataParameter('genreform') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(escape_dc(esc_specialchars((string) $genre->getTerm()))); ?></genreform>
           <?php } ?>
 
           <?php foreach ($subjects as $subject) { ?>
@@ -373,34 +373,34 @@
           <?php } ?>
 
           <?php foreach ($placeEvents as $place) { ?>
-            <geogname role="<?php echo $place->getObject()->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('geog'.$place->getObject()->getType()->getRole()))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('geogDefault'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $place->objectId; ?>_place"><?php echo escape_dc(esc_specialchars((string) $place->getTerm())); ?></geogname>
+            <geogname role="<?php echo $place->getObject()->getType()->getRole(); ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('geog'.$place->getObject()->getType()->getRole()) ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('geogDefault') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?> id="atom_<?php echo $place->objectId; ?>_place"><?php echo escape_dc(esc_specialchars((string) $place->getTerm())); ?></geogname>
           <?php } ?>
 
         </controlaccess>
 
       <?php } ?>
 
-      <?php if (0 < strlen($value = $descendant->getPhysicalCharacteristics(['cultureFallback' => true]))) { ?>
+      <?php if (0 < strlen($value = $descendant->getPhysicalCharacteristics(['cultureFallback' => true]) ?? '')) { ?>
         <phystech encodinganalog="<?php echo $ead->getMetadataParameter('phystech'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></phystech>
       <?php } ?>
 
-      <?php if (0 < strlen($value = $descendant->getAppraisal(['cultureFallback' => true]))) { ?>
-        <appraisal <?php if (0 < strlen($encoding = $ead->getMetadataParameter('appraisal'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><p><?php echo escape_dc(esc_specialchars($value)); ?></p></appraisal>
+      <?php if (0 < strlen($value = $descendant->getAppraisal(['cultureFallback' => true]) ?? '')) { ?>
+        <appraisal <?php if (0 < strlen($encoding = $ead->getMetadataParameter('appraisal') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><p><?php echo escape_dc(esc_specialchars($value)); ?></p></appraisal>
       <?php } ?>
 
-      <?php if (0 < strlen($value = $descendant->getAcquisition(['cultureFallback' => true]))) { ?>
+      <?php if (0 < strlen($value = $descendant->getAcquisition(['cultureFallback' => true]) ?? '')) { ?>
         <acqinfo encodinganalog="<?php echo $ead->getMetadataParameter('acqinfo'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></acqinfo>
       <?php } ?>
 
-      <?php if (0 < strlen($value = $descendant->getAccruals(['cultureFallback' => true]))) { ?>
+      <?php if (0 < strlen($value = $descendant->getAccruals(['cultureFallback' => true]) ?? '')) { ?>
         <accruals encodinganalog="<?php echo $ead->getMetadataParameter('accruals'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></accruals>
       <?php } ?>
 
-      <?php if (0 < strlen($value = $descendant->getArchivalHistory(['cultureFallback' => true]))) { ?>
+      <?php if (0 < strlen($value = $descendant->getArchivalHistory(['cultureFallback' => true]) ?? '')) { ?>
         <custodhist encodinganalog="<?php echo $ead->getMetadataParameter('custodhist'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></custodhist>
       <?php } ?>
 
-      <?php if (0 < strlen($value = $descendant->getRevisionHistory(['cultureFallback' => true]))) { ?>
+      <?php if (0 < strlen($value = $descendant->getRevisionHistory(['cultureFallback' => true]) ?? '')) { ?>
         <processinfo><p><date><?php echo escape_dc(esc_specialchars($value)); ?></date></p></processinfo>
       <?php } ?>
 
@@ -410,33 +410,33 @@
         <?php } ?>
       <?php } ?>
 
-      <?php if (0 < strlen($value = $descendant->getLocationOfOriginals(['cultureFallback' => true]))) { ?>
+      <?php if (0 < strlen($value = $descendant->getLocationOfOriginals(['cultureFallback' => true]) ?? '')) { ?>
         <originalsloc encodinganalog="<?php echo $ead->getMetadataParameter('originalsloc'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></originalsloc>
       <?php } ?>
 
-      <?php if (0 < strlen($value = $descendant->getLocationOfCopies(['cultureFallback' => true]))) { ?>
+      <?php if (0 < strlen($value = $descendant->getLocationOfCopies(['cultureFallback' => true]) ?? '')) { ?>
         <altformavail encodinganalog="<?php echo $ead->getMetadataParameter('altformavail'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></altformavail>
       <?php } ?>
 
-      <?php if (0 < strlen($value = $descendant->getRelatedUnitsOfDescription(['cultureFallback' => true]))) { ?>
+      <?php if (0 < strlen($value = $descendant->getRelatedUnitsOfDescription(['cultureFallback' => true]) ?? '')) { ?>
         <relatedmaterial encodinganalog="<?php echo $ead->getMetadataParameter('relatedmaterial'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></relatedmaterial>
       <?php } ?>
 
-      <?php if (0 < strlen($value = $descendant->getAccessConditions(['cultureFallback' => true]))) { ?>
+      <?php if (0 < strlen($value = $descendant->getAccessConditions(['cultureFallback' => true]) ?? '')) { ?>
         <accessrestrict encodinganalog="<?php echo $ead->getMetadataParameter('accessrestrict'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></accessrestrict>
       <?php } ?>
 
-      <?php if (0 < strlen($value = $descendant->getReproductionConditions(['cultureFallback' => true]))) { ?>
+      <?php if (0 < strlen($value = $descendant->getReproductionConditions(['cultureFallback' => true]) ?? '')) { ?>
         <userestrict encodinganalog="<?php echo $ead->getMetadataParameter('userestrict'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></userestrict>
       <?php } ?>
 
-      <?php if (0 < strlen($value = $descendant->getFindingAids(['cultureFallback' => true]))) { ?>
+      <?php if (0 < strlen($value = $descendant->getFindingAids(['cultureFallback' => true]) ?? '')) { ?>
         <otherfindaid encodinganalog="<?php echo $ead->getMetadataParameter('otherfindaid'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></otherfindaid>
       <?php } ?>
 
       <?php if (0 < count($publicationNotes = $descendant->getNotesByType(['noteTypeId' => QubitTerm::PUBLICATION_NOTE_ID]))) { ?>
         <?php foreach ($publicationNotes as $note) { ?>
-          <bibliography <?php if (0 < strlen($encoding = $ead->getMetadataParameter('bibliography'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><p><?php echo escape_dc(esc_specialchars($note->getContent(['cultureFallback' => true]))); ?></p></bibliography>
+          <bibliography <?php if (0 < strlen($encoding = $ead->getMetadataParameter('bibliography') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><p><?php echo escape_dc(esc_specialchars($note->getContent(['cultureFallback' => true]))); ?></p></bibliography>
         <?php } ?>
       <?php } ?>
 
@@ -445,7 +445,7 @@
 
           <?php if (0 < count($notes = $descendant->getNotesByType(['noteTypeId' => $noteTypeId]))) { ?>
             <?php foreach ($notes as $note) { ?>
-              <odd type="<?php echo $xmlType; ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter($xmlType))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><p><?php echo escape_dc(esc_specialchars($note->getContent(['cultureFallback' => true]))); ?></p></odd>
+              <odd type="<?php echo $xmlType; ?>" <?php if (0 < strlen($encoding = $ead->getMetadataParameter($xmlType) ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><p><?php echo escape_dc(esc_specialchars($note->getContent(['cultureFallback' => true]))); ?></p></odd>
             <?php } ?>
           <?php } ?>
       <?php } ?>

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
@@ -12,20 +12,20 @@
     <unittitle>
       <bibseries>
 
-        <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('titleProperOfPublishersSeries')->__toString())) { ?>
-          <title <?php if (0 < strlen($encoding = $ead->getMetadataParameter('titleProperOfPublishersSeries'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></title>
+        <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('titleProperOfPublishersSeries')->__toString() ?? '')) { ?>
+          <title <?php if (0 < strlen($encoding = $ead->getMetadataParameter('titleProperOfPublishersSeries') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></title>
         <?php } ?>
-        <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('parallelTitleOfPublishersSeries')->__toString())) { ?>
-          <title type="parallel" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('parallelTitleOfPublishersSeries'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></title>
+        <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('parallelTitleOfPublishersSeries')->__toString() ?? '')) { ?>
+          <title type="parallel" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('parallelTitleOfPublishersSeries') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></title>
         <?php } ?>
-        <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('otherTitleInformationOfPublishersSeries')->__toString())) { ?>
-          <title type="otherInfo" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('otherTitleInformationOfPublishersSeries'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></title>
+        <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('otherTitleInformationOfPublishersSeries')->__toString() ?? '')) { ?>
+          <title type="otherInfo" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('otherTitleInformationOfPublishersSeries') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></title>
         <?php } ?>
-        <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('statementOfResponsibilityRelatingToPublishersSeries')->__toString())) { ?>
-          <title type="statRep" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('statementOfResponsibilityRelatingToPublishersSeries'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></title>
+        <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('statementOfResponsibilityRelatingToPublishersSeries')->__toString() ?? '')) { ?>
+          <title type="statRep" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('statementOfResponsibilityRelatingToPublishersSeries') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></title>
         <?php } ?>
-        <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('numberingWithinPublishersSeries')->__toString())) { ?>
-          <num <?php if (0 < strlen($encoding = $ead->getMetadataParameter('numberingWithinPublishersSeries'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></num>
+        <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('numberingWithinPublishersSeries')->__toString() ?? '')) { ?>
+          <num <?php if (0 < strlen($encoding = $ead->getMetadataParameter('numberingWithinPublishersSeries') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></num>
         <?php } ?>
 
       </bibseries>
@@ -33,32 +33,32 @@
 
   <?php } ?>
 
-  <?php if (0 < strlen($value = ${$resourceVar}->getTitle(['cultureFallback' => true]))) { ?>
+  <?php if (0 < strlen($value = ${$resourceVar}->getTitle(['cultureFallback' => true]) ?? '')) { ?>
     <unittitle encodinganalog="<?php echo $ead->getMetadataParameter('unittitle'); ?>"><?php echo escape_dc(esc_specialchars($value)); ?></unittitle>
   <?php } ?>
 
-  <?php if (0 < strlen($value = ${$resourceVar}->alternateTitle)) { ?>
-    <unittitle type="parallel" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('parallel'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></unittitle>
+  <?php if (0 < strlen($value = ${$resourceVar}->alternateTitle ?? '')) { ?>
+    <unittitle type="parallel" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('parallel') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></unittitle>
   <?php } ?>
 
-  <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('otherTitleInformation')->__toString())) { ?>
-    <unittitle type="otherInfo" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('otherinfo'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></unittitle>
+  <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('otherTitleInformation')->__toString() ?? '')) { ?>
+    <unittitle type="otherInfo" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('otherinfo') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></unittitle>
   <?php } ?>
 
-  <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('titleStatementOfResponsibility')->__toString())) { ?>
-    <unittitle type="statRep" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('statrep'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></unittitle>
+  <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('titleStatementOfResponsibility')->__toString() ?? '')) { ?>
+    <unittitle type="statRep" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('statrep') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></unittitle>
   <?php } ?>
 
-  <?php if (0 < strlen($value = ${$resourceVar}->getEdition(['cultureFallback' => true]))) { ?>
-    <unittitle type="editionStat" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('editionstatement'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><edition><?php echo escape_dc(esc_specialchars($value)); ?></edition></unittitle>
+  <?php if (0 < strlen($value = ${$resourceVar}->getEdition(['cultureFallback' => true]) ?? '')) { ?>
+    <unittitle type="editionStat" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('editionstatement') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><edition><?php echo escape_dc(esc_specialchars($value)); ?></edition></unittitle>
   <?php } ?>
 
-  <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('editionStatementOfResponsibility')->__toString())) { ?>
-    <unittitle type="statRep" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('statementofresp'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><edition><?php echo escape_dc(esc_specialchars($value)); ?></edition></unittitle>
+  <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('editionStatementOfResponsibility')->__toString() ?? '')) { ?>
+    <unittitle type="statRep" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('statementofresp') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><edition><?php echo escape_dc(esc_specialchars($value)); ?></edition></unittitle>
   <?php } ?>
 
   <?php $repository = null; ?>
-  <?php if (0 < strlen(${$resourceVar}->getIdentifier())) { ?>
+  <?php if (0 < strlen(${$resourceVar}->getIdentifier() ?? '')) { ?>
     <?php foreach (${$resourceVar}->ancestors->andSelf()->orderBy('rgt') as $item) { ?>
       <?php if (isset($item->repository)) { ?>
         <?php $repository = $item->repository; ?>
@@ -72,16 +72,16 @@
     <unitid type="alternative" label="<?php echo escape_dc(esc_specialchars($item->name)); ?>"><?php echo escape_dc(esc_specialchars($item->getValue(['sourceCulture' => true]))); ?></unitid>
   <?php } ?>
 
-  <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('standardNumber')->__toString())) { ?>
-    <unitid type="standard" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('standardNumber'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></unitid>
+  <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('standardNumber')->__toString() ?? '')) { ?>
+    <unitid type="standard" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('standardNumber') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></unitid>
   <?php } ?>
 
   <?php foreach (${$resourceVar}->getDates() as $date) { ?>
-    <unitdate <?php if (null !== $date->getActor() || null !== $date->getPlace()) { ?> <?php echo 'id="atom_'.$date->id.'_event"'; ?> <?php } ?> <?php if (QubitTerm::CREATION_ID != $date->typeId) { ?><?php if ($type = $date->getType()->__toString()) { ?><?php echo 'datechar="'.strtolower($type).'" '; ?><?php } ?><?php } else { ?><?php $type = null; ?><?php } ?><?php if ($startdate = $date->getStartDate()) { ?><?php echo 'normal="'; ?><?php echo Qubit::renderDate($startdate); ?><?php if (0 < strlen($enddate = $date->getEndDate())) { ?><?php echo '/'; ?><?php echo Qubit::renderDate($enddate); ?><?php } ?><?php echo '"'; ?><?php } ?> <?php if (0 < strlen($encoding = $ead->getMetadataParameter('unitdate'.strtolower($type)))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('unitdateDefault'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars(Qubit::renderDateStartEnd($date->getDate(['cultureFallback' => true]), $date->startDate, $date->endDate))); ?></unitdate>
+    <unitdate <?php if (null !== $date->getActor() || null !== $date->getPlace()) { ?> <?php echo 'id="atom_'.$date->id.'_event"'; ?> <?php } ?> <?php if (QubitTerm::CREATION_ID != $date->typeId) { ?><?php if ($type = $date->getType()->__toString()) { ?><?php echo 'datechar="'.strtolower($type ?? '').'" '; ?><?php } ?><?php } else { ?><?php $type = null; ?><?php } ?><?php if ($startdate = $date->getStartDate()) { ?><?php echo 'normal="'; ?><?php echo Qubit::renderDate($startdate); ?><?php if (0 < strlen($enddate = $date->getEndDate() ?? '')) { ?><?php echo '/'; ?><?php echo Qubit::renderDate($enddate); ?><?php } ?><?php echo '"'; ?><?php } ?> <?php if (0 < strlen($encoding = $ead->getMetadataParameter('unitdate'.strtolower($type ?? '')) ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } elseif (0 < strlen($encoding = $ead->getMetadataParameter('unitdateDefault') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars(Qubit::renderDateStartEnd($date->getDate(['cultureFallback' => true]), $date->startDate, $date->endDate))); ?></unitdate>
   <?php } ?>
 
-  <?php if (0 < strlen($value = ${$resourceVar}->getExtentAndMedium(['cultureFallback' => true]))) { ?>
-    <physdesc <?php if (0 < strlen($encoding = $ead->getMetadataParameter('extent'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>>
+  <?php if (0 < strlen($value = ${$resourceVar}->getExtentAndMedium(['cultureFallback' => true]) ?? '')) { ?>
+    <physdesc <?php if (0 < strlen($encoding = $ead->getMetadataParameter('extent') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>>
         <?php echo escape_dc(esc_specialchars($value)); ?>
     </physdesc>
   <?php } ?>
@@ -91,31 +91,31 @@
       <corpname><?php echo escape_dc(esc_specialchars($value->__toString())); ?></corpname>
       <?php if ($address = $value->getPrimaryContact()) { ?>
         <address>
-          <?php if (0 < strlen($addressline = $address->getStreetAddress())) { ?>
+          <?php if (0 < strlen($addressline = $address->getStreetAddress() ?? '')) { ?>
             <addressline><?php echo escape_dc(esc_specialchars($addressline)); ?></addressline>
           <?php } ?>
-          <?php if (0 < strlen($addressline = $address->getCity())) { ?>
+          <?php if (0 < strlen($addressline = $address->getCity() ?? '')) { ?>
             <addressline><?php echo escape_dc(esc_specialchars($addressline)); ?></addressline>
           <?php } ?>
-          <?php if (0 < strlen($addressline = $address->getRegion())) { ?>
+          <?php if (0 < strlen($addressline = $address->getRegion() ?? '')) { ?>
             <addressline><?php echo escape_dc(esc_specialchars($addressline)); ?></addressline>
           <?php } ?>
-          <?php if (0 < strlen($addressline = ${$resourceVar}->getRepositoryCountry())) { ?>
+          <?php if (0 < strlen($addressline = ${$resourceVar}->getRepositoryCountry() ?? '')) { ?>
             <addressline><?php echo escape_dc(esc_specialchars($addressline)); ?></addressline>
           <?php } ?>
-          <?php if (0 < strlen($addressline = $address->getPostalCode())) { ?>
+          <?php if (0 < strlen($addressline = $address->getPostalCode() ?? '')) { ?>
             <addressline><?php echo escape_dc(esc_specialchars($addressline)); ?></addressline>
           <?php } ?>
-          <?php if (0 < strlen($addressline = $address->getTelephone())) { ?>
+          <?php if (0 < strlen($addressline = $address->getTelephone() ?? '')) { ?>
             <addressline><?php echo __('Telephone: ').escape_dc(esc_specialchars($addressline)); ?></addressline>
           <?php } ?>
-          <?php if (0 < strlen($addressline = $address->getFax())) { ?>
+          <?php if (0 < strlen($addressline = $address->getFax() ?? '')) { ?>
             <addressline><?php echo __('Fax: ').escape_dc(esc_specialchars($addressline)); ?></addressline>
           <?php } ?>
-          <?php if (0 < strlen($addressline = $address->getEmail())) { ?>
+          <?php if (0 < strlen($addressline = $address->getEmail() ?? '')) { ?>
             <addressline><?php echo __('Email: ').escape_dc(esc_specialchars($addressline)); ?></addressline>
           <?php } ?>
-          <?php if (0 < strlen($addressline = $address->getWebsite())) { ?>
+          <?php if (0 < strlen($addressline = $address->getWebsite() ?? '')) { ?>
             <addressline><?php echo escape_dc(esc_specialchars($addressline)); ?></addressline>
           <?php } ?>
         </address>
@@ -126,7 +126,7 @@
   <?php if (0 < count(${$resourceVar}->language) || 0 < count(${$resourceVar}->script) || 0 < count(${$resourceVar}->getNotesByType(['noteTypeId' => QubitTerm::LANGUAGE_NOTE_ID]))) { ?>
     <langmaterial encodinganalog="<?php echo $ead->getMetadataParameter('langmaterial'); ?>">
     <?php foreach (${$resourceVar}->language as $languageCode) { ?>
-      <language langcode="<?php echo strtolower($iso639convertor->getID2($languageCode)); ?>"><?php echo format_language($languageCode); ?></language>
+      <language langcode="<?php echo strtolower($iso639convertor->getID2($languageCode) ?? ''); ?>"><?php echo format_language($languageCode); ?></language>
     <?php } ?>
     <?php foreach (${$resourceVar}->script as $scriptCode) { ?>
       <language scriptcode="<?php echo $scriptCode; ?>"><?php echo format_script($scriptCode); ?></language>
@@ -143,37 +143,37 @@
 
   <?php if (0 < count($notes = ${$resourceVar}->getNotesByType(['noteTypeId' => QubitTerm::GENERAL_NOTE_ID]))) { ?>
     <?php foreach ($notes as $note) { ?>
-      <note type="generalNote" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('generalNote'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>>
+      <note type="generalNote" <?php if (0 < strlen($encoding = $ead->getMetadataParameter('generalNote') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>>
         <p><?php echo escape_dc(esc_specialchars($note->getContent(['cultureFallback' => true]))); ?></p>
       </note>
     <?php } ?>
   <?php } ?>
 
-  <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('statementOfScaleCartographic')->__toString())) { ?>
-    <materialspec type='cartographic'  <?php if (0 < strlen($encoding = $ead->getMetadataParameter('cartographic'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></materialspec>
+  <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('statementOfScaleCartographic')->__toString() ?? '')) { ?>
+    <materialspec type='cartographic'  <?php if (0 < strlen($encoding = $ead->getMetadataParameter('cartographic') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></materialspec>
   <?php } ?>
 
-  <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('statementOfProjection')->__toString())) { ?>
-     <materialspec type='projection' <?php if (0 < strlen($encoding = $ead->getMetadataParameter('projection'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></materialspec>
+  <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('statementOfProjection')->__toString() ?? '')) { ?>
+     <materialspec type='projection' <?php if (0 < strlen($encoding = $ead->getMetadataParameter('projection') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></materialspec>
   <?php } ?>
 
-  <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('statementOfCoordinates')->__toString())) { ?>
-    <materialspec type='coordinates' <?php if (0 < strlen($encoding = $ead->getMetadataParameter('coordinates'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></materialspec>
+  <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('statementOfCoordinates')->__toString() ?? '')) { ?>
+    <materialspec type='coordinates' <?php if (0 < strlen($encoding = $ead->getMetadataParameter('coordinates') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></materialspec>
   <?php } ?>
 
-  <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('statementOfScaleArchitectural')->__toString())) { ?>
-    <materialspec type='architectural' <?php if (0 < strlen($encoding = $ead->getMetadataParameter('architectural'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></materialspec>
+  <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('statementOfScaleArchitectural')->__toString() ?? '')) { ?>
+    <materialspec type='architectural' <?php if (0 < strlen($encoding = $ead->getMetadataParameter('architectural') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></materialspec>
   <?php } ?>
 
-  <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('issuingJurisdictionAndDenomination')->__toString())) { ?>
-    <materialspec type='philatelic' <?php if (0 < strlen($encoding = $ead->getMetadataParameter('philatelic'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></materialspec>
+  <?php if (0 < strlen($value = ${$resourceVar}->getPropertyByName('issuingJurisdictionAndDenomination')->__toString() ?? '')) { ?>
+    <materialspec type='philatelic' <?php if (0 < strlen($encoding = $ead->getMetadataParameter('philatelic') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($value)); ?></materialspec>
   <?php } ?>
 
   <?php if (null !== $digitalObject = ${$resourceVar}->digitalObjectsRelatedByobjectId[0]) { ?>
     <?php if (QubitTerm::OFFLINE_ID != $digitalObject->usageId) { ?>
       <?php if (QubitAcl::check(${$resourceVar}, 'readMaster') && 0 < strlen($url = QubitTerm::EXTERNAL_URI_ID == $digitalObject->usageId ? $digitalObject->getPath() : $ead->getAssetPath($digitalObject))) { ?>
         <dao linktype="simple" href="<?php echo $url; ?>" role="master" actuate="onrequest" show="embed"/>
-      <?php } elseif (null !== $digitalObject->reference && QubitAcl::check(${$resourceVar}, 'readReference') && 0 < strlen($url = $ead->getAssetPath($digitalObject, true))) { ?>
+      <?php } elseif (null !== $digitalObject->reference && QubitAcl::check(${$resourceVar}, 'readReference') && 0 < strlen($url = $ead->getAssetPath($digitalObject, true) ?? '')) { ?>
         <dao linktype="simple" href="<?php echo $url; ?>" role="reference" actuate="onrequest" show="embed"/>
       <?php } ?>
     <?php } ?>

--- a/plugins/sfIsaarPlugin/lib/sfIsaarPlugin.class.php
+++ b/plugins/sfIsaarPlugin/lib/sfIsaarPlugin.class.php
@@ -56,6 +56,7 @@ class sfIsaarPlugin implements ArrayAccess
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         $args = func_get_args();
@@ -63,6 +64,7 @@ class sfIsaarPlugin implements ArrayAccess
         return call_user_func_array([$this, '__isset'], $args);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $args = func_get_args();
@@ -70,6 +72,7 @@ class sfIsaarPlugin implements ArrayAccess
         return call_user_func_array([$this, '__get'], $args);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $args = func_get_args();
@@ -77,6 +80,7 @@ class sfIsaarPlugin implements ArrayAccess
         return call_user_func_array([$this, '__set'], $args);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $args = func_get_args();

--- a/plugins/sfIsadPlugin/lib/sfIsadPlugin.class.php
+++ b/plugins/sfIsadPlugin/lib/sfIsadPlugin.class.php
@@ -97,6 +97,7 @@ class sfIsadPlugin implements ArrayAccess
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         $args = func_get_args();
@@ -104,6 +105,7 @@ class sfIsadPlugin implements ArrayAccess
         return call_user_func_array([$this, '__isset'], $args);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $args = func_get_args();
@@ -111,6 +113,7 @@ class sfIsadPlugin implements ArrayAccess
         return call_user_func_array([$this, '__get'], $args);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $args = func_get_args();
@@ -118,6 +121,7 @@ class sfIsadPlugin implements ArrayAccess
         return call_user_func_array([$this, '__set'], $args);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $args = func_get_args();

--- a/plugins/sfIsdfPlugin/lib/sfIsdfPlugin.class.php
+++ b/plugins/sfIsdfPlugin/lib/sfIsdfPlugin.class.php
@@ -114,6 +114,7 @@ class sfIsdfPlugin implements ArrayAccess
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         $args = func_get_args();
@@ -121,6 +122,7 @@ class sfIsdfPlugin implements ArrayAccess
         return call_user_func_array([$this, '__isset'], $args);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $args = func_get_args();
@@ -128,6 +130,7 @@ class sfIsdfPlugin implements ArrayAccess
         return call_user_func_array([$this, '__get'], $args);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $args = func_get_args();
@@ -135,6 +138,7 @@ class sfIsdfPlugin implements ArrayAccess
         return call_user_func_array([$this, '__set'], $args);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $args = func_get_args();

--- a/plugins/sfModsPlugin/lib/sfModsPlugin.class.php
+++ b/plugins/sfModsPlugin/lib/sfModsPlugin.class.php
@@ -158,6 +158,7 @@ class sfModsPlugin implements ArrayAccess
         return $string;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         $args = func_get_args();
@@ -226,6 +227,7 @@ class sfModsPlugin implements ArrayAccess
         return QubitRights::getOne($criteria);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $args = func_get_args();
@@ -233,6 +235,7 @@ class sfModsPlugin implements ArrayAccess
         return call_user_func_array([$this, '__get'], $args);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $args = func_get_args();
@@ -240,6 +243,7 @@ class sfModsPlugin implements ArrayAccess
         return call_user_func_array([$this, '__set'], $args);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $args = func_get_args();

--- a/vendor/symfony/lib/cache/sfAPCCache.class.php
+++ b/vendor/symfony/lib/cache/sfAPCCache.class.php
@@ -18,6 +18,9 @@
  */
 class sfAPCCache extends sfCache
 {
+  public $infoKey;
+  public $createTimeKey;
+  public $modTimeKey;
   /**
    * Initializes this sfCache instance.
    *

--- a/vendor/symfony/lib/form/sfFormField.class.php
+++ b/vendor/symfony/lib/form/sfFormField.class.php
@@ -351,6 +351,7 @@ class sfFormField implements ArrayAccess
     return call_user_func_array(array($this->parent->getWidget()->__get($this->name), 'getOption'), $args);
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -358,6 +359,7 @@ class sfFormField implements ArrayAccess
     return call_user_func_array(array($this, '__get'), $args);
   }
 
+  #[\ReturnTypeWillChange]
   public function __set($name, $value)
   {
     $args = func_get_args();
@@ -365,6 +367,7 @@ class sfFormField implements ArrayAccess
     return call_user_func_array(array($this->parent->getWidget()->__get($this->name), 'setOption'), $args);
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -372,6 +375,7 @@ class sfFormField implements ArrayAccess
     return call_user_func_array(array($this, '__set'), $args);
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();


### PR DESCRIPTION
- Add ReturnTypeWillChange attribute to all offset Get/Set/Unset/Exists methods
- Fix deprecation warnings for call_user_func_array calls
- Fix instances of strlen and strtolower in sfEadPlugin, BaseActor, and
BaseProperty that could run with null values and generate deprecation
warnings, since PHP 8 expects strlen and strtolower to only accept
strings.
- Add missing property to sfEadPlugin.class.php since dynamically creating
properties is deprecated in PHP 8.