### PR TITLE
Close cURL handles on DO downloads

### DIFF
--- a/lib/arInstall.class.php
+++ b/lib/arInstall.class.php
@@ -299,6 +299,7 @@ class arInstall
 
         $curlHttpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         curl_close($curl);
+        $curl = null;
 
         if (200 !== $curlHttpCode) {
             throw new Exception("Elasticsearch error: {$curlHttpCode}");

--- a/lib/arInstall.class.php
+++ b/lib/arInstall.class.php
@@ -298,7 +298,7 @@ class arInstall
         }
 
         $curlHttpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-        curl_close($curl);
+        // set curl handle to null to close connection
         $curl = null;
 
         if (200 !== $curlHttpCode) {

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -3496,11 +3496,13 @@ class QubitDigitalObject extends BaseDigitalObject
             }
 
             if (false !== $contents = $browser->getResponseText()) {
+                $browser->close();
                 return $contents;
             }
         }
 
         // Throw exception on failure
+        $browser->close();
         throw new sfException(sprintf('Error downloading "%s" (attempts: %s).', $uri, $i));
     }
 

--- a/lib/model/QubitDigitalObject.php
+++ b/lib/model/QubitDigitalObject.php
@@ -3497,12 +3497,14 @@ class QubitDigitalObject extends BaseDigitalObject
 
             if (false !== $contents = $browser->getResponseText()) {
                 $browser->close();
+
                 return $contents;
             }
         }
 
         // Throw exception on failure
         $browser->close();
+
         throw new sfException(sprintf('Error downloading "%s" (attempts: %s).', $uri, $i));
     }
 

--- a/plugins/arStorageServicePlugin/lib/arStorageServiceUtils.class.php
+++ b/plugins/arStorageServicePlugin/lib/arStorageServiceUtils.class.php
@@ -62,7 +62,7 @@ class arStorageServiceUtils
         curl_exec($ch);
         $status = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
 
-        curl_close($ch);
+        // set curl handle to null to close connection
         $ch = null;
 
         return $status;

--- a/plugins/arStorageServicePlugin/lib/arStorageServiceUtils.class.php
+++ b/plugins/arStorageServicePlugin/lib/arStorageServiceUtils.class.php
@@ -63,6 +63,7 @@ class arStorageServiceUtils
         $status = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
 
         curl_close($ch);
+        $ch = null;
 
         return $status;
     }

--- a/plugins/sfModsPlugin/lib/sfModsConvertor.class.php
+++ b/plugins/sfModsPlugin/lib/sfModsConvertor.class.php
@@ -339,6 +339,7 @@ class sfModsConvertor extends QubitSaxParser
         file_put_contents($tempFile, curl_exec($curlSession));
 
         curl_close($curlSession);
+        $curlSession = null;
 
         // Add temp file to digital object import queue
         $pathParts = pathinfo($this->data());

--- a/plugins/sfModsPlugin/lib/sfModsConvertor.class.php
+++ b/plugins/sfModsPlugin/lib/sfModsConvertor.class.php
@@ -338,7 +338,7 @@ class sfModsConvertor extends QubitSaxParser
         $tempFile = tempnam(sys_get_temp_dir(), 'atomFile');
         file_put_contents($tempFile, curl_exec($curlSession));
 
-        curl_close($curlSession);
+        // set curl handle to null to close connection
         $curlSession = null;
 
         // Add temp file to digital object import queue

--- a/plugins/sfWebBrowserPlugin/lib/sfCurlAdapter.class.php
+++ b/plugins/sfWebBrowserPlugin/lib/sfCurlAdapter.class.php
@@ -124,7 +124,7 @@ class sfCurlAdapter
 
     public function __destruct()
     {
-        curl_close($this->curl);
+        $this->close();
     }
 
     public function close()

--- a/plugins/sfWebBrowserPlugin/lib/sfCurlAdapter.class.php
+++ b/plugins/sfWebBrowserPlugin/lib/sfCurlAdapter.class.php
@@ -129,8 +129,8 @@ class sfCurlAdapter
 
     public function close()
     {
-        if ($this->curl) {     // works for resource and CurlHandle
-            curl_close($this->curl);
+        // If curl handle exists, set it to null to close connection
+        if ($this->curl) {
             $this->curl = null;
         }
     }

--- a/plugins/sfWebBrowserPlugin/lib/sfCurlAdapter.class.php
+++ b/plugins/sfWebBrowserPlugin/lib/sfCurlAdapter.class.php
@@ -122,18 +122,17 @@ class sfCurlAdapter
         curl_setopt($this->curl, CURLOPT_HEADERFUNCTION, [$this, 'read_header']);
     }
 
+    public function __destruct()
+    {
+        curl_close($this->curl);
+    }
+
     public function close()
     {
         if ($this->curl) {     // works for resource and CurlHandle
             curl_close($this->curl);
             $this->curl = null;
         }
-    }
-
-
-    public function __destruct()
-    {
-        curl_close($this->curl);
     }
 
     /**

--- a/plugins/sfWebBrowserPlugin/lib/sfCurlAdapter.class.php
+++ b/plugins/sfWebBrowserPlugin/lib/sfCurlAdapter.class.php
@@ -122,6 +122,15 @@ class sfCurlAdapter
         curl_setopt($this->curl, CURLOPT_HEADERFUNCTION, [$this, 'read_header']);
     }
 
+    public function close()
+    {
+        if ($this->curl) {     // works for resource and CurlHandle
+            curl_close($this->curl);
+            $this->curl = null;
+        }
+    }
+
+
     public function __destruct()
     {
         curl_close($this->curl);

--- a/plugins/sfWebBrowserPlugin/lib/sfWebBrowser.class.php
+++ b/plugins/sfWebBrowserPlugin/lib/sfWebBrowser.class.php
@@ -743,8 +743,7 @@ class sfWebBrowser
         return $headers;
     }
 
-
-    /* Explicitly close the underlying adapter if it supports close(). */
+    // Explicitly close the underlying adapter if it supports close().
     public function close()
     {
         if (isset($this->adapter) && method_exists($this->adapter, 'close')) {

--- a/plugins/sfWebBrowserPlugin/lib/sfWebBrowser.class.php
+++ b/plugins/sfWebBrowserPlugin/lib/sfWebBrowser.class.php
@@ -743,6 +743,15 @@ class sfWebBrowser
         return $headers;
     }
 
+
+    /* Explicitly close the underlying adapter if it supports close(). */
+    public function close()
+    {
+        if (isset($this->adapter) && method_exists($this->adapter, 'close')) {
+            $this->adapter->close();
+        }
+    }
+
     protected function parseArgumentAsArray($name, $value, &$vars)
     {
         if (false !== $pos = strpos($name, '[')) {


### PR DESCRIPTION
- Added `close()` method in sfCurlAdapter to explicitly release the cURL handle.
- Added `close()` passthrough in sfWebBrowser to call adapter cleanup safely.
- Updated QubitDigitalObject::downloadExternalObject() to call `$browser->close()` after successful download and before throwing exceptions.

This ensures that external digital object imports release sockets immediately, preventing buildup of CLOSE_WAIT connections during large CSV imports.