### PR TITLE
Handle inherited repository when matching information objects

### DIFF
--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -508,7 +508,7 @@ class QubitFlatfileImport
         if (isset($this->className)) {
             $skipRowProcessing = $this->fetchOrCreateObjectByClass();
 
-            if (property_exists(get_class($this->object), 'disableNestedSetUpdating')) {
+            if (!$skipRowProcessing && property_exists(get_class($this->object), 'disableNestedSetUpdating')) {
                 $this->object->disableNestedSetUpdating = $this->disableNestedSetUpdating;
             }
         } else {

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -2156,6 +2156,10 @@ class QubitInformationObject extends BaseInformationObject
     /**
      * Try to match informationObject to an existing one in system.
      *
+     * If $repoName is set, then the repository is searched for recursively in parent records
+     * until a non-NULL repository is found. This enables matching by repository even when the
+     * repository is inherited from a parent record.
+     *
      * @param string $identifier informationObject identifier
      * @param string $title      informationObject title
      * @param string $repoName   repository authorizedFormOfName
@@ -2181,13 +2185,26 @@ class QubitInformationObject extends BaseInformationObject
                 $params[':repoName'] = $repoName;
 
                 // Select the repository id of the nearest parent that has one set.
+
+                // hierarchy table: Recursively searches until a parent record is found that has
+                // the repository_id set. This repository_id is set in the effective_repo_id. It
+                // may be NULL if there is no repository to inherit! Terminates when the effective
+                // repo ID is null, or when the parent_id is NULL (reached the top of the hierarchy)
+
+                // resolved table: Filter the hierarchy table for the first non-NULL
+                // effective_repo_id. For this part:
+                //
+                //   ROW_NUMBER() OVER (PARTITION BY original_id ORDER BY depth DESC) AS rn
+                //
+                // the recursive query will terminate when effective_repo_id != NULL. The repo ID
+                // at this point is at the maximum depth, so sorting the depth in descending order
+                // returns the first parent that had a repository_id set.
                 $sql = '
-                    WITH RECURSIVE InformationHierarchy AS (
+                    WITH RECURSIVE hierarchy AS (
                         SELECT
                             id AS original_id,
                             parent_id,
-                            repository_id AS effective_repo_id,
-                            id AS current_node_id,
+                            repository_id AS effective_repo_id,  -- <- Inherited repo ID
                             1 AS depth
                         FROM
                             information_object
@@ -2198,12 +2215,13 @@ class QubitInformationObject extends BaseInformationObject
                             child.original_id,
                             parent.parent_id,
                             COALESCE(child.effective_repo_id, parent.repository_id) AS effective_repo_id,
-                            parent.id AS current_node_id,
                             child.depth + 1
                         FROM
-                            InformationHierarchy child
+                            hierarchy child
                         INNER JOIN
-                            information_object parent ON parent.id = child.parent_id
+                            information_object parent
+                        ON
+                            parent.id = child.parent_id
                         WHERE
                             child.effective_repo_id IS NULL AND child.parent_id IS NOT NULL
                     )
@@ -2217,7 +2235,7 @@ class QubitInformationObject extends BaseInformationObject
                             effective_repo_id,
                             ROW_NUMBER() OVER (PARTITION BY original_id ORDER BY depth DESC) AS rn
                         FROM
-                            InformationHierarchy
+                            hierarchy
                         WHERE
                             effective_repo_id IS NOT NULL
                     ) AS resolved

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -2170,17 +2170,6 @@ class QubitInformationObject extends BaseInformationObject
             $sf_user = sfContext::getInstance()->getUser();
             $culture = $sf_user->getCulture();
 
-            $selectClause = '
-                SELECT io.id
-                FROM information_object io
-                INNER JOIN information_object_i18n io_i18n 
-                    ON io_i18n.id = io.id 
-                AND io_i18n.culture = :culture
-            ';
-            $whereClause = '
-                WHERE io.identifier = :identifier
-                AND io_i18n.title = :title
-            ';
             // Parameters for the query.
             $params = [
                 ':identifier' => $identifier,
@@ -2188,24 +2177,93 @@ class QubitInformationObject extends BaseInformationObject
                 ':culture' => $culture,
             ];
 
-            // If a repository name is provided, add joins and condition on the repository authorized name.
             if (null !== $repoName) {
-                $selectClause .= '
-                    INNER JOIN repository r 
-                        ON r.id = io.repository_id
-                    INNER JOIN actor a 
-                        ON a.id = io.repository_id
-                    INNER JOIN actor_i18n a_i18n 
-                        ON a_i18n.id = a.id 
-                    AND a_i18n.culture = :culture
-                ';
-                $whereClause .= '
-                    AND a_i18n.authorized_form_of_name = :repoName
-                ';
                 $params[':repoName'] = $repoName;
-            }
 
-            $sql = $selectClause.$whereClause.' LIMIT 1';
+                // Select the repository id of the nearest parent that has one set.
+                $sql = '
+                    WITH RECURSIVE InformationHierarchy AS (
+                        SELECT
+                            id AS original_id,
+                            parent_id,
+                            repository_id AS effective_repo_id,
+                            id AS current_node_id,
+                            1 AS depth
+                        FROM
+                            information_object
+
+                        UNION ALL
+
+                        SELECT
+                            child.original_id,
+                            parent.parent_id,
+                            COALESCE(child.effective_repo_id, parent.repository_id) AS effective_repo_id,
+                            parent.id AS current_node_id,
+                            child.depth + 1
+                        FROM
+                            InformationHierarchy child
+                        INNER JOIN
+                            information_object parent ON parent.id = child.parent_id
+                        WHERE
+                            child.effective_repo_id IS NULL AND child.parent_id IS NOT NULL
+                    )
+                    SELECT
+                        io.id
+                    FROM
+                        information_object io
+                    INNER JOIN (
+                        SELECT
+                            original_id,
+                            effective_repo_id,
+                            ROW_NUMBER() OVER (PARTITION BY original_id ORDER BY depth DESC) AS rn
+                        FROM
+                            InformationHierarchy
+                        WHERE
+                            effective_repo_id IS NOT NULL
+                    ) AS resolved
+                    ON
+                        io.id = resolved.original_id
+                        AND resolved.rn = 1
+                        AND io.identifier = :identifier
+                    INNER JOIN
+                        information_object_i18n io_i18n
+                    ON
+                        io_i18n.id = io.id
+                        AND io_i18n.culture = :culture
+                        AND io_i18n.title = :title
+                    INNER JOIN
+                        repository r
+                    ON
+                        r.id = resolved.effective_repo_id
+                    INNER JOIN
+                        actor a
+                    ON
+                        a.id = resolved.effective_repo_id
+                    INNER JOIN
+                        actor_i18n a_i18n
+                    ON
+                        a_i18n.id = a.id
+                        AND a_i18n.culture = :culture
+                        AND a_i18n.authorized_form_of_name = :repoName
+                    LIMIT 1;
+                ';
+            } else {
+                $sql = '
+                    SELECT
+                        io.id
+                    FROM
+                        information_object io
+                    INNER JOIN
+                        information_object_i18n io_i18n
+                    ON
+                        io_i18n.id = io.id
+                        AND io_i18n.culture = :culture
+                        AND io_i18n.title = :title
+                    WHERE
+                        io.identifier = :identifier
+                    LIMIT 1;
+                ';
+            }
 
             // If a matching record is found, return its ID.
             if ($row = QubitPdo::fetchOne($sql, $params)) {

--- a/test/phpunit/QubitInformationObjectTest.php
+++ b/test/phpunit/QubitInformationObjectTest.php
@@ -89,4 +89,202 @@ class QubitInformationObjectTest extends TransactionTestCase
             ['TestDescriptionIdentifierX', 'TestDescriptionTitle', 'TestRepository', true, null],
         ];
     }
+
+    /**
+     * @dataProvider dataProviderForGetByTitleIdentifierAndRepoInherit
+     *
+     * Tests that getByTitleIdentifierAndRepo works when the repository is inherited (i.e., when
+     * the information object with the matching title + identifier has NULL for the repository ID).
+     *
+     * @param string $identifier    the child information object identifier
+     * @param string $title         the child information object title
+     * @param string $repoName      the repository authorized_form_of_name
+     * @param bool   $parentHasRepo whether the parent should have a linked repository
+     * @param string $expectedTitle expected localized title if a match is found; otherwise, null
+     */
+    public function testGetByTitleIdentifierAndRepoInherit($identifier, $title, $repoName, $parentHasRepo, $expectedTitle)
+    {
+        $randomString = rand(1000000, 9999999);
+
+        $parent = new QubitInformationObject();
+        $parent->title = 'TestParentTitle'.$randomString;
+        $parent->identifier = 'TestParentIdentifier'.$randomString;
+
+        if (true === $parentHasRepo) {
+            $repository = new QubitRepository();
+            $repository->indexOnSave = false;
+            $repository->setAuthorizedFormOfName('TestRepository'.$randomString);
+            $repository->save();
+            $parent->setRepositoryId($repository->id);
+        }
+
+        $parent->indexOnSave = false;
+        $parent->save();
+
+        $child = new QubitInformationObject();
+        $child->title = 'TestChildTitle'.$randomString;
+        $child->identifier = 'TestChildIdentifier'.$randomString;
+        $child->parentId = $parent->id;
+        $child->indexOnSave = false;
+        $child->save();
+
+        if (null !== $repoName) {
+            $repoName .= $randomString;
+        }
+
+        $result = QubitInformationObject::getByTitleIdentifierAndRepo(
+            $identifier.$randomString,
+            $title.$randomString,
+            $repoName
+        );
+
+        if (null === $expectedTitle) {
+            $this->assertNull($result, 'Expected null result when no matching record exists.');
+        } else {
+            $this->assertNotNull($result, 'Expected a valid integer id when data should match.');
+            $this->assertIsInt($result, 'Expected the returned id to be an integer.');
+
+            $resultIo = QubitInformationObject::getById($result);
+            $this->assertNotNull($resultIo, 'Expected a valid information object.');
+            $this->assertEquals($expectedTitle.$randomString, $resultIo->title, 'The information object title does not match expected.');
+        }
+    }
+
+    public function dataProviderForGetByTitleIdentifierAndRepoInherit()
+    {
+        // Order of fields: $identifier, $title, $repoName, $parentHasRepo, $expectedTitle
+        return [
+            // Child matches id and title, parent has matching repo: matching success.
+            ['TestChildIdentifier', 'TestChildTitle', 'TestRepository', true, 'TestChildTitle'],
+            // Child matches id and title, parent has repo but repo name doesn't match: matching fail.
+            ['TestChildIdentifier', 'TestChildTitle', 'TestRepositoryX', true, null],
+            // Child matches id and title, parent has no repo but repo name specified: matching fail.
+            ['TestChildIdentifier', 'TestChildTitle', 'TestRepository', false, null],
+            // Child matches id and title, parent has repo but no repo name specified: matching success.
+            ['TestChildIdentifier', 'TestChildTitle', null, true, 'TestChildTitle'],
+            // Child matches id and title, parent has no repo and no repo name specified: matching success.
+            ['TestChildIdentifier', 'TestChildTitle', null, false, 'TestChildTitle'],
+            // Child id doesn't match, parent has matching repo: matching fail.
+            ['TestChildIdentifierX', 'TestChildTitle', 'TestRepository', true, null],
+            // Child title doesn't match, parent has matching repo: matching fail.
+            ['TestChildIdentifier', 'TestChildTitleX', 'TestRepository', true, null],
+        ];
+    }
+
+    /**
+     * Test that repository is inherited from a grandparent when immediate parent has no repository.
+     * Creates a three-level hierarchy: grandparent (with repo) -> parent (no repo) -> child (no repo).
+     * Verifies child can be found when searching with grandparent's repository.
+     */
+    public function testGetByTitleIdentifierAndRepoWithMultiLevelInheritance()
+    {
+        $randomString = rand(1000000, 9999999);
+
+        $repository = new QubitRepository();
+        $repository->indexOnSave = false;
+        $repository->setAuthorizedFormOfName('TestRepository'.$randomString);
+        $repository->save();
+
+        // Has repository
+        $grandparent = new QubitInformationObject();
+        $grandparent->title = 'TestGrandparentTitle'.$randomString;
+        $grandparent->identifier = 'TestGrandparentIdentifier'.$randomString;
+        $grandparent->setRepositoryId($repository->id);
+        $grandparent->indexOnSave = false;
+        $grandparent->save();
+
+        // No repository
+        $parent = new QubitInformationObject();
+        $parent->title = 'TestParentTitle'.$randomString;
+        $parent->identifier = 'TestParentIdentifier'.$randomString;
+        $parent->parentId = $grandparent->id;
+        $parent->indexOnSave = false;
+        $parent->save();
+
+        // No repository
+        $child = new QubitInformationObject();
+        $child->title = 'TestChildTitle'.$randomString;
+        $child->identifier = 'TestChildIdentifier'.$randomString;
+        $child->parentId = $parent->id;
+        $child->indexOnSave = false;
+        $child->save();
+
+        $result = QubitInformationObject::getByTitleIdentifierAndRepo(
+            'TestChildIdentifier'.$randomString,
+            'TestChildTitle'.$randomString,
+            'TestRepository'.$randomString
+        );
+
+        $this->assertNotNull($result, 'Expected a valid integer id when repository is inherited from grandparent.');
+        $this->assertIsInt($result, 'Expected the returned id to be an integer.');
+
+        $resultIo = QubitInformationObject::getById($result);
+        $this->assertNotNull($resultIo, 'Expected a valid information object.');
+        $this->assertEquals('TestChildTitle'.$randomString, $resultIo->title, 'The information object title does not match expected.');
+    }
+
+    /**
+     * Test that nearest parent repository takes precedence over more distant ancestor repositories.
+     * Creates a three-level hierarchy with different repositories: grandparent (repo A) -> parent (repo B) -> child (no repo).
+     * Verifies child matches with parent's repo B but not grandparent's repo A.
+     */
+    public function testGetByTitleIdentifierAndRepoWithNearestParentRepository()
+    {
+        $randomString = rand(1000000, 9999999);
+
+        $grandparentRepo = new QubitRepository();
+        $grandparentRepo->indexOnSave = false;
+        $grandparentRepo->setAuthorizedFormOfName('TestGrandparentRepository'.$randomString);
+        $grandparentRepo->save();
+
+        $parentRepo = new QubitRepository();
+        $parentRepo->indexOnSave = false;
+        $parentRepo->setAuthorizedFormOfName('TestParentRepository'.$randomString);
+        $parentRepo->save();
+
+        // Grandparent has a repository...
+        $grandparent = new QubitInformationObject();
+        $grandparent->title = 'TestGrandparentTitle'.$randomString;
+        $grandparent->identifier = 'TestGrandparentIdentifier'.$randomString;
+        $grandparent->setRepositoryId($grandparentRepo->id);
+        $grandparent->indexOnSave = false;
+        $grandparent->save();
+
+        // ...and so does the parent. We want to check we're matching on the parent's
+        $parent = new QubitInformationObject();
+        $parent->title = 'TestParentTitle'.$randomString;
+        $parent->identifier = 'TestParentIdentifier'.$randomString;
+        $parent->parentId = $grandparent->id;
+        $parent->setRepositoryId($parentRepo->id);
+        $parent->indexOnSave = false;
+        $parent->save();
+
+        $child = new QubitInformationObject();
+        $child->title = 'TestChildTitle'.$randomString;
+        $child->identifier = 'TestChildIdentifier'.$randomString;
+        $child->parentId = $parent->id;
+        $child->indexOnSave = false;
+        $child->save();
+
+        $result = QubitInformationObject::getByTitleIdentifierAndRepo(
+            'TestChildIdentifier'.$randomString,
+            'TestChildTitle'.$randomString,
+            'TestParentRepository'.$randomString
+        );
+
+        $this->assertNotNull($result, 'Expected a valid integer id when matching nearest parent repository.');
+        $this->assertIsInt($result, 'Expected the returned id to be an integer.');
+
+        $resultIo = QubitInformationObject::getById($result);
+        $this->assertNotNull($resultIo, 'Expected a valid information object.');
+        $this->assertEquals('TestChildTitle'.$randomString, $resultIo->title, 'The information object title does not match expected.');
+
+        $resultWithWrongRepo = QubitInformationObject::getByTitleIdentifierAndRepo(
+            'TestChildIdentifier'.$randomString,
+            'TestChildTitle'.$randomString,
+            'TestGrandparentRepository'.$randomString
+        );
+
+        $this->assertNull($resultWithWrongRepo, 'Expected null when searching with grandparent repository since nearest parent has different repository.');
+    }
 }


### PR DESCRIPTION
Closes #2070
Closes #2071

Adjusts the `QubitInformationObject::getByTitleIdentifierAndRepo` function to handle the case when `repository_id` is NULL, but a parent has a repository ID set. This fixes the issue where information_object matches are not found when the repository is inherited.

I've written a recursive SQL query that gets the repository ID of the nearest parent that has a repository ID set (I call this the `effective_repo_id` in the query).

This query is a bit of a behemoth so I'd understand if we wanted to adjust how the parent repo ID is computed to make the query more manageable. The one nice thing about this query though is that it is a single query, so it'll be quick. It would be possible to call `getRepository()` to get the inherited repository, but that function makes multiple SQL queries so that will likely be quite a bit slower.