### PR TITLE
Save related QubitObject in rename-slug. (#2153)

### DIFF
--- a/lib/task/tools/renameSlugTask.class.php
+++ b/lib/task/tools/renameSlugTask.class.php
@@ -131,6 +131,7 @@ EOF;
         } else {
             $oldSlugObject->slug = $newSlug;
             $oldSlugObject->save();
+            QubitObject::getBySlug($newSlug)->save();
             $this->logSection('rename-slug', "Slug {$oldSlug} updated to {$newSlug} successfully.");
             $this->addToLogFile($oldSlug, $newSlug);
         }


### PR DESCRIPTION
Retrieve associated QubitObject using the updated slug and save when running `tools:rename-slug` via command line.