### PR TITLE
Restore new related material formatting and fix 500 error when linking containers

### DIFF
--- a/apps/qubit/modules/informationobject/templates/_relatedMaterialDescriptions.php
+++ b/apps/qubit/modules/informationobject/templates/_relatedMaterialDescriptions.php
@@ -5,55 +5,54 @@
   <?php } else { ?>
     <h3><?php echo __('Related descriptions'); ?></h3>
   <?php } ?>
-
   <div>
     <ul>
       <?php foreach ($resource->relationsRelatedBysubjectId as $item) { ?>
-        <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->object->getPublicationStatus()->statusId) { ?>
-          <?php $itemTitle = $item->object->__toString(); ?>
+        <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
+          <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->object->getPublicationStatus()->statusId) { ?>
+            <?php $itemTitle = $item->object->__toString(); ?>
 
-          <?php if (property_exists($item->object, 'levelOfDescription') || property_exists($item->object, 'identifier')) { ?>
-            <?php $itemTitle = "- {$itemTitle}"; ?>
-              <?php if (property_exists($item->object, 'identifier')) { ?>
-                <?php $itemTitle = "{$item->object->referenceCode} {$itemTitle}"; ?>
-              <?php } ?>
-              <?php if (property_exists($item->object, 'levelOfDescription')) { ?>
-                <?php $itemTitle = "{$item->object->levelOfDescription} {$itemTitle}"; ?>
-              <?php } ?>
-          <?php } ?>
+            <?php if (isset($item->object->levelOfDescription) || isset($item->object->identifier)) { ?>
+              <?php $itemTitle = "- {$itemTitle}"; ?>
+                <?php if (isset($item->object->identifier)) { ?>
+                  <?php $itemTitle = "{$item->object->referenceCode} {$itemTitle}"; ?>
+                <?php } ?>
+                <?php if (isset($item->object->levelOfDescription)) { ?>
+                  <?php $itemTitle = "{$item->object->levelOfDescription} {$itemTitle}"; ?>
+                <?php } ?>
+            <?php } ?>
 
-          <?php $status = $item->object->getPublicationStatus(); ?>
-          <?php if ($status && QubitTerm::PUBLICATION_STATUS_DRAFT_ID === $status->id) { ?>
-            <?php $itemTitle .= " ({$status})"; ?>
-          <?php } ?>
+            <?php if (QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $item->object->getPublicationStatus()->statusId) { ?>
+              <?php $itemTitle .= " ({$item->object->getPublicationStatus()})"; ?>
+            <?php } ?>
 
-          <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
             <li><?php echo link_to($itemTitle, [$item->object, 'module' => 'informationobject']); ?></li>
+
           <?php } ?>
         <?php } ?>
       <?php } ?>
 
       <?php foreach ($resource->relationsRelatedByobjectId as $item) { ?>
-        <?php if (method_exists($item->subject, 'getPublicationStatus') && ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->subject->getPublicationStatus()->statusId)) { ?>
-          <?php $itemTitle = $item->subject->__toString(); ?>
+        <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
+          <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->subject->getPublicationStatus()->statusId) { ?>
+            <?php $itemTitle = $item->subject->__toString(); ?>
 
-          <?php if (property_exists($item->subject, 'levelOfDescription') || property_exists($item->subject, 'identifier')) { ?>
-            <?php $itemTitle = "- {$itemTitle}"; ?>
-              <?php if (property_exists($item->subject, 'identifier')) { ?>
-                <?php $itemTitle = "{$item->subject->referenceCode} {$itemTitle}"; ?>
-              <?php } ?>
-              <?php if (property_exists($item->subject, 'levelOfDescription')) { ?>
-                <?php $itemTitle = "{$item->subject->levelOfDescription} {$itemTitle}"; ?>
-              <?php } ?>
-          <?php } ?>
+            <?php if (isset($item->subject->levelOfDescription) || isset($item->subject->identifier)) { ?>
+              <?php $itemTitle = "- {$itemTitle}"; ?>
+                <?php if (isset($item->subject->identifier)) { ?>
+                  <?php $itemTitle = "{$item->subject->referenceCode} {$itemTitle}"; ?>
+                <?php } ?>
+                <?php if (isset($item->subject->levelOfDescription)) { ?>
+                  <?php $itemTitle = "{$item->subject->levelOfDescription} {$itemTitle}"; ?>
+                <?php } ?>
+            <?php } ?>
 
-          <?php $status = $item->subject->getPublicationStatus(); ?>
-          <?php if ($status && QubitTerm::PUBLICATION_STATUS_DRAFT_ID === $status->id) { ?>
-            <?php $itemTitle .= " ({$status})"; ?>
-          <?php } ?>
+            <?php if (QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $item->subject->getPublicationStatus()->statusId) { ?>
+              <?php $itemTitle .= " ({$item->subject->getPublicationStatus()})"; ?>
+            <?php } ?>
 
-          <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
             <li><?php echo link_to($itemTitle, [$item->subject, 'module' => 'informationobject']); ?></li>
+
           <?php } ?>
         <?php } ?>
       <?php } ?>

--- a/apps/qubit/modules/informationobject/templates/_relatedMaterialDescriptions.php
+++ b/apps/qubit/modules/informationobject/templates/_relatedMaterialDescriptions.php
@@ -5,6 +5,7 @@
   <?php } else { ?>
     <h3><?php echo __('Related descriptions'); ?></h3>
   <?php } ?>
+  
   <div>
     <ul>
       <?php foreach ($resource->relationsRelatedBysubjectId as $item) { ?>

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_relatedMaterialDescriptions.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_relatedMaterialDescriptions.php
@@ -31,7 +31,7 @@
 
             <?php } ?>
           <?php } ?>
-          <?php } ?>
+        <?php } ?>
 
         <?php foreach ($resource->relationsRelatedByobjectId as $item) { ?>
           <?php if (QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->getTypeId()) { ?>
@@ -60,5 +60,4 @@
 
     </ul>
   </div>
-
 </div>

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_relatedMaterialDescriptions.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_relatedMaterialDescriptions.php
@@ -9,7 +9,7 @@
   <div class="<?php echo render_b5_show_value_css_classes(); ?>">
     <ul class="<?php echo render_b5_show_list_css_classes(); ?>">
       <?php foreach ($resource->relationsRelatedBysubjectId as $item) { ?>
-          <?php if (QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->getTypeId()) { ?>
+          <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->getTypeId()) { ?>
             <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->object->getPublicationStatus()->statusId) { ?>
               <?php $itemTitle = $item->object->__toString(); ?>
 
@@ -34,7 +34,7 @@
         <?php } ?>
 
         <?php foreach ($resource->relationsRelatedByobjectId as $item) { ?>
-          <?php if (QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->getTypeId()) { ?>
+          <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->getTypeId()) { ?>
             <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->subject->getPublicationStatus()->statusId) { ?>
               <?php $itemTitle = $item->subject->__toString(); ?>
 
@@ -57,7 +57,7 @@
             <?php } ?>
           <?php } ?>
         <?php } ?>
-
     </ul>
   </div>
+
 </div>

--- a/plugins/arDominionB5Plugin/modules/informationobject/templates/_relatedMaterialDescriptions.php
+++ b/plugins/arDominionB5Plugin/modules/informationobject/templates/_relatedMaterialDescriptions.php
@@ -9,56 +9,55 @@
   <div class="<?php echo render_b5_show_value_css_classes(); ?>">
     <ul class="<?php echo render_b5_show_list_css_classes(); ?>">
       <?php foreach ($resource->relationsRelatedBysubjectId as $item) { ?>
-        <?php if ($sf_user->isAuthenticated() || (method_exists($item->subject, 'getPublicationStatus') && QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->object->getPublicationStatus()->statusId)) { ?>
-          <?php $itemTitle = $item->object->__toString(); ?>
+          <?php if (QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->getTypeId()) { ?>
+            <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->object->getPublicationStatus()->statusId) { ?>
+              <?php $itemTitle = $item->object->__toString(); ?>
 
-          <?php if (property_exists($item->object, 'levelOfDescription') || property_exists($item->object, 'identifier')) { ?>
-            <?php $itemTitle = "- {$itemTitle}"; ?>
-              <?php if (property_exists($item->object, 'identifier')) { ?>
-                <?php $itemTitle = "{$item->object->referenceCode} {$itemTitle}"; ?>
+              <?php if (isset($item->object->levelOfDescription) || isset($item->object->identifier)) { ?>
+                <?php $itemTitle = "- {$itemTitle}"; ?>
+                  <?php if (isset($item->object->identifier)) { ?>
+                    <?php $itemTitle = "{$item->object->referenceCode} {$itemTitle}"; ?>
+                  <?php } ?>
+                  <?php if (isset($item->object->levelOfDescription)) { ?>
+                    <?php $itemTitle = "{$item->object->levelOfDescription} {$itemTitle}"; ?>
+                  <?php } ?>
               <?php } ?>
-              <?php if (property_exists($item->object, 'levelOfDescription')) { ?>
-                <?php $itemTitle = "{$item->object->levelOfDescription} {$itemTitle}"; ?>
-              <?php } ?>
-          <?php } ?>
 
-          <?php if (method_exists($item->subject, 'getPublicationStatus')) { ?>
-            <?php $status = $item->object->getPublicationStatus(); ?>
-            <?php if ($status && QubitTerm::PUBLICATION_STATUS_DRAFT_ID === $status->id) { ?>
-              <?php $itemTitle .= " ({$status})"; ?>
+              <?php if (QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $item->object->getPublicationStatus()->statusId) { ?>
+                <?php $itemTitle .= " ({$item->object->getPublicationStatus()})"; ?>
+              <?php } ?>
+
+              <li><?php echo link_to($itemTitle, [$item->object, 'module' => 'informationobject']); ?></li>
+
             <?php } ?>
           <?php } ?>
+          <?php } ?>
 
-          <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
-            <li><?php echo link_to($itemTitle, [$item->object, 'module' => 'informationobject']); ?></li>
+        <?php foreach ($resource->relationsRelatedByobjectId as $item) { ?>
+          <?php if (QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->getTypeId()) { ?>
+            <?php if ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->subject->getPublicationStatus()->statusId) { ?>
+              <?php $itemTitle = $item->subject->__toString(); ?>
+
+              <?php if (isset($item->subject->levelOfDescription) || isset($item->subject->identifier)) { ?>
+                <?php $itemTitle = "- {$itemTitle}"; ?>
+                  <?php if (isset($item->subject->identifier)) { ?>
+                    <?php $itemTitle = "{$item->subject->referenceCode} {$itemTitle}"; ?>
+                  <?php } ?>
+                  <?php if (isset($item->subject->levelOfDescription)) { ?>
+                    <?php $itemTitle = "{$item->subject->levelOfDescription} {$itemTitle}"; ?>
+                  <?php } ?>
+              <?php } ?>
+
+              <?php if (QubitTerm::PUBLICATION_STATUS_DRAFT_ID == $item->subject->getPublicationStatus()->statusId) { ?>
+                <?php $itemTitle .= " ({$item->subject->getPublicationStatus()})"; ?>
+              <?php } ?>
+
+              <li><?php echo link_to($itemTitle, [$item->subject, 'module' => 'informationobject']); ?></li>
+
+            <?php } ?>
           <?php } ?>
         <?php } ?>
-      <?php } ?>
 
-      <?php foreach ($resource->relationsRelatedByobjectId as $item) { ?>
-        <?php if (method_exists($item->subject, 'getPublicationStatus') && ($sf_user->isAuthenticated() || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID == $item->subject->getPublicationStatus()->statusId)) { ?>
-          <?php $itemTitle = $item->subject->__toString(); ?>
-
-          <?php if (property_exists($item->subject, 'levelOfDescription') || property_exists($item->subject, 'identifier')) { ?>
-            <?php $itemTitle = "- {$itemTitle}"; ?>
-              <?php if (property_exists($item->subject, 'identifier')) { ?>
-                <?php $itemTitle = "{$item->subject->referenceCode} {$itemTitle}"; ?>
-              <?php } ?>
-              <?php if (property_exists($item->subject, 'levelOfDescription')) { ?>
-                <?php $itemTitle = "{$item->subject->levelOfDescription} {$itemTitle}"; ?>
-              <?php } ?>
-          <?php } ?>
-
-          <?php $status = $item->subject->getPublicationStatus(); ?>
-          <?php if ($status && QubitTerm::PUBLICATION_STATUS_DRAFT_ID === $status->id) { ?>
-            <?php $itemTitle .= " ({$status})"; ?>
-          <?php } ?>
-
-          <?php if (isset($item->type) && QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $item->type->id) { ?>
-            <li><?php echo link_to($itemTitle, [$item->subject, 'module' => 'informationobject']); ?></li>
-          <?php } ?>
-        <?php } ?>
-      <?php } ?>
     </ul>
   </div>
 


### PR DESCRIPTION
PR reverts all previous fix attempts to the related material descriptions field back to what was introduced in #1900 and properly addresses the 500 error caused when storage containers were added to descriptions with related material links.

Basically since containers are also relations, the relations here should have just included information objects. #1900 didn't do that, so it crashed (#1987). The existing type check just needed to be moved earlier. The previous fix attempts using `property_exists` and `method_exists` were always returning `false`, meaning the error was being removed by way of never allowing the new elements added in #1900 to be included in the link. All intended functionality is now restored (as far as I can tell).