### PR TITLE
Add VSCode files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ cypress/downloads
 cypress/screenshots
 cypress/videos
 cypress.env.json
+
+# IDE-specific files
+.vscode/
+*.code-workspace


### PR DESCRIPTION
Closes #2099 

Adds VSCode-specific files to the gitignore so they don't appear in the git staging area & do not get accidentally committed to this repository.