### PR TITLE
Fix export bulk csv

### DIFF
--- a/lib/task/export/csvExportBulkTask.class.php
+++ b/lib/task/export/csvExportBulkTask.class.php
@@ -63,20 +63,7 @@ class csvExportBulkTask extends exportBulkBaseTask
 
         echo 'Exporting as '.strtoupper($options['standard']).".\n";
 
-        // Instantiate CSV writer
-        $writer = new csvInformationObjectExport(
-            $arguments['path'],
-            $options['standard'],
-            $options['rows-per-file']
-        );
-
-        $writer->user = $context->getUser();
-        $writer->setOptions($options);
-
-        $prevPath = $arguments['path'];
-
         foreach ($rows as $row) {
-            $writer->user->setCulture($row['culture']);
             $resource = QubitInformationObject::getById($row['id']);
 
             // Don't export draft descriptions with public option
@@ -107,18 +94,15 @@ class csvExportBulkTask extends exportBulkBaseTask
                 $filePath = sprintf('%s/%s', $arguments['path'], $filename);
             }
 
-            // Make a new writer
-            if ($prevPath !== $filePath) {
-                $writer = new csvInformationObjectExport(
-                    $filePath,
-                    $options['standard'],
-                    $options['rows-per-file']
-                );
-                $writer->user = $context->getUser();
-                $writer->setOptions($options);
-
-                $prevPath = $filePath;
-            }
+            // Make a new writer for each row
+            $writer = new csvInformationObjectExport(
+                $filePath,
+                $options['standard'],
+                $options['rows-per-file']
+            );
+            $writer->user = $context->getUser();
+            $writer->user->setCulture($row['culture']);
+            $writer->setOptions($options);
 
             $writer->exportResource($resource);
 

--- a/lib/task/export/csvExportBulkTask.class.php
+++ b/lib/task/export/csvExportBulkTask.class.php
@@ -110,7 +110,7 @@ class csvExportBulkTask extends exportBulkBaseTask
 
             ++$itemsExported;
 
-            if (0 == $itemsExported++ % 1000) {
+            if (0 === ($itemsExported % 1000)) {
                 Qubit::clearClassCaches();
             }
         }

--- a/lib/task/export/csvExportBulkTask.class.php
+++ b/lib/task/export/csvExportBulkTask.class.php
@@ -73,6 +73,8 @@ class csvExportBulkTask extends exportBulkBaseTask
         $writer->user = $context->getUser();
         $writer->setOptions($options);
 
+        $prevPath = $arguments['path'];
+
         foreach ($rows as $row) {
             $writer->user->setCulture($row['culture']);
             $resource = QubitInformationObject::getById($row['id']);
@@ -103,6 +105,19 @@ class csvExportBulkTask extends exportBulkBaseTask
                   $resource, 'csv', $options['standard']
                 );
                 $filePath = sprintf('%s/%s', $arguments['path'], $filename);
+            }
+
+            // Make a new writer
+            if ($prevPath !== $filePath) {
+                $writer = new csvInformationObjectExport(
+                    $filePath,
+                    $options['standard'],
+                    $options['rows-per-file']
+                );
+                $writer->user = $context->getUser();
+                $writer->setOptions($options);
+
+                $prevPath = $filePath;
             }
 
             $writer->exportResource($resource);


### PR DESCRIPTION
Closes #2179 

- Make a new CSV writer for each row so that each description gets written to a separate file.
- Fix duplicate description count (`$itemsExported` was incremented twice each loop iteration)

Previously, the same CSV writer at the same path was being used every iteration, so it was essentially working like a regular `csv:export`. These changes make it so that each description gets written to a separate file which I believe is the proper way for this task to function.