### PR TITLE
Fix PHP error in QubitLimitIp (#2178)

### DIFF
--- a/lib/filter/QubitLimitIp.class.php
+++ b/lib/filter/QubitLimitIp.class.php
@@ -60,7 +60,7 @@ class QubitLimitIpFilter extends sfFilter
 
     public function setLimit()
     {
-        $this->limit = explode(';', sfConfig::get('app_limit_admin_ip', []));
+        $this->limit = explode(';', sfConfig::get('app_limit_admin_ip', ''));
     }
 
     /**

--- a/test/phpunit/lib/filter/QubitLimitIpTest.php
+++ b/test/phpunit/lib/filter/QubitLimitIpTest.php
@@ -50,7 +50,7 @@ class QubitLimitIpTest extends TestCase
     public function testBypassLimitEmptyLimit()
     {
         $debug = false;
-        $limit = explode(';', '');
+        $limit = null;
         $firstCall = true;
         $module = 'settings';
         $action = 'global';


### PR DESCRIPTION
Fix PHP error in QubitLimitIp by setting the default value to empty string instead of empty array for explode.