### PR TITLE
Fix accession type option in clipboard export

### DIFF
--- a/apps/qubit/modules/clipboard/actions/exportAction.class.php
+++ b/apps/qubit/modules/clipboard/actions/exportAction.class.php
@@ -238,8 +238,11 @@ class ClipboardExportAction extends DefaultEditAction
             'informationObject' => sfConfig::get('app_ui_label_informationobject'),
             'actor' => sfConfig::get('app_ui_label_actor'),
             'repository' => sfConfig::get('app_ui_label_repository'),
-            'accession' => sfConfig::get('app_ui_label_accession'),
         ];
+
+        if ($this->context->user->hasCredential(['editor', 'administrator'], false)) {
+            $this->typeChoices['accession'] = sfConfig::get('app_ui_label_accession');
+        }
 
         $this->form->getValidatorSchema()->setOption('allow_extra_fields', true);
     }

--- a/js/exportOptions.js
+++ b/js/exportOptions.js
@@ -174,6 +174,7 @@
       {
         case 'actor':
         case 'repository':
+        case 'accession':
           url += type;
 
           break;

--- a/js/exportOptions.js
+++ b/js/exportOptions.js
@@ -165,7 +165,7 @@
       switch (type) {
         case "actor":
         case "repository":
-        case 'accession':
+        case "accession":
           url += type;
 
           break;


### PR DESCRIPTION
Closes #2221 
Closes #2222 

These issues are closely related so I addressed them both in this PR.

There is some JS that watches for changes in the Type selector on the clipboard export page, and "accession" was not one of the expected types, so it always fell back to "informationObject". This is why it wasn't possible to select the Accession option.

And now I'm only showing the Accession option in that dropdown when the user is an editor or admin.