### PR TITLE
Fix shifted columns in CSV exports

### DIFF
--- a/lib/flatfile/QubitFlatfileExport.class.php
+++ b/lib/flatfile/QubitFlatfileExport.class.php
@@ -25,7 +25,7 @@
 class QubitFlatfileExport
 {
     public $columnNames = [];       // ordered header column names
-    public $maxColumnIndexes = 0;     // total column indexes used for removing hidden elements
+    public $totalColumnsIncludingHidden = 0;  // total number of columns including hidden elements
     public $standardColumns = [];       // flatfile columns that are object properties
     public $columnMap = [];       // flatfile columns that map to object properties
     public $propertyMap = [];       // flatfile columns that map to Qubit properties
@@ -108,8 +108,7 @@ class QubitFlatfileExport
         }
 
         $this->columnNames = $config['columnNames'];
-        // Add 1 for referenceCode which is not part of columnNames
-        $this->maxColumnIndexes = count($this->columnNames) + 1;
+        $this->totalColumnsIncludingHidden = count($this->columnNames);
         $this->standardColumns = isset($config['direct']) ? $config['direct'] : [];
         $this->columnMap = isset($config['map']) ? $config['map'] : [];
         $this->propertyMap = isset($config['property']) ? $config['property'] : [];
@@ -311,18 +310,17 @@ class QubitFlatfileExport
         }
 
         // Write row to file and initialize row
-        if (!empty($this->nonVisibleElementsIncluded)) {
-            $totalRows = $this->maxColumnIndexes - count($this->nonVisibleElementsIncluded);
-            if (count($this->row) > $totalRows) {
-                sort($this->nonVisibleElementsIndexes);
-                foreach ($this->nonVisibleElementsIndexes as $index) {
+        if (!empty($this->nonVisibleElementsIndexes)) {
+            sort($this->nonVisibleElementsIndexes);
+            foreach ($this->nonVisibleElementsIndexes as $index) {
+                if (array_key_exists($index, $this->row)) {
                     unset($this->row[$index]);
                 }
             }
         }
 
         $this->appendRowToCsvFile($filePath, $this->row);
-        $this->row = array_fill(0, count($this->columnNames), null);
+        $this->row = array_fill(0, $this->totalColumnsIncludingHidden, null);
         ++$this->rowsExported;
     }
 

--- a/test/phpunit/QubitFlatfileExportTest.php
+++ b/test/phpunit/QubitFlatfileExportTest.php
@@ -184,7 +184,42 @@ class QubitFlatfileExportTest extends TestCase
         $this->assertEquals(['1|2|3', 'u|v|w', 'C'], $rowData);
     }
 
-    public function testExportSingleResourceHiddenCols(): void
+    public function testExportSingleResourceOneHiddenCol(): void
+    {
+        $csvFile = $this->vfs->url().'/output.csv';
+
+        // Hide colA
+        $mockExporter = $this->createMockExporter(
+            outputPath: $csvFile,
+            columnNames: ['colA', 'colB', 'colC', 'colD'],
+            hiddenColumns: ['colA'],
+        );
+
+        $mockResource = $this->createMockResource(properties: [
+            'colA' => 'A',
+            'colB' => 'B',
+            'colC' => 'C',
+            'colD' => 'D',
+        ]);
+
+        $mockExporter->exportResource($mockResource);
+
+        $this->assertTrue(file_exists($csvFile));
+
+        $csvContent = file_get_contents($csvFile);
+        $rows = str_getcsv($csvContent, "\n");
+
+        // Should have two rows (one header, one data row)
+        $this->assertCount(2, $rows);
+
+        $headerData = str_getcsv($rows[0]);
+        $rowData = str_getcsv($rows[1]);
+
+        $this->assertEquals(['colB', 'colC', 'colD'], $headerData);
+        $this->assertEquals(['B', 'C', 'D'], $rowData);
+    }
+
+    public function testExportSingleResourceMultipleHiddenCols(): void
     {
         $csvFile = $this->vfs->url().'/output.csv';
 
@@ -259,7 +294,7 @@ class QubitFlatfileExportTest extends TestCase
         $this->assertEquals(['A3', 'B3', 'C3'], $rowData3);
     }
 
-    public function testExportMultipleResourcesHiddenCols(): void
+    public function testExportMultipleResourcesOneHiddenCol(): void
     {
         $csvFile = $this->vfs->url().'/output.csv';
 
@@ -298,5 +333,47 @@ class QubitFlatfileExportTest extends TestCase
         $this->assertEquals(['B1', 'C1'], $rowData1);
         $this->assertEquals(['B2', 'C2'], $rowData2);
         $this->assertEquals(['B3', 'C3'], $rowData3);
+    }
+
+    public function testExportMultipleResourcesMultipleHiddenCols(): void
+    {
+        $csvFile = $this->vfs->url().'/output.csv';
+
+        // Hide colB, colD
+        $mockExporter = $this->createMockExporter(
+            outputPath: $csvFile,
+            columnNames: ['colA', 'colB', 'colC', 'colD'],
+            hiddenColumns: ['colB', 'colD'],
+        );
+
+        // Create and export 3 resources
+        foreach (range(1, 3) as $i) {
+            $mockResource = $this->createMockResource([
+                'colA' => "A{$i}",
+                'colB' => "B{$i}",
+                'colC' => "C{$i}",
+                'colD' => "D{$i}",
+            ]);
+
+            $mockExporter->exportResource($mockResource);
+        }
+
+        $this->assertTrue(file_exists($csvFile));
+
+        $csvContent = file_get_contents($csvFile);
+        $rows = str_getcsv($csvContent, "\n");
+
+        // Should have four rows (one header, three data rows)
+        $this->assertCount(4, $rows);
+
+        $headerData = str_getcsv($rows[0]);
+        $rowData1 = str_getcsv($rows[1]);
+        $rowData2 = str_getcsv($rows[2]);
+        $rowData3 = str_getcsv($rows[3]);
+
+        $this->assertEquals(['colA', 'colC'], $headerData);
+        $this->assertEquals(['A1', 'C1'], $rowData1);
+        $this->assertEquals(['A2', 'C2'], $rowData2);
+        $this->assertEquals(['A3', 'C3'], $rowData3);
     }
 }

--- a/test/phpunit/QubitFlatfileExportTest.php
+++ b/test/phpunit/QubitFlatfileExportTest.php
@@ -245,7 +245,7 @@ class QubitFlatfileExportTest extends TestCase
         $csvContent = file_get_contents($csvFile);
         $rows = str_getcsv($csvContent, "\n");
 
-        // Should have two rows (one header, one data row)
+        // Should have four rows (one header, three data rows)
         $this->assertCount(4, $rows);
 
         $headerData = str_getcsv($rows[0]);
@@ -286,7 +286,7 @@ class QubitFlatfileExportTest extends TestCase
         $csvContent = file_get_contents($csvFile);
         $rows = str_getcsv($csvContent, "\n");
 
-        // Should have two rows (one header, one data row)
+        // Should have four rows (one header, three data rows)
         $this->assertCount(4, $rows);
 
         $headerData = str_getcsv($rows[0]);

--- a/test/phpunit/QubitFlatfileExportTest.php
+++ b/test/phpunit/QubitFlatfileExportTest.php
@@ -1,0 +1,294 @@
+<?php
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @covers \QubitFlatFileExport
+ */
+class QubitFlatfileExportTest extends TestCase
+{
+    protected $vfs; // virtual filesystem
+
+    public function setUp(): void
+    {
+        $directory = [];
+
+        // Set up and cache the virtual file system
+        $this->vfs = vfsStream::setup('root', null, $directory);
+    }
+
+    /**
+     * Creates a mock exporter with the specified column names and hidden columns.
+     *
+     * @param mixed      $outputPath    The path to the output file
+     * @param mixed      $columnNames   The column names for the output CSV file
+     * @param mixed      $hiddenColumns The columns to hide from the output CSV file
+     * @param null|mixed $params
+     *
+     * @return PHPUnit\Framework\MockObject\MockObject|QubitFlatfileExport
+     */
+    public function createMockExporter($outputPath, $columnNames, $hiddenColumns)
+    {
+        $exporter = $this->getMockBuilder(QubitFlatfileExport::class)
+            ->setConstructorArgs([$outputPath])
+            ->onlyMethods([
+                'loadResourceSpecificConfiguration',
+                'getHiddenVisibleElementCsvHeaders',
+            ])
+            ->getMock();
+
+        $exporter->method('loadResourceSpecificConfiguration')
+            ->willReturnCallback(function () use ($exporter, $columnNames) {
+                // Simulate what loadResourceSpecificConfiguration does
+                $exporter->columnNames = $columnNames;
+                $exporter->standardColumns = $columnNames;
+                $exporter->totalColumnsIncludingHidden = count($columnNames);
+                $exporter->columnMap = [];
+                $exporter->propertyMap = [];
+
+                $reflection = new ReflectionClass($exporter);
+
+                $configurationLoadedProperty = $reflection->getProperty('configurationLoaded');
+                $configurationLoadedProperty->setValue($exporter, true);
+
+                // Initialize row array like the real method does
+                // Need to use reflection because row is protected
+                $rowProperty = $reflection->getProperty('row');
+                $rowProperty->setAccessible(true);
+                $rowProperty->setValue($exporter, array_fill(0, count($exporter->columnNames), null));
+            });
+
+        $exporter->method('getHiddenVisibleElementCsvHeaders')
+            ->willReturnCallback(function () use ($exporter, $columnNames, $hiddenColumns) {
+                $reflection = new ReflectionClass($exporter);
+
+                $nonVisibleElementsIncludedProperty = $reflection->getProperty('nonVisibleElementsIncluded');
+                $nonVisibleElementsIncludedProperty->setValue($exporter, $hiddenColumns);
+
+                $indices = [];
+                foreach ($hiddenColumns as $col) {
+                    $index = array_search($col, $columnNames);
+                    array_push($indices, $index);
+                }
+
+                $nonVisibleElementsIncludedProperty = $reflection->getProperty('nonVisibleElementsIndexes');
+                $nonVisibleElementsIncludedProperty->setValue($exporter, $indices);
+            });
+
+        $exporter->setParams([
+            'nonVisibleElementsIncluded' => [],
+        ]);
+
+        return $exporter;
+    }
+
+    /**
+     * Create a mock resource to export.
+     *
+     * Applies array key=>value pairs to properties on a mock object.
+     *
+     * @param mixed $properties the properties to add to the mock object
+     *
+     * @return PHPUnit\Framework\MockObject\MockObject|stdClass
+     */
+    public function createMockResource($properties)
+    {
+        $mockResource = $this->getMockBuilder(stdClass::class)
+            ->addMethods(['getDigitalObject'])
+            ->getMock();
+
+        foreach ($properties as $prop => $value) {
+            $mockResource->{$prop} = $value;
+        }
+
+        $mockResource->method('getDigitalObject')
+            ->willReturn(null);
+
+        return $mockResource;
+    }
+
+    public function testExportSingleResource(): void
+    {
+        $csvFile = $this->vfs->url().'/output.csv';
+
+        $mockExporter = $this->createMockExporter(
+            outputPath: $csvFile,
+            columnNames: ['colA', 'colB', 'colC'],
+            hiddenColumns: [],
+        );
+
+        $mockResource = $this->createMockResource(properties: [
+            'colA' => 'A',
+            'colB' => 'B',
+            'colC' => 'C',
+        ]);
+
+        $mockExporter->exportResource($mockResource);
+
+        $this->assertTrue(file_exists($csvFile));
+
+        $csvContent = file_get_contents($csvFile);
+        $rows = str_getcsv($csvContent, "\n");
+
+        // Should have two rows (one header, one data row)
+        $this->assertCount(2, $rows);
+
+        $headerData = str_getcsv($rows[0]);
+        $rowData = str_getcsv($rows[1]);
+
+        $this->assertEquals(['colA', 'colB', 'colC'], $headerData);
+        $this->assertEquals(['A', 'B', 'C'], $rowData);
+    }
+
+    public function testExportSingleResourceWithArrayContent(): void
+    {
+        $csvFile = $this->vfs->url().'/output.csv';
+
+        $mockExporter = $this->createMockExporter(
+            outputPath: $csvFile,
+            columnNames: ['colA', 'colB', 'colC'],
+            hiddenColumns: [],
+        );
+
+        $mockResource = $this->createMockResource(properties: [
+            'colA' => ['1', '2', '3'],
+            'colB' => ['u', 'v', 'w'],
+            'colC' => 'C',
+        ]);
+
+        $mockExporter->exportResource($mockResource);
+
+        $this->assertTrue(file_exists($csvFile));
+
+        $csvContent = file_get_contents($csvFile);
+        $rows = str_getcsv($csvContent, "\n");
+
+        // Should have two rows (one header, one data row)
+        $this->assertCount(2, $rows);
+
+        $headerData = str_getcsv($rows[0]);
+        $rowData = str_getcsv($rows[1]);
+
+        $this->assertEquals(['colA', 'colB', 'colC'], $headerData);
+        $this->assertEquals(['1|2|3', 'u|v|w', 'C'], $rowData);
+    }
+
+    public function testExportSingleResourceHiddenCols(): void
+    {
+        $csvFile = $this->vfs->url().'/output.csv';
+
+        // Hide colB and colD
+        $mockExporter = $this->createMockExporter(
+            outputPath: $csvFile,
+            columnNames: ['colA', 'colB', 'colC', 'colD'],
+            hiddenColumns: ['colB', 'colD'],
+        );
+
+        $mockResource = $this->createMockResource(properties: [
+            'colA' => 'A',
+            'colB' => 'B',
+            'colC' => 'C',
+            'colD' => 'D',
+        ]);
+
+        $mockExporter->exportResource($mockResource);
+
+        $this->assertTrue(file_exists($csvFile));
+
+        $csvContent = file_get_contents($csvFile);
+        $rows = str_getcsv($csvContent, "\n");
+
+        // Should have two rows (one header, one data row)
+        $this->assertCount(2, $rows);
+
+        $headerData = str_getcsv($rows[0]);
+        $rowData = str_getcsv($rows[1]);
+
+        $this->assertEquals(['colA', 'colC'], $headerData);
+        $this->assertEquals(['A', 'C'], $rowData);
+    }
+
+    public function testExportMultipleResources(): void
+    {
+        $csvFile = $this->vfs->url().'/output.csv';
+
+        $mockExporter = $this->createMockExporter(
+            outputPath: $csvFile,
+            columnNames: ['colA', 'colB', 'colC'],
+            hiddenColumns: [],
+        );
+
+        // Create and export 3 resources
+        foreach (range(1, 3) as $i) {
+            $mockResource = $this->createMockResource([
+                'colA' => "A{$i}",
+                'colB' => "B{$i}",
+                'colC' => "C{$i}",
+            ]);
+
+            $mockExporter->exportResource($mockResource);
+        }
+
+        $this->assertTrue(file_exists($csvFile));
+
+        $csvContent = file_get_contents($csvFile);
+        $rows = str_getcsv($csvContent, "\n");
+
+        // Should have two rows (one header, one data row)
+        $this->assertCount(4, $rows);
+
+        $headerData = str_getcsv($rows[0]);
+        $rowData1 = str_getcsv($rows[1]);
+        $rowData2 = str_getcsv($rows[2]);
+        $rowData3 = str_getcsv($rows[3]);
+
+        $this->assertEquals(['colA', 'colB', 'colC'], $headerData);
+        $this->assertEquals(['A1', 'B1', 'C1'], $rowData1);
+        $this->assertEquals(['A2', 'B2', 'C2'], $rowData2);
+        $this->assertEquals(['A3', 'B3', 'C3'], $rowData3);
+    }
+
+    public function testExportMultipleResourcesHiddenCols(): void
+    {
+        $csvFile = $this->vfs->url().'/output.csv';
+
+        // Hide colA
+        $mockExporter = $this->createMockExporter(
+            outputPath: $csvFile,
+            columnNames: ['colA', 'colB', 'colC'],
+            hiddenColumns: ['colA'],
+        );
+
+        // Create and export 3 resources
+        foreach (range(1, 3) as $i) {
+            $mockResource = $this->createMockResource([
+                'colA' => "A{$i}",
+                'colB' => "B{$i}",
+                'colC' => "C{$i}",
+            ]);
+
+            $mockExporter->exportResource($mockResource);
+        }
+
+        $this->assertTrue(file_exists($csvFile));
+
+        $csvContent = file_get_contents($csvFile);
+        $rows = str_getcsv($csvContent, "\n");
+
+        // Should have two rows (one header, one data row)
+        $this->assertCount(4, $rows);
+
+        $headerData = str_getcsv($rows[0]);
+        $rowData1 = str_getcsv($rows[1]);
+        $rowData2 = str_getcsv($rows[2]);
+        $rowData3 = str_getcsv($rows[3]);
+
+        $this->assertEquals(['colB', 'colC'], $headerData);
+        $this->assertEquals(['B1', 'C1'], $rowData1);
+        $this->assertEquals(['B2', 'C2'], $rowData2);
+        $this->assertEquals(['B3', 'C3'], $rowData3);
+    }
+}

--- a/test/phpunit/QubitFlatfileExportTest.php
+++ b/test/phpunit/QubitFlatfileExportTest.php
@@ -82,8 +82,8 @@ class QubitFlatfileExportTest extends TestCase
                     array_push($indices, $index);
                 }
 
-                $nonVisibleElementsIncludedProperty = $reflection->getProperty('nonVisibleElementsIndexes');
-                $nonVisibleElementsIncludedProperty->setValue($exporter, $indices);
+                $nonVisibleElementsIndexesProperty = $reflection->getProperty('nonVisibleElementsIndexes');
+                $nonVisibleElementsIndexesProperty->setValue($exporter, $indices);
             });
 
         $exporter->setParams([

--- a/test/phpunit/QubitFlatfileExportTest.php
+++ b/test/phpunit/QubitFlatfileExportTest.php
@@ -43,19 +43,27 @@ class QubitFlatfileExportTest extends TestCase
         $exporter->method('loadResourceSpecificConfiguration')
             ->willReturnCallback(function () use ($exporter, $columnNames) {
                 // Simulate what loadResourceSpecificConfiguration does
+
+                $mockUser = $this->getMockBuilder(stdClass::class)
+                    ->addMethods(['isAuthenticated'])
+                    ->getMock();
+
+                $mockUser->method('isAuthenticated')
+                    ->willReturn(true);
+
                 $exporter->columnNames = $columnNames;
                 $exporter->standardColumns = $columnNames;
                 $exporter->totalColumnsIncludingHidden = count($columnNames);
                 $exporter->columnMap = [];
                 $exporter->propertyMap = [];
+                $exporter->user = $mockUser;
 
+                // Need to use reflection to change protected members
                 $reflection = new ReflectionClass($exporter);
 
                 $configurationLoadedProperty = $reflection->getProperty('configurationLoaded');
                 $configurationLoadedProperty->setValue($exporter, true);
 
-                // Initialize row array like the real method does
-                // Need to use reflection because row is protected
                 $rowProperty = $reflection->getProperty('row');
                 $rowProperty->setAccessible(true);
                 $rowProperty->setValue($exporter, array_fill(0, count($exporter->columnNames), null));


### PR DESCRIPTION
Closes #2122 

Fixes the off-by-one error causing columns to be shifted right in flatfile exports.

I've also written some unit tests to run some checks against the `exportResource` logic.