### PR TITLE
Fix i18n string in the browse page (#2050)

### DIFF
--- a/lib/model/om/BaseActor.php
+++ b/lib/model/om/BaseActor.php
@@ -242,7 +242,7 @@ abstract class BaseActor extends QubitObject implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrentactorI18n($options), '__get'), $args) ?? '') && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrentactorI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrentactorI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }

--- a/lib/model/om/BaseProperty.php
+++ b/lib/model/om/BaseProperty.php
@@ -264,7 +264,7 @@ abstract class BaseProperty implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrentpropertyI18n($options), '__get'), $args) ?? '') && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrentpropertyI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrentpropertyI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }


### PR DESCRIPTION
Cast inputs to strlen as strings in BaseActor and BaseProperty instead of passing empty string if they're null.

(strlen expects strings, and will output a deprecation warning if null is passed to it since PHP 8.2)