### PR TITLE
Clipboard fixes

### DIFF
--- a/apps/qubit/modules/clipboard/actions/saveAction.class.php
+++ b/apps/qubit/modules/clipboard/actions/saveAction.class.php
@@ -36,7 +36,16 @@ class ClipboardSaveAction extends sfAction
         } else {
             $this->saveClipboard($validatedSlugs, $password);
 
-            $itemsCount = count($validatedSlugs['informationObject']) + count($validatedSlugs['actor']) + count($validatedSlugs['repository']);
+            $itemsCount = 0;
+            if (array_key_exists('informationObject', $validatedSlugs)) {
+                $itemsCount += count($validatedSlugs['informationObject']);
+            }
+            if (array_key_exists('actor', $validatedSlugs)) {
+                $itemsCount += count($validatedSlugs['actor']);
+            }
+            if (array_key_exists('repository', $validatedSlugs)) {
+                $itemsCount += count($validatedSlugs['repository']);
+            }
 
             $loadUrl = $this->context->routing->generate(null, ['module' => 'clipboard', 'action' => 'load']);
             $message = $this->context->i18n->__("Clipboard saved with %1% items. Clipboard ID is <b>%2%</b>. Please write this number down. When you want to reload this clipboard in the future, open the Clipboard menu, select <a class='alert-link' href='%3%'>Load clipboard</a>, and enter this number in the Clipboard ID field.", ['%1%' => $itemsCount, '%2%' => $password, '%3%' => $loadUrl]);

--- a/plugins/arDominionB5Plugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/sfIsdiahPlugin/templates/indexSuccess.php
@@ -54,7 +54,7 @@
     <h4 class="h5 mb-2"><?php echo __('Clipboard'); ?></h4>
     <ul class="list-unstyled">
       <li>
-        <?php echo get_component('clipboard', 'button', ['slug' => $resource->slug, 'wide' => true, 'type' => 'informationObject']); ?>
+        <?php echo get_component('clipboard', 'button', ['slug' => $resource->slug, 'wide' => true, 'type' => 'repository']); ?>
       </li>
     </ul>
 


### PR DESCRIPTION
PR fixes a bug that breaks clipboard save functionality caused by changes in PHP 8.

In PHP 8, the [count()](https://www.php.net/manual/en/function.count.php) function now throws a fatal error if the array doesn't exist (such as when any of the 3 clipboards are empty), rather than just returning 0 as it did with previous versions. This PR just adds a check for each key and only counts them if they exist.

PR also fixes a bug where the clipboard button type was incorrect for repository pages for the BS5 theme. This was causing these clipboard items to be counted as Archival descriptions and not show up properly in the clipboard.