### PR TITLE
Reduce year input to 4 digits for fields with datepickers

### DIFF
--- a/apps/qubit/modules/informationobject/actions/browseAction.class.php
+++ b/apps/qubit/modules/informationobject/actions/browseAction.class.php
@@ -378,7 +378,7 @@ class InformationObjectBrowseAction extends DefaultBrowseAction
             case 'startDate':
             case 'endDate':
                 $this->form->setValidator($name, new sfValidatorString());
-                $this->form->setWidget($name, new sfWidgetFormInput([], ['placeholder' => 'YYYY-MM-DD']));
+                $this->form->setWidget($name, new sfWidgetFormInput([], ['placeholder' => 'YYYY-MM-DD', 'max' => '9999-12-31']));
                 $this->form->setValidator($name, new sfValidatorDate([
                     'date_format' => '/^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})$/',
                     'date_format_error' => 'YYYY-MM-DD',

--- a/apps/qubit/modules/right/actions/editAction.class.php
+++ b/apps/qubit/modules/right/actions/editAction.class.php
@@ -60,6 +60,7 @@ class RightEditAction extends sfAction
     {
         $widget = new sfWidgetFormInput();
         $widget->setAttribute('type', 'date');
+        $widget->setAttribute('max', '9999-12-31');
 
         return $widget;
     }

--- a/plugins/qtAccessionPlugin/modules/accession/actions/editAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/accession/actions/editAction.class.php
@@ -233,7 +233,7 @@ class AccessionEditAction extends DefaultEditAction
                     $this->form->setDefault('date', $dt->format('Y-m-d'));
                 }
 
-                $this->form->setWidget('date', new sfWidgetFormInput());
+                $this->form->setWidget('date', new sfWidgetFormInput([], ['max' => '9999-12-31']));
                 $this->form->setValidator('date', new sfValidatorDate([
                     'date_format' => '/^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})$/',
                     'date_format_error' => 'YYYY-MM-DD',

--- a/plugins/qtAccessionPlugin/modules/deaccession/actions/editAction.class.php
+++ b/plugins/qtAccessionPlugin/modules/deaccession/actions/editAction.class.php
@@ -119,7 +119,7 @@ class DeaccessionEditAction extends DefaultEditAction
                     $this->form->setDefault('date', $dt->format('Y-m-d'));
                 }
 
-                $this->form->setWidget('date', new sfWidgetFormInput());
+                $this->form->setWidget('date', new sfWidgetFormInput([], ['max' => '9999-12-31']));
                 $this->form->setValidator('date', new sfValidatorDate([
                     'date_format' => '/^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})$/',
                     'date_format_error' => 'YYYY-MM-DD',


### PR DESCRIPTION
PR reduces the number of possible digits for the year to 4 when inputing start and end dates in advanced search for information objects.

Some browsers like Chrome/Edge allow 6 digits, which means that the input doesn't naturally move from the YYYY segment to the MM segment when using these browsers. For reference, Firefox just uses 4 digits.