### PR TITLE
Run unit test that creates objects in a transaction

### DIFF
--- a/test/TransactionTestCase.php
+++ b/test/TransactionTestCase.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace AccessToMemory\test;
+
+use PHPUnit\Framework\TestCase;
+
+
+/**
+ * Custom test case class for tests that modify the database. Runs all tests in a
+ * separate transaction.
+ */
+class TransactionTestCase extends TestCase
+{
+    protected $connection;
+
+    /**
+     * Start a transaction before the test starts.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = \Propel::getConnection();
+        $this->connection->beginTransaction();
+    }
+
+    /**
+     * Rollback once the test completes.
+     */
+    protected function tearDown(): void
+    {
+        if ($this->connection?->inTransaction()) {
+            $this->connection->rollback();
+        }
+
+        parent::tearDown();
+    }
+}

--- a/test/TransactionTestCase.php
+++ b/test/TransactionTestCase.php
@@ -4,10 +4,13 @@ namespace AccessToMemory\test;
 
 use PHPUnit\Framework\TestCase;
 
-
 /**
  * Custom test case class for tests that modify the database. Runs all tests in a
  * separate transaction.
+ *
+ * @internal
+ *
+ * @coversNothing
  */
 class TransactionTestCase extends TestCase
 {

--- a/test/phpunit/QubitInformationObjectTest.php
+++ b/test/phpunit/QubitInformationObjectTest.php
@@ -23,46 +23,48 @@ class QubitInformationObjectTest extends TestCase
      */
     public function testGetByTitleIdentifierAndRepo($identifier, $title, $repoName, $hasLinkedRepo, $expectedTitle)
     {
-        $randomString = rand(1000000, 9999999);
+        $this->withTransaction(function () use ($identifier, $title, $repoName, $hasLinkedRepo, $expectedTitle) {
+            $randomString = rand(1000000, 9999999);
 
-        $io = new QubitInformationObject();
-        $io->title = 'TestDescriptionTitle'.$randomString;
-        $io->identifier = 'TestDescriptionIdentifier'.$randomString;
+            $io = new QubitInformationObject();
+            $io->title = 'TestDescriptionTitle'.$randomString;
+            $io->identifier = 'TestDescriptionIdentifier'.$randomString;
 
-        // Set up a linked repository if needed for the test.
-        if (true === $hasLinkedRepo) {
-            $repository = new QubitRepository();
-            $repository->indexOnSave = false;
-            $repository->setAuthorizedFormOfName('TestRepository'.$randomString);
-            $repository->save();
-            $io->setRepositoryId($repository->id);
-        }
+            // Set up a linked repository if needed for the test.
+            if (true === $hasLinkedRepo) {
+                $repository = new QubitRepository();
+                $repository->indexOnSave = false;
+                $repository->setAuthorizedFormOfName('TestRepository'.$randomString);
+                $repository->save();
+                $io->setRepositoryId($repository->id);
+            }
 
-        $io->indexOnSave = false;
-        $io->save();
+            $io->indexOnSave = false;
+            $io->save();
 
-        if (null !== $repoName) {
-            $repoName .= $randomString;
-        }
+            if (null !== $repoName) {
+                $repoName .= $randomString;
+            }
 
-        $result = QubitInformationObject::getByTitleIdentifierAndRepo(
-            $identifier.$randomString,
-            $title.$randomString,
-            $repoName
-        );
+            $result = QubitInformationObject::getByTitleIdentifierAndRepo(
+                $identifier.$randomString,
+                $title.$randomString,
+                $repoName
+            );
 
-        if (null === $expectedTitle) {
-            // No match expected.
-            $this->assertNull($result, 'Expected null result when no matching record exists.');
-        } else {
-            // A match is expected.
-            $this->assertNotNull($result, 'Expected a valid integer id when data should match.');
-            $this->assertIsInt($result, 'Expected the returned id to be an integer.');
+            if (null === $expectedTitle) {
+                // No match expected.
+                $this->assertNull($result, 'Expected null result when no matching record exists.');
+            } else {
+                // A match is expected.
+                $this->assertNotNull($result, 'Expected a valid integer id when data should match.');
+                $this->assertIsInt($result, 'Expected the returned id to be an integer.');
 
-            $resultIo = QubitInformationObject::getById($result);
-            $this->assertNotNull($resultIo, 'Expected a valid information object.');
-            $this->assertEquals($expectedTitle.$randomString, $resultIo->title, 'The information object title does not match expected.');
-        }
+                $resultIo = QubitInformationObject::getById($result);
+                $this->assertNotNull($resultIo, 'Expected a valid information object.');
+                $this->assertEquals($expectedTitle.$randomString, $resultIo->title, 'The information object title does not match expected.');
+            }
+        });
     }
 
     public function dataProviderForGetByTitleIdentifierAndRepo()
@@ -88,5 +90,17 @@ class QubitInformationObjectTest extends TestCase
             // Id, title and repository specified but id not matched: matching fail.
             ['TestDescriptionIdentifierX', 'TestDescriptionTitle', 'TestRepository', true, null],
         ];
+    }
+
+    private function withTransaction($callback)
+    {
+        try {
+            $conn = Propel::getConnection();
+            $conn->beginTransaction();
+
+            return call_user_func($callback);
+        } finally {
+            $conn->rollBack();
+        }
     }
 }

--- a/test/phpunit/QubitInformationObjectTest.php
+++ b/test/phpunit/QubitInformationObjectTest.php
@@ -1,13 +1,13 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
+use AccessToMemory\test\TransactionTestCase;
 
 /**
  * @internal
  *
  * @covers \QubitInformationObject::getByTitleIdentifierAndRepo
  */
-class QubitInformationObjectTest extends TestCase
+class QubitInformationObjectTest extends TransactionTestCase
 {
     protected $io;
     protected $repo;
@@ -23,48 +23,46 @@ class QubitInformationObjectTest extends TestCase
      */
     public function testGetByTitleIdentifierAndRepo($identifier, $title, $repoName, $hasLinkedRepo, $expectedTitle)
     {
-        $this->withTransaction(function () use ($identifier, $title, $repoName, $hasLinkedRepo, $expectedTitle) {
-            $randomString = rand(1000000, 9999999);
+        $randomString = rand(1000000, 9999999);
 
-            $io = new QubitInformationObject();
-            $io->title = 'TestDescriptionTitle'.$randomString;
-            $io->identifier = 'TestDescriptionIdentifier'.$randomString;
+        $io = new QubitInformationObject();
+        $io->title = 'TestDescriptionTitle'.$randomString;
+        $io->identifier = 'TestDescriptionIdentifier'.$randomString;
 
-            // Set up a linked repository if needed for the test.
-            if (true === $hasLinkedRepo) {
-                $repository = new QubitRepository();
-                $repository->indexOnSave = false;
-                $repository->setAuthorizedFormOfName('TestRepository'.$randomString);
-                $repository->save();
-                $io->setRepositoryId($repository->id);
-            }
+        // Set up a linked repository if needed for the test.
+        if (true === $hasLinkedRepo) {
+            $repository = new QubitRepository();
+            $repository->indexOnSave = false;
+            $repository->setAuthorizedFormOfName('TestRepository'.$randomString);
+            $repository->save();
+            $io->setRepositoryId($repository->id);
+        }
 
-            $io->indexOnSave = false;
-            $io->save();
+        $io->indexOnSave = false;
+        $io->save();
 
-            if (null !== $repoName) {
-                $repoName .= $randomString;
-            }
+        if (null !== $repoName) {
+            $repoName .= $randomString;
+        }
 
-            $result = QubitInformationObject::getByTitleIdentifierAndRepo(
-                $identifier.$randomString,
-                $title.$randomString,
-                $repoName
-            );
+        $result = QubitInformationObject::getByTitleIdentifierAndRepo(
+            $identifier.$randomString,
+            $title.$randomString,
+            $repoName
+        );
 
-            if (null === $expectedTitle) {
-                // No match expected.
-                $this->assertNull($result, 'Expected null result when no matching record exists.');
-            } else {
-                // A match is expected.
-                $this->assertNotNull($result, 'Expected a valid integer id when data should match.');
-                $this->assertIsInt($result, 'Expected the returned id to be an integer.');
+        if (null === $expectedTitle) {
+            // No match expected.
+            $this->assertNull($result, 'Expected null result when no matching record exists.');
+        } else {
+            // A match is expected.
+            $this->assertNotNull($result, 'Expected a valid integer id when data should match.');
+            $this->assertIsInt($result, 'Expected the returned id to be an integer.');
 
-                $resultIo = QubitInformationObject::getById($result);
-                $this->assertNotNull($resultIo, 'Expected a valid information object.');
-                $this->assertEquals($expectedTitle.$randomString, $resultIo->title, 'The information object title does not match expected.');
-            }
-        });
+            $resultIo = QubitInformationObject::getById($result);
+            $this->assertNotNull($resultIo, 'Expected a valid information object.');
+            $this->assertEquals($expectedTitle.$randomString, $resultIo->title, 'The information object title does not match expected.');
+        }
     }
 
     public function dataProviderForGetByTitleIdentifierAndRepo()
@@ -90,22 +88,5 @@ class QubitInformationObjectTest extends TestCase
             // Id, title and repository specified but id not matched: matching fail.
             ['TestDescriptionIdentifierX', 'TestDescriptionTitle', 'TestRepository', true, null],
         ];
-    }
-
-    /**
-     * Runs a function within a transaction.
-     *
-     * @param mixed $callback the function to run in the transaction
-     */
-    private function withTransaction($callback)
-    {
-        try {
-            $conn = Propel::getConnection();
-            $conn->beginTransaction();
-
-            return call_user_func($callback);
-        } finally {
-            $conn->rollBack();
-        }
     }
 }

--- a/test/phpunit/QubitInformationObjectTest.php
+++ b/test/phpunit/QubitInformationObjectTest.php
@@ -92,6 +92,11 @@ class QubitInformationObjectTest extends TestCase
         ];
     }
 
+    /**
+     * Runs a function within a transaction.
+     *
+     * @param mixed $callback the function to run in the transaction
+     */
     private function withTransaction($callback)
     {
         try {


### PR DESCRIPTION
Closes #2125 

Wraps the `testGetByTitleIdentifierAndRepo` unit test within a transaction so that the objects it creates in the database are rolled back when the test exits or throws an exception.