### PR TITLE
Fix DACS header map for 'Physical access'. (#2087)

### DIFF
--- a/lib/job/visibleElementsHeaderMap.yml
+++ b/lib/job/visibleElementsHeaderMap.yml
@@ -542,5 +542,5 @@ dacs_access_points_area:
 dacs_physical_access:
   label: "Physical access"
   csv:
-    - accessionNumber
+    - physicalCharacteristics
   xml:


### PR DESCRIPTION
Map DACS 'Physical access' field to 'physicalCharacteristics' instead of 'accessionNumber'.