### PR TITLE
Add max_result_window setting to ES config (#2237)

### DIFF
--- a/plugins/arElasticSearchPlugin/config/search.yml
+++ b/plugins/arElasticSearchPlugin/config/search.yml
@@ -31,6 +31,7 @@ all:
         number_of_shards: 4
         number_of_replicas: 1
         mapping.total_fields.limit: 3000
+        max_result_window: 10000
 
         analysis:
 


### PR DESCRIPTION
Allow users to increase index.max_result_window to support large fullwidth treeview hierarchies. This addresses an issue where treeview fails to load when treeview_items_per_page_max is set above ES's default 10000 result limit.