### PR TITLE
Mark currentPassword as optional if user doesn't exist

### DIFF
--- a/apps/qubit/modules/user/actions/editAction.class.php
+++ b/apps/qubit/modules/user/actions/editAction.class.php
@@ -196,9 +196,9 @@ class UserEditAction extends DefaultEditAction
                 $this->form->setDefault('currentPassword', null);
 
                 $this->form->setValidator('currentPassword', new sfValidatorAnd([
-                    new sfValidatorString(['required' => !isset($this->getRoute()->resource)]),
+                    new sfValidatorString(['required' => isset($this->getRoute()->resource)]),
                     new sfValidatorCallback(['callback' => [$this, 'verify']]),
-                ], ['required' => true]));
+                ]));
 
                 $this->form->setWidget('currentPassword', new sfWidgetFormInputPassword([], [
                     'autocomplete' => 'new-password',

--- a/plugins/arDominionB5Plugin/modules/user/templates/editSuccess.mod_standard.php
+++ b/plugins/arDominionB5Plugin/modules/user/templates/editSuccess.mod_standard.php
@@ -49,7 +49,7 @@
                 </div>
                 <?php $resourceAlreadyExists = isset($sf_request->getAttribute('sf_route')->resource); ?>
                 <?php if ($resourceAlreadyExists) { ?>
-                  <?php echo render_field($form->currentPassword->label($sf_user->user->username.__('\'s current password')), null); ?>
+                  <?php echo render_field($form->currentPassword->label(__("%1%'s current password", ['%1%' => $sf_user->user->username])), null); ?>
                   <?php echo render_field($form->password->label(__('New password')), null, ['class' => 'password-strength']); ?>
                 <?php } else { ?>
                   <?php echo render_field($form->password->label(__('New password')), null, ['class' => 'password-strength']); ?>
@@ -58,7 +58,9 @@
               </div>
               <div class="col-md-6 template" hidden>
                 <?php if ($resourceAlreadyExists) { ?>
-                  <div class="mb-3 bg-light p-3 rounded border-start border-4">Your current password is required to confirm your identity before making changes to this user's account</div>
+                  <div class="mb-3 bg-light p-3 rounded border-start border-4">
+                    <?php echo __("Your current password is required to confirm your identity before making changes to this user's account"); ?>
+                  </div>
                 <?php } ?>
                 <div class="mb-3 bg-light p-3 rounded border-start border-4">
                   <label class="form-label"><?php echo __('Password strength:'); ?></label>

--- a/plugins/arDominionB5Plugin/modules/user/templates/editSuccess.mod_standard.php
+++ b/plugins/arDominionB5Plugin/modules/user/templates/editSuccess.mod_standard.php
@@ -47,7 +47,8 @@
                   data-confirm-failure="<?php echo __('Your password confirmation did not match your password.'); ?>"
                 >
                 </div>
-                <?php if (isset($sf_request->getAttribute('sf_route')->resource)) { ?>
+                <?php $resourceAlreadyExists = isset($sf_request->getAttribute('sf_route')->resource); ?>
+                <?php if ($resourceAlreadyExists) { ?>
                   <?php echo render_field($form->currentPassword->label($sf_user->user->username.__('\'s current password')), null); ?>
                   <?php echo render_field($form->password->label(__('New password')), null, ['class' => 'password-strength']); ?>
                 <?php } else { ?>
@@ -56,7 +57,9 @@
                 <?php echo render_field($form->confirmPassword->label(__('Confirm new password')), null, ['class' => 'password-confirm']); ?>
               </div>
               <div class="col-md-6 template" hidden>
-                <div class="mb-3 bg-light p-3 rounded border-start border-4">Your current password is required to confirm your identity before making changes to this user's account</div>
+                <?php if ($resourceAlreadyExists) { ?>
+                  <div class="mb-3 bg-light p-3 rounded border-start border-4">Your current password is required to confirm your identity before making changes to this user's account</div>
+                <?php } ?>
                 <div class="mb-3 bg-light p-3 rounded border-start border-4">
                   <label class="form-label"><?php echo __('Password strength:'); ?></label>
 		  <div class="progress mb-3">


### PR DESCRIPTION
Closes #2137 

Makes `currentPassword` optional if the user doesn't exist yet. Conditionally displays the message about current password only if the user already exists.