### PR TITLE
CSV import culture-agnostic matching

### DIFF
--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -1856,24 +1856,51 @@ class QubitFlatfileImport
 
             if (null === $this->object) {
                 // No match found in keymap, try to match on title, repository and identifier.
-                $this->setInformationObjectByFields();
+                $ids = $this->setInformationObjectByFields();
+
+                if (1 < count($ids)) {
+                    $msg = sprintf(
+                        'Multiple matching descriptions found for row (identifier: %s, title: %s, culture: %s). Skipping record.',
+                        $this->columnExists('title') ? $this->columnValue('title') : '',
+                        $this->columnExists('identifier') ? $this->columnValue('identifier') : '',
+                        $this->columnExists('culture') ? $this->columnValue('culture') : ''
+                    );
+                    echo $this->logError($msg);
+
+                    return true; // Skip row processing
+                }
             }
         }
 
         $this->checkInformationObjectMatchLimit(); // Handle --limit option.
 
+        if (null === $this->object && ($this->skipUnmatched || $this->roundtrip)) {
+            $msg = sprintf(
+                'Unable to match row (identifier: %s, title: %s, culture: %s). Skipping record.',
+                $this->columnExists('title') ? $this->columnValue('title') : '',
+                $this->columnExists('identifier') ? $this->columnValue('identifier') : '',
+                $this->columnExists('culture') ? $this->columnValue('culture') : ''
+            );
+
+            echo $this->logError($msg);
+
+            return true; // Skip row processing
+        }
+
+        // Still no match found, create IO if not roundtripping or if --skip-unmatched is not set.
         if (null === $this->object) {
-            // Still no match found, create IO if not roundtripping or if --skip-unmatched is not set in options.
-            return $this->createNewInformationObject();
+            $this->createNewInformationObject();
+
+            return false;
         }
 
         if ($this->object->sourceCulture == $this->columnValue('culture')) {
             $msg = sprintf(
-                'Matching description found, %s; row (id: %s, culture: %s, legacyId: %s)...',
+                'Matching description found, %s; row (identifier: %s, title: %s, culture: %s)',
                 $this->getActionDescription(),
-                $this->object->id,
-                $this->object->sourceCulture,
-                $legacyId
+                $this->columnExists('title') ? $this->columnValue('title') : '',
+                $this->columnExists('identifier') ? $this->columnValue('identifier') : '',
+                $this->columnExists('culture') ? $this->columnValue('culture') : ''
             );
 
             if ($this->isUpdating()) {
@@ -1938,21 +1965,7 @@ class QubitFlatfileImport
      */
     private function createNewInformationObject()
     {
-        if ($this->skipUnmatched || $this->roundtrip) {
-            $msg = sprintf(
-                'Unable to match row. Skipping record: %s (id: %s)',
-                $this->columnExists('title') ? trim($this->columnValue('title')) : '',
-                $this->columnExists('identifier') ? trim($this->columnValue('identifier')) : ''
-            );
-
-            echo $this->logError($msg);
-
-            return true;
-        }
-
         $this->object = new $this->className();
-
-        return false;
     }
 
     /**
@@ -1990,17 +2003,21 @@ class QubitFlatfileImport
      */
     private function setInformationObjectByFields()
     {
+        $objectIds = [];
+
         if ($this->columnExists('identifier') && $this->columnExists('title') && $this->columnExists('repository')) {
-            $objectId = QubitInformationObject::getByTitleIdentifierAndRepo(
+            $objectIds = QubitInformationObject::getByTitleIdentifierAndRepo(
                 $this->columnValue('identifier'),
                 $this->columnValue('title'),
                 $this->columnValue('repository')
             );
 
-            if ($objectId) {
-                $this->object = QubitInformationObject::getById($objectId);
+            if (1 === count($objectIds)) {
+                $this->object = QubitInformationObject::getById($objectIds[0]);
             }
         }
+
+        return $objectIds;
     }
 
     private function setInformationObjectByKeymap($legacyId)

--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -1015,15 +1015,15 @@ class QubitXmlImport
                 $passesLimitFunctionName = 'passesLimitOptionForIo';
                 $deleteFunctionName = 'deleteFullHierarchy';
 
-                $matchId = QubitInformationObject::getByTitleIdentifierAndRepo(
+                $matchIds = QubitInformationObject::getByTitleIdentifierAndRepo(
                     $resource->identifier,
                     $resource->title,
                     // EAD XML does not include repo in child recs - Use parent's repo.
                     ($this->rootObject !== $resource) ? $this->rootObject->repository->authorizedFormOfName : $resource->repository->authorizedFormOfName
                 );
 
-                if ($matchId) {
-                    $matchResource = QubitInformationObject::getById($matchId);
+                if (1 === count($matchIds)) {
+                    $matchResource = QubitInformationObject::getById($matchIds[0]);
                 }
 
                 // If resource not found, try matching against keymap table. eadUrl is

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -2164,133 +2164,109 @@ class QubitInformationObject extends BaseInformationObject
      * @param string $title      informationObject title
      * @param string $repoName   repository authorizedFormOfName
      *
-     * @return int InfoObj id
+     * @return int[] matching information object IDs (ascending by id)
      */
-    public static function getByTitleIdentifierAndRepo($identifier, $title, $repoName): ?int
+    public static function getByTitleIdentifierAndRepo($identifier, $title, $repoName): array
     {
         // Proceed only if both identifier and title are provided.
-        if (null !== $identifier && null !== $title) {
-            // Get the current culture from the user session.
-            $sf_user = sfContext::getInstance()->getUser();
-            $culture = $sf_user->getCulture();
-
-            // Parameters for the query.
-            $params = [
-                ':identifier' => $identifier,
-                ':title' => $title,
-                ':culture' => $culture,
-            ];
-
-            if (null !== $repoName) {
-                $params[':repoName'] = $repoName;
-
-                // Select the repository id of the nearest parent that has one set.
-
-                // hierarchy table: Recursively searches until a parent record is found that has
-                // the repository_id set. This repository_id is set in the effective_repo_id. It
-                // may be NULL if there is no repository to inherit! Terminates when the effective
-                // repo ID is null, or when the parent_id is NULL (reached the top of the hierarchy)
-
-                // resolved table: Filter the hierarchy table for the first non-NULL
-                // effective_repo_id. For this part:
-                //
-                //   ROW_NUMBER() OVER (PARTITION BY original_id ORDER BY depth DESC) AS rn
-                //
-                // the recursive query will terminate when effective_repo_id != NULL. The repo ID
-                // at this point is at the maximum depth, so sorting the depth in descending order
-                // returns the first parent that had a repository_id set.
-                $sql = '
-                    WITH RECURSIVE hierarchy AS (
-                        SELECT
-                            id AS original_id,
-                            parent_id,
-                            repository_id AS effective_repo_id,  -- <- Inherited repo ID
-                            1 AS depth
-                        FROM
-                            information_object
-
-                        UNION ALL
-
-                        SELECT
-                            child.original_id,
-                            parent.parent_id,
-                            COALESCE(child.effective_repo_id, parent.repository_id) AS effective_repo_id,
-                            child.depth + 1
-                        FROM
-                            hierarchy child
-                        INNER JOIN
-                            information_object parent
-                        ON
-                            parent.id = child.parent_id
-                        WHERE
-                            child.effective_repo_id IS NULL AND child.parent_id IS NOT NULL
-                    )
-                    SELECT
-                        io.id
-                    FROM
-                        information_object io
-                    INNER JOIN (
-                        SELECT
-                            original_id,
-                            effective_repo_id,
-                            ROW_NUMBER() OVER (PARTITION BY original_id ORDER BY depth DESC) AS rn
-                        FROM
-                            hierarchy
-                        WHERE
-                            effective_repo_id IS NOT NULL
-                    ) AS resolved
-                    ON
-                        io.id = resolved.original_id
-                        AND resolved.rn = 1
-                        AND io.identifier = :identifier
-                    INNER JOIN
-                        information_object_i18n io_i18n
-                    ON
-                        io_i18n.id = io.id
-                        AND io_i18n.culture = :culture
-                        AND io_i18n.title = :title
-                    INNER JOIN
-                        repository r
-                    ON
-                        r.id = resolved.effective_repo_id
-                    INNER JOIN
-                        actor a
-                    ON
-                        a.id = resolved.effective_repo_id
-                    INNER JOIN
-                        actor_i18n a_i18n
-                    ON
-                        a_i18n.id = a.id
-                        AND a_i18n.culture = :culture
-                        AND a_i18n.authorized_form_of_name = :repoName
-                    LIMIT 1;
-                ';
-            } else {
-                $sql = '
-                    SELECT
-                        io.id
-                    FROM
-                        information_object io
-                    INNER JOIN
-                        information_object_i18n io_i18n
-                    ON
-                        io_i18n.id = io.id
-                        AND io_i18n.culture = :culture
-                        AND io_i18n.title = :title
-                    WHERE
-                        io.identifier = :identifier
-                    LIMIT 1;
-                ';
-            }
-
-            // If a matching record is found, return its ID.
-            if ($row = QubitPdo::fetchOne($sql, $params)) {
-                return $row->id;
-            }
+        if (null === $identifier || null === $title) {
+            return [];
         }
 
-        // Return null if no match is found.
-        return null;
+        // 1) Find candidate IO by identifier + title in any culture.
+        //
+        // Culture handling:
+        // - Match culture-agnostically using EXISTS against information_object_i18n,
+        //   so any translation (including the source culture) will satisfy the title match.
+        $sqlCandidate = '
+            SELECT io.id
+            FROM information_object io
+            WHERE io.identifier = :identifier
+              AND EXISTS (
+                SELECT 1
+                FROM information_object_i18n t
+                WHERE t.id = io.id AND t.title = :title
+              )
+            ORDER BY io.id ASC;
+        ';
+
+        $candidateIds = QubitPdo::fetchAll($sqlCandidate, [
+            ':identifier' => $identifier,
+            ':title' => $title,
+        ], ['fetchMode' => PDO::FETCH_COLUMN]);
+
+        if (empty($candidateIds)) {
+            return [];
+        }
+
+        // 2) No repo filter: return all candidate ids (identifier + title), ordered by id ASC.
+        //    Culture-agnostic; caller decides how to handle zero/one/many.
+        if (null === $repoName) {
+            return array_map('intval', $candidateIds);
+        }
+
+        // 3) Find the nearest inherited repository starting from the candidate ids and
+        //    match the repository name in any culture.
+        //
+        // Repository inheritance via recursive CTE:
+        // - hierarchy CTE: Anchored at the set of candidates (CTE `candidates`). For each
+        //   original_id, propagate the first non-NULL repository_id encountered into
+        //   effective_repo_id and move up the tree via parent_id until either a repo is found
+        //   or we reach the root.
+        // - resolved CTE: For each original_id, pick the nearest ancestor with a non-NULL
+        //   effective_repo_id using ROW_NUMBER() ordered by depth DESC.
+        //
+        // Culture handling for repository name:
+        // - Join actor_i18n without a culture constraint and compare the provided
+        //   authorized_form_of_name across any available translation.
+        $sqlRepo = '
+            WITH RECURSIVE candidates AS (
+                SELECT io.id, io.parent_id, io.repository_id
+                FROM information_object io
+                WHERE io.identifier = :identifier
+                  AND EXISTS (
+                    SELECT 1
+                    FROM information_object_i18n t
+                    WHERE t.id = io.id AND t.title = :title
+                  )
+            ),
+            hierarchy AS (
+                SELECT c.id AS original_id,
+                       c.parent_id,
+                       c.repository_id AS effective_repo_id,
+                       1 AS depth
+                FROM candidates c
+                UNION ALL
+                SELECT h.original_id,
+                       p.parent_id,
+                       COALESCE(h.effective_repo_id, p.repository_id) AS effective_repo_id,
+                       h.depth + 1
+                FROM hierarchy h
+                JOIN information_object p ON p.id = h.parent_id
+                WHERE h.effective_repo_id IS NULL AND h.parent_id IS NOT NULL
+            ),
+            resolved AS (
+                SELECT original_id,
+                       effective_repo_id,
+                       ROW_NUMBER() OVER (PARTITION BY original_id ORDER BY depth DESC) AS rn
+                FROM hierarchy
+                WHERE effective_repo_id IS NOT NULL
+            )
+            SELECT DISTINCT r.original_id AS id
+            FROM resolved r
+            JOIN actor_i18n ai ON ai.id = r.effective_repo_id
+            WHERE r.rn = 1
+              AND ai.authorized_form_of_name = :repoName
+            ORDER BY r.original_id ASC;
+        ';
+
+        $matches = QubitPdo::fetchAll($sqlRepo, [
+            ':identifier' => $identifier,
+            ':title' => $title,
+            ':repoName' => $repoName,
+        ], ['fetchMode' => PDO::FETCH_COLUMN]);
+
+        return array_map('intval', $matches);
     }
 
     // Publication Status

--- a/test/phpunit/QubitInformationObjectTest.php
+++ b/test/phpunit/QubitInformationObjectTest.php
@@ -53,13 +53,15 @@ class QubitInformationObjectTest extends TransactionTestCase
 
         if (null === $expectedTitle) {
             // No match expected.
-            $this->assertNull($result, 'Expected null result when no matching record exists.');
+            $this->assertIsArray($result);
+            $this->assertCount(0, $result, 'Expected empty result when no matching record exists.');
         } else {
             // A match is expected.
-            $this->assertNotNull($result, 'Expected a valid integer id when data should match.');
-            $this->assertIsInt($result, 'Expected the returned id to be an integer.');
+            $this->assertIsArray($result);
+            $this->assertCount(1, $result, 'Expected exactly one matching id.');
+            $this->assertIsInt($result[0], 'Expected the returned id to be an integer.');
 
-            $resultIo = QubitInformationObject::getById($result);
+            $resultIo = QubitInformationObject::getById($result[0]);
             $this->assertNotNull($resultIo, 'Expected a valid information object.');
             $this->assertEquals($expectedTitle.$randomString, $resultIo->title, 'The information object title does not match expected.');
         }
@@ -139,12 +141,14 @@ class QubitInformationObjectTest extends TransactionTestCase
         );
 
         if (null === $expectedTitle) {
-            $this->assertNull($result, 'Expected null result when no matching record exists.');
+            $this->assertIsArray($result, 'Expected array result when no matching record exists.');
+            $this->assertCount(0, $result, 'Expected empty result when no matching record exists.');
         } else {
-            $this->assertNotNull($result, 'Expected a valid integer id when data should match.');
-            $this->assertIsInt($result, 'Expected the returned id to be an integer.');
+            $this->assertIsArray($result, 'Expected array result when data should match.');
+            $this->assertCount(1, $result, 'Expected exactly one matching id when data should match.');
+            $this->assertIsInt($result[0], 'Expected the returned id to be an integer.');
 
-            $resultIo = QubitInformationObject::getById($result);
+            $resultIo = QubitInformationObject::getById($result[0]);
             $this->assertNotNull($resultIo, 'Expected a valid information object.');
             $this->assertEquals($expectedTitle.$randomString, $resultIo->title, 'The information object title does not match expected.');
         }
@@ -214,11 +218,11 @@ class QubitInformationObjectTest extends TransactionTestCase
             'TestChildTitle'.$randomString,
             'TestRepository'.$randomString
         );
+        $this->assertIsArray($result, 'Expected an array of ids when repository is inherited from grandparent.');
+        $this->assertCount(1, $result, 'Expected exactly one matching id.');
+        $this->assertIsInt($result[0], 'Expected the returned id to be an integer.');
 
-        $this->assertNotNull($result, 'Expected a valid integer id when repository is inherited from grandparent.');
-        $this->assertIsInt($result, 'Expected the returned id to be an integer.');
-
-        $resultIo = QubitInformationObject::getById($result);
+        $resultIo = QubitInformationObject::getById($result[0]);
         $this->assertNotNull($resultIo, 'Expected a valid information object.');
         $this->assertEquals('TestChildTitle'.$randomString, $resultIo->title, 'The information object title does not match expected.');
     }
@@ -272,10 +276,11 @@ class QubitInformationObjectTest extends TransactionTestCase
             'TestParentRepository'.$randomString
         );
 
-        $this->assertNotNull($result, 'Expected a valid integer id when matching nearest parent repository.');
-        $this->assertIsInt($result, 'Expected the returned id to be an integer.');
+        $this->assertIsArray($result, 'Expected an array of ids.');
+        $this->assertCount(1, $result, 'Expected exactly one matching id when matching nearest parent repository.');
+        $this->assertIsInt($result[0], 'Expected the returned id to be an integer.');
 
-        $resultIo = QubitInformationObject::getById($result);
+        $resultIo = QubitInformationObject::getById($result[0]);
         $this->assertNotNull($resultIo, 'Expected a valid information object.');
         $this->assertEquals('TestChildTitle'.$randomString, $resultIo->title, 'The information object title does not match expected.');
 
@@ -285,6 +290,248 @@ class QubitInformationObjectTest extends TransactionTestCase
             'TestGrandparentRepository'.$randomString
         );
 
-        $this->assertNull($resultWithWrongRepo, 'Expected null when searching with grandparent repository since nearest parent has different repository.');
+        $this->assertIsArray($resultWithWrongRepo, 'Expected an array of ids.');
+        $this->assertCount(0, $resultWithWrongRepo, 'Expected empty result when searching with grandparent repository since nearest parent has different repository.');
+    }
+
+    /**
+     * Ensure matching works when the title exists only in the source/default culture
+     * and the current/default culture has no translation. Option A should be
+     * culture-agnostic for title matching.
+     */
+    public function testGetByTitleIdentifierAndRepoMatchesWhenTitleOnlyInSourceCulture()
+    {
+        $random = rand(1000000, 9999999);
+
+        // Remember current culture and ensure we write English-only data first.
+        $prevCulture = sfPropel::getDefaultCulture();
+        sfPropel::setDefaultCulture('en');
+        if (sfContext::hasInstance()) {
+            sfContext::getInstance()->getUser()->setCulture('en');
+        }
+
+        $io = new QubitInformationObject();
+        $io->indexOnSave = false;
+        $io->title = 'TitleEn'.$random; // only in English
+        $io->identifier = 'Identifier'.$random;
+        $io->save();
+
+        // Switch to a different culture without adding translations
+        sfPropel::setDefaultCulture('fr');
+        if (sfContext::hasInstance()) {
+            sfContext::getInstance()->getUser()->setCulture('fr');
+        }
+
+        $result = QubitInformationObject::getByTitleIdentifierAndRepo(
+            'Identifier'.$random,
+            'TitleEn'.$random,
+            null
+        );
+
+        $this->assertIsArray($result, 'Expected an array of ids.');
+        $this->assertCount(1, $result, 'Expected a single match even when current culture lacks a title translation.');
+        $this->assertIsInt($result[0]);
+
+        // Restore culture
+        sfPropel::setDefaultCulture($prevCulture);
+        if (sfContext::hasInstance()) {
+            sfContext::getInstance()->getUser()->setCulture($prevCulture);
+        }
+    }
+
+    /**
+     * Ensure matching works when the repository name exists only in the source/default culture
+     * and the current/default culture has no translation. Option A should be
+     * culture-agnostic for repository name matching.
+     */
+    public function testGetByTitleIdentifierAndRepoMatchesWhenRepoNameOnlyInSourceCulture()
+    {
+        $random = rand(1000000, 9999999);
+
+        // Remember current culture
+        $prevCulture = sfPropel::getDefaultCulture();
+
+        // Create repository with English-only name
+        sfPropel::setDefaultCulture('en');
+        if (sfContext::hasInstance()) {
+            sfContext::getInstance()->getUser()->setCulture('en');
+        }
+
+        $repository = new QubitRepository();
+        $repository->indexOnSave = false;
+        $repository->setAuthorizedFormOfName('RepoEn'.$random);
+        $repository->save();
+
+        // Create IO linked to repository; title only in English
+        $io = new QubitInformationObject();
+        $io->indexOnSave = false;
+        $io->title = 'TitleEn'.$random;
+        $io->identifier = 'Identifier'.$random;
+        $io->setRepositoryId($repository->id);
+        $io->save();
+
+        // Switch to a different culture without adding translations
+        sfPropel::setDefaultCulture('fr');
+        if (sfContext::hasInstance()) {
+            sfContext::getInstance()->getUser()->setCulture('fr');
+        }
+
+        $result = QubitInformationObject::getByTitleIdentifierAndRepo(
+            'Identifier'.$random,
+            'TitleEn'.$random,
+            'RepoEn'.$random
+        );
+
+        $this->assertIsArray($result, 'Expected an array of ids.');
+        $this->assertCount(1, $result, 'Expected a single match even when current culture lacks a repository name translation.');
+        $this->assertIsInt($result[0]);
+
+        // Restore culture
+        sfPropel::setDefaultCulture($prevCulture);
+        if (sfContext::hasInstance()) {
+            sfContext::getInstance()->getUser()->setCulture($prevCulture);
+        }
+    }
+
+    /**
+     * Ensure inherited repository matching works when the repo name exists only in source culture.
+     */
+    public function testGetByTitleIdentifierAndRepoInheritedRepoNameOnlyInSourceCulture()
+    {
+        $random = rand(1000000, 9999999);
+
+        $prevCulture = sfPropel::getDefaultCulture();
+
+        // English-only repository name on parent
+        sfPropel::setDefaultCulture('en');
+        if (sfContext::hasInstance()) {
+            sfContext::getInstance()->getUser()->setCulture('en');
+        }
+
+        $repo = new QubitRepository();
+        $repo->indexOnSave = false;
+        $repo->setAuthorizedFormOfName('RepoEn'.$random);
+        $repo->save();
+
+        $parent = new QubitInformationObject();
+        $parent->indexOnSave = false;
+        $parent->title = 'ParentTitleEn'.$random;
+        $parent->identifier = 'ParentIdentifier'.$random;
+        $parent->setRepositoryId($repo->id);
+        $parent->save();
+
+        $child = new QubitInformationObject();
+        $child->indexOnSave = false;
+        $child->title = 'ChildTitleEn'.$random;
+        $child->identifier = 'ChildIdentifier'.$random;
+        $child->parentId = $parent->id; // inherits repo
+        $child->save();
+
+        // Switch to different culture without adding translations
+        sfPropel::setDefaultCulture('fr');
+        if (sfContext::hasInstance()) {
+            sfContext::getInstance()->getUser()->setCulture('fr');
+        }
+
+        $result = QubitInformationObject::getByTitleIdentifierAndRepo(
+            'ChildIdentifier'.$random,
+            'ChildTitleEn'.$random,
+            'RepoEn'.$random
+        );
+
+        $this->assertIsArray($result, 'Expected an array of ids.');
+        $this->assertCount(1, $result, 'Expected a single match when repo is inherited and repo name only exists in source culture.');
+        $this->assertIsInt($result[0]);
+
+        // Restore culture
+        sfPropel::setDefaultCulture($prevCulture);
+        if (sfContext::hasInstance()) {
+            sfContext::getInstance()->getUser()->setCulture($prevCulture);
+        }
+    }
+
+    /**
+     * When no repository is supplied and multiple information objects share
+     * the same identifier and title, expect multiple results in ascending id order.
+     */
+    public function testGetByTitleIdentifierAndRepoReturnsMultipleWithoutRepo()
+    {
+        $random = rand(1000000, 9999999);
+
+        $title = 'MultiTitle'.$random;
+        $identifier = 'MultiIdentifier'.$random;
+
+        $io1 = new QubitInformationObject();
+        $io1->indexOnSave = false;
+        $io1->title = $title;
+        $io1->identifier = $identifier;
+        $io1->save();
+
+        $io2 = new QubitInformationObject();
+        $io2->indexOnSave = false;
+        $io2->title = $title;
+        $io2->identifier = $identifier;
+        $io2->save();
+
+        $result = QubitInformationObject::getByTitleIdentifierAndRepo($identifier, $title, null);
+
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result, 'Expected two matching ids for duplicate identifier+title.');
+
+        $expected = [min((int) $io1->id, (int) $io2->id), max((int) $io1->id, (int) $io2->id)];
+        $this->assertSame($expected, $result, 'Expected results ordered ascending by id.');
+    }
+
+    /**
+     * When a repository is supplied and multiple information objects in that repository
+     * share the same identifier and title, expect multiple results in ascending id order.
+     */
+    public function testGetByTitleIdentifierAndRepoReturnsMultipleWithRepo()
+    {
+        $random = rand(1000000, 9999999);
+
+        $title = 'MultiTitle'.$random;
+        $identifier = 'MultiIdentifier'.$random;
+        $repoName = 'MultiRepo'.$random;
+
+        $repo = new QubitRepository();
+        $repo->indexOnSave = false;
+        $repo->setAuthorizedFormOfName($repoName);
+        $repo->save();
+
+        $io1 = new QubitInformationObject();
+        $io1->indexOnSave = false;
+        $io1->title = $title;
+        $io1->identifier = $identifier;
+        $io1->setRepositoryId($repo->id);
+        $io1->save();
+
+        $io2 = new QubitInformationObject();
+        $io2->indexOnSave = false;
+        $io2->title = $title;
+        $io2->identifier = $identifier;
+        $io2->setRepositoryId($repo->id);
+        $io2->save();
+
+        // Add an IO with same identifier+title but different repo to ensure it is excluded
+        $otherRepo = new QubitRepository();
+        $otherRepo->indexOnSave = false;
+        $otherRepo->setAuthorizedFormOfName('MultiRepoOther'.$random);
+        $otherRepo->save();
+
+        $io3 = new QubitInformationObject();
+        $io3->indexOnSave = false;
+        $io3->title = $title;
+        $io3->identifier = $identifier;
+        $io3->setRepositoryId($otherRepo->id);
+        $io3->save();
+
+        $result = QubitInformationObject::getByTitleIdentifierAndRepo($identifier, $title, $repoName);
+
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result, 'Expected two matching ids for duplicate identifier+title within the same repository.');
+
+        $expected = [min((int) $io1->id, (int) $io2->id), max((int) $io1->id, (int) $io2->id)];
+        $this->assertSame($expected, $result, 'Expected results ordered ascending by id and excluding other repository.');
     }
 }


### PR DESCRIPTION
- Make getByTitleIdentifierAndRepo culture-agnostic:
  - Title: replace culture-bound `INNER JOIN` with `EXISTS on` information_object_i18n (no culture filter).
  - Repo name: match via actor_i18n without culture filter.
- Anchor recursive CTE to the candidate IO (io.id = :id) to find the nearest repository instead of generating hierarchy for all rows.
- Remove dependency on user/session culture (no sfContext user reads).
- Drop repository table join since actor_i18n suffices for name matching, and `effective_repo_id` originates from information_object.repository_id which guarantees the actor refers to a repository.
- Preserve behavior when repoName is null: return the first candidate by identifier + title
- Add PHPUnit tests covering missing-translation scenarios:
  - Title only in source/default culture.
  - Repo name only in source/default culture.
  - Inherited repo where the name exists only in source culture.