### PR TITLE
Fix JS challenge unit test for PHP 8.3

### DIFF
--- a/lib/QubitUserChallenge.class.php
+++ b/lib/QubitUserChallenge.class.php
@@ -19,6 +19,10 @@
 
 class QubitUserChallenge
 {
+    protected $testHeadless;
+    protected $cookieNameHeadless;
+    protected $context;
+
     public function __construct(bool $testHeadless, string $cookieNameHeadless)
     {
         $this->testHeadless = $testHeadless;

--- a/lib/filter/QubitUserChallengeFilter.class.php
+++ b/lib/filter/QubitUserChallengeFilter.class.php
@@ -19,6 +19,9 @@
 
 class QubitUserChallengeFilter extends sfFilter
 {
+    protected $request;
+    protected $remoteIp;
+
     public function execute($filterChain)
     {
         $this->context = $this->getContext();
@@ -146,7 +149,7 @@ class QubitUserChallengeFilter extends sfFilter
     {
         $pathInfo = $this->request->getPathInfoArray();
 
-        return $pathInfo['REMOTE_ADDR'];
+        return $pathInfo['REMOTE_ADDR'] ?? null;
     }
 
     /**

--- a/test/phpunit/lib/QubitGeoIpHelperTest.php
+++ b/test/phpunit/lib/QubitGeoIpHelperTest.php
@@ -89,6 +89,7 @@ class QubitGeoIpHelperTest extends TestCase
 
     public function testGetCountryReturnsNullForInvalidIP()
     {
+        $this->geoIpHelper->setCityDbPath('/new/city/db/path');
         $this->assertNull($this->geoIpHelper->getCountry('invalid-ip'), 'Invalid IP should return null.');
         $this->assertNull($this->geoIpHelper->getCountry(''), 'Empty IP should return null.');
     }
@@ -105,6 +106,7 @@ class QubitGeoIpHelperTest extends TestCase
 
     public function testGetAsnReturnsNullForInvalidIP()
     {
+        $this->geoIpHelper->setAsnDbPath('/new/asn/db/path');
         $this->assertNull($this->geoIpHelper->getAsn('invalid-ip'), 'Invalid IP should return null.');
         $this->assertNull($this->geoIpHelper->getAsn(''), 'Empty IP should return null.');
     }


### PR DESCRIPTION
Fix unit tests for js challenge which were returning PHP 8.x related deprecation warnings and errors. 
- Update QubitUserChallenge and QubitUserChallengeFilter to explicitly declare dynamic properties.
- Also update getRemoteAddress in the QubitUserChallengeFilter to return null if request->getPathInfoArray returns null.