### PR TITLE
Fix XML esc_specialchars for DO URLs (#2135)

### DIFF
--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
@@ -177,7 +177,7 @@
   <?php if (null !== $digitalObject = ${$resourceVar}->digitalObjectsRelatedByobjectId[0]) { ?>
     <?php if (QubitTerm::OFFLINE_ID != $digitalObject->usageId) { ?>
       <?php if (QubitAcl::check(${$resourceVar}, 'readMaster') && 0 < strlen($url = QubitTerm::EXTERNAL_URI_ID == $digitalObject->usageId ? $digitalObject->getPath() : $ead->getAssetPath($digitalObject))) { ?>
-        <dao linktype="simple" href="<?php echo $url; ?>" role="master" actuate="onrequest" show="embed"/>
+        <dao linktype="simple" href="<?php echo escape_dc(esc_specialchars($url)); ?>" role="master" actuate="onrequest" show="embed"/>
       <?php } elseif (null !== $digitalObject->reference && QubitAcl::check(${$resourceVar}, 'readReference') && 0 < strlen($url = $ead->getAssetPath($digitalObject, true) ?? '')) { ?>
         <dao linktype="simple" href="<?php echo $url; ?>" role="reference" actuate="onrequest" show="embed"/>
       <?php } ?>


### PR DESCRIPTION
Added proper XML escaping using escape_dc(esc_specialchars()) for DAO href attributes to handle special characters in URLs.