### PR TITLE
Use getLabel when displaying a physical object

### DIFF
--- a/apps/qubit/modules/physicalobject/templates/autocompleteSuccess.php
+++ b/apps/qubit/modules/physicalobject/templates/autocompleteSuccess.php
@@ -3,7 +3,7 @@
     <?php foreach ($physicalObjects as $item) { ?>
       <tr class="<?php echo 0 == @++$row % 2 ? 'even' : 'odd'; ?>">
         <td>
-          <?php echo link_to(render_title($item), [$item, 'module' => 'physicalobject']); ?>
+          <?php echo link_to(render_title($item->getLabel()), [$item, 'module' => 'physicalobject']); ?>
         </td>
       </tr>
     <?php } ?>


### PR DESCRIPTION
Closes #2240 

The name composition logic already exists and resides in QubitPhysicalObject->getLabel, utilize that instead of falling back to __toString.