### PR TITLE
Fix warnings in EAD XML exports

### DIFF
--- a/lib/task/export/exportBulkBaseTask.class.php
+++ b/lib/task/export/exportBulkBaseTask.class.php
@@ -65,6 +65,8 @@ abstract class exportBulkBaseTask extends sfBaseTask
                 $ead = new sfEadPlugin($resource, $options);
 
                 $findingAid = isset($options['findingAidVisibilitiy']) ? (bool) $options['findingAidVisibilitiy'] : false;
+                $authenticated = isset($options['public']) ? !$options['public'] : false;
+                $defTemplate = sfConfig::get('app_default_template_informationobject');
 
                 extract([
                     'resource' => $resource,

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBody.xml.php
@@ -80,7 +80,7 @@
       </langusage>
     <?php } ?>
     <?php $rulesConv = 'app_element_visibility_'.$template.'_control_rules_conventions'; ?>
-    <?php if (0 < strlen($rules = $resource->getRules(['cultureFallback' => true])) && ($authenticated || 1 == sfConfig::get($rulesConv))) { ?>
+    <?php if (0 < strlen($rules = $resource->getRules(['cultureFallback' => true]) ?? '') && ($authenticated || 1 == sfConfig::get($rulesConv))) { ?>
       <descrules <?php if (0 < strlen($encoding = $ead->getMetadataParameter('descrules'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><?php echo escape_dc(esc_specialchars($rules)); ?></descrules>
     <?php } ?>
   </profiledesc>
@@ -246,24 +246,24 @@
     </controlaccess>
   <?php } ?>
   <?php 'isad' == $template ? $physCond = 'app_element_visibility_isad_physical_condition' : $physCond = 'app_element_visibility_rad_physical_access'; ?>
-  <?php if (0 < strlen($value = $resource->getPhysicalCharacteristics(['cultureFallback' => true])) && ($authenticated || (1 == sfConfig::get($physCond) && !$findingAid))) { ?>
+  <?php if (0 < strlen($value = $resource->getPhysicalCharacteristics(['cultureFallback' => true]) ?? '') && ($authenticated || (1 == sfConfig::get($physCond) && !$findingAid))) { ?>
     <phystech encodinganalog="<?php echo $ead->getMetadataParameter('phystech'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></phystech>
   <?php } ?>
-  <?php if (0 < strlen($value = $resource->getAppraisal(['cultureFallback' => true])) && ($authenticated || 1 == sfConfig::get('app_element_visibility_isad_appraisal_destruction'))) { ?>
+  <?php if (0 < strlen($value = $resource->getAppraisal(['cultureFallback' => true]) ?? '') && ($authenticated || 1 == sfConfig::get('app_element_visibility_isad_appraisal_destruction'))) { ?>
     <appraisal <?php if (0 < strlen($encoding = $ead->getMetadataParameter('appraisal'))) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><p><?php echo escape_dc(esc_specialchars($value)); ?></p></appraisal>
   <?php } ?>
-  <?php if (0 < strlen($value = $resource->getAcquisition(['cultureFallback' => true])) && ($authenticated || (1 == sfConfig::get('app_element_visibility_isad_archival_history') && !$findingAid))) { ?>
+  <?php if (0 < strlen($value = $resource->getAcquisition(['cultureFallback' => true]) ?? '') && ($authenticated || (1 == sfConfig::get('app_element_visibility_isad_archival_history') && !$findingAid))) { ?>
     <acqinfo encodinganalog="<?php echo $ead->getMetadataParameter('acqinfo'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></acqinfo>
   <?php } ?>
   <?php if (0 < strlen($value = $resource->getAccruals(['cultureFallback' => true]) ?? '')) { ?>
     <accruals encodinganalog="<?php echo $ead->getMetadataParameter('accruals'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></accruals>
   <?php } ?>
-  <?php if (0 < strlen($value = $resource->getArchivalHistory(['cultureFallback' => true])) && ($authenticated || (1 == sfConfig::get('app_element_visibility_isad_archival_history') && !$findingAid))) { ?>
+  <?php if (0 < strlen($value = $resource->getArchivalHistory(['cultureFallback' => true]) ?? '') && ($authenticated || (1 == sfConfig::get('app_element_visibility_isad_archival_history') && !$findingAid))) { ?>
     <custodhist encodinganalog="<?php echo $ead->getMetadataParameter('custodhist'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></custodhist>
   <?php } ?>
 
   <?php $archivistsNotes = $resource->getNotesByType(['noteTypeId' => QubitTerm::ARCHIVIST_NOTE_ID]); ?>
-  <?php if (0 < strlen($value = $resource->getRevisionHistory(['cultureFallback' => true])) || 0 < count($archivistsNotes)) { ?>
+  <?php if (0 < strlen($value = $resource->getRevisionHistory(['cultureFallback' => true]) ?? '') || 0 < count($archivistsNotes)) { ?>
     <?php 'isad' == $template ? $datesOfCreation = 'app_element_visibility_isad_control_dates' : $datesOfCreation = 'app_element_visibility_rad_control_dates'; ?>
     <processinfo>
       <?php if ($value && ($authenticated || (1 == sfConfig::get($datesOfCreation) && !$findingAid))) { ?>
@@ -394,7 +394,7 @@
 
       <?php } ?>
 
-      <?php if (0 < strlen($value = $descendant->getPhysicalCharacteristics(['cultureFallback' => true])) && ($authenticated || 1 == sfConfig::get('app_element_visibility_rad_physical_condition'))) { ?>
+      <?php if (0 < strlen($value = $descendant->getPhysicalCharacteristics(['cultureFallback' => true]) ?? '') && ($authenticated || 1 == sfConfig::get('app_element_visibility_rad_physical_condition'))) { ?>
         <phystech encodinganalog="<?php echo $ead->getMetadataParameter('phystech'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></phystech>
       <?php } ?>
 
@@ -402,7 +402,7 @@
         <appraisal <?php if (0 < strlen($encoding = $ead->getMetadataParameter('appraisal') ?? '')) { ?>encodinganalog="<?php echo $encoding; ?>"<?php } ?>><p><?php echo escape_dc(esc_specialchars($value)); ?></p></appraisal>
       <?php } ?>
 
-      <?php if (0 < strlen($value = $descendant->getAcquisition(['cultureFallback' => true])) && ($authenticated || (1 == sfConfig::get('app_element_visibility_rad_immediate_source') && !$findingAid))) { ?>
+      <?php if (0 < strlen($value = $descendant->getAcquisition(['cultureFallback' => true]) ?? '') && ($authenticated || (1 == sfConfig::get('app_element_visibility_rad_immediate_source') && !$findingAid))) { ?>
         <acqinfo encodinganalog="<?php echo $ead->getMetadataParameter('acqinfo'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></acqinfo>
       <?php } ?>
 
@@ -410,7 +410,7 @@
         <accruals encodinganalog="<?php echo $ead->getMetadataParameter('accruals'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></accruals>
       <?php } ?>
 
-      <?php if (0 < strlen($value = $descendant->getArchivalHistory(['cultureFallback' => true])) && ($authenticated || (1 == sfConfig::get('app_element_visibility_rad_archival_history') && !$findingAid))) { ?>
+      <?php if (0 < strlen($value = $descendant->getArchivalHistory(['cultureFallback' => true]) ?? '') && ($authenticated || (1 == sfConfig::get('app_element_visibility_rad_archival_history') && !$findingAid))) { ?>
         <custodhist encodinganalog="<?php echo $ead->getMetadataParameter('custodhist'); ?>"><p><?php echo escape_dc(esc_specialchars($value)); ?></p></custodhist>
       <?php } ?>
 

--- a/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
+++ b/plugins/sfEadPlugin/modules/sfEadPlugin/templates/indexSuccessBodyDidElement.xml.php
@@ -36,7 +36,7 @@
 
   <?php } ?>
 
-  <?php if ('dc' != $defTemplate && 0 < strlen($value = ${$resourceVar}->getTitle(['cultureFallback' => true]))) { ?>
+  <?php if ('dc' != $defTemplate && 0 < strlen($value = ${$resourceVar}->getTitle(['cultureFallback' => true]) ?? '')) { ?>
     <unittitle encodinganalog="<?php echo $ead->getMetadataParameter('unittitle'); ?>"><?php echo escape_dc(esc_specialchars($value)); ?></unittitle>
   <?php } ?>
 
@@ -61,7 +61,7 @@
   <?php } ?>
 
   <?php $repository = null; ?>
-  <?php if ('dc' != $defTemplate && 0 < strlen(${$resourceVar}->getIdentifier())) { ?>
+  <?php if ('dc' != $defTemplate && 0 < strlen(${$resourceVar}->getIdentifier() ?? '')) { ?>
     <?php foreach (${$resourceVar}->ancestors->andSelf()->orderBy('rgt') as $item) { ?>
       <?php if (isset($item->repository)) { ?>
         <?php $repository = $item->repository; ?>


### PR DESCRIPTION
Closes #2269 

Adds two variables referenced in XML templates and coalesces null strings to `''` in `strlen()` calls to fix large amount of warnings when running XML exports.

I didn't fix the warning mentioned in the issue in `BaseEvent.model.php` because that felt like a separate issue. I think #1957 might be a better issue to address that since the `strlen()` call in that example sits within a `call_user_func_array`. I can address that in this pull request though if needed.