### PR TITLE
Update ES plugin to call forcemergeAll()

### DIFF
--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPlugin.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPlugin.class.php
@@ -153,7 +153,7 @@ class arElasticSearchPlugin extends QubitSearchEngine
      */
     public function optimize($args = [])
     {
-        return $this->client->optimizeAll($args);
+        return $this->client->forcemergeAll($args);
     }
 
     /*


### PR DESCRIPTION
Elastica has deprecated the function `optimizeAll()` in favour of `forcemergeAll()`. This commit updates arElasticSearchPlugin::optimize() to use this new Elastica method.