### PR TITLE
Update DebugPDO.php for PHP8

### DIFF
--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel/util/DebugPDO.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel/util/DebugPDO.php
@@ -328,7 +328,7 @@ class DebugPDO extends PropelPDO
 	 * @see        http://php.net/manual/en/pdo.query.php for a description of the possible parameters.
 	 * @return     PDOStatement
 	 */
-	public function query()
+	public function query(string $query, ?int $fetchMode = null, mixed ...$fetchModeArgs): PDOStatement|false
 	{
 		$debug	= $this->getDebugSnapshot();
 		$args	= func_get_args();


### PR DESCRIPTION
From the ica-atom-users listserv Alberto Pereira recommended this change to make debug mode work.

https://groups.google.com/g/ica-atom-users/c/jBw4fyD5ZvE/m/L8B1ECsKBwAJ