### PR TITLE
Filter empty fields from bound form values

### DIFF
--- a/apps/qubit/modules/informationobject/actions/browseAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/browseAction.class.php
@@ -196,9 +196,14 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
         // Add advanced form filter to the query
         $this->search->addAdvancedSearchFilters($this::$NAMES, $this->getParameters, $this->template);
 
+        // Bind filled values to form (skip null and empty fields)
+        $filteredRequestParams = array_filter($request->getRequestParameters(), fn ($item) => !empty($item));
+        $filteredGetParams = array_filter($this->getParameters, fn ($item) => !empty($item));
+
+        $this->form->bind($filteredRequestParams + $filteredGetParams);
+
         // Stop if the input is not valid. It must be after the query is created but before
         // it's executed to keep the boolean search and other params for the next request
-        $this->form->bind($request->getRequestParameters() + $request->getGetParameters());
         if (!$this->form->isValid()) {
             return;
         }
@@ -509,7 +514,7 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
         }
 
         // Set label for date range
-        if (isset($request->startDate) || isset($request->endDate)) {
+        if (!empty($request->startDate) || !empty($request->endDate)) {
             $dateRangeLabel = '[ '.$request->startDate.' - '.$request->endDate.' ]';
             $this->setFilterTagLabel('dateRange', $dateRangeLabel);
         }


### PR DESCRIPTION
Addresses #1991 

Before this change, the values bound to the advanced search form look like this:

- First request, searching "Sample":
  - `sf0="Sample"` is bound to the form
  - `startDate=""` is bound to the form
  - `endDate=""` is bound to the form
- Second request, adding date range "2000-01-01" to "2000-12-31"
  - `sf0="Sample"` is bound to the form
  - `startDate` is not set, hence it is not bound to the form
  - `endDate` is not set, hence it is not bound to the form

This has the effect of completely removing the searched date range, as if the user had never entered the date range. If a *third* request is made with a date range, the startDate and endDate are both set. I'm thinking this is probably because there was no value bound to the form for startDate and endDate in the second search request.

With the changes included in this pull request, the values bound to the form look like this:

- First request, searching "Sample":
  - `sf0="Sample"` is bound to the form
  - `startDate` is not set, hence it is not bound to the form
  - `endDate` is not set, hence it is not bound to the form
- Second request, adding date range "2000-01-01" to "2000-12-31"
  - `sf0="Sample"` is bound to the form
  - `startDate="2000-01-01"` is bound to the form
  - `endDate="2000-12-31"` is bound to the form

This prevents the startDate and endDate from being erased from the results.