### PR TITLE
Add system dates to informationobject read (GET) endpoint

### DIFF
--- a/plugins/arRestApiPlugin/modules/api/actions/informationobjectsReadAction.class.php
+++ b/plugins/arRestApiPlugin/modules/api/actions/informationobjectsReadAction.class.php
@@ -378,6 +378,12 @@ class ApiInformationObjectsReadAction extends QubitApiAction
             $this->addItemToArray($ioData, 'digital_object', $doData);
         }
 
+        $systemDates = [];
+        $this->addItemToArray($systemDates, 'created_at', $this->resource->createdAt);
+        $this->addItemToArray($systemDates, 'updated_at', $this->resource->updatedAt);
+
+        $this->addItemToArray($ioData, 'system_dates', $systemDates);
+
         return $ioData;
     }
 

--- a/plugins/arRestApiPlugin/modules/api/actions/informationobjectsReadAction.class.php
+++ b/plugins/arRestApiPlugin/modules/api/actions/informationobjectsReadAction.class.php
@@ -378,11 +378,11 @@ class ApiInformationObjectsReadAction extends QubitApiAction
             $this->addItemToArray($ioData, 'digital_object', $doData);
         }
 
-        $systemDates = [];
-        $this->addItemToArray($systemDates, 'created_at', $this->resource->createdAt);
-        $this->addItemToArray($systemDates, 'updated_at', $this->resource->updatedAt);
+        $timestamps = [];
+        $this->addItemToArray($timestamps, 'created_at', $this->resource->createdAt);
+        $this->addItemToArray($timestamps, 'updated_at', $this->resource->updatedAt);
 
-        $this->addItemToArray($ioData, 'system_dates', $systemDates);
+        $this->addItemToArray($ioData, 'atom_timestamps', $timestamps);
 
         return $ioData;
     }


### PR DESCRIPTION
PR adds system dates (`created_at` and `updated_at`) to the informationobject read (GET) endpoint.

This came out of a conversation with a colleague about potential ways of monitoring AtoM's system generated `updated_at` date without having direct database access. This would then be used as a means of automatically triggering the export and syncing of descriptive information that would exist on a secondary non-AtoM based system (like a library OPAC). Beyond this use case, having access to these data can help with version control between separately managed systems.

Currently the only way of getting the `updated_at` date without querying the database directly is via the description edit page, as it's not included as part of the other export methods (DC, EAD, or .csv). It also doesn't fit well in the DC and EAD standards, so the API seems like the logical place to have these data. Additionally, since the API requires authentication, the system dates remain only accessible to authenticated users.

Example output:
![API_systemDates](https://github.com/user-attachments/assets/6b70db8f-c31d-4c85-a00c-2af190dc7b7f)

