### PR TITLE
Limit XML clipboard exports

### DIFF
--- a/apps/qubit/modules/clipboard/actions/exportAction.class.php
+++ b/apps/qubit/modules/clipboard/actions/exportAction.class.php
@@ -19,6 +19,9 @@
 
 class ClipboardExportAction extends DefaultEditAction
 {
+    // Limit how many XML information object a user can export
+    private const XML_EXPORT_LIMIT_DESCENDANTS = 1000;
+
     // Arrays not allowed in class constants
     public static $NAMES = [
         'levels',
@@ -265,6 +268,26 @@ class ClipboardExportAction extends DefaultEditAction
                         '%close_link%' => '</a>',
                     ]
                 ));
+            }
+        }
+
+        if (
+            'arInformationObjectXmlExportJob' == $jobName
+            && !$options['current-level-only'] ?? false
+        ) {
+            $countRecords = $this->countInformationObjectsToExport($options);
+
+            if ($countRecords > $this::XML_EXPORT_LIMIT_DESCENDANTS) {
+                $message = $this->context->i18n->__(
+                    'This XML export would include %1% records, which exceeds the maximum of %2%. '
+                    .'Please refine the scope of your export by reducing the number of selected '
+                    .'items or de-selecting the "Include descendants" option.',
+                    ['%1%' => $countRecords, '%2%' => $this::XML_EXPORT_LIMIT_DESCENDANTS],
+                );
+
+                $this->response->setStatusCode(400);
+
+                return $this->renderText(json_encode(['error' => $message]));
             }
         }
 
@@ -525,6 +548,51 @@ class ClipboardExportAction extends DefaultEditAction
             default:
                 return parent::processField($field);
         }
+    }
+
+    /**
+     * Count the number of information objects that would be included by an export. Accounts for
+     * descendants, and public-only exports.
+     *
+     * @param array $options export options including slugs
+     *
+     * @return int the number of records to be exported
+     */
+    private function countInformationObjectsToExport($options)
+    {
+        $slugs = $options['params']['slugs'] ?? [];
+
+        if (empty($slugs)) {
+            return 0;
+        }
+
+        if ($options['current-level-only'] ?? false) {
+            return count($slugs);
+        }
+
+        $placeholders = implode(',', array_fill(0, count($slugs), '?'));
+        $params = array_values($slugs);
+
+        // Count all information objects that fall within the nested set range
+        // of the clipboard items (i.e. the items themselves plus descendants).
+        // When 'public' is set, exclude draft records to match the actual
+        // export behaviour.
+        $sql = "SELECT COUNT(DISTINCT d.id) AS total
+            FROM slug s
+            INNER JOIN information_object io ON s.object_id = io.id
+            INNER JOIN information_object d
+                ON d.lft >= io.lft AND d.rgt <= io.rgt
+            WHERE s.slug IN ({$placeholders})";
+
+        if ($options['public'] ?? false) {
+            $sql .= ' AND d.id IN (SELECT st.object_id FROM status st WHERE st.type_id = ? AND st.status_id = ?)';
+            $params[] = QubitTerm::STATUS_TYPE_PUBLICATION_ID;
+            $params[] = QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID;
+        }
+
+        $result = QubitPdo::fetchOne($sql, $params);
+
+        return (int) $result->total;
     }
 
     private function getJobNameString()

--- a/apps/qubit/modules/clipboard/actions/exportAction.class.php
+++ b/apps/qubit/modules/clipboard/actions/exportAction.class.php
@@ -19,9 +19,6 @@
 
 class ClipboardExportAction extends DefaultEditAction
 {
-    // Limit how many XML information object a user can export
-    private const XML_EXPORT_LIMIT_DESCENDANTS = 1000;
-
     // Arrays not allowed in class constants
     public static $NAMES = [
         'levels',
@@ -277,12 +274,14 @@ class ClipboardExportAction extends DefaultEditAction
         ) {
             $countRecords = $this->countInformationObjectsToExport($options);
 
-            if ($countRecords > $this::XML_EXPORT_LIMIT_DESCENDANTS) {
+            $xmlExportLimit = sfConfig::get('app_clipboard_export_xml_limit', 1000);
+
+            if ($countRecords > $xmlExportLimit) {
                 $message = $this->context->i18n->__(
                     'This XML export would include %1% records, which exceeds the maximum of %2%. '
                     .'Please refine the scope of your export by reducing the number of selected '
                     .'items or de-selecting the "Include descendants" option.',
-                    ['%1%' => $countRecords, '%2%' => $this::XML_EXPORT_LIMIT_DESCENDANTS],
+                    ['%1%' => $countRecords, '%2%' => $xmlExportLimit],
                 );
 
                 $this->response->setStatusCode(400);

--- a/apps/qubit/modules/settings/actions/clipboardAction.class.php
+++ b/apps/qubit/modules/settings/actions/clipboardAction.class.php
@@ -28,6 +28,7 @@ class SettingsClipboardAction extends SettingsEditAction
         'clipboard_send_message_html',
         'clipboard_send_http_method',
         'clipboard_export_digitalobjects_enabled',
+        'clipboard_export_xml_limit',
     ];
     public static $I18N = [
         'clipboard_send_button_text',
@@ -47,6 +48,7 @@ class SettingsClipboardAction extends SettingsEditAction
             'clipboard_send_message_html' => $this->i18n->__('Sending...'),
             'clipboard_send_http_method' => 'POST',
             'clipboard_export_digitalobjects_enabled' => '0',
+            'clipboard_export_xml_limit' => '1000',
         ];
     }
 
@@ -59,6 +61,12 @@ class SettingsClipboardAction extends SettingsEditAction
             case 'clipboard_send_button_text':
             case 'clipboard_send_message_html':
                 $this->form->setValidator($name, new sfValidatorString());
+                $this->form->setWidget($name, new sfWidgetFormInput());
+
+                break;
+
+            case 'clipboard_export_xml_limit':
+                $this->form->setValidator($name, new sfValidatorInteger(['min' => 1]));
                 $this->form->setWidget($name, new sfWidgetFormInput());
 
                 break;

--- a/apps/qubit/modules/settings/templates/clipboardSuccess.php
+++ b/apps/qubit/modules/settings/templates/clipboardSuccess.php
@@ -78,6 +78,14 @@
           <div class="accordion-body">
             <?php echo render_field($form->clipboard_export_digitalobjects_enabled
                 ->label(__('Enable digital object export'))); ?>
+
+            <?php echo render_field(
+                $form->clipboard_export_xml_limit
+                    ->label(__('Limit the number of information objects that can be exported as XML'))
+                    ->help(_('Affects XML clipboard exports only, not CSV exports')),
+                null,
+                ['type' => 'number'],
+            ); ?>
           </div>
         </div>
       </div>

--- a/data/fixtures/settings.yml
+++ b/data/fixtures/settings.yml
@@ -3,7 +3,7 @@ QubitSetting:
     name: version
     editable: 0
     deleteable: 0
-    value: 197
+    value: 198
   milestone:
     name: milestone
     editable: 0
@@ -29,6 +29,11 @@ QubitSetting:
     editable: 1
     deleteable: 0
     value: 1
+  QubitSetting_clipboard_export_xml_limit:
+    name: clipboard_export_xml_limit
+    editable: 1
+    deleteable: 0
+    value: 1000
   QubitSetting_sort_treeview:
     name: sort_treeview_informationobject
     editable: 1

--- a/lib/task/migrate/migrations/arMigration0198.class.php
+++ b/lib/task/migrate/migrations/arMigration0198.class.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add new setting for the maximum number of information objects that can be
+ * exported as XML from the clipboard.
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0198
+{
+    public const VERSION = 198;
+    public const MIN_MILESTONE = 2;
+
+    public function up($configuration)
+    {
+        // Add clipboard XML export limit setting.
+        if (null === QubitSetting::getByName('clipboard_export_xml_limit')) {
+            $setting = new QubitSetting();
+            $setting->name = 'clipboard_export_xml_limit';
+            $setting->editable = 1;
+            $setting->value = '1000';
+            $setting->save();
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Sets a limit for XML exports from the clipboard. See the screenshot below for the alert shown when this limit is exceeded. This applies only to information object object XML exports from the clipboard (XML exports from the backend are not limited).

<img width="750" alt="xml_export_screenshot" src="https://github.com/user-attachments/assets/489573b4-f2f6-4f59-9343-95d3aa4000e5" />
