### PR TITLE
Fix REST API digital object downloads

### DIFF
--- a/plugins/arRestApiPlugin/modules/api/actions/informationobjectsDownloadDigitalObjectAction.class.php
+++ b/plugins/arRestApiPlugin/modules/api/actions/informationobjectsDownloadDigitalObjectAction.class.php
@@ -66,7 +66,7 @@ class ApiInformationObjectsDownloadDigitalObjectAction extends QubitApiAction
             }
         }
 
-        $this->downloadDigitalObject($request);
+        return $this->downloadDigitalObject($request);
     }
 
     protected function downloadDigitalObject($request)
@@ -97,8 +97,8 @@ class ApiInformationObjectsDownloadDigitalObjectAction extends QubitApiAction
             ob_end_clean();
         }
 
-        $this->getResponse()->setContent(readfile($this->path));
-        $this->getResponse()->sendContent();
+        readfile($this->path);
+        $this->getResponse()->setHeaderOnly(true);
 
         return 'DigitalObject';
     }


### PR DESCRIPTION
Return the digital object download marker from the action and stream the file contents directly. The previous code passed readfile() into setContent(), which mixed immediate output with Symfony response content handling and stored the byte count returned by readfile() as response content.

Mark the Symfony response as header-only after readfile() so the final rendering filter does not send response content after the file body has already been emitted.