### PR TITLE
Bump MySQL version for docker

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -56,7 +56,7 @@ services:
       - "127.0.0.1:63002:9200"
 
   percona:
-    image: percona:8.0
+    image: percona/percona-server:8.4
     env_file: etc/environment
     volumes:
       - percona_data:/var/lib/mysql:rw

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -55,7 +55,7 @@ services:
       - "127.0.0.1:63002:9200"
 
   percona:
-    image: percona:8.0
+    image: percona/percona-server:8.4
     env_file: etc/environment
     volumes:
       - percona_data:/var/lib/mysql:rw

--- a/docker/etc/mysql/mysqld.cnf
+++ b/docker/etc/mysql/mysqld.cnf
@@ -1,7 +1,6 @@
 [mysqld]
 character-set-server=utf8mb4
 collation-server=utf8mb4_0900_ai_ci
-skip-character-set-client-handshake
 init_connect="SET collation_connection = utf8mb4_0900_ai_ci;SET NAMES utf8mb4"
 # Removed from default sql_mode: NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY
 sql_mode=STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION


### PR DESCRIPTION
Bump MySQL (percona) to 8.4 for docker. Also remove skip-character-set-client-handshake flag which has been removed.