### PR TITLE
Add physical object type and location to box label reports

### DIFF
--- a/apps/qubit/modules/informationobject/templates/boxLabelSuccess.php
+++ b/apps/qubit/modules/informationobject/templates/boxLabelSuccess.php
@@ -31,6 +31,10 @@
         </th><th>
           <?php echo $this->i18n->__('Physical object name'); ?>
         </th><th>
+          <?php echo $this->i18n->__('Physical object type'); ?>
+        </th><th>
+          <?php echo $this->i18n->__('Physical object location'); ?>
+        </th><th>
           <?php echo $this->i18n->__('Title'); ?>
         </th><th>
           <?php echo $this->i18n->__('Creation date(s)'); ?>
@@ -45,7 +49,11 @@
           </td><td>
             <?php echo render_value_inline($item['referenceCode']); ?>
           </td><td>
-            <?php echo render_value_inline($item['physicalObjectName']); ?>
+            <?php echo link_to(render_value_inline($item['physicalObjectName']), sfConfig::get('app_siteBaseUrl').'/'.$item['physicalObjectSlug']); ?>
+          </td><td>
+            <?php echo render_value_inline($item['physicalObjectType']); ?>
+          </td><td>
+            <?php echo render_value_inline($item['physicalObjectLocation']); ?>
           </td><td>
             <?php echo render_value_inline($item['title']); ?>
           </td><td>

--- a/lib/job/arGenerateReportJob.class.php
+++ b/lib/job/arGenerateReportJob.class.php
@@ -231,11 +231,13 @@ class arGenerateReportJob extends arBaseJob
                 $creationDates[] = $item->getDate(['cultureFallback' => true]);
             }
 
-            // Write reference code, container name, title, creation dates
             foreach ($informationObject->getPhysicalObjects() as $item) {
                 $results[] = [
                     'referenceCode' => $informationObject->referenceCode,
-                    'physicalObjectName' => $item->__toString(),
+                    'physicalObjectName' => $item->getName(['cultureFallback' => true]),
+                    'physicalObjectSlug' => $item->slug,
+                    'physicalObjectType' => $item->getType(['cultureFallback' => true]),
+                    'physicalObjectLocation' => $item->getLocation(['cultureFallback' => true]),
                     'title' => $informationObject->__toString(),
                     'creationDates' => implode('|', $creationDates),
                 ];


### PR DESCRIPTION
Closes #2241 

Adds the physical storage type and physical storage location to generated box label reports. Additionally, I've added a hyperlink to the physical storage object to match the physical storage location report.

Before my changes:

<img width="1000" alt="before-change" src="https://github.com/user-attachments/assets/6e3038cf-7bf6-4364-8866-9d22aaf631bf" />

After my changes:

<img width="1000" alt="after-change" src="https://github.com/user-attachments/assets/d3d4731c-6e16-4527-8b14-a057e8022090" />
