### PR TITLE
Bump Dockerfile to use PHP8.3, the recommended version for 2.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm-alpine
+FROM php:8.3-fpm-alpine
 
 ENV FOP_HOME=/usr/share/fop-2.1 \
     COMPOSER_ALLOW_SUPERUSER=1 \


### PR DESCRIPTION
The recommended version of PHP is 8.3 per the AtoM documentation for 2.9
