### PR TITLE
Update environment - remove spaces after bootstrap.system_call_filter

### DIFF
--- a/docker/etc/environment
+++ b/docker/etc/environment
@@ -3,7 +3,7 @@ bootstrap.memory_lock=true
 cluster.routing.allocation.disk.threshold_enabled=false
 discovery.type=single-node
 ES_JAVA_OPTS=-Xms640m -Xmx640m
-bootstrap.system_call_filter = false
+bootstrap.system_call_filter=false
 
 # MySQL
 MYSQL_ROOT_PASSWORD=my-secret-pw


### PR DESCRIPTION
The docker set up worked perfectly in MacOS + Docker but under another Linux + Docker environment I got this exception from Elasticsearch when starting the container.

```
uncaught exception in thread [main]
java.lang.IllegalArgumentException: unknown setting [bootstrap.system_call_filter ] did you mean [bootstrap.system_call_filter]?
	at org.elasticsearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:544)
	at org.elasticsearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:489)
	at org.elasticsearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:460)
	at org.elasticsearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:431)
	at org.elasticsearch.common.settings.SettingsModule.<init>(SettingsModule.java:149)
	at org.elasticsearch.node.Node.<init>(Node.java:406)
	at org.elasticsearch.node.Node.<init>(Node.java:289)
	at org.elasticsearch.bootstrap.Bootstrap$5.<init>(Bootstrap.java:227)
	at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:227)
	at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:393)
	at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:170)
	at org.elasticsearch.bootstrap.Elasticsearch.execute(Elasticsearch.java:161)
	at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:86)
	at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:127)
	at org.elasticsearch.cli.Command.main(Command.java:90)
	at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:126)
	at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:92)
For complete error details, refer to the log at /usr/share/elasticsearch/logs/docker-cluster.log
```

While I haven't dug deep into the environments / versions where this error is present, the change is innocuous enough and fixes one issue I had.