### PR TITLE
Fix descriptions with related descriptions. (#2018)

### DIFF
--- a/lib/model/QubitRights.php
+++ b/lib/model/QubitRights.php
@@ -23,11 +23,11 @@ class QubitRights extends BaseRights
     {
         $string = [];
 
-        if (isset($this->basis)) {
+        if (property_exists($this, 'basis') && isset($this->basis)) {
             $string[] = $this->basis;
         }
 
-        if (isset($this->act)) {
+        if (property_exists($this, 'act') && isset($this->act)) {
             $string[] = $this->act;
         }
 

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_relatedMaterialDescriptions.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_relatedMaterialDescriptions.php
@@ -9,7 +9,7 @@
   <div class="<?php echo render_b5_show_value_css_classes(); ?>">
     <ul class="<?php echo render_b5_show_list_css_classes(); ?>">
       <?php foreach ($resource->relationsRelatedBysubjectId as $item) { ?>
-        <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->object->getPublicationStatus()->statusId) { ?>
+        <?php if ($sf_user->isAuthenticated() || (method_exists($item->subject, 'getPublicationStatus') && QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->object->getPublicationStatus()->statusId)) { ?>
           <?php $itemTitle = $item->object->__toString(); ?>
 
           <?php if (property_exists($item->object, 'levelOfDescription') || property_exists($item->object, 'identifier')) { ?>
@@ -22,9 +22,11 @@
               <?php } ?>
           <?php } ?>
 
-          <?php $status = $item->object->getPublicationStatus(); ?>
-          <?php if ($status && QubitTerm::PUBLICATION_STATUS_DRAFT_ID === $status->id) { ?>
-            <?php $itemTitle .= " ({$status})"; ?>
+          <?php if (method_exists($item->subject, 'getPublicationStatus')) { ?>
+            <?php $status = $item->object->getPublicationStatus(); ?>
+            <?php if ($status && QubitTerm::PUBLICATION_STATUS_DRAFT_ID === $status->id) { ?>
+              <?php $itemTitle .= " ({$status})"; ?>
+            <?php } ?>
           <?php } ?>
 
           <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>


### PR DESCRIPTION
500 error was result of call to non-existent property in QubitRights.