### PR TITLE
Add user to export context

### DIFF
--- a/lib/flatfile/QubitFlatfileExport.class.php
+++ b/lib/flatfile/QubitFlatfileExport.class.php
@@ -30,6 +30,7 @@ class QubitFlatfileExport
     public $columnMap = [];       // flatfile columns that map to object properties
     public $propertyMap = [];       // flatfile columns that map to Qubit properties
     public $user;          // user doing the export
+    public $environment;   // environment the export is being run in
     protected $configurationLoaded = false;  // has the configuuration been loaded?
 
     protected $resource;                     // current resource being exported
@@ -70,6 +71,11 @@ class QubitFlatfileExport
         if (false !== $rowsPerFile) {
             $this->rowsPerFile = $rowsPerFile;
         }
+
+        $context = sfContext::getInstance();
+
+        $this->user = $context->getUser();
+        $this->environment = $context->getConfiguration()->getEnvironment();
 
         include_once sfConfig::get('sf_root_dir').'/lib/helper/QubitHelper.php';
     }
@@ -282,7 +288,7 @@ class QubitFlatfileExport
         }
 
         // Remove accessionNumber from public exports
-        if (!$this->user->isAuthenticated()) {
+        if (!in_array($this->environment, ['cli', 'worker']) && $this->user && !$this->user->isAuthenticated()) {
             if (!in_array('accessionNumber', $this->nonVisibleElementsIncluded)) {
                 array_push($this->nonVisibleElementsIncluded, 'accessionNumber');
             }

--- a/lib/flatfile/QubitFlatfileExport.class.php
+++ b/lib/flatfile/QubitFlatfileExport.class.php
@@ -288,7 +288,7 @@ class QubitFlatfileExport
         }
 
         // Remove accessionNumber from public exports
-        if (!in_array($this->environment, ['cli', 'worker']) && $this->user && !$this->user->isAuthenticated()) {
+        if (!in_array($this->environment, ['cli', 'worker']) && (!$this->user || !$this->user->isAuthenticated())) {
             if (!in_array('accessionNumber', $this->nonVisibleElementsIncluded)) {
                 array_push($this->nonVisibleElementsIncluded, 'accessionNumber');
             }


### PR DESCRIPTION
Closes #2117 

Sets the user and the environment in the `QubitFlatfileExport` class.

For the `accessionNumber` logic, the field is excluded if the exporter is not running in the cli/worker, and if the user is not set or if the user is unauthenticated.