### PR TITLE
Remove all ES_TYPE references

### DIFF
--- a/js/fullWidthTreeView.js
+++ b/js/fullWidthTreeView.js
@@ -395,16 +395,24 @@
         let url =
           parentNode.a_attr.href + "/informationobject/fullWidthTreeViewSync";
 
-        $.get(url, (response) => {
-          if (response["repair_successful"] === true) {
-            // Refresh parent's child nodes if a repair was needed and was successful
-            this.$fwTreeView.jstree("refresh_node", parent);
-          } else if (response["repair_successful"] === false) {
-            // Allow for syncing to be attempted again if a repair was needed, but failed
-            delete this.syncInitiated[parent];
-          }
+        $.ajax({
+          url: url,
+          type: 'GET',
+          dataType: 'json',
+          success: (response) => {
+            if ("repair_successful" in response && response["repair_successful"] === true) {
+              // Refresh parent's child nodes if a repair was needed and was successful
+              this.$fwTreeView.jstree("refresh_node", parent);
+            } else if ("repair_successful" in response && response["repair_successful"] === false) {
+              // Allow for syncing to be attempted again if a repair was needed, but failed
+              delete this.syncInitiated[parent];
+            }
 
-          this.commandNodeAndChildren(this.$fwTreeView, parent, "enable_node");
+            this.commandNodeAndChildren(this.$fwTreeView, parent, "enable_node");
+          },
+          error: (response) => {
+            console.error(response);
+          }
         });
       }
     };

--- a/lib/QubitLftSyncer.class.php
+++ b/lib/QubitLftSyncer.class.php
@@ -93,7 +93,6 @@ class QubitLftSyncer
 
         $bulk = new Elastica\Bulk(QubitSearch::getInstance()->client);
         $bulk->setIndex(QubitSearch::getInstance()->index->getIndex('QubitInformationObject'));
-        $bulk->setType(QubitSearch::getInstance()::ES_TYPE);
 
         foreach ($results as $row) {
             $bulk->addAction(

--- a/lib/task/search/arDocumentTask.class.php
+++ b/lib/task/search/arDocumentTask.class.php
@@ -37,9 +37,7 @@ class arSearchDocumentTask extends arBaseTask
         if (null !== $slugObject = QubitObject::getBySlug($arguments['slug'])) {
             $this->log(sprintf("Fetching data for %s ID %d...\n", $slugObject->className, $slugObject->id));
 
-            // Dummy type is needed for ES 6, this should be updated in ES 7.x when type is not required for getDocument()
-            $esType = QubitSearch::getInstance()::ES_TYPE;
-            $doc = QubitSearch::getInstance()->index->getIndex($slugObject->className)->getType($esType)->getDocument($slugObject->id);
+            $doc = QubitSearch::getInstance()->index->getIndex($slugObject->className)->getDocument($slugObject->id);
 
             echo json_encode($doc->getData(), JSON_PRETTY_PRINT)."\n";
         } else {


### PR DESCRIPTION
Closes #2169 

Removes all instances where `ES_TYPE` was being referenced:

- In `search:document`
- When the full-width treeview was refreshed in `QubitLftSyncer`

Additionally, while testing the full-width treeview refresh code, I found the Javascript was silently failing if the response had an error - I'm writing the error to the console now in case there is one.