### PR TITLE
Add clipboard retention in save success message

### DIFF
--- a/apps/qubit/modules/clipboard/actions/saveAction.class.php
+++ b/apps/qubit/modules/clipboard/actions/saveAction.class.php
@@ -49,20 +49,9 @@ class ClipboardSaveAction extends sfAction
 
             $loadUrl = $this->context->routing->generate(null, ['module' => 'clipboard', 'action' => 'load']);
 
-            if (1 == $itemsCount) {
-                $itemsUnit = $this->context->i18n->__('item');
-            } else {
-                $itemsUnit = $this->context->i18n->__('items');
-            }
-
             $retention = sfconfig::get('app_clipboard_save_max_age');
-            if (1 == $retention) {
-                $retentionUnit = $this->context->i18n->__('day');
-            } else {
-                $retentionUnit = $this->context->i18n->__('days');
-            }
 
-            $message = $this->context->i18n->__('Clipboard saved with %1% %2%. Clipboard ID is <b>%3%</b>. Please write this number down. When you want to reload this clipboard in the future, open the Clipboard menu, select <a class="alert-link" href="%4%">Load clipboard</a>, and enter this number in the Clipboard ID field. Clipboards are eligible for deletion after <b>%5% %6%</b>.', ['%1%' => $itemsCount, '%2%' => $itemsUnit, '%3%' => $password, '%4%' => $loadUrl, '%5%' => $retention, '%6%' => $retentionUnit]);
+            $message = $this->context->i18n->__('Clipboard saved with %1% item(s). Clipboard ID is <b>%2%</b>. Please write this number down. When you want to reload this clipboard in the future, open the Clipboard menu, select <a class="alert-link" href="%3%">Load clipboard</a>, and enter this number in the Clipboard ID field. Clipboards are eligible for deletion after <b>%4% day(s)</b>.', ['%1%' => $itemsCount, '%2%' => $password, '%3%' => $loadUrl, '%4%' => $retention]);
             $this->response->setStatusCode(200);
             $responseData = ['success' => $message];
         }

--- a/apps/qubit/modules/clipboard/actions/saveAction.class.php
+++ b/apps/qubit/modules/clipboard/actions/saveAction.class.php
@@ -49,9 +49,20 @@ class ClipboardSaveAction extends sfAction
 
             $loadUrl = $this->context->routing->generate(null, ['module' => 'clipboard', 'action' => 'load']);
 
-            $retention = sfconfig::get('app_clipboard_save_max_age');
+            if ($itemsCount == 1) {
+                $itemsUnit = $this->context->i18n->__('item');
+            } else {
+                $itemsUnit = $this->context->i18n->__('items');
+            }
 
-            $message = $this->context->i18n->__('Clipboard saved with %1% items. Clipboard ID is <b>%2%</b>. Please write this number down. When you want to reload this clipboard in the future, open the Clipboard menu, select <a class="alert-link" href="%3%">Load clipboard</a>, and enter this number in the Clipboard ID field. Clipboards are eligible for deletion after <b>%4% days.<b>', ['%1%' => $itemsCount, '%2%' => $password, '%3%' => $loadUrl, '%4%' => $retention]);
+            $retention = sfconfig::get('app_clipboard_save_max_age');
+            if ($retention == 1) {
+                $retentionUnit = $this->context->i18n->__('day');
+            } else {
+                $retentionUnit = $this->context->i18n->__('days');
+            }
+
+            $message = $this->context->i18n->__('Clipboard saved with %1% %2%. Clipboard ID is <b>%3%</b>. Please write this number down. When you want to reload this clipboard in the future, open the Clipboard menu, select <a class="alert-link" href="%4%">Load clipboard</a>, and enter this number in the Clipboard ID field. Clipboards are eligible for deletion after <b>%5% %6%.<b>', ['%1%' => $itemsCount, '%2%' => $itemsUnit, '%3%' => $password, '%4%' => $loadUrl, '%5%' => $retention, '%6%' => $retentionUnit]);
             $this->response->setStatusCode(200);
             $responseData = ['success' => $message];
         }

--- a/apps/qubit/modules/clipboard/actions/saveAction.class.php
+++ b/apps/qubit/modules/clipboard/actions/saveAction.class.php
@@ -62,7 +62,7 @@ class ClipboardSaveAction extends sfAction
                 $retentionUnit = $this->context->i18n->__('days');
             }
 
-            $message = $this->context->i18n->__('Clipboard saved with %1% %2%. Clipboard ID is <b>%3%</b>. Please write this number down. When you want to reload this clipboard in the future, open the Clipboard menu, select <a class="alert-link" href="%4%">Load clipboard</a>, and enter this number in the Clipboard ID field. Clipboards are eligible for deletion after <b>%5% %6%.<b>', ['%1%' => $itemsCount, '%2%' => $itemsUnit, '%3%' => $password, '%4%' => $loadUrl, '%5%' => $retention, '%6%' => $retentionUnit]);
+            $message = $this->context->i18n->__('Clipboard saved with %1% %2%. Clipboard ID is <b>%3%</b>. Please write this number down. When you want to reload this clipboard in the future, open the Clipboard menu, select <a class="alert-link" href="%4%">Load clipboard</a>, and enter this number in the Clipboard ID field. Clipboards are eligible for deletion after <b>%5% %6%<b>.', ['%1%' => $itemsCount, '%2%' => $itemsUnit, '%3%' => $password, '%4%' => $loadUrl, '%5%' => $retention, '%6%' => $retentionUnit]);
             $this->response->setStatusCode(200);
             $responseData = ['success' => $message];
         }

--- a/apps/qubit/modules/clipboard/actions/saveAction.class.php
+++ b/apps/qubit/modules/clipboard/actions/saveAction.class.php
@@ -62,7 +62,7 @@ class ClipboardSaveAction extends sfAction
                 $retentionUnit = $this->context->i18n->__('days');
             }
 
-            $message = $this->context->i18n->__('Clipboard saved with %1% %2%. Clipboard ID is <b>%3%</b>. Please write this number down. When you want to reload this clipboard in the future, open the Clipboard menu, select <a class="alert-link" href="%4%">Load clipboard</a>, and enter this number in the Clipboard ID field. Clipboards are eligible for deletion after <b>%5% %6%<b>.', ['%1%' => $itemsCount, '%2%' => $itemsUnit, '%3%' => $password, '%4%' => $loadUrl, '%5%' => $retention, '%6%' => $retentionUnit]);
+            $message = $this->context->i18n->__('Clipboard saved with %1% %2%. Clipboard ID is <b>%3%</b>. Please write this number down. When you want to reload this clipboard in the future, open the Clipboard menu, select <a class="alert-link" href="%4%">Load clipboard</a>, and enter this number in the Clipboard ID field. Clipboards are eligible for deletion after <b>%5% %6%</b>.', ['%1%' => $itemsCount, '%2%' => $itemsUnit, '%3%' => $password, '%4%' => $loadUrl, '%5%' => $retention, '%6%' => $retentionUnit]);
             $this->response->setStatusCode(200);
             $responseData = ['success' => $message];
         }

--- a/apps/qubit/modules/clipboard/actions/saveAction.class.php
+++ b/apps/qubit/modules/clipboard/actions/saveAction.class.php
@@ -48,8 +48,10 @@ class ClipboardSaveAction extends sfAction
             }
 
             $loadUrl = $this->context->routing->generate(null, ['module' => 'clipboard', 'action' => 'load']);
-            $message = $this->context->i18n->__('Clipboard saved with %1% items. Clipboard ID is <b>%2%</b>. Please write this number down. When you want to reload this clipboard in the future, open the Clipboard menu, select <a class="alert-link" href="%3%">Load clipboard</a>, and enter this number in the Clipboard ID field.', ['%1%' => $itemsCount, '%2%' => $password, '%3%' => $loadUrl]);
 
+            $retention = sfconfig::get('app_clipboard_save_max_age');
+
+            $message = $this->context->i18n->__('Clipboard saved with %1% items. Clipboard ID is <b>%2%</b>. Please write this number down. When you want to reload this clipboard in the future, open the Clipboard menu, select <a class="alert-link" href="%3%">Load clipboard</a>, and enter this number in the Clipboard ID field. Clipboards are eligible for deletion after <b>%4% days.<b>', ['%1%' => $itemsCount, '%2%' => $password, '%3%' => $loadUrl, '%4%' => $retention]);
             $this->response->setStatusCode(200);
             $responseData = ['success' => $message];
         }

--- a/apps/qubit/modules/clipboard/actions/saveAction.class.php
+++ b/apps/qubit/modules/clipboard/actions/saveAction.class.php
@@ -49,14 +49,14 @@ class ClipboardSaveAction extends sfAction
 
             $loadUrl = $this->context->routing->generate(null, ['module' => 'clipboard', 'action' => 'load']);
 
-            if ($itemsCount == 1) {
+            if (1 == $itemsCount) {
                 $itemsUnit = $this->context->i18n->__('item');
             } else {
                 $itemsUnit = $this->context->i18n->__('items');
             }
 
             $retention = sfconfig::get('app_clipboard_save_max_age');
-            if ($retention == 1) {
+            if (1 == $retention) {
                 $retentionUnit = $this->context->i18n->__('day');
             } else {
                 $retentionUnit = $this->context->i18n->__('days');


### PR DESCRIPTION
PR adds additional feedback to clipboard save success message to let users know how many days until clipboards are eligible for deletion. This reflects the clipboard max age setting which is typically only viewable by users with admin privileges.

I've also made the success message sensative to the correct grammatical number for 'item/items' saved, as well as for 'day/days' the clipboard will be retained. I think I've done this in a way that should work with Weblate.