### PR TITLE
Fix permission checking for Contact Information

### DIFF
--- a/plugins/qbAclPlugin/lib/QubitAcl.class.php
+++ b/plugins/qbAclPlugin/lib/QubitAcl.class.php
@@ -774,6 +774,11 @@ class QubitAcl
             case 'QubitDonor':
             case 'QubitFunctionObject':
             case 'QubitRightsHolder':
+                $hasAccess = $user->isAuthenticated() && ($user->hasGroup(QubitAclGroup::ADMINISTRATOR_ID)
+                    || $user->hasGroup(QubitAclGroup::EDITOR_ID));
+
+                break;
+
             case 'QubitContactInformation':
                 $hasAccess = QubitContactInformationAcl::isAllowed(
                     $user,

--- a/plugins/qbAclPlugin/lib/QubitAcl.class.php
+++ b/plugins/qbAclPlugin/lib/QubitAcl.class.php
@@ -775,7 +775,7 @@ class QubitAcl
             case 'QubitFunctionObject':
             case 'QubitRightsHolder':
                 $hasAccess = $user->isAuthenticated() && ($user->hasGroup(QubitAclGroup::ADMINISTRATOR_ID)
-                    || $user->hasGroup(QubitAclGroup::EDITOR_ID));
+                            || $user->hasGroup(QubitAclGroup::EDITOR_ID));
 
                 break;
 

--- a/plugins/qbAclPlugin/lib/QubitAcl.class.php
+++ b/plugins/qbAclPlugin/lib/QubitAcl.class.php
@@ -775,8 +775,12 @@ class QubitAcl
             case 'QubitFunctionObject':
             case 'QubitRightsHolder':
             case 'QubitContactInformation':
-                $hasAccess = $user->isAuthenticated() && ($user->hasGroup(QubitAclGroup::ADMINISTRATOR_ID)
-                            || $user->hasGroup(QubitAclGroup::EDITOR_ID));
+                $hasAccess = QubitContactInformationAcl::isAllowed(
+                    $user,
+                    $resource,
+                    $action,
+                    $options
+                );
 
                 break;
 

--- a/plugins/qbAclPlugin/lib/QubitContactInformationAcl.class.php
+++ b/plugins/qbAclPlugin/lib/QubitContactInformationAcl.class.php
@@ -51,19 +51,11 @@ class QubitContactInformationAcl extends QubitAcl
         //
         // If the contact information is linked to either, do the permission check on the parent object instead.
 
-        $criteria = new Criteria();
-        $criteria->add(QubitRepository::ID, $resource->actorId);
-        $repository = QubitRepository::getOne($criteria);
-
-        if ($repository) {
+        if (null !== $repository = QubitRepository::getById($resource->actorId)) {
             return parent::isAllowed($user, $repository, $action, $options);
         }
 
-        $criteria = new Criteria();
-        $criteria->add(QubitActor::ID, $resource->actorId);
-        $actor = QubitActor::getOne($criteria);
-
-        if ($actor) {
+        if (null !== $actor = QubitActor::getById($resource->actorId)) {
             return parent::isAllowed($user, $actor, $action, $options);
         }
 

--- a/plugins/qbAclPlugin/lib/QubitContactInformationAcl.class.php
+++ b/plugins/qbAclPlugin/lib/QubitContactInformationAcl.class.php
@@ -47,7 +47,7 @@ class QubitContactInformationAcl extends QubitAcl
 
         // A contact information may be a child of a:
         // - QubitRepository
-        // - QubitActor (and it's various sub-classes, like QubitDonor)
+        // - QubitActor (and its various sub-classes, like QubitDonor)
         //
         // If the contact information is linked to either, do the permission check on the parent object instead.
 

--- a/plugins/qbAclPlugin/lib/QubitContactInformationAcl.class.php
+++ b/plugins/qbAclPlugin/lib/QubitContactInformationAcl.class.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Custom ACL rules for QubitContactInformation resources.
+ *
+ * @author     Daniel Lovegrove <d.lovegrove11@gmail.com>
+ */
+class QubitContactInformationAcl extends QubitAcl
+{
+    /**
+     * Do custom ACL checks for QubitContactInformation resources.
+     *
+     * @param myUser                  $user     to authorize
+     * @param QubitContactInformation $resource target of the requested action
+     * @param string                  $action   requested for authorization (e.g. 'read')
+     * @param null|array              $options  optional parameters
+     *
+     * @return bool true if the access request is authorized
+     */
+    public static function isAllowed($user, $resource, $action, $options = [])
+    {
+        if (!$user->isAuthenticated()) {
+            return false;
+        }
+
+        // Always allow when the user is an editor or administrator
+        if ($user->hasGroup(QubitAclGroup::ADMINISTRATOR_ID) || $user->hasGroup(QubitAclGroup::EDITOR_ID)) {
+            return true;
+        }
+
+        // A contact information may be a child of a:
+        // - QubitRepository
+        // - QubitActor (and it's various sub-classes, like QubitDonor)
+        //
+        // If the contact information is linked to either, do the permission check on the parent object instead.
+
+        $criteria = new Criteria();
+        $criteria->add(QubitRepository::ID, $resource->actorId);
+        $repository = QubitRepository::getOne($criteria);
+
+        if ($repository) {
+            return parent::isAllowed($user, $repository, $action, $options);
+        }
+
+        $criteria = new Criteria();
+        $criteria->add(QubitActor::ID, $resource->actorId);
+        $actor = QubitActor::getOne($criteria);
+
+        if ($actor) {
+            return parent::isAllowed($user, $actor, $action, $options);
+        }
+
+        return false;
+    }
+}

--- a/test/phpunit/QubitContactInformationAclTest.php
+++ b/test/phpunit/QubitContactInformationAclTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use AccessToMemory\test\TransactionTestCase;
+
+/**
+ * @internal
+ *
+ * @covers \QubitContactInformationAcl
+ */
+class QubitContactInformationAclTest extends TransactionTestCase
+{
+    public function testUnauthenticatedUserIsDenied()
+    {
+        $user = $this->createMockUser(false);
+        $resource = new QubitContactInformation();
+
+        $this->assertFalse(
+            QubitContactInformationAcl::isAllowed($user, $resource, 'read')
+        );
+    }
+
+    public function testAdministratorIsAllowed()
+    {
+        $user = $this->createMockUser(true, [QubitAclGroup::ADMINISTRATOR_ID]);
+        $resource = new QubitContactInformation();
+
+        $this->assertTrue(
+            QubitContactInformationAcl::isAllowed($user, $resource, 'update')
+        );
+    }
+
+    public function testEditorIsAllowed()
+    {
+        $user = $this->createMockUser(true, [QubitAclGroup::EDITOR_ID]);
+        $resource = new QubitContactInformation();
+
+        $this->assertTrue(
+            QubitContactInformationAcl::isAllowed($user, $resource, 'update')
+        );
+    }
+
+    public function testAuthenticatedNonPrivilegedUserWithNoParentIsDenied()
+    {
+        $user = $this->createMockUser(true);
+        $resource = new QubitContactInformation();
+        $resource->actorId = 0;
+
+        $this->assertFalse(
+            QubitContactInformationAcl::isAllowed($user, $resource, 'read')
+        );
+    }
+
+    public function testDelegatesToRepositoryWhenParentRepositoryExists()
+    {
+        $qubitUser = new QubitUser();
+        $qubitUser->username = 'testuser_'.rand(1000000, 9999999);
+        $qubitUser->email = 'test'.rand(1000000, 9999999).'@example.com';
+        $qubitUser->setPassword('password');
+        $qubitUser->active = true;
+        $qubitUser->save();
+
+        $contextUser = sfContext::getInstance()->getUser();
+        $contextUser->signIn($qubitUser);
+
+        $repository = new QubitRepository();
+        $repository->indexOnSave = false;
+        $repository->setAuthorizedFormOfName('TestRepo'.rand(1000000, 9999999));
+        $repository->save();
+
+        $resource = new QubitContactInformation();
+        $resource->actorId = $repository->id;
+
+        // With default ACL settings, the authenticated group has read
+        // permission. Delegating to the repository should return true.
+        $this->assertTrue(
+            QubitContactInformationAcl::isAllowed($contextUser, $resource, 'read')
+        );
+
+        QubitAcl::destruct();
+        $contextUser->signOut();
+    }
+
+    public function testDelegatesToActorWhenParentActorExists()
+    {
+        $qubitUser = new QubitUser();
+        $qubitUser->username = 'testuser_'.rand(1000000, 9999999);
+        $qubitUser->email = 'test'.rand(1000000, 9999999).'@example.com';
+        $qubitUser->setPassword('password');
+        $qubitUser->active = true;
+        $qubitUser->save();
+
+        $contextUser = sfContext::getInstance()->getUser();
+        $contextUser->signIn($qubitUser);
+
+        $actor = new QubitActor();
+        $actor->indexOnSave = false;
+        $actor->setAuthorizedFormOfName('TestDonor'.rand(1000000, 9999999));
+        $actor->save();
+
+        $resource = new QubitContactInformation();
+        $resource->actorId = $actor->id;
+
+        // With default ACL settings, the authenticated group has read
+        // permission. Delegating to the donor should return true.
+        $this->assertTrue(
+            QubitContactInformationAcl::isAllowed($contextUser, $resource, 'read')
+        );
+
+        QubitAcl::destruct();
+        $contextUser->signOut();
+    }
+
+    private function createMockUser(bool $authenticated, array $groups = [])
+    {
+        $user = $this->getMockBuilder(stdClass::class)
+            ->addMethods(['isAuthenticated', 'hasGroup'])
+            ->getMock();
+
+        $user->method('isAuthenticated')
+            ->willReturn($authenticated);
+
+        $user->method('hasGroup')
+            ->willReturnCallback(function ($groupId) use ($groups) {
+                return in_array($groupId, $groups);
+            });
+
+        return $user;
+    }
+}

--- a/test/phpunit/QubitContactInformationAclTest.php
+++ b/test/phpunit/QubitContactInformationAclTest.php
@@ -101,7 +101,7 @@ class QubitContactInformationAclTest extends TransactionTestCase
         $resource->actorId = $actor->id;
 
         // With default ACL settings, the authenticated group has read
-        // permission. Delegating to the donor should return true.
+        // permission. Delegating to the actor should return true.
         $this->assertTrue(
             QubitContactInformationAcl::isAllowed($contextUser, $resource, 'read')
         );


### PR DESCRIPTION
Closes #2095 

Delegate contact information permission checking to parent `QubitRepository` or `QubitActor` when a contact information is linked to either.