### PR TITLE
Improve nested set build performance

### DIFF
--- a/lib/task/propel/propelBuildNestedSetTask.class.php
+++ b/lib/task/propel/propelBuildNestedSetTask.class.php
@@ -179,38 +179,27 @@ EOF;
             return;
         }
 
-        $lftParams = [];
-        $rgtParams = [];
-        $idParams = [];
+        $lftCases = [];
+        $rgtCases = [];
+        $ids = [];
 
         foreach ($this->pendingUpdates as $node) {
-            // WHEN id THEN lft
-            $lftParams[] = $node['id'];
-            $lftParams[] = $node['lft'];
-
-            // WHEN id THEN rgt
-            $rgtParams[] = $node['id'];
-            $rgtParams[] = $node['rgt'];
-
-            $idParams[] = $node['id'];
+            $lftCases[] = sprintf('WHEN %d THEN %d', $node['id'], $node['lft']);
+            $rgtCases[] = sprintf('WHEN %d THEN %d', $node['id'], $node['rgt']);
+            $ids[] = $node['id'];
         }
-
-        $numUpdates = count($this->pendingUpdates);
-
-        $casePlaceholders = implode(' ', array_fill(0, $numUpdates, 'WHEN ? THEN ?'));
-        $idPlaceholders = implode(',', array_fill(0, $numUpdates, '?'));
 
         $sql = sprintf(
             'UPDATE %s SET %s = CASE id %s END, %s = CASE id %s END WHERE id IN (%s);',
             $classname::TABLE_NAME,
             $classname::LFT,
-            $casePlaceholders,  // <- $lftParams maps to these
+            implode(' ', $lftCases),
             $classname::RGT,
-            $casePlaceholders,  // <- $rgtParams maps to these
-            $idPlaceholders,  // <- $idParams maps to these
+            implode(' ', $rgtCases),
+            implode(',', $ids),
         );
 
-        QubitPdo::modify($sql, [...$lftParams, ...$rgtParams, ...$idParams]);
+        QubitPdo::modify($sql, []);
 
         $this->pendingUpdates = [];
     }

--- a/lib/task/propel/propelBuildNestedSetTask.class.php
+++ b/lib/task/propel/propelBuildNestedSetTask.class.php
@@ -199,7 +199,7 @@ EOF;
             implode(',', $ids),
         );
 
-        QubitPdo::modify($sql, []);
+        $this->conn->exec($sql);
 
         $this->pendingUpdates = [];
     }

--- a/lib/task/propel/propelBuildNestedSetTask.class.php
+++ b/lib/task/propel/propelBuildNestedSetTask.class.php
@@ -26,6 +26,8 @@ class propelBuildNestedSetTask extends arBaseTask
 {
     private $children;
     private $conn;
+    private $pendingUpdates = [];
+    private $batchSize = 64;
 
     /**
      * @see sfTask
@@ -86,6 +88,7 @@ class propelBuildNestedSetTask extends arBaseTask
 
             try {
                 self::recursivelyUpdateTree($rootNode, $classname);
+                $this->flushUpdates($classname);
             } catch (PDOException $e) {
                 $this->conn->rollback();
 
@@ -153,20 +156,64 @@ EOF;
 
         $node['rgt'] = $node['lft'] + $width - 1;
 
-        $sql = 'UPDATE '.$classname::TABLE_NAME;
-        $sql .= ' SET lft = '.$node['lft'];
-        $sql .= ', rgt = '.$node['rgt'];
-        $sql .= ' WHERE id = '.$node['id'].';';
+        $this->pendingUpdates[] = $node;
 
-        $this->conn->exec($sql);
+        if (count($this->pendingUpdates) >= $this->batchSize) {
+            $this->flushUpdates($classname);
+        }
 
-        if ($options['index']) {
-            if ($node['id'] != $classname::ROOT_ID) {
-                $this->reindexLft($classname, $node['id'], $node['lft']);
-            }
+        if ($this->options['index'] && $node['id'] != $classname::ROOT_ID) {
+            $this->reindexLft($classname, $node['id'], $node['lft']);
         }
 
         return $width;
+    }
+
+    /**
+     * Write all pending updates to the database.
+     *
+     * @param mixed $classname The object type for which the nested set update is taking place
+     */
+    protected function flushUpdates($classname)
+    {
+        if (empty($this->pendingUpdates)) {
+            return;
+        }
+
+        $lftParams = [];
+        $rgtParams = [];
+        $idParams = [];
+
+        foreach ($this->pendingUpdates as $node) {
+            // WHEN id THEN lft
+            $lftParams[] = $node['id'];
+            $lftParams[] = $node['lft'];
+
+            // WHEN id THEN rgt
+            $rgtParams[] = $node['id'];
+            $rgtParams[] = $node['rgt'];
+
+            $idParams[] = $node['id'];
+        }
+
+        $numUpdates = count($this->pendingUpdates);
+
+        $casePlaceholders = implode(' ', array_fill(0, $numUpdates, 'WHEN ? THEN ?'));
+        $idPlaceholders = implode(',', array_fill(0, $numUpdates, '?'));
+
+        $sql = sprintf(
+            'UPDATE %s SET %s = CASE id %s END, %s = CASE id %s END WHERE id IN (%s);',
+            $classname::TABLE_NAME,
+            $classname::LFT,
+            $casePlaceholders,  // <- $lftParams maps to these
+            $classname::RGT,
+            $casePlaceholders,  // <- $rgtParams maps to these
+            $idPlaceholders,  // <- $idParams maps to these
+        );
+
+        QubitPdo::modify($sql, [...$lftParams, ...$rgtParams, ...$idParams]);
+
+        $this->pendingUpdates = [];
     }
 
     protected function reindexLft(string $classname, int $id, int $lft)

--- a/lib/task/propel/propelBuildNestedSetTask.class.php
+++ b/lib/task/propel/propelBuildNestedSetTask.class.php
@@ -73,11 +73,10 @@ class propelBuildNestedSetTask extends arBaseTask
 
             // Build hash of child rows keyed on parent_id
             foreach ($this->conn->query($sql, PDO::FETCH_ASSOC) as $item) {
-                if (isset($this->children[$item['parent_id']])) {
-                    array_push($this->children[$item['parent_id']], $item['id']);
-                } else {
-                    $this->children[$item['parent_id']] = [$item['id']];
+                if (!isset($this->children[$item['parent_id']])) {
+                    $this->children[$item['parent_id']] = [];
                 }
+                $this->children[$item['parent_id']][] = $item['id'];
             }
 
             $rootNode = [


### PR DESCRIPTION
Closes #2272 

Reduce the execution time of `propel:build-nested-set` by around 90% by applying a couple of performance optimizations:

- Batch-update lft and rgt values instead of writing them one-by-one
- Use `[]` to create child-parent array instead of `array_push()`