### PR TITLE
arOidcPlugin: use `expires_in` for access token

### DIFF
--- a/plugins/arOidcPlugin/lib/oidcUser.class.php
+++ b/plugins/arOidcPlugin/lib/oidcUser.class.php
@@ -255,8 +255,8 @@ class oidcUser extends myUser implements Zend_Acl_Role_Interface
                     return false;
                 }
 
-                if (isset($refreshResult->refresh_expires_in) && is_numeric($refreshResult->refresh_expires_in)) {
-                    $newExpiryTime = $currentTime + (int) $refreshResult->refresh_expires_in;
+                if (isset($refreshResult->expires_in) && is_numeric($refreshResult->expires_in)) {
+                    $newExpiryTime = $currentTime + (int) $refreshResult->expires_in;
                     $this->logger->info(sprintf('$newExpiryTime: %s', $newExpiryTime));
                 } else {
                     $this->logger->err('Error calculating new token expiry. Session no longer active.');


### PR DESCRIPTION
The OIDC plugin was previously updating `oidc-expiry` using `refresh_expires_in` from the token endpoint response. This value represents the *refresh token* lifetime, not the access token’s. As a result, AtoM only refreshed the access token once and then waited until the refresh token was close to expiry, causing user sessions to end unexpectedly.

This change fixes the logic to use `expires_in` to compute the new access token expiry. With this adjustment, AtoM refreshes tokens regularly according to the configured access token lifespan, improving session stability when using Keycloak and other OIDC providers.

Connects to https://github.com/artefactual/atom/issues/2139