### PR TITLE
Exclude accessionNumber from public CSV exports.

### DIFF
--- a/lib/flatfile/QubitFlatfileExport.class.php
+++ b/lib/flatfile/QubitFlatfileExport.class.php
@@ -281,6 +281,18 @@ class QubitFlatfileExport
             }
         }
 
+        // Remove accessionNumber from public exports
+        if (!$this->user->isAuthenticated()) {
+            if (!in_array('accessionNumber', $this->nonVisibleElementsIncluded)) {
+                array_push($this->nonVisibleElementsIncluded, 'accessionNumber');
+            }
+
+            $accessionIndex = array_search('accessionNumber', $this->columnNames);
+            if (false !== $accessionIndex && !in_array($accessionIndex, $this->nonVisibleElementsIndexes)) {
+                array_push($this->nonVisibleElementsIndexes, $accessionIndex);
+            }
+        }
+
         $this->prepareRowFromResource();
 
         if (!empty($this->nonVisibleElementsIncluded)) {


### PR DESCRIPTION
This PR uses the logic from [Fix CSV exports with hidden elements. (#2086)](https://github.com/artefactual/atom/pull/2086).