### PR TITLE
Speed up install fixture loading

### DIFF
--- a/lib/arInstall.class.php
+++ b/lib/arInstall.class.php
@@ -387,6 +387,12 @@ class arInstall
         $accessConditionalWarning = $i18n->__(
             'This record has not yet been reviewed for personal or confidential information. Please contact the Reference Archivist to request access and initiate an access review.'
         );
+        $translations = QubitI18N::getTranslationsForStrings([
+            $accessDisallowWarning,
+            $accessConditionalWarning,
+        ]);
+        $accessDisallowWarningTranslations = $translations[$accessDisallowWarning];
+        $accessConditionalWarningTranslations = $translations[$accessConditionalWarning];
 
         foreach (
             QubitTaxonomy::getTermsById(QubitTaxonomy::RIGHT_BASIS_ID) as $item
@@ -396,9 +402,7 @@ class arInstall
             $setting->scope = 'access_statement';
             $setting->setValue($accessDisallowWarning, ['culture' => 'en']);
 
-            foreach (
-                QubitI18N::getTranslations($accessDisallowWarning) as $langCode => $message
-            ) {
+            foreach ($accessDisallowWarningTranslations as $langCode => $message) {
                 $setting->setValue($message, ['culture' => $langCode]);
             }
 
@@ -409,9 +413,7 @@ class arInstall
             $setting->scope = 'access_statement';
             $setting->setValue($accessConditionalWarning, ['culture' => 'en']);
 
-            foreach (
-                QubitI18N::getTranslations($accessConditionalWarning) as $langCode => $message
-            ) {
+            foreach ($accessConditionalWarningTranslations as $langCode => $message) {
                 $setting->setValue($message, ['culture' => $langCode]);
             }
 

--- a/lib/i18n/QubitI18N.class.php
+++ b/lib/i18n/QubitI18N.class.php
@@ -32,31 +32,48 @@ class QubitI18N
      */
     public static function getTranslations($string)
     {
-        $translations = [];
+        $translations = self::getTranslationsForStrings([$string]);
 
-        // Index the array with all the language codes available in the application
+        return $translations[$string];
+    }
+
+    /**
+     * Return translations for several source strings in one pass over the
+     * configured application languages. This keeps getTranslations() compatible
+     * while allowing install tasks to avoid rebuilding i18n state for each
+     * string.
+     */
+    public static function getTranslationsForStrings(array $strings)
+    {
+        $translations = [];
+        foreach ($strings as $string) {
+            $translations[$string] = [];
+        }
+
+        // Index the language codes available in the application.
+        $languageCodes = [];
         foreach (new DirectoryIterator(sfConfig::get('sf_app_i18n_dir')) as $fileInfo) {
             if ($fileInfo->isDot()) {
                 continue;
             }
 
-            $translations[$fileInfo->getBasename()] = '';
+            $languageCodes[] = $fileInfo->getBasename();
         }
 
         $configuration = sfContext::getInstance()->getConfiguration();
-        $cache = new sfNoCache();
-        foreach ($translations as $langCode => &$value) {
-            $i18n = new sfI18N($configuration, $cache, ['culture' => $langCode]);
+        foreach ($languageCodes as $langCode) {
+            $i18n = new sfI18N($configuration, new sfNoCache(), ['culture' => $langCode]);
 
-            // Mark untranslated messages
+            // Mark untranslated messages so they can be omitted below.
             $i18n->getMessageFormat()->setUntranslatedPS(['[T]', '[/T]']);
 
-            // Update the value of this language in the dictionary
-            $value = $i18n->__($string);
+            foreach ($strings as $string) {
+                $value = $i18n->__($string);
 
-            // But discard the message if it's untranslated
-            if (empty($value) || 0 === strpos($value, '[T]', 0)) {
-                unset($translations[$langCode]);
+                // Discard empty and untranslated messages.
+                if (!empty($value) && 0 !== strpos($value, '[T]', 0)) {
+                    $translations[$string][$langCode] = $value;
+                }
             }
         }
 

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/addon/sfPropelData.class.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/addon/sfPropelData.class.php
@@ -115,7 +115,7 @@ class sfPropelData extends sfData
 
           // foreign key?
           $columnCheck = !empty($column) && (isset($column) ? true : false);
--         $objectCheck = !empty($value) && is_string($value) && (isset($this->object_references[$value]) ? true : false);
+          $objectCheck = !empty($value) && is_string($value) && (isset($this->object_references[$value]) ? true : false);
           if ($columnCheck && $column->isForeignKey() && $objectCheck)
           {
             $value = $this->object_references[$value]->getPrimaryKey();


### PR DESCRIPTION
I've been finding the installer a bit slow in my local development environment, likely made more noticeable by shared-volume filesystem overhead. While profiling `tools:purge --demo`, I found a couple of small fixture-loading fixes that significantly reduce the time spent loading the initial data during install/purge.

Measured `tools:purge --demo` improving from about 54s before this optimization pass to about 10s after it. This is more noticeable on slower shared filesystems, but it still avoids repeated i18n work on faster environments too.