### PR TITLE
Fix #2198 : Add Elastic fallback for version es7.0 track_total_hits s…

### DIFF
--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginQuery.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginQuery.class.php
@@ -41,9 +41,8 @@ class arElasticSearchPluginQuery
         // but older Elastic clients do not include this method.
         // Older Elastica doesn’t have that method, so we check first
         // and fall back to setting the track_total_hits param manually.
-
         if (method_exists($this->query, 'setTrackTotalHits')) {
-            $this->query->setTrackTotalHits(true);     
+            $this->query->setTrackTotalHits(true);
         } else {
             $this->query->setParam('track_total_hits', true);
         }

--- a/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginQuery.class.php
+++ b/plugins/arElasticSearchPlugin/lib/arElasticSearchPluginQuery.class.php
@@ -36,6 +36,18 @@ class arElasticSearchPluginQuery
         $this->query->setSize($limit);
         $this->query->setFrom($skip);
 
+        // Elasticsearch 7 changed total hit counting — full result counts are not returned by default.
+        // Newer versions of Elastic provide setTrackTotalHits() to enable full hit tracking,
+        // but older Elastic clients do not include this method.
+        // Older Elastica doesn’t have that method, so we check first
+        // and fall back to setting the track_total_hits param manually.
+
+        if (method_exists($this->query, 'setTrackTotalHits')) {
+            $this->query->setTrackTotalHits(true);     
+        } else {
+            $this->query->setParam('track_total_hits', true);
+        }
+
         $this->queryBool = new \Elastica\Query\BoolQuery();
     }
 

--- a/plugins/arRestApiPlugin/lib/QubitApiAction.class.php
+++ b/plugins/arRestApiPlugin/lib/QubitApiAction.class.php
@@ -80,6 +80,14 @@ class QubitApiAction extends sfAction
 
     protected function prepareEsPagination(Elastica\Query &$query, $limit = null)
     {
+        // Elasticsearch 7 requires explicitly enabling full hit counting via track_total_hits.
+        // Check for the method to support both ES7+ environments and legacy Elastic installs
+        if (method_exists($query, 'setTrackTotalHits')) {
+            $query->setTrackTotalHits(true); // to cap work
+        } else {
+            $query->setParam('track_total_hits', true);
+        }
+
         $limit = empty($limit) ? sfConfig::get('app_hits_per_page', 10) : $limit;
         $limit = $this->request->getGetParameter('limit', $limit);
         if ($limit > 100) {


### PR DESCRIPTION
Fix: Ensure accurate total hit count in ES7 by adding Elastic search compatibility check

ES7 requires track_total_hits to return accurate hit counts. Older Elastica versions don't support setTrackTotalHits(), resulting in incorrect totals (e.g., showing 10000+ even when more than 30,000 records exist). 

This update adds a compatibility check and falls back to manually setting track_total_hits, ensuring accurate counts across versions.

This patch adds a method check and falls back to setting the track_total_hits param, ensuring correct results and backwards compatibility.