### PR TITLE
Fix for remove invisible fields on csv export

### DIFF
--- a/lib/flatfile/QubitFlatfileExport.class.php
+++ b/lib/flatfile/QubitFlatfileExport.class.php
@@ -243,9 +243,7 @@ class QubitFlatfileExport
      */
     public function exportResource(&$resource)
     {
-        if (!$this->configurationLoaded) {
-            $this->loadResourceSpecificConfiguration(get_class($resource));
-        }
+        $this->loadResourceSpecificConfiguration(get_class($resource));
 
         if (!$this->params['nonVisibleElementsIncluded']) {
             $this->getHiddenVisibleElementCsvHeaders();


### PR DESCRIPTION
This PR fixes #2041

Current implementation is loading resource configuration just on the first record, but we need to make sure invisible fields are removed on every execution of `QubitFlatfileExport.exportResource`.
