### PR TITLE
Set elasticsearch setting for Docker Environment

### DIFF
--- a/docker/etc/environment
+++ b/docker/etc/environment
@@ -1,6 +1,7 @@
 # Elasticsearch
 bootstrap.memory_lock=true
 cluster.routing.allocation.disk.threshold_enabled=false
+bootstrap.system_call_filter: false
 ES_JAVA_OPTS=-Xms640m -Xmx640m
 
 # MySQL


### PR DESCRIPTION
I had to set bootstrap.system_call_filter: false as I was getting the following error


```
elasticsearch-1  | OpenJDK 64-Bit Server VM warning: UseAVX=2 is not supported on this CPU, setting it to UseAVX=0
elasticsearch-1  | [2025-04-11T14:07:12,860][WARN ][o.e.b.JNANatives         ] [unknown] unable to install syscall filter:
elasticsearch-1  | java.lang.UnsupportedOperationException: seccomp unavailable: CONFIG_SECCOMP not compiled into kernel, CONFIG_SECCOMP and CONFIG_SECCOMP_FILTER are needed
elasticsearch-1  | 	at org.elasticsearch.bootstrap.SystemCallFilter.linuxImpl(SystemCallFilter.java:342) ~[elasticsearch-6.8.23.jar:6.8.23]
elasticsearch-1  | 	at org.elasticsearch.bootstrap.SystemCallFilter.init(SystemCallFilter.java:617) ~[elasticsearch-6.8.23.jar:6.8.23]
elasticsearch-1  | 	at org.elasticsearch.bootstrap.JNANatives.tryInstallSystemCallFilter(JNANatives.java:260) [elasticsearch-6.8.23.jar:6.8.23]
elasticsearch-1  | 	at org.elasticsearch.bootstrap.Natives.tryInstallSystemCallFilter(Natives.java:113) [elasticsearch-6.8.23.jar:6.8.23]
elasticsearch-1  | 	at org.elasticsearch.bootstrap.Bootstrap.initializeNatives(Bootstrap.java:108) [elasticsearch-6.8.23.jar:6.8.23]
elasticsearch-1  | 	at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:170) [elasticsearch-6.8.23.jar:6.8.23]
elasticsearch-1  | 	at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:333) [elasticsearch-6.8.23.jar:6.8.23]
elasticsearch-1  | 	at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:159) [elasticsearch-6.8.23.jar:6.8.23]
elasticsearch-1  | 	at org.elasticsearch.bootstrap.Elasticsearch.execute(Elasticsearch.java:150) [elasticsearch-6.8.23.jar:6.8.23]
elasticsearch-1  | 	at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:86) [elasticsearch-6.8.23.jar:6.8.23]
elasticsearch-1  | 	at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:124) [elasticsearch-cli-6.8.23.jar:6.8.23]
elasticsearch-1  | 	at org.elasticsearch.cli.Command.main(Command.java:90) [elasticsearch-cli-6.8.23.jar:6.8.23]
elasticsearch-1  | 	at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:116) [elasticsearch-6.8.23.jar:6.8.23]
elasticsearch-1  | 	at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:93) [elasticsearch-6.8.23.jar:6.8.23]
elasticsearch-1  | [2025-04-11T14:07:13,433][INFO ][o.e.e.NodeEnvironment    ] [cjPL5ta] using [1] data paths, mounts [[/usr/share/elasticsearch/data (/dev/vda1)]], net usable_space [924.1gb], net total_space [1006.8gb], types [ext4]
elasticsearch-1  | [2025-04-11T14:07:13,434][INFO ][o.e.e.NodeEnvironment    ] [cjPL5ta] heap size [640mb], compressed ordinary object pointers [true]
elasticsearch-1  | [2025-04-11T14:07:13,463][INFO ][o.e.n.Node               ] [cjPL5ta] node name derived from node ID [cjPL5taaSyKHZqsn_30KHQ]; set [node.name] to override
elasticsearch-1  | [2025-04-11T14:07:13,464][INFO ][o.e.n.Node               ] [cjPL5ta] version[6.8.23], pid[1], build[oss/docker/4f67856/2022-01-06T21:30:50.087716Z], OS[Linux/6.10.14-linuxkit/amd64], JVM[AdoptOpenJDK/OpenJDK 64-Bit Server VM/15.0.1/15.0.1+9]
elasticsearch-1  | [2025-04-11T14:07:13,464][INFO ][o.e.n.Node               ] [cjPL5ta] JVM arguments [-Xms1g, -Xmx1g, -XX:+UseG1GC, -XX:G1ReservePercent=25, -XX:InitiatingHeapOccupancyPercent=30, -Des.networkaddress.cache.ttl=60, -Des.networkaddress.cache.negative.ttl=10, -XX:+AlwaysPreTouch, -Xss1m, -Djava.awt.headless=true, -Dfile.encoding=UTF-8, -Djna.nosys=true, -XX:-OmitStackTraceInFastThrow, -XX:+ShowCodeDetailsInExceptionMessages, -Dio.netty.noUnsafe=true, -Dio.netty.noKeySetOptimization=true, -Dio.netty.recycler.maxCapacityPerThread=0, -Dlog4j.shutdownHookEnabled=false, -Dlog4j2.disable.jmx=true, -Dlog4j2.formatMsgNoLookups=true, -Djava.io.tmpdir=/tmp/elasticsearch-2089402841443649266, -XX:+HeapDumpOnOutOfMemoryError, -XX:HeapDumpPath=data, -XX:ErrorFile=logs/hs_err_pid%p.log, -Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m, -Djava.locale.providers=COMPAT, -XX:UseAVX=2, -Des.cgroups.hierarchy.override=/, -Xms640m, -Xmx640m, -Des.path.home=/usr/share/elasticsearch, -Des.path.conf=/usr/share/elasticsearch/config, -Des.distribution.flavor=oss, -Des.distribution.type=docker]
elasticsearch-1  | [2025-04-11T14:07:14,353][INFO ][o.e.p.PluginsService     ] [cjPL5ta] loaded module [aggs-matrix-stats]
elasticsearch-1  | [2025-04-11T14:07:14,354][INFO ][o.e.p.PluginsService     ] [cjPL5ta] loaded module [analysis-common]
elasticsearch-1  | [2025-04-11T14:07:14,354][INFO ][o.e.p.PluginsService     ] [cjPL5ta] loaded module [ingest-common]
elasticsearch-1  | [2025-04-11T14:07:14,354][INFO ][o.e.p.PluginsService     ] [cjPL5ta] loaded module [ingest-geoip]
elasticsearch-1  | [2025-04-11T14:07:14,354][INFO ][o.e.p.PluginsService     ] [cjPL5ta] loaded module [ingest-user-agent]
elasticsearch-1  | [2025-04-11T14:07:14,354][INFO ][o.e.p.PluginsService     ] [cjPL5ta] loaded module [lang-expression]
elasticsearch-1  | [2025-04-11T14:07:14,354][INFO ][o.e.p.PluginsService     ] [cjPL5ta] loaded module [lang-mustache]
elasticsearch-1  | [2025-04-11T14:07:14,354][INFO ][o.e.p.PluginsService     ] [cjPL5ta] loaded module [lang-painless]
elasticsearch-1  | [2025-04-11T14:07:14,354][INFO ][o.e.p.PluginsService     ] [cjPL5ta] loaded module [mapper-extras]
elasticsearch-1  | [2025-04-11T14:07:14,354][INFO ][o.e.p.PluginsService     ] [cjPL5ta] loaded module [parent-join]
elasticsearch-1  | [2025-04-11T14:07:14,354][INFO ][o.e.p.PluginsService     ] [cjPL5ta] loaded module [percolator]
elasticsearch-1  | [2025-04-11T14:07:14,354][INFO ][o.e.p.PluginsService     ] [cjPL5ta] loaded module [rank-eval]
elasticsearch-1  | [2025-04-11T14:07:14,354][INFO ][o.e.p.PluginsService     ] [cjPL5ta] loaded module [reindex]
elasticsearch-1  | [2025-04-11T14:07:14,354][INFO ][o.e.p.PluginsService     ] [cjPL5ta] loaded module [repository-url]
elasticsearch-1  | [2025-04-11T14:07:14,354][INFO ][o.e.p.PluginsService     ] [cjPL5ta] loaded module [transport-netty4]
elasticsearch-1  | [2025-04-11T14:07:14,354][INFO ][o.e.p.PluginsService     ] [cjPL5ta] loaded module [tribe]
elasticsearch-1  | [2025-04-11T14:07:14,355][INFO ][o.e.p.PluginsService     ] [cjPL5ta] no plugins loaded
elasticsearch-1  | [2025-04-11T14:07:17,672][INFO ][o.e.d.DiscoveryModule    ] [cjPL5ta] using discovery type [zen] and host providers [settings]
elasticsearch-1  | [2025-04-11T14:07:18,077][INFO ][o.e.n.Node               ] [cjPL5ta] initialized
elasticsearch-1  | [2025-04-11T14:07:18,077][INFO ][o.e.n.Node               ] [cjPL5ta] starting ...
elasticsearch-1  | [2025-04-11T14:07:18,198][INFO ][o.e.t.TransportService   ] [cjPL5ta] publish_address {172.18.0.4:9300}, bound_addresses {[::]:9300}
elasticsearch-1  | [2025-04-11T14:07:18,246][INFO ][o.e.b.BootstrapChecks    ] [cjPL5ta] bound or publishing to a non-loopback address, enforcing bootstrap checks
elasticsearch-1  | ERROR: [1] bootstrap checks failed
elasticsearch-1  | [1]: system call filters failed to install; check the logs and fix your configuration or disable system call filters at your own risk
```


I'm running on an Apple M2 Pro, so not sure if related to that, or just a change in the version of Elasticsearch with the 2.9 release, or even just because it's running in a container?

