### PR TITLE
Fix ImageMagick Warnings

### DIFF
--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -1937,7 +1937,7 @@ class QubitDigitalObject extends BaseDigitalObject
      */
     public function setPageCount($connection = null)
     {
-        if ($this->canThumbnail() && self::hasImageMagick()) {
+        if ($this->canThumbnail() && sfImageMagickAdapter::isImageMagickAvailable()) {
             $filename = ($this->derivativesGeneratedFromExternalMaster($this->usageId)) ? $this->getLocalPath() : $this->getAbsolutePath();
 
             $extension = pathinfo($filename, PATHINFO_EXTENSION);
@@ -2047,7 +2047,7 @@ class QubitDigitalObject extends BaseDigitalObject
     public function createCompoundChildren($connection = null)
     {
         // Bail out if the imagemagick library is not installed
-        if (false === self::hasImageMagick()) {
+        if (false === sfImageMagickAdapter::isImageMagickAvailable()) {
             return $this;
         }
 
@@ -2396,7 +2396,7 @@ class QubitDigitalObject extends BaseDigitalObject
             return $context->get('thumbnailAdapter');
         }
 
-        if (QubitDigitalObject::hasImageMagick()) {
+        if (sfImageMagickAdapter::isImageMagickAvailable()) {
             $adapter = 'sfImageMagickAdapter';
         } elseif (QubitDigitalObject::hasGdExtension()) {
             $adapter = 'sfGDAdapter';
@@ -2405,19 +2405,6 @@ class QubitDigitalObject extends BaseDigitalObject
         $context->set('thumbnailAdapter', $adapter);
 
         return $adapter;
-    }
-
-    /**
-     * Test if ImageMagick library is installed.
-     *
-     * @return bool true if ImageMagick is found
-     */
-    public static function hasImageMagick()
-    {
-        $command = 'convert -version';
-        exec($command, $output, $status);
-
-        return 0 < count($output) && false !== strpos($output[0], 'ImageMagick');
     }
 
     /**

--- a/plugins/sfThumbnailPlugin/lib/sfImageMagickAdapter.class.php
+++ b/plugins/sfThumbnailPlugin/lib/sfImageMagickAdapter.class.php
@@ -205,9 +205,9 @@ class sfImageMagickAdapter
      *
      * The convert command changed to "magick" in ImageMagick version 7.
      *
-     * @throws Exception when the convert command is not found
-     *
      * @return string The command string used to invoke convert
+     *
+     * @throws Exception when the convert command is not found
      */
     public static function getDefaultConvertCommand()
     {
@@ -234,9 +234,9 @@ class sfImageMagickAdapter
     /**
      * Get (and cache) the default ImageMagick identify command.
      *
-     * @throws Exception when the identify command is not found
-     *
      * @return string The command string used to invoke identify
+     *
+     * @throws Exception when the identify command is not found
      */
     public static function getDefaultIdentifyCommand()
     {

--- a/plugins/sfThumbnailPlugin/lib/sfImageMagickAdapter.class.php
+++ b/plugins/sfThumbnailPlugin/lib/sfImageMagickAdapter.class.php
@@ -141,17 +141,31 @@ class sfImageMagickAdapter
     public function __construct($maxWidth, $maxHeight, $scale, $inflate, $quality, $options)
     {
         $this->magickCommands = [];
-        $this->magickCommands['convert'] = isset($options['convert']) ? escapeshellcmd($options['convert']) : 'convert';
-        $this->magickCommands['identify'] = isset($options['identify']) ? escapeshellcmd($options['identify']) : 'identify';
 
-        exec($this->magickCommands['convert'], $stdout);
-        if (false === strpos($stdout[0], 'ImageMagick')) {
-            throw new Exception(sprintf('ImageMagick convert command not found'));
+        if (isset($options['convert'])) {
+            $this->magickCommands['convert'] = escapeshellcmd($options['convert']);
+
+            $stdout = [];
+            exec($this->magickCommands['convert'], $stdout);
+
+            if (false === strpos($stdout[0], 'ImageMagick')) {
+                throw new Exception(sprintf('Could not find the ImageMagick convert command: %s', $options['convert']));
+            }
+        } else {
+            $this->magickCommands['convert'] = self::getDefaultConvertCommand();
         }
 
-        exec($this->magickCommands['identify'], $stdout);
-        if (false === strpos($stdout[0], 'ImageMagick')) {
-            throw new Exception(sprintf('ImageMagick identify command not found'));
+        if (isset($options['identify'])) {
+            $this->magickCommands['identify'] = escapeshellcmd($options['identify']);
+
+            $stdout = [];
+            exec($this->magickCommands['identify'], $stdout);
+
+            if (false === strpos($stdout[0], 'ImageMagick')) {
+                throw new Exception(sprintf('Could not find the ImageMagick identify command: %s', $options['identify']));
+            }
+        } else {
+            $this->magickCommands['identify'] = self::getDefaultIdentifyCommand();
         }
 
         $this->maxWidth = $maxWidth;

--- a/plugins/sfThumbnailPlugin/lib/sfImageMagickAdapter.class.php
+++ b/plugins/sfThumbnailPlugin/lib/sfImageMagickAdapter.class.php
@@ -479,9 +479,21 @@ class sfImageMagickAdapter
         return $this->sourceMime;
     }
 
+    /**
+     * Test for the pdfinfo command and cache whether it was found.
+     *
+     * @return bool true if pdfinfo is available, false if not
+     */
     public static function pdfinfoToolAvailable()
     {
-        return !empty(shell_exec('which pdfinfo'));
+        if (null !== self::$pdfInfoAvailable) {
+            return self::$pdfInfoAvailable;
+        }
+
+        exec('pdfinfo -h 2>&1', $stdout);
+        self::$pdfInfoAvailable = false !== strpos($stdout[0], 'pdfinfo');
+
+        return self::$pdfInfoAvailable;
     }
 
     public static function getPdfPageCount($filename)

--- a/plugins/sfThumbnailPlugin/lib/sfImageMagickAdapter.class.php
+++ b/plugins/sfThumbnailPlugin/lib/sfImageMagickAdapter.class.php
@@ -29,6 +29,12 @@ class sfImageMagickAdapter
     protected $source;
     protected $magickCommands;
 
+    // Cached static properties
+    protected static $defaultConvertCommand;
+    protected static $defaultIdentifyCommand;
+    protected static $imageMagickAvailable;
+    protected static $pdfInfoAvailable;
+
     /**
      * Mime types this adapter supports.
      */
@@ -154,6 +160,87 @@ class sfImageMagickAdapter
         $this->inflate = $inflate;
         $this->quality = $quality;
         $this->options = $options;
+    }
+
+    /**
+     * Test for the ImageMagick commands convert & identify, and cache whether they were found or
+     * not.
+     *
+     * @return bool true if ImageMagick is available, false if not
+     */
+    public static function isImageMagickAvailable()
+    {
+        if (null !== self::$imageMagickAvailable) {
+            return self::$imageMagickAvailable;
+        }
+
+        try {
+            // Either of these functions will throw an exception if ImageMagick is not installed
+            self::getDefaultConvertCommand();
+            self::getDefaultIdentifyCommand();
+            self::$imageMagickAvailable = true;
+        } catch (Exception) {
+            self::$imageMagickAvailable = false;
+        }
+
+        return self::$imageMagickAvailable;
+    }
+
+    /**
+     * Get (and cache) the default ImageMagick convert command.
+     *
+     * The convert command changed to "magick" in ImageMagick version 7.
+     *
+     * @throws Exception when the convert command is not found
+     *
+     * @return string The command string used to invoke convert
+     */
+    public static function getDefaultConvertCommand()
+    {
+        if (self::$defaultConvertCommand) {
+            return self::$defaultConvertCommand;
+        }
+
+        $convertCommand = 'convert';
+
+        exec("{$convertCommand} -help 2>&1", $stdout);
+
+        // The convert command is deprected in v7, use magick instead
+        if (false !== strpos($stdout[0], 'The convert command is deprecated')) {
+            $convertCommand = 'magick';
+        } elseif (false === strpos($stdout[0], 'ImageMagick')) {
+            throw new Exception('ImageMagick convert command not found');
+        }
+
+        self::$defaultConvertCommand = $convertCommand;
+
+        return self::$defaultConvertCommand;
+    }
+
+    /**
+     * Get (and cache) the default ImageMagick identify command.
+     *
+     * @throws Exception when the identify command is not found
+     *
+     * @return string The command string used to invoke identify
+     */
+    public static function getDefaultIdentifyCommand()
+    {
+        if (self::$defaultIdentifyCommand) {
+            return self::$defaultIdentifyCommand;
+        }
+
+        $identifyCommand = 'identify';
+
+        exec("{$identifyCommand} -help", $stdout);
+
+        if (false === strpos($stdout[0], 'ImageMagick')) {
+            throw new Exception('ImageMagick identify command not found');
+        }
+
+        self::$defaultIdentifyCommand = $identifyCommand;
+
+        return self::$defaultIdentifyCommand;
     }
 
     public function toString($thumbnail, $targetMime = null)

--- a/plugins/sfThumbnailPlugin/lib/sfImageMagickAdapter.class.php
+++ b/plugins/sfThumbnailPlugin/lib/sfImageMagickAdapter.class.php
@@ -457,7 +457,8 @@ class sfImageMagickAdapter
         $output = (is_null($thumbDest)) ? '-' : $thumbDest;
         $output = (($mime = array_search($targetMime, $this->mimeMap)) ? $mime.':' : '').$output;
 
-        $cmd = $this->magickCommands['convert'].' '.$command.' '.escapeshellarg($this->image).$extract.' '.escapeshellarg($output);
+        $cmd = $this->magickCommands['convert'].' '.escapeshellarg($this->image).$extract.' '.$command.' '.escapeshellarg($output);
+
         (is_null($thumbDest)) ? passthru($cmd) : exec($cmd);
     }
 


### PR DESCRIPTION
This addresses #1918 

Changes include:

- Use the command `magick` instead of `convert` in ImageMagick version 7. See [Command Changes on this page](https://imagemagick.org/script/porting.php).
  - The new function `getDefaultConvertCommand()` automatically detects if `magick` should be used instead of `convert` by looking for the deprecation message.
- Fix ordering of `convert` arguments that caused the error message "convert: missing required argument"
  - The input file path is supposed to come before all the arguments, so I swapped those around.
- Pass `-help` to `identify` to resolve seeing the error message "identify: missing required argument"
- Cache checking for commands `identify`, `convert`, and `pdfinfo`. This will improve performance by checking for the existence of those tools at most one time.

Before making this change, the output of `digitalobject:load` looks like this:

![Screenshot-Before-Change](https://github.com/user-attachments/assets/43fccdc1-683e-4187-8286-d2ddb570a82d)

And after making this change, the output of `digitalobject:load` looks like this:

![Screenshot-After-Change](https://github.com/user-attachments/assets/6ded49a7-5928-41e6-8217-943dafac78ad)
