### PR TITLE
Fix language variable in various cultures

### DIFF
--- a/plugins/sfTranslatePlugin/i18n/fr/messages.xml
+++ b/plugins/sfTranslatePlugin/i18n/fr/messages.xml
@@ -18,7 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>%language% translation</source>
-        <target>%Langue% de traduction</target>
+        <target>%language% de traduction</target>
       </trans-unit>
       <trans-unit id="5">
         <source>Save translation</source>

--- a/plugins/sfTranslatePlugin/i18n/hu/messages.xml
+++ b/plugins/sfTranslatePlugin/i18n/hu/messages.xml
@@ -18,7 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>%language% translation</source>
-        <target>%nyelvű% fordítás</target>
+        <target>%language% fordítás</target>
       </trans-unit>
       <trans-unit id="5">
         <source>Save translation</source>

--- a/plugins/sfTranslatePlugin/i18n/id/messages.xml
+++ b/plugins/sfTranslatePlugin/i18n/id/messages.xml
@@ -18,7 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>%language% translation</source>
-        <target>%Bahasa% terjemahan</target>
+        <target>%language% terjemahan</target>
       </trans-unit>
       <trans-unit id="5">
         <source>Save translation</source>

--- a/plugins/sfTranslatePlugin/i18n/is/messages.xml
+++ b/plugins/sfTranslatePlugin/i18n/is/messages.xml
@@ -18,7 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>%language% translation</source>
-        <target>%tungumál% þýðing</target>
+        <target>%language% þýðing</target>
       </trans-unit>
       <trans-unit id="5">
         <source>Save translation</source>

--- a/plugins/sfTranslatePlugin/i18n/ja/messages.xml
+++ b/plugins/sfTranslatePlugin/i18n/ja/messages.xml
@@ -22,7 +22,7 @@
       </trans-unit>
       <trans-unit id="9">
         <source>%language% translation</source>
-        <target>%言語% 翻訳</target>
+        <target>%language% 翻訳</target>
       </trans-unit>
     </body>
   </file>

--- a/plugins/sfTranslatePlugin/i18n/mk/messages.xml
+++ b/plugins/sfTranslatePlugin/i18n/mk/messages.xml
@@ -18,7 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>%language% translation</source>
-        <target>%јазик% превод</target>
+        <target>%language% превод</target>
       </trans-unit>
       <trans-unit id="5">
         <source>Save translation</source>

--- a/plugins/sfTranslatePlugin/i18n/pl/messages.xml
+++ b/plugins/sfTranslatePlugin/i18n/pl/messages.xml
@@ -18,7 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>%language% translation</source>
-        <target>%język% tłumaczenie</target>
+        <target>%language% tłumaczenie</target>
       </trans-unit>
       <trans-unit id="5">
         <source>Save translation</source>

--- a/plugins/sfTranslatePlugin/i18n/pt_BR/messages.xml
+++ b/plugins/sfTranslatePlugin/i18n/pt_BR/messages.xml
@@ -22,7 +22,7 @@
       </trans-unit>
       <trans-unit id="9">
         <source>%language% translation</source>
-        <target>%idioma% tradução</target>
+        <target>%language% tradução</target>
       </trans-unit>
     </body>
   </file>

--- a/plugins/sfTranslatePlugin/i18n/sr/messages.xml
+++ b/plugins/sfTranslatePlugin/i18n/sr/messages.xml
@@ -18,7 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>%language% translation</source>
-        <target>%језик% превод</target>
+        <target>%language% превод</target>
       </trans-unit>
       <trans-unit id="5">
         <source>Save translation</source>

--- a/plugins/sfTranslatePlugin/i18n/th/messages.xml
+++ b/plugins/sfTranslatePlugin/i18n/th/messages.xml
@@ -18,7 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>%language% translation</source>
-        <target>%ภาษา%การแปล</target>
+        <target>%language%การแปล</target>
       </trans-unit>
       <trans-unit id="5">
         <source>Save translation</source>

--- a/plugins/sfTranslatePlugin/i18n/vi/messages.xml
+++ b/plugins/sfTranslatePlugin/i18n/vi/messages.xml
@@ -18,7 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>%language% translation</source>
-        <target>%Ngôn ngữ% phiên dịch</target>
+        <target>%language% phiên dịch</target>
       </trans-unit>
       <trans-unit id="5">
         <source>Save translation</source>

--- a/plugins/sfTranslatePlugin/i18n/zh/messages.xml
+++ b/plugins/sfTranslatePlugin/i18n/zh/messages.xml
@@ -18,7 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>%language% translation</source>
-        <target>%语言% 翻译</target>
+        <target>%language% 翻译</target>
       </trans-unit>
       <trans-unit id="5">
         <source>Save translation</source>


### PR DESCRIPTION
Closes #2012

Fixes the mistakenly translated language variable back to "%language%" for all languages.

As noted in the issue, `fr` and `pt_BR` were two cultures where this was an issue, but there were a few more as well.