### PR TITLE
Fix implode call for arGenerateReportJob (#2068)

### DIFF
--- a/lib/job/arGenerateReportJob.class.php
+++ b/lib/job/arGenerateReportJob.class.php
@@ -237,7 +237,7 @@ class arGenerateReportJob extends arBaseJob
                     'referenceCode' => $informationObject->referenceCode,
                     'physicalObjectName' => $item->__toString(),
                     'title' => $informationObject->__toString(),
-                    'creationDates' => implode($creationDates, '|'),
+                    'creationDates' => implode('|', $creationDates),
                 ];
             }
         }


### PR DESCRIPTION
Update implode function call in arGenerateReportJob to use string parameter first and array second since the alternative function signature that allows the string to be second has been discontinued in PHP 8.0