### PR TITLE
Add clear and update mode for csv:import

### DIFF
--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -1983,6 +1983,9 @@ class QubitFlatfileImport
      */
     private function handleClearAndUpdate()
     {
+        if (!$this->object instanceof QubitInformationObject) {
+            throw new sfException("Cannot handle clear-and-update for objects that are not QubitInformationObject! Got: ".get_class($this->object));
+        }
     }
 
     /**

--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -68,6 +68,10 @@ class QubitFlatfileImport
 
     // Replaceable logic to filter content before entering Qubit
     public $contentFilterLogic;
+    public $contentLogic;
+
+    // The object being imported/updated
+    public $object;
 
     public function __construct($options = [])
     {
@@ -1996,22 +2000,18 @@ class QubitFlatfileImport
     {
         $directProperties = [];
 
-        switch (get_class($this->object)) {
-            case 'QubitInformationObject':
-                $directProperties = [
-                    'descriptionIdentifier',
-                    'descriptionDetailId',
-                    'descriptionStatusId',
-                    'levelOfDescriptionId',
-                    'repositoryId',
-                ];
-
-                break;
-
-            default:
-                throw new sfException(
-                    'Cannot handle clear-and-update for objects that are not QubitInformationObject! Got: '.get_class($this->object)
-                );
+        if ($this->object instanceof QubitInformationObject) {
+            $directProperties = [
+                'descriptionIdentifier',
+                'descriptionDetailId',
+                'descriptionStatusId',
+                'levelOfDescriptionId',
+                'repositoryId',
+            ];
+        } else {
+            throw new sfException(
+                'Cannot handle clear-and-update for objects that are not QubitInformationObject! Got: '.get_class($this->object)
+            );
         }
 
         // Clear all properties that exist on the object itself
@@ -2096,6 +2096,13 @@ class QubitFlatfileImport
             }
 
             $relation->delete();
+        }
+
+        // Remove digital object unless --keep-digital-objects is set
+        if (!$this->keepDigitalObjects) {
+            if (null !== $do = $this->object->getDigitalObject()) {
+                $do->delete();
+            }
         }
     }
 

--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -1978,13 +1978,124 @@ class QubitFlatfileImport
     }
 
     /**
-     * Clear the content of the given information object to prepare it to be re-created in-place.
-     * @return void
+     * Clear the content of the given object to prepare it to be re-defined in place. This enables
+     * all fields of information to be re-written without having to delete the object.
+     *
+     * Clears:
+     * - Direct properties of the object
+     * - Properties on i18n objects for the selected culture
+     *
+     * Deletes:
+     * - Related QubitObjectTermRelation objects
+     * - Related QubitProperty objects
+     * - QubitRelation objects where this is the "Object" part of the relationship
+     * - QubitRelation objects where this is the "Subject" part of the relationship (except for
+     *   related description relationships which can't be imported via CSV)
      */
     private function handleClearAndUpdate()
     {
-        if (!$this->object instanceof QubitInformationObject) {
-            throw new sfException("Cannot handle clear-and-update for objects that are not QubitInformationObject! Got: ".get_class($this->object));
+        $directProperties = [];
+
+        switch (get_class($this->object)) {
+            case 'QubitInformationObject':
+                $directProperties = [
+                    'descriptionIdentifier',
+                    'descriptionDetailId',
+                    'descriptionStatusId',
+                    'levelOfDescriptionId',
+                    'repositoryId',
+                ];
+
+                break;
+
+            default:
+                throw new sfException(
+                    'Cannot handle clear-and-update for objects that are not QubitInformationObject! Got: '.get_class($this->object)
+                );
+        }
+
+        // Clear all properties that exist on the object itself
+        // e.g., Description identifier, level of description
+        foreach ($directProperties as $directProperty) {
+            $this->object->{$directProperty} = null;
+        }
+
+        // Clear i18n object for the given culture
+        // e.g., Title, Scope and content
+        $culture = $this->columnValue('culture');
+        $i18ns = $this->object->informationObjectI18ns->indexBy('culture');
+
+        if (isset($i18ns[$culture])) {
+            $i18n = $i18ns[$culture];
+
+            foreach ($this->standardColumns as $column) {
+                if (in_array($column, ['createdAt', 'updatedAt', 'culture'])) {
+                    continue;
+                }
+                $i18n->{$column} = null;
+            }
+        }
+
+        // Remove all object-term relations
+        // e.g., Place access points, name access points
+        $criteria = new Criteria();
+        $criteria->add(QubitObjectTermRelation::OBJECT_ID, $this->object->id);
+        $objectTermRelations = QubitObjectTermRelation::get($criteria);
+
+        foreach ($objectTermRelations as $objectTermRelation) {
+            $objectTermRelation->delete();
+        }
+
+        // Remove all notes
+        // e.g., Archivist note, Credits note
+        $criteria = new Criteria();
+        $criteria->add(QubitNote::OBJECT_ID, $this->object->id);
+        $notes = QubitNote::get($criteria);
+
+        foreach ($notes as $note) {
+            $note->delete();
+        }
+
+        // Remove all events
+        $criteria = new Criteria();
+        $criteria->add(QubitEvent::OBJECT_ID, $this->object->id);
+        $events = QubitEvent::get($criteria);
+
+        foreach ($events as $event) {
+            $event->delete();
+        }
+
+        // Remove all special properties stored as QubitProperty objects
+        // e.g., Script of description, Alternative identifiers
+        $properties = $this->object->getProperties();
+
+        foreach ($properties as $property) {
+            $property->delete();
+        }
+
+        // Remove relationships where the relationship terminates at this object
+        // e.g., Physical object -> has -> Information object
+        $criteria = new Criteria();
+        $criteria = $this->object->addrelationsRelatedByobjectIdCriteria($criteria);
+        $objectRelations = QubitRelation::get($criteria);
+
+        foreach ($objectRelations as $relation) {
+            $relation->delete();
+        }
+
+        // Remove relationships where the relationship originates from this object
+        // e.g., Information object -> has -> Accession object
+        $criteria = new Criteria();
+        $criteria = $this->object->addrelationsRelatedBysubjectIdCriteria($criteria);
+        $subjectRelations = QubitRelation::get($criteria);
+
+        foreach ($subjectRelations as $relation) {
+            // There is no way to import this type of relationship, so skip removing it
+            if (QubitTerm::RELATED_MATERIAL_DESCRIPTIONS_ID == $relation->typeId) {
+                continue;
+            }
+
+            $relation->delete();
         }
     }
 

--- a/lib/QubitFlatfileImport.class.php
+++ b/lib/QubitFlatfileImport.class.php
@@ -33,6 +33,7 @@ class QubitFlatfileImport
     public $searchIndexingDisabled = true;  // disable per-object search indexing by default
     public $disableNestedSetUpdating = false; // update nested set on object creation
     public $matchAndUpdate = false; // match existing records & update them
+    public $clearAndUpdate = false; // clear matching records & update them
     public $deleteAndReplace = false; // delete matching records & replace them
     public $skipMatched = false; // skip creating new record if matching one is found
     public $skipUnmatched = false; // skip creating new record if matching one is not found
@@ -132,6 +133,13 @@ class QubitFlatfileImport
                 case 'delete-and-replace':
                     // Delete any matching records, and re-import them (attach to existing entities if possible).
                     $this->deleteAndReplace = true;
+
+                    break;
+
+                case 'clear-and-update':
+                    // Clear matching records before updating them in-place
+                    $this->clearAndUpdate = true;
+                    $this->keepDigitalObjects = $options['keep-digital-objects'];
 
                     break;
 
@@ -537,7 +545,7 @@ class QubitFlatfileImport
 
     public function isUpdating()
     {
-        return $this->matchAndUpdate || $this->deleteAndReplace;
+        return $this->matchAndUpdate || $this->clearAndUpdate || $this->deleteAndReplace;
     }
 
     /**
@@ -929,7 +937,7 @@ class QubitFlatfileImport
         }
 
         // Change actor history when updating a match in the same repo
-        if ($this->matchAndUpdate) {
+        if ($this->matchAndUpdate || $this->clearAndUpdate) {
             $actor->history = $options['history'];
             $actor->save();
 
@@ -1914,6 +1922,10 @@ class QubitFlatfileImport
                     $this->handleDeleteAndReplace();
                 }
 
+                if ($this->clearAndUpdate) {
+                    $this->handleClearAndUpdate();
+                }
+
                 // Execute ad-hoc row pre-update logic (remove related data, etc.)
                 $this->executeClosurePropertyIfSet('updatePreparationLogic');
                 $skipRowProcessing = false;
@@ -1941,6 +1953,9 @@ class QubitFlatfileImport
         if ($this->matchAndUpdate) {
             return 'updating in place';
         }
+        if ($this->clearAndUpdate) {
+            return 'clearing and updating in place';
+        }
 
         return 'skipping';
     }
@@ -1960,6 +1975,14 @@ class QubitFlatfileImport
         $this->object->delete();
         $this->object = new QubitInformationObject();
         $this->object->slug = $oldSlug; // Retain previous record's slug
+    }
+
+    /**
+     * Clear the content of the given information object to prepare it to be re-created in-place.
+     * @return void
+     */
+    private function handleClearAndUpdate()
+    {
     }
 
     /**
@@ -2130,8 +2153,8 @@ class QubitFlatfileImport
             // Execute ad-hoc row pre-update logic (remove related data, etc.)
             $this->executeClosurePropertyIfSet('updatePreparationLogic');
 
-            // Match and update: update current object
-            if ($this->matchAndUpdate) {
+            // Match and update & clear and update: update current object
+            if ($this->matchAndUpdate || $this->clearAndUpdate) {
                 return false;
             }
 

--- a/lib/task/import/csvImportBaseTask.class.php
+++ b/lib/task/import/csvImportBaseTask.class.php
@@ -24,6 +24,9 @@
  */
 abstract class csvImportBaseTask extends arBaseTask
 {
+    // Some classes may not implement this method, enable this feature only if the sub-class explicitly allows for it
+    protected bool $enableClearAndUpdate = false;
+
     /**
      * If updating, delete existing digital object if updating, a path or UI has
      * been specified, and not keeping digial objects.
@@ -490,8 +493,15 @@ abstract class csvImportBaseTask extends arBaseTask
             throw new sfException('The --limit option requires the --update option to be present.');
         }
 
-        if ($options['keep-digital-objects'] && 'match-and-update' != trim($options['update'])) {
-            throw new sfException('The --keep-digital-objects option can only be used when --update=\'match-and-update\' option is present.');
+        if ($options['keep-digital-objects']) {
+            $updateMode = trim($options['update']);
+
+            if (!$this->enableClearAndUpdate && 'match-and-update' != $updateMode) {
+                throw new sfException('The --keep-digital-objects option can only be used when --update=\'match-and-update\' option is present.');
+            }
+            elseif ($this->enableClearAndUpdate && !array_search($updateMode, ['match-and-update', 'clear-and-update'])) {
+                throw new sfException('The --keep-digital-objects option can only be used when the --update=\'match-and-update\' or --update=\'clear-and-update\' option is present.');
+            }
         }
 
         $this->validateUpdateOptions($options);
@@ -509,6 +519,10 @@ abstract class csvImportBaseTask extends arBaseTask
         }
 
         $validParams = ['match-and-update', 'delete-and-replace'];
+
+        if ($this->enableClearAndUpdate) {
+            $validParams[] = 'clear-and-update';
+        }
 
         if (!in_array(trim($options['update']), $validParams)) {
             $msg = sprintf('Parameter "%s" is not valid for --update option. ', $options['update']);

--- a/lib/task/import/csvImportBaseTask.class.php
+++ b/lib/task/import/csvImportBaseTask.class.php
@@ -505,6 +505,10 @@ abstract class csvImportBaseTask extends arBaseTask
         }
 
         $this->validateUpdateOptions($options);
+
+        if ($this->enableClearAndUpdate && 'clear-and-update' === trim($options['update'])) {
+            echo "WARNING: The clear-and-update import mode is experimental.\n";
+        }
     }
 
     /**

--- a/lib/task/import/csvImportBaseTask.class.php
+++ b/lib/task/import/csvImportBaseTask.class.php
@@ -499,7 +499,7 @@ abstract class csvImportBaseTask extends arBaseTask
             if (!$this->enableClearAndUpdate && 'match-and-update' != $updateMode) {
                 throw new sfException('The --keep-digital-objects option can only be used when --update=\'match-and-update\' option is present.');
             }
-            elseif ($this->enableClearAndUpdate && !array_search($updateMode, ['match-and-update', 'clear-and-update'])) {
+            if ($this->enableClearAndUpdate && !array_search($updateMode, ['match-and-update', 'clear-and-update'])) {
                 throw new sfException('The --keep-digital-objects option can only be used when the --update=\'match-and-update\' or --update=\'clear-and-update\' option is present.');
             }
         }

--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -953,7 +953,7 @@ EOF;
                 'keep-digital-objects',
                 null,
                 sfCommandOption::PARAMETER_NONE,
-                'Skip the deletion of existing digital objects and their derivatives when using --update with "match-and-update".'
+                'Skip the deletion of existing digital objects and their derivatives when using --update with "match-and-update" or "clear-and-update".'
             ),
             new sfCommandOption(
                 'roundtrip',

--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -24,6 +24,9 @@
  */
 class csvImportTask extends csvImportBaseTask
 {
+    // Enable clearing and updating
+    protected bool $enableClearAndUpdate = true;
+
     protected $namespace = 'csv';
     protected $name = 'import';
     protected $briefDescription = 'Import csv information object data';
@@ -913,7 +916,7 @@ EOF;
                 'update',
                 null,
                 sfCommandOption::PARAMETER_REQUIRED,
-                'Attempt to update if description has already been imported. Valid option values are "match-and-update" & "delete-and-replace".'
+                'Attempt to update if description has already been imported. Valid option values are "match-and-update", "clear-and-update", & "delete-and-replace".'
             ),
             new sfCommandOption(
                 'skip-matched',

--- a/lib/task/import/csvImportTask.class.php
+++ b/lib/task/import/csvImportTask.class.php
@@ -32,7 +32,7 @@ class csvImportTask extends csvImportBaseTask
     protected $briefDescription = 'Import csv information object data';
 
     protected $detailedDescription = <<<'EOF'
-Import CSV data
+Import new or update existing information objects via CSV
 EOF;
 
     /**

--- a/test/phpunit/QubitFlatfileImportTest.php
+++ b/test/phpunit/QubitFlatfileImportTest.php
@@ -1,0 +1,141 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @covers \QubitFlatfileImport
+ */
+class QubitFlatfileImportTest extends TestCase
+{
+    /**
+     * Test that handleClearAndUpdate deletes digital object when keepDigitalObjects is false.
+     */
+    public function testHandleClearAndUpdateDeletesDigitalObject(): void
+    {
+        // Create mock digital object
+        $mockDigitalObject = $this->createMock(QubitDigitalObject::class);
+        $mockDigitalObject->expects($this->once())
+            ->method('delete');
+
+        // Create mock information object
+        $mockInformationObject = $this->getMockBuilder(QubitInformationObject::class)
+            ->onlyMethods([
+                'getDigitalObject',
+                'getProperties',
+            ])
+            ->getMock();
+
+        $mockInformationObject->method('getDigitalObject')
+            ->willReturn($mockDigitalObject);
+
+        $mockInformationObject->method('getProperties')
+            ->willReturn([]);
+
+        $mockInformationObject->informationObjectI18ns = new ArrayObject();
+
+        // Create importer with keepDigitalObjects = false
+        $import = new QubitFlatfileImport([
+            'columnNames' => ['title', 'culture'],
+            'standardColumns' => ['title'],
+            'keepDigitalObjects' => false,
+        ]);
+
+        $import->object = $mockInformationObject;
+        $import->setStatus('row', ['Test title', 'en']);
+
+        // Use reflection to call private method
+        $reflection = new ReflectionClass($import);
+        $method = $reflection->getMethod('handleClearAndUpdate');
+        $method->setAccessible(true);
+
+        $method->invoke($import);
+    }
+
+    /**
+     * Test that handleClearAndUpdate keeps digital object when keepDigitalObjects is true.
+     */
+    public function testHandleClearAndUpdateKeepsDigitalObjectWhenOptionSet(): void
+    {
+        // Create mock digital object - should NOT have delete called
+        $mockDigitalObject = $this->createMock(QubitDigitalObject::class);
+        $mockDigitalObject->expects($this->never())
+            ->method('delete');
+
+        // Create mock information object
+        $mockInformationObject = $this->getMockBuilder(QubitInformationObject::class)
+            ->onlyMethods([
+                'getDigitalObject',
+                'getProperties',
+            ])
+            ->getMock();
+
+        $mockInformationObject->method('getDigitalObject')
+            ->willReturn($mockDigitalObject);
+
+        $mockInformationObject->method('getProperties')
+            ->willReturn([]);
+
+        $mockInformationObject->informationObjectI18ns = new ArrayObject();
+
+        // Create importer with keepDigitalObjects = true
+        $import = new QubitFlatfileImport([
+            'columnNames' => ['title', 'culture'],
+            'standardColumns' => ['title'],
+            'keepDigitalObjects' => true,
+        ]);
+
+        $import->object = $mockInformationObject;
+        $import->setStatus('row', ['Test title', 'en']);
+
+        // Use reflection to call private method
+        $reflection = new ReflectionClass($import);
+        $method = $reflection->getMethod('handleClearAndUpdate');
+        $method->setAccessible(true);
+
+        $method->invoke($import);
+    }
+
+    /**
+     * Test that handleClearAndUpdate handles case when no digital object exists.
+     */
+    public function testHandleClearAndUpdateHandlesNoDigitalObject(): void
+    {
+        // Create mock information object with no digital object
+        $mockInformationObject = $this->getMockBuilder(QubitInformationObject::class)
+            ->onlyMethods([
+                'getDigitalObject',
+                'getProperties',
+            ])
+            ->getMock();
+
+        $mockInformationObject->method('getDigitalObject')
+            ->willReturn(null);
+
+        $mockInformationObject->method('getProperties')
+            ->willReturn([]);
+
+        $mockInformationObject->informationObjectI18ns = new ArrayObject();
+
+        // Create importer with keepDigitalObjects = false
+        $import = new QubitFlatfileImport([
+            'columnNames' => ['title', 'culture'],
+            'standardColumns' => ['title'],
+            'keepDigitalObjects' => false,
+        ]);
+
+        $import->object = $mockInformationObject;
+        $import->setStatus('row', ['Test title', 'en']);
+
+        // Use reflection to call private method - should not throw
+        $reflection = new ReflectionClass($import);
+        $method = $reflection->getMethod('handleClearAndUpdate');
+        $method->setAccessible(true);
+
+        // This should complete without error
+        $method->invoke($import);
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Closes #2208 

Adds a new `clear-and-update` import mode for information objects. Here is a table outlining how this mode compares to the other modes:

| Feature                                 | match-and-update | delete-and-replace | clear-and-update |
| --------------------------------------- | ---------------- | ------------------ | ---------------- |
| Update all fields                    | ⚠️ (only some)   | ✅                  | ✅                |
| \* Can use regular import CSV           | ❌                | ✅                  | ✅                |
| Optionally keep original digital object | ✅                | ❌                  | ✅                |
| Keep original legacy ID                 | ✅                | ❌                  | ✅                |

\* The match-and-update CSV needs to be specially crafted to include only the fields that need to be updated. Using delete-and-replace or clear-and-update, "what you see is what you get" with the import CSV. One important distinction is that an empty field in a match and update CSV is ignored, but an empty field in a "regular" import CSV means that field will not have content in the final updated description.

For now, this is a proof of concept that shows that this is possible. More discussion is likely needed to determine whether this is a valuable feature to add to AtoM.