### PR TITLE
CAS Fixes (Upgrade CAS, and address package name change)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "phing/phing": "2.*",
         "league/csv": "^9.4",
-        "apereo/phpcas": "^1.3.8",
+        "apereo/phpcas": "^1.6.1",
         "ezyang/htmlpurifier": "^4.13",
         "ruflin/elastica": "6.*",
         "jumbojett/openid-connect-php": "^1.0",

--- a/plugins/arCasPlugin/config/app.yml
+++ b/plugins/arCasPlugin/config/app.yml
@@ -5,6 +5,9 @@ all:
     # CAS version 3.0 is required for parsing CAS attributes into user groups.
     cas_version: '3.0'
 
+    # Enable debugging of CAS
+    debug: false
+
     # Default to live demo server for testing and QA.
     server_name: 'django-cas-ng-demo-server.herokuapp.com'
     server_port: 443 

--- a/plugins/arCasPlugin/config/app.yml
+++ b/plugins/arCasPlugin/config/app.yml
@@ -38,8 +38,8 @@ all:
             attribute_value: 'atom-translators'
             group_id: 103
 
-    # Override default service URL.
-    # Needed when hostname does not match the host part of the AtoM
+    # Set the default service URL. (Required)
+    # phpCAS requires setting a default service URL
     # instance URL
     # e.g. https://atom.somedomain.org/cas/login
     service_url:

--- a/plugins/arCasPlugin/lib/arCAS.class.php
+++ b/plugins/arCasPlugin/lib/arCAS.class.php
@@ -34,8 +34,6 @@ class arCAS
             return;
         }
 
-        require_once sfConfig::get('sf_root_dir').'/vendor/composer/autoload.php';
-
         if (true == sfConfig::get('sf_debug', false)) {
             $debugLogPath = sfConfig::get('sf_log_dir').'/phpcas.log';
             phpCAS::setDebug($debugLogPath);

--- a/plugins/arCasPlugin/lib/arCAS.class.php
+++ b/plugins/arCasPlugin/lib/arCAS.class.php
@@ -34,7 +34,7 @@ class arCAS
             return;
         }
 
-        if (true == sfConfig::get('sf_debug', false)) {
+        if (true == sfConfig::get('sf_debug', false) || true == sfConfig::get('app_cas_debug', false)) {
             $debugLogPath = sfConfig::get('sf_log_dir').'/phpcas.log';
             phpCAS::setDebug($debugLogPath);
             phpCAS::setVerbose(true);

--- a/plugins/arCasPlugin/lib/arCAS.class.php
+++ b/plugins/arCasPlugin/lib/arCAS.class.php
@@ -34,7 +34,7 @@ class arCAS
             return;
         }
 
-        require_once sfConfig::get('sf_root_dir').'/vendor/composer/jasig/phpcas/CAS.php';
+        require_once sfConfig::get('sf_root_dir').'/vendor/composer/autoload.php';
 
         if (true == sfConfig::get('sf_debug', false)) {
             $debugLogPath = sfConfig::get('sf_log_dir').'/phpcas.log';
@@ -51,6 +51,7 @@ class arCAS
             sfConfig::get('app_cas_server_name'),
             sfConfig::get('app_cas_server_port'),
             sfConfig::get('app_cas_server_path'),
+            sfConfig::get('app_cas_service_url'),
             false  // Let Symfony handle the session
         );
 

--- a/plugins/arCasPlugin/lib/casUser.class.php
+++ b/plugins/arCasPlugin/lib/casUser.class.php
@@ -57,7 +57,13 @@ class casUser extends myUser implements Zend_Acl_Role_Interface
         }
 
         $authenticated = true;
-        $this->signIn($user);
+
+        // Clear template cache.
+        $cacheClear = new sfCacheClearTask(sfContext::getInstance()->getEventDispatcher(), new sfFormatter());
+        $cacheClear->run([], ['type' => 'template']);
+
+        // Refresh user so new groups and credentials are immediately available on signIn().
+        $this->signIn(QubitUser::getById($user->id));
 
         return $authenticated;
     }


### PR DESCRIPTION
- **Upgrade phpCAS to at least version 1.6.1 / Service URL for CAS Required**
- **Allow for debugging CAS on it's own**
- **Clear template cache and reset the user after login for CAS**

The vendor name for phpcas changed from jasig to apereo, but when you include the file it says to use composer. I changed the require_once to include the composer autoload instead directly loading the library directly.
