### PR TITLE
Fix Symfony debug mode in BS5 theme

### DIFF
--- a/lib/QubitMarkdown.class.php
+++ b/lib/QubitMarkdown.class.php
@@ -31,6 +31,8 @@ class QubitMarkdown
         'bold' => '__',
     ];
 
+    protected $parsedown;
+
     private $enabled;
 
     protected function __construct()

--- a/lib/filter/QubitCSPFilter.php
+++ b/lib/filter/QubitCSPFilter.php
@@ -21,8 +21,8 @@ class QubitCSP extends sfFilter
 {
     public function execute($filterChain)
     {
-        // Only use CSP headers if theme is b5.
-        if (!sfConfig::get('app_b5_theme', false)) {
+        // Only use CSP headers if theme is b5, or if not debugging
+        if (!sfConfig::get('app_b5_theme', false) || $this->getContext()->getConfiguration()->isDebug()) {
             $filterChain->execute();
 
             return;

--- a/lib/form/arB5WidgetFormSchemaFormatter.class.php
+++ b/lib/form/arB5WidgetFormSchemaFormatter.class.php
@@ -19,6 +19,7 @@
 
 class arB5WidgetFormSchemaFormatter extends sfWidgetFormSchemaFormatter
 {
+    public $form;
     protected $rowFormat = "<div class=\"mb-3\">\n  %label%\n  %field%\n"
         ."  %error%\n  %help%\n  %hidden_fields%\n</div>";
     protected $formErrorListFormat = '<div class="alert alert-danger"'

--- a/lib/model/QubitMenu.php
+++ b/lib/model/QubitMenu.php
@@ -470,6 +470,7 @@ class QubitMenu extends BaseMenu
 
         $module = $route['parameters']['module'];
         $action = $route['parameters']['action'];
+
         // Check access from security.yml rules
         return $context->getUser()->checkModuleActionAccess($module, $action);
     }

--- a/lib/model/QubitMenu.php
+++ b/lib/model/QubitMenu.php
@@ -462,9 +462,14 @@ class QubitMenu extends BaseMenu
         // Parse module and action from path
         $path = $this->getPath(['getUrl' => true, 'resolveAlias' => true]);
         $route = $context->getRouting()->findRoute($path);
+
+        // If the route does not exist, just return true
+        if (false == $route) {
+            return true;
+        }
+
         $module = $route['parameters']['module'];
         $action = $route['parameters']['action'];
-
         // Check access from security.yml rules
         return $context->getUser()->checkModuleActionAccess($module, $action);
     }

--- a/lib/model/om/BaseStaticPage.php
+++ b/lib/model/om/BaseStaticPage.php
@@ -76,7 +76,7 @@ abstract class BaseStaticPage extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__isset'), $args);
+      return call_user_func_array('QubitObject::__isset', $args);
     }
     catch (sfException $e)
     {
@@ -115,7 +115,7 @@ abstract class BaseStaticPage extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__get'), $args);
+      return call_user_func_array('QubitObject::__get', $args);
     }
     catch (sfException $e)
     {

--- a/lib/routing/QubitRoute.class.php
+++ b/lib/routing/QubitRoute.class.php
@@ -146,7 +146,7 @@ class QubitRoute extends sfRoute
         foreach ($tokens as $token) {
             switch ($token[0]) {
                 case 'variable':
-                    if ((!$optional || !isset($this->defaults[$token[3]]) || $parameters[$token[3]] != $this->defaults[$token[3]]) && $parameters[$token[3]]) {
+                    if ((!$optional || !isset($this->defaults[$token[3]]) || $parameters[$token[3]] != $this->defaults[$token[3]]) && null !== $parameters[$token[3]]) {
                         $url[] = QubitRoute::urlencode3986($parameters[$token[3]]);
                         $optional = false;
                     }

--- a/lib/routing/QubitRoute.class.php
+++ b/lib/routing/QubitRoute.class.php
@@ -146,7 +146,7 @@ class QubitRoute extends sfRoute
         foreach ($tokens as $token) {
             switch ($token[0]) {
                 case 'variable':
-                    if (!$optional || !isset($this->defaults[$token[3]]) || $parameters[$token[3]] != $this->defaults[$token[3]]) {
+                    if ((!$optional || !isset($this->defaults[$token[3]]) || $parameters[$token[3]] != $this->defaults[$token[3]]) && $parameters[$token[3]]) {
                         $url[] = QubitRoute::urlencode3986($parameters[$token[3]]);
                         $optional = false;
                     }

--- a/vendor/symfony/lib/form/sfForm.class.php
+++ b/vendor/symfony/lib/form/sfForm.class.php
@@ -926,7 +926,7 @@ $this->widgetSchema->setFormFormatterName($name);
    */
   public function isCSRFProtected()
   {
-    return null !== $this->validatorSchema[self::$CSRFFieldName];
+    return null !== $this->validatorSchema && null !== $this->validatorSchema[self::$CSRFFieldName];
   }
 
   /**

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel/util/DebugPDO.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel/util/DebugPDO.php
@@ -320,29 +320,30 @@ class DebugPDO extends PropelPDO
 	}
 
 	/**
-	 * Executes an SQL statement, returning a result set as a PDOStatement object.  Despite its signature here,
-	 * this method takes a variety of parameters.
+	 * Executes an SQL statement, returning a result set as a PDOStatement object.
 	 *
 	 * Overridden for query counting and logging.
 	 *
 	 * @see        http://php.net/manual/en/pdo.query.php for a description of the possible parameters.
 	 * @return     PDOStatement
 	 */
-	public function query()
+	#[\ReturnTypeWillChange]
+	public function query($query, mixed ...$otherArgs)
 	{
 		$debug	= $this->getDebugSnapshot();
-		$args	= func_get_args();
+		$args   = func_get_args();
+
 		if (version_compare(PHP_VERSION, '5.3', '<')) {
-			$return	= call_user_func_array(array($this, 'parent::query'), $args);
+			$return = call_user_func_array(array($this, 'parent::query'), $args);
 		} else {
-			$return	= call_user_func_array('parent::query', $args);
+			$return = call_user_func_array('parent::query', $args);
 		}
-		
-		$sql = $args[0];
+
+		$sql = $query;
 		$this->log($sql, null, __METHOD__, $debug);
 		$this->setLastExecutedQuery($sql);
 		$this->incrementQueryCount();
-		
+
 		return $return;
 	}
 


### PR DESCRIPTION
Closes #2031 

I've been curious about using debug mode in Symfony so I took a look at this issue. Here is the debug mode bar working in the BS5 theme:

<img width="1307" height="611" alt="debug mode working" src="https://github.com/user-attachments/assets/bfa9065b-dc98-4cb8-bd45-dce0f64e77c7" />

The main issue besides the one fixed in the `DebugPDO` class was the fact that **the Symfony debug bar is incompatible with the strict content security policy** that's enabled for BS5 themes. Rather than refactor how the debug bar gets rendered, I disabled the CSP when debug mode is on.

## Other issues addressed

One interesting thing with debug mode is that warnings and errors are rendered directly to the HTML displayed to the user. I wasn't able to fix all of these, but I fixed a number of the most obvious ones that get rendered to the homepage.

The "random" changes I made in this pull request address those errors. For example, adding the `$parsedown` variable to `QubitMarkdown.class.php` fixes this error from being rendered:

<img width="1278" height="230" alt="parsedown error" src="https://github.com/user-attachments/assets/d405d522-2cd0-40a4-8758-0235adb4e0b1" />

