### PR TITLE
Add test-debug composer script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,10 @@
     },
     "scripts": {
         "test": "phpunit",
+        "test-debug": [
+            "@putenv XDEBUG_SESSION=1",
+            "phpunit"
+        ],
         "test-cov": "@php -dpcov.enabled=1 -dpcov.directory=. ./vendor/composer/bin/phpunit --coverage-html=.coverage/html",
         "test-cov-strict": "@php -dpcov.enabled=1 -dpcov.directory=. ./vendor/composer/bin/phpunit --coverage-html=.coverage/html --strict-coverage",
         "php-cs-fixer": "php-cs-fixer"


### PR DESCRIPTION
This PR adds a new composer command to run phpunit with xdebug enabled. This makes it so that you can debug tests in your IDE with xdebug.

Closes #2046 