### PR TITLE
Add optional sidebar block “Newest additions”

### DIFF
--- a/apps/qubit/modules/default/templates/_newest.php
+++ b/apps/qubit/modules/default/templates/_newest.php
@@ -1,0 +1,24 @@
+<section id="newest-additions" class="card mb-3">
+  <h2 class="h5 p-3 mb-0"><?php echo __('Newest additions'); ?></h2>
+  <div class="list-group list-group-flush">
+    <?php
+      // Fetch the 5 most recent records by creation date
+      $criteria = new Criteria;
+      $criteria->addDescendingOrderByColumn(QubitInformationObject::CREATED_AT);
+      $criteria->setLimit(5);
+      $recent = QubitInformationObject::get($criteria);
+
+      if (count($recent)) {
+        foreach ($recent as $object) { ?>
+          <a class="list-group-item list-group-item-action text-break"
+             href="<?php echo url_for([$object]); ?>">
+            <?php echo render_title($object); ?>
+          </a>
+        <?php }
+      } else { ?>
+        <div class="list-group-item text-muted">
+          <?php echo __('No recent descriptions.'); ?>
+        </div>
+      <?php } ?>
+  </div>
+</section>


### PR DESCRIPTION
I have been testing a small improvement for the sidebar: adding an optional block that displays the five most recent archival descriptions.

The implementation uses QubitInformationObject with a simple criteria (ORDER BY created_at DESC LIMIT 5) and reuses existing helper functions like render_title() and url_for().

The goal is to provide end users with a quick overview of the latest material available in the system, in the same way the “Popular this week” block highlights frequently accessed descriptions.

The code is lightweight, requires only one query, and can be easily extended to support caching if desired.
<img width="376" height="366" alt="Screenshot 2025-09-25 at 11 25 18 PM" src="https://github.com/user-attachments/assets/66637f12-c250-43be-9f8f-8e86b417b89a" />
