### PR TITLE
Enable searching by term name for accessions

### DIFF
--- a/apps/qubit/modules/informationobject/actions/browseAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/browseAction.class.php
@@ -196,9 +196,14 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
         // Add advanced form filter to the query
         $this->search->addAdvancedSearchFilters($this::$NAMES, $this->getParameters, $this->template);
 
+        // Bind filled values to form (skip null and empty fields)
+        $filteredRequestParams = array_filter($request->getRequestParameters(), fn ($item) => !empty($item));
+        $filteredGetParams = array_filter($this->getParameters, fn ($item) => !empty($item));
+
+        $this->form->bind($filteredRequestParams + $filteredGetParams);
+
         // Stop if the input is not valid. It must be after the query is created but before
         // it's executed to keep the boolean search and other params for the next request
-        $this->form->bind($request->getRequestParameters() + $request->getGetParameters());
         if (!$this->form->isValid()) {
             return;
         }
@@ -509,7 +514,7 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
         }
 
         // Set label for date range
-        if (isset($request->startDate) || isset($request->endDate)) {
+        if (!empty($request->startDate) || !empty($request->endDate)) {
             $dateRangeLabel = '[ '.$request->startDate.' - '.$request->endDate.' ]';
             $this->setFilterTagLabel('dateRange', $dateRangeLabel);
         }

--- a/apps/qubit/modules/informationobject/templates/_relatedMaterialDescriptions.php
+++ b/apps/qubit/modules/informationobject/templates/_relatedMaterialDescriptions.php
@@ -12,18 +12,22 @@
         <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->object->getPublicationStatus()->statusId) { ?>
           <?php $itemTitle = $item->object->__toString(); ?>
 
-          <?php if (isset($item->object->levelOfDescription) || isset($item->object->identifier)) { ?>
+          <?php if (property_exists($item->object, 'levelOfDescription') || property_exists($item->object, 'identifier')) { ?>
             <?php $itemTitle = "- {$itemTitle}"; ?>
-              <?php if (isset($item->object->identifier)) { ?>
+              <?php if (property_exists($item->object, 'identifier')) { ?>
                 <?php $itemTitle = "{$item->object->referenceCode} {$itemTitle}"; ?>
               <?php } ?>
-              <?php if (isset($item->object->levelOfDescription)) { ?>
+              <?php if (property_exists($item->object, 'levelOfDescription')) { ?>
                 <?php $itemTitle = "{$item->object->levelOfDescription} {$itemTitle}"; ?>
               <?php } ?>
           <?php } ?>
 
-          <?php if (QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $item->object->getPublicationStatus()->statusId) { ?>
-            <?php $itemTitle .= " ({$item->object->getPublicationStatus()})"; ?>
+
+          <?php if (method_exists($item->object, 'getPublicationStatus')) { ?>
+            <?php $status = $item->object->getPublicationStatus(); ?>
+            <?php if ($status && QubitTerm::PUBLICATION_STATUS_DRAFT_ID === $status->id) { ?>
+              <?php $itemTitle .= " ({$status})"; ?>
+            <?php } ?>
           <?php } ?>
 
           <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
@@ -36,18 +40,21 @@
         <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->subject->getPublicationStatus()->statusId) { ?>
           <?php $itemTitle = $item->subject->__toString(); ?>
 
-          <?php if (isset($item->subject->levelOfDescription) || isset($item->subject->identifier)) { ?>
+          <?php if (property_exists($item->subject, 'levelOfDescription') || property_exists($item->subject, 'identifier')) { ?>
             <?php $itemTitle = "- {$itemTitle}"; ?>
-              <?php if (isset($item->subject->identifier)) { ?>
+              <?php if (property_exists($item->subject, 'identifier')) { ?>
                 <?php $itemTitle = "{$item->subject->referenceCode} {$itemTitle}"; ?>
               <?php } ?>
-              <?php if (isset($item->subject->levelOfDescription)) { ?>
+              <?php if (property_exists($item->subject, 'levelOfDescription')) { ?>
                 <?php $itemTitle = "{$item->subject->levelOfDescription} {$itemTitle}"; ?>
               <?php } ?>
           <?php } ?>
 
-          <?php if (QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $item->subject->getPublicationStatus()->statusId) { ?>
-            <?php $itemTitle .= " ({$item->subject->getPublicationStatus()})"; ?>
+          <?php if (method_exists($item->subject, 'getPublicationStatus')) { ?>
+            <?php $status = $item->subject->getPublicationStatus(); ?>
+            <?php if ($status && QubitTerm::PUBLICATION_STATUS_DRAFT_ID === $status->id) { ?>
+              <?php $itemTitle .= " ({$status})"; ?>
+            <?php } ?>
           <?php } ?>
 
           <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>

--- a/apps/qubit/modules/informationobject/templates/_relatedMaterialDescriptions.php
+++ b/apps/qubit/modules/informationobject/templates/_relatedMaterialDescriptions.php
@@ -9,7 +9,7 @@
   <div>
     <ul>
       <?php foreach ($resource->relationsRelatedBysubjectId as $item) { ?>
-        <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->object->getPublicationStatus()->statusId) { ?>
+        <?php if (method_exists($item->object, 'getPublicationStatus') && ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->object->getPublicationStatus()->statusId)) { ?>
           <?php $itemTitle = $item->object->__toString(); ?>
 
           <?php if (property_exists($item->object, 'levelOfDescription') || property_exists($item->object, 'identifier')) { ?>
@@ -22,12 +22,9 @@
               <?php } ?>
           <?php } ?>
 
-
-          <?php if (method_exists($item->object, 'getPublicationStatus')) { ?>
-            <?php $status = $item->object->getPublicationStatus(); ?>
-            <?php if ($status && QubitTerm::PUBLICATION_STATUS_DRAFT_ID === $status->id) { ?>
-              <?php $itemTitle .= " ({$status})"; ?>
-            <?php } ?>
+          <?php $status = $item->object->getPublicationStatus(); ?>
+          <?php if ($status && QubitTerm::PUBLICATION_STATUS_DRAFT_ID === $status->id) { ?>
+            <?php $itemTitle .= " ({$status})"; ?>
           <?php } ?>
 
           <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
@@ -37,7 +34,7 @@
       <?php } ?>
 
       <?php foreach ($resource->relationsRelatedByobjectId as $item) { ?>
-        <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->subject->getPublicationStatus()->statusId) { ?>
+        <?php if (method_exists($item->subject, 'getPublicationStatus') && ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->subject->getPublicationStatus()->statusId)) { ?>
           <?php $itemTitle = $item->subject->__toString(); ?>
 
           <?php if (property_exists($item->subject, 'levelOfDescription') || property_exists($item->subject, 'identifier')) { ?>
@@ -50,11 +47,9 @@
               <?php } ?>
           <?php } ?>
 
-          <?php if (method_exists($item->subject, 'getPublicationStatus')) { ?>
-            <?php $status = $item->subject->getPublicationStatus(); ?>
-            <?php if ($status && QubitTerm::PUBLICATION_STATUS_DRAFT_ID === $status->id) { ?>
-              <?php $itemTitle .= " ({$status})"; ?>
-            <?php } ?>
+          <?php $status = $item->subject->getPublicationStatus(); ?>
+          <?php if ($status && QubitTerm::PUBLICATION_STATUS_DRAFT_ID === $status->id) { ?>
+            <?php $itemTitle .= " ({$status})"; ?>
           <?php } ?>
 
           <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "phing/phing": "2.*",
         "league/csv": "^9.4",
-        "apereo/phpcas": "^1.3.8",
+        "apereo/phpcas": "^1.6.1",
         "ezyang/htmlpurifier": "^4.13",
         "ruflin/elastica": "6.*",
         "jumbojett/openid-connect-php": "^1.0",

--- a/lib/model/om/BaseObject.php
+++ b/lib/model/om/BaseObject.php
@@ -132,7 +132,7 @@ abstract class BaseObject implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {

--- a/plugins/arCasPlugin/config/app.yml
+++ b/plugins/arCasPlugin/config/app.yml
@@ -5,6 +5,9 @@ all:
     # CAS version 3.0 is required for parsing CAS attributes into user groups.
     cas_version: '3.0'
 
+    # Enable debugging of CAS
+    debug: false
+
     # Default to live demo server for testing and QA.
     server_name: 'django-cas-ng-demo-server.herokuapp.com'
     server_port: 443 
@@ -38,8 +41,8 @@ all:
             attribute_value: 'atom-translators'
             group_id: 103
 
-    # Override default service URL.
-    # Needed when hostname does not match the host part of the AtoM
+    # Set the default service URL. (Required)
+    # phpCAS requires setting a default service URL
     # instance URL
     # e.g. https://atom.somedomain.org/cas/login
     service_url:

--- a/plugins/arCasPlugin/lib/arCAS.class.php
+++ b/plugins/arCasPlugin/lib/arCAS.class.php
@@ -34,9 +34,7 @@ class arCAS
             return;
         }
 
-        require_once sfConfig::get('sf_root_dir').'/vendor/composer/jasig/phpcas/CAS.php';
-
-        if (true == sfConfig::get('sf_debug', false)) {
+        if (true == sfConfig::get('sf_debug', false) || true == sfConfig::get('app_cas_debug', false)) {
             $debugLogPath = sfConfig::get('sf_log_dir').'/phpcas.log';
             phpCAS::setDebug($debugLogPath);
             phpCAS::setVerbose(true);
@@ -51,6 +49,7 @@ class arCAS
             sfConfig::get('app_cas_server_name'),
             sfConfig::get('app_cas_server_port'),
             sfConfig::get('app_cas_server_path'),
+            sfConfig::get('app_cas_service_url'),
             false  // Let Symfony handle the session
         );
 

--- a/plugins/arCasPlugin/lib/casUser.class.php
+++ b/plugins/arCasPlugin/lib/casUser.class.php
@@ -57,7 +57,13 @@ class casUser extends myUser implements Zend_Acl_Role_Interface
         }
 
         $authenticated = true;
-        $this->signIn($user);
+
+        // Clear template cache.
+        $cacheClear = new sfCacheClearTask(sfContext::getInstance()->getEventDispatcher(), new sfFormatter());
+        $cacheClear->run([], ['type' => 'template']);
+
+        // Refresh user so new groups and credentials are immediately available on signIn().
+        $this->signIn(QubitUser::getById($user->id));
 
         return $authenticated;
     }

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_relatedMaterialDescriptions.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_relatedMaterialDescriptions.php
@@ -9,7 +9,7 @@
   <div class="<?php echo render_b5_show_value_css_classes(); ?>">
     <ul class="<?php echo render_b5_show_list_css_classes(); ?>">
       <?php foreach ($resource->relationsRelatedBysubjectId as $item) { ?>
-        <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->object->getPublicationStatus()->statusId) { ?>
+        <?php if (method_exists($item->object, 'getPublicationStatus') && ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->object->getPublicationStatus()->statusId)) { ?>
           <?php $itemTitle = $item->object->__toString(); ?>
 
           <?php if (property_exists($item->object, 'levelOfDescription') || property_exists($item->object, 'identifier')) { ?>
@@ -22,12 +22,9 @@
               <?php } ?>
           <?php } ?>
 
-
-          <?php if (method_exists($item->object, 'getPublicationStatus')) { ?>
-            <?php $status = $item->object->getPublicationStatus(); ?>
-            <?php if ($status && QubitTerm::PUBLICATION_STATUS_DRAFT_ID === $status->id) { ?>
-              <?php $itemTitle .= " ({$status})"; ?>
-            <?php } ?>
+          <?php $status = $item->object->getPublicationStatus(); ?>
+          <?php if ($status && QubitTerm::PUBLICATION_STATUS_DRAFT_ID === $status->id) { ?>
+            <?php $itemTitle .= " ({$status})"; ?>
           <?php } ?>
 
           <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
@@ -37,7 +34,7 @@
       <?php } ?>
 
       <?php foreach ($resource->relationsRelatedByobjectId as $item) { ?>
-        <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->subject->getPublicationStatus()->statusId) { ?>
+        <?php if (method_exists($item->subject, 'getPublicationStatus') && ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->subject->getPublicationStatus()->statusId)) { ?>
           <?php $itemTitle = $item->subject->__toString(); ?>
 
           <?php if (property_exists($item->subject, 'levelOfDescription') || property_exists($item->subject, 'identifier')) { ?>
@@ -50,11 +47,9 @@
               <?php } ?>
           <?php } ?>
 
-          <?php if (method_exists($item->subject, 'getPublicationStatus')) { ?>
-            <?php $status = $item->subject->getPublicationStatus(); ?>
-            <?php if ($status && QubitTerm::PUBLICATION_STATUS_DRAFT_ID === $status->id) { ?>
-              <?php $itemTitle .= " ({$status})"; ?>
-            <?php } ?>
+          <?php $status = $item->subject->getPublicationStatus(); ?>
+          <?php if ($status && QubitTerm::PUBLICATION_STATUS_DRAFT_ID === $status->id) { ?>
+            <?php $itemTitle .= " ({$status})"; ?>
           <?php } ?>
 
           <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_relatedMaterialDescriptions.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_relatedMaterialDescriptions.php
@@ -12,18 +12,22 @@
         <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->object->getPublicationStatus()->statusId) { ?>
           <?php $itemTitle = $item->object->__toString(); ?>
 
-          <?php if (isset($item->object->levelOfDescription) || isset($item->object->identifier)) { ?>
+          <?php if (property_exists($item->object, 'levelOfDescription') || property_exists($item->object, 'identifier')) { ?>
             <?php $itemTitle = "- {$itemTitle}"; ?>
-              <?php if (isset($item->object->identifier)) { ?>
+              <?php if (property_exists($item->object, 'identifier')) { ?>
                 <?php $itemTitle = "{$item->object->referenceCode} {$itemTitle}"; ?>
               <?php } ?>
-              <?php if (isset($item->object->levelOfDescription)) { ?>
+              <?php if (property_exists($item->object, 'levelOfDescription')) { ?>
                 <?php $itemTitle = "{$item->object->levelOfDescription} {$itemTitle}"; ?>
               <?php } ?>
           <?php } ?>
 
-          <?php if (QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $item->object->getPublicationStatus()->statusId) { ?>
-            <?php $itemTitle .= " ({$item->object->getPublicationStatus()})"; ?>
+
+          <?php if (method_exists($item->object, 'getPublicationStatus')) { ?>
+            <?php $status = $item->object->getPublicationStatus(); ?>
+            <?php if ($status && QubitTerm::PUBLICATION_STATUS_DRAFT_ID === $status->id) { ?>
+              <?php $itemTitle .= " ({$status})"; ?>
+            <?php } ?>
           <?php } ?>
 
           <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
@@ -36,18 +40,21 @@
         <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->subject->getPublicationStatus()->statusId) { ?>
           <?php $itemTitle = $item->subject->__toString(); ?>
 
-          <?php if (isset($item->subject->levelOfDescription) || isset($item->subject->identifier)) { ?>
+          <?php if (property_exists($item->subject, 'levelOfDescription') || property_exists($item->subject, 'identifier')) { ?>
             <?php $itemTitle = "- {$itemTitle}"; ?>
-              <?php if (isset($item->subject->identifier)) { ?>
+              <?php if (property_exists($item->subject, 'identifier')) { ?>
                 <?php $itemTitle = "{$item->subject->referenceCode} {$itemTitle}"; ?>
               <?php } ?>
-              <?php if (isset($item->subject->levelOfDescription)) { ?>
+              <?php if (property_exists($item->subject, 'levelOfDescription')) { ?>
                 <?php $itemTitle = "{$item->subject->levelOfDescription} {$itemTitle}"; ?>
               <?php } ?>
           <?php } ?>
 
-          <?php if (QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $item->subject->getPublicationStatus()->statusId) { ?>
-            <?php $itemTitle .= " ({$item->subject->getPublicationStatus()})"; ?>
+          <?php if (method_exists($item->subject, 'getPublicationStatus')) { ?>
+            <?php $status = $item->subject->getPublicationStatus(); ?>
+            <?php if ($status && QubitTerm::PUBLICATION_STATUS_DRAFT_ID === $status->id) { ?>
+              <?php $itemTitle .= " ({$status})"; ?>
+            <?php } ?>
           <?php } ?>
 
           <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>

--- a/plugins/arElasticSearchPlugin/config/mapping.yml
+++ b/plugins/arElasticSearchPlugin/config/mapping.yml
@@ -419,6 +419,7 @@ mapping:
     _foreign_types:
       accession_events: accession_event
       alternative_identifiers: other_name
+      acquisition_type: term
       donors: donor
     dynamic: strict
     properties:

--- a/plugins/arElasticSearchPlugin/lib/model/arElasticSearchAccession.class.php
+++ b/plugins/arElasticSearchPlugin/lib/model/arElasticSearchAccession.class.php
@@ -177,6 +177,11 @@ class arElasticSearchAccession extends arElasticSearchModelBase
             $serialized['creators'][] = $creators;
         }
 
+        if (null !== $data['acquisition_type_id']) {
+            $node = new arElasticSearchTermPdo($data['acquisition_type_id']);
+            $serialized['acquisitionType'] = $node->serialize();
+        }
+
         $serialized['accessionEvents'] = self::getAccessionEvents($id);
 
         return $serialized;

--- a/plugins/qtAccessionPlugin/modules/accession/actions/browseAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/browseAction.class.php
@@ -101,6 +101,7 @@ class AccessionBrowseAction extends sfAction
                 'i18n.%s.physicalCharacteristics' => 1,
                 'i18n.%s.receivedExtentUnits' => 1,
                 'alternativeIdentifiers.i18n.%s.name' => 1,
+                'acquisitionType.i18n.%s.name' => 1,
                 'creators.i18n.%s.authorizedFormOfName' => 1,
                 'alternativeIdentifiers.i18n.%s.note' => 1,
                 'alternativeIdentifiers.type.i18n.%s.name' => 1,


### PR DESCRIPTION
Addresses #1986 

Enables the four terms directly linked to an accession to be searchable from the frontend:

- Acquisition type
- Resource type
- Processing status
- Processing priority