### PR TITLE
Add clipboard count UI labels to AtoM fixtures

### DIFF
--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -1497,3 +1497,27 @@ QubitSetting:
   Qubit_Settings_csvValidatorDefaultImportBehaviour:
     name: csv_validator_default_import_behaviour
     value: 0
+  QubitSettings_descriptioncount:
+    name: descriptioncount
+    scope: ui_label
+    editable: 1
+    deleteable: 0
+    source_culture: en
+    value:
+      en: 'Archival description count:&nbsp;'
+  QubitSettings_authorityrecordcount:
+    name: authorityrecordcount
+    scope: ui_label
+    editable: 1
+    deleteable: 0
+    source_culture: en
+    value:
+      en: 'Authority record count:&nbsp;'
+  QubitSettings_repositorycount:
+    name: repositorycount
+    scope: ui_label
+    editable: 1
+    deleteable: 0
+    source_culture: en
+    value:
+      en: 'Archival institution count:&nbsp;'

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -1504,7 +1504,9 @@ QubitSetting:
     deleteable: 0
     source_culture: en
     value:
+      ar: '&nbsp;:عدد أوصاف الأرشيف'
       en: 'Archival description count:&nbsp;'
+      fr: 'Nombre de descriptions archivistiques:&nbsp;'
   QubitSettings_authorityrecordcount:
     name: authorityrecordcount
     scope: ui_label
@@ -1512,7 +1514,9 @@ QubitSetting:
     deleteable: 0
     source_culture: en
     value:
+      ar: '&nbsp;:عدد سجلات الهيئة الاستنادية'
       en: 'Authority record count:&nbsp;'
+      fr: 'Nombre de notices d''autorité:&nbsp;'
   QubitSettings_repositorycount:
     name: repositorycount
     scope: ui_label
@@ -1520,4 +1524,6 @@ QubitSetting:
     deleteable: 0
     source_culture: en
     value:
+      ar: '&nbsp;:عدد المؤسسات الأرشيفية'
       en: 'Archival institution count:&nbsp;'
+      fr: 'Nombre d''institutions archivistiques:&nbsp;'


### PR DESCRIPTION
Adding these to fixtures so that they're present by default in new AtoM installations.