### PR TITLE
Allow configuration of conversion quality params (#2033)

### DIFF
--- a/apps/qubit/modules/settings/actions/uploadsAction.class.php
+++ b/apps/qubit/modules/settings/actions/uploadsAction.class.php
@@ -25,6 +25,9 @@ class SettingsUploadsAction extends SettingsEditAction
         'explode_multipage_files',
         'repository_quota',
         'upload_quota',
+        'convert_density',
+        'convert_quality',
+        'convert_memory',
     ];
 
     public function earlyExecute()
@@ -38,6 +41,9 @@ class SettingsUploadsAction extends SettingsEditAction
             'explode_multipage_files' => 0,
             'repository_quota' => 0,
             'upload_quota' => -1,
+            'convert_density' => 150,
+            'convert_quality' => 90,
+            'convert_memory' => "500M",
         ];
 
         // Set form decorator
@@ -89,6 +95,31 @@ class SettingsUploadsAction extends SettingsEditAction
                 ));
                 $this->form->setWidget($name, new sfWidgetFormInput());
 
+                break;
+
+            case 'convert_density':
+                $this->form->setValidator($name, new sfValidatorNumber(
+                    ['required' => true, 'min' => 10, 'max' => 2000],
+                    ['min' => $this->i18n->__('Minimum value is "%min%"'),
+                        'max' => $this->i18n->__('Maximum value is "%max%"')]
+                ));
+                $this->form->setWidget($name, new sfWidgetFormInput());
+
+                break;
+
+            case 'convert_quality':
+                $this->form->setValidator($name, new sfValidatorNumber(
+                    ['required' => true, 'min' => 10, 'max' => 100],
+                    ['min' => $this->i18n->__('Minimum value is "%min%"'),
+                        'max' => $this->i18n->__('Maximum value is "%max%"')]
+                ));
+                $this->form->setWidget($name, new sfWidgetFormInput());
+
+                break;
+
+            case 'convert_memory':
+                $this->form->setValidator($name, new sfValidatorString(['required' => true]));
+                $this->form->setWidget($name, new sfWidgetFormInput());
                 break;
 
             case 'upload_quota':

--- a/apps/qubit/modules/settings/actions/uploadsAction.class.php
+++ b/apps/qubit/modules/settings/actions/uploadsAction.class.php
@@ -43,7 +43,7 @@ class SettingsUploadsAction extends SettingsEditAction
             'upload_quota' => -1,
             'convert_density' => 150,
             'convert_quality' => 90,
-            'convert_memory' => "500M",
+            'convert_memory' => '500M',
         ];
 
         // Set form decorator
@@ -120,6 +120,7 @@ class SettingsUploadsAction extends SettingsEditAction
             case 'convert_memory':
                 $this->form->setValidator($name, new sfValidatorString(['required' => true]));
                 $this->form->setWidget($name, new sfWidgetFormInput());
+
                 break;
 
             case 'upload_quota':

--- a/apps/qubit/modules/settings/templates/uploadsSuccess.php
+++ b/apps/qubit/modules/settings/templates/uploadsSuccess.php
@@ -80,6 +80,27 @@
               ->renderRow();
           ?>
 
+          <?php echo $form
+              ->convert_density
+              ->label(__('Derivatives density'))
+              ->help(__('Density of media conversion in dpi, reduce it to reduce quality.'))
+              ->renderRow();
+          ?>
+
+          <?php echo $form
+              ->convert_quality
+              ->label(__('Derivatives quality'))
+              ->help(__('Quality of derivatives, a number from 1 to 100, the higher the number, the better the quality, but large derivative files.'))
+              ->renderRow();
+          ?>
+
+          <?php echo $form
+              ->convert_memory
+              ->label(__('Derivatives memory limit'))
+              ->help(__('Memory limit, you can use suffixes like MB, GB, or KiB, MiB, GiB to specify the unit.'))
+              ->renderRow();
+          ?>
+
         </tbody>
       </table>
 

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -36,6 +36,10 @@ class QubitDigitalObject extends BaseDigitalObject
     // Flag for updating search index on save or delete
     public $createDerivatives = true;
 
+    public static $defaultConvertDensity = 150;
+    public static $defaultConvertQuality = 90;
+    public static $defaultConvertMemoryLimit = "500MiB";
+    
     /*
      * The following mime-type array is taken from the Gallery 2 project
      * http://gallery.menalto.com
@@ -1997,12 +2001,15 @@ class QubitDigitalObject extends BaseDigitalObject
     /**
      * Explode multi-page asset into multiple image files.
      *
-     * @return unknown
+     * @return array
+     * @throws sfException
      */
     public function explodeMultiPageAsset()
     {
-        $pageCount = $this->getPageCount();
+        $logger = sfContext::getInstance()->getLogger();
 
+        $pageCount = $this->getPageCount();
+        $fileList = [];
         if ($pageCount > 1 && $this->canThumbnail()) {
             if ($this->derivativesGeneratedFromExternalMaster($this->usageId)) {
                 $path = $this->localPath;
@@ -2012,9 +2019,27 @@ class QubitDigitalObject extends BaseDigitalObject
 
             $filenameMinusExtension = preg_replace('/\.[a-zA-Z]{2,3}$/', '', $path);
 
-            $command = 'convert -density 300 -alpha remove -quality 100 ';
-            $command .= $path;
+            $command = 'convert -alpha remove ';
+            $params = [];
+            $memory = sfConfig::get('convert_memory', $this::$defaultConvertMemoryLimit);
+            if ($memory) {
+                $params[] = "-limit memory $memory";
+            }
+
+            $density = sfConfig::get('convert_density', $this::$defaultConvertDensity);
+            if ($density) {
+                $params[] = "-density $density";
+            }
+
+            $quality = sfConfig::get('convert_quality', self::$defaultConvertQuality);
+            if ($quality) {
+                $params[] = "-quality $quality";
+            }
+
+            $command .= implode(' ', $params);
+            $command .= ' '.$path;
             $command .= ' '.$filenameMinusExtension.'_%02d.'.self::THUMB_EXTENSION;
+            $logger->info($command);
             exec($command, $output, $status);
 
             if (1 == $status) {
@@ -2204,7 +2229,7 @@ class QubitDigitalObject extends BaseDigitalObject
         if (null === $this->localPath && QubitTerm::EXTERNAL_FILE_ID == $this->usageId) {
             $filename = basename($this->path);
             if (false === $contents = $this->file_get_contents_if_not_empty($this->path)) {
-                throw new sfException(sprintf('Error reading file or file is empty.', $filepath));
+                throw new sfException(sprintf('Error reading file or file is empty.', $this->path));
             }
             $this->localPath = Qubit::saveTemporaryFile($filename, $contents);
         }

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -38,8 +38,8 @@ class QubitDigitalObject extends BaseDigitalObject
 
     public static $defaultConvertDensity = 150;
     public static $defaultConvertQuality = 90;
-    public static $defaultConvertMemoryLimit = "500MiB";
-    
+    public static $defaultConvertMemoryLimit = '500MiB';
+
     /*
      * The following mime-type array is taken from the Gallery 2 project
      * http://gallery.menalto.com
@@ -2002,6 +2002,7 @@ class QubitDigitalObject extends BaseDigitalObject
      * Explode multi-page asset into multiple image files.
      *
      * @return array
+     *
      * @throws sfException
      */
     public function explodeMultiPageAsset()
@@ -2023,17 +2024,17 @@ class QubitDigitalObject extends BaseDigitalObject
             $params = [];
             $memory = sfConfig::get('convert_memory', $this::$defaultConvertMemoryLimit);
             if ($memory) {
-                $params[] = "-limit memory $memory";
+                $params[] = "-limit memory {$memory}";
             }
 
             $density = sfConfig::get('convert_density', $this::$defaultConvertDensity);
             if ($density) {
-                $params[] = "-density $density";
+                $params[] = "-density {$density}";
             }
 
             $quality = sfConfig::get('convert_quality', self::$defaultConvertQuality);
             if ($quality) {
-                $params[] = "-quality $quality";
+                $params[] = "-quality {$quality}";
             }
 
             $command .= implode(' ', $params);

--- a/plugins/arDominionB5Plugin/modules/settings/templates/uploadsSuccess.php
+++ b/plugins/arDominionB5Plugin/modules/settings/templates/uploadsSuccess.php
@@ -62,6 +62,24 @@
 
             <?php echo render_field($form->explode_multipage_files
                 ->label(__('Upload multi-page files as multiple descriptions'))); ?>
+
+            <?php echo render_field($form
+                ->convert_density
+                ->label(__('Derivatives density'))
+                ->help(__('Density of media conversion in dpi, reduce it to reduce quality.')));
+            ?>
+
+            <?php echo render_field($form
+                ->convert_quality
+                ->label(__('Derivatives quality'))
+                ->help(__('Quality of derivatives, a number from 1 to 100, the higher the number, the better the quality, but large derivative files.')));
+            ?>
+
+            <?php echo render_field($form
+                ->convert_memory
+                ->label(__('Derivatives memory limit'))
+                ->help(__('Memory limit, you can use suffixes like MB, GB, or KiB, MiB, GiB to specify the unit.')));
+            ?>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This issue solves #2033 , by allowing a set of new params on the Uploads Settings panel:

<img width="1319" alt="image" src="https://github.com/user-attachments/assets/b6fb9e66-c17f-41d3-bdd3-c0b4c8cc20e5" />

* Density: in dpi. Default value is 150. Used by ImageMagick `convert` to set the [density param](https://imagemagick.org/script/command-line-options.php#density).
* Quality: a number from 0 to 100. Default value is 90. Used by ImageMagick `convert` to set the [quality param](https://imagemagick.org/script/command-line-options.php#quality).
* Max memory: set the max memory ImageMagick `convert` will use (see [limit param](https://imagemagick.org/script/command-line-options.php#limit))

It also modifies the way the `QubitDigitalObject` creates derivatives, by using those params.