### PR TITLE
Fail when CSV export file cannot be opened

### DIFF
--- a/lib/flatfile/QubitFlatfileExport.class.php
+++ b/lib/flatfile/QubitFlatfileExport.class.php
@@ -529,6 +529,10 @@ class QubitFlatfileExport
     {
         if (!isset($this->currentFileHandle)) {
             $this->currentFileHandle = fopen($filePath, 'a');
+
+            if (false === $this->currentFileHandle) {
+                throw new sfException("Failed to open the file at the path '{$filePath}'");
+            }
         }
 
         fputcsv($this->currentFileHandle, $row);


### PR DESCRIPTION
Closes #2289 

Checks that the CSV export file is opened successfully, and throws an exception if not. This will ensure that the output file handle is valid before trying to write to it.