### PR TITLE
Add env option for activating the OIDC plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ cypress.env.json
 # IDE-specific files
 .vscode/
 *.code-workspace
+
+# OIDC plugin activation flag
+activate-oidc-plugin

--- a/config/ProjectConfiguration.class.php
+++ b/config/ProjectConfiguration.class.php
@@ -50,7 +50,8 @@ class ProjectConfiguration extends sfProjectConfiguration
 
         // Check if the OIDC plugin should be enabled.
         $filePath = 'activate-oidc-plugin';
-        if (file_exists($filePath) && 0 === filesize($filePath)) {
+        $activateOidcEnv = filter_var(getenv('ATOM_ACTIVATE_OIDC_PLUGIN'), FILTER_VALIDATE_BOOLEAN);
+        if ((file_exists($filePath) && 0 === filesize($filePath)) || $activateOidcEnv) {
             $plugins[] = 'arOidcPlugin';
         }
 


### PR DESCRIPTION
Adds the ability to activate the OIDC plugin using an environment variable. Setting the env var 'ATOM_ACTIVATE_OIDC_PLUGIN' to "true" before starting AtoM will activate the OIDC plugin.