### PR TITLE
Refactor HTTP_X_ATOM_CULTURE handling

### DIFF
--- a/apps/qubit/config/filters.yml
+++ b/apps/qubit/config/filters.yml
@@ -10,6 +10,9 @@ security: ~
 settings:
   class: QubitSettingsFilter
 
+culture_header:
+  class: QubitCultureHeaderFilter
+
 QubitLimitIp:
   class: QubitLimitIpFilter
 

--- a/lib/filter/QubitCultureHeaderFilter.class.php
+++ b/lib/filter/QubitCultureHeaderFilter.class.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class QubitCultureHeaderFilter extends sfFilter
+{
+    protected static $allowedCultures;
+
+    public function execute($filterChain)
+    {
+        // Allow reverse proxies to pass a header to change culture
+        if (!empty($_SERVER['HTTP_X_ATOM_CULTURE'])) {
+            $culture = trim($_SERVER['HTTP_X_ATOM_CULTURE']);
+
+            if ($this->isAllowedCulture($culture)) {
+                sfContext::getInstance()->getUser()->setCulture($culture);
+            }
+        }
+
+        $filterChain->execute();
+    }
+
+    protected function isAllowedCulture($culture)
+    {
+        if (!is_string($culture) || '' === $culture) {
+            return false;
+        }
+
+        if (null === self::$allowedCultures) {
+            self::$allowedCultures = array_fill_keys(
+                sfConfig::get('app_i18n_languages', []),
+                true
+            );
+        }
+
+        return isset(self::$allowedCultures[$culture]);
+    }
+}

--- a/lib/myUser.class.php
+++ b/lib/myUser.class.php
@@ -77,11 +77,6 @@ class myUser extends sfBasicSecurityUser implements Zend_Acl_Role_Interface
         if (!isset($_COOKIE['atom_authenticated']) || $_COOKIE['atom_authenticated'] != $isAuthenticated) {
             setcookie('atom_authenticated', $isAuthenticated, ['path' => '/', 'secure' => true, 'samesite' => 'strict']);
         }
-
-        // Allow reverse proxies to pass a header to change culture
-        if (!empty($_SERVER['HTTP_X_ATOM_CULTURE'])) {
-            $this->setCulture($_SERVER['HTTP_X_ATOM_CULTURE']);
-        }
     }
 
     public function signIn($user)

--- a/test/phpunit/lib/filter/QubitCultureHeaderFilterTest.php
+++ b/test/phpunit/lib/filter/QubitCultureHeaderFilterTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once 'lib/filter/QubitCultureHeaderFilter.class.php';
+
+/**
+ * @internal
+ *
+ * @covers \QubitCultureHeaderFilter
+ */
+class QubitCultureHeaderFilterTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        sfConfig::set('app_i18n_languages', ['en', 'fr', 'es']);
+
+        $reflection = new ReflectionClass(QubitCultureHeaderFilter::class);
+        $allowedCultures = $reflection->getProperty('allowedCultures');
+        $allowedCultures->setAccessible(true);
+        $allowedCultures->setValue(null, null);
+    }
+
+    public function testAllowsConfiguredCulture()
+    {
+        $filter = new TestQubitCultureHeaderFilter($this->createMock(sfContext::class), []);
+
+        $this->assertTrue($filter->isAllowedCultureForTest('en'));
+        $this->assertTrue($filter->isAllowedCultureForTest('es'));
+    }
+
+    public function testAllowsConfiguredCultureWithWhitespace()
+    {
+        $filter = new TestQubitCultureHeaderFilter($this->createMock(sfContext::class), []);
+
+        $this->assertTrue($filter->isAllowedCultureForTest('fr'));
+    }
+
+    public function testRejectsCultureOutsideAllowList()
+    {
+        $filter = new TestQubitCultureHeaderFilter($this->createMock(sfContext::class), []);
+
+        $this->assertFalse($filter->isAllowedCultureForTest('de'));
+    }
+
+    public function testRejectsEmptyAndNonStringCultures()
+    {
+        $filter = new TestQubitCultureHeaderFilter($this->createMock(sfContext::class), []);
+
+        $this->assertFalse($filter->isAllowedCultureForTest(''));
+        $this->assertFalse($filter->isAllowedCultureForTest('   '));
+        $this->assertFalse($filter->isAllowedCultureForTest(null));
+        $this->assertFalse($filter->isAllowedCultureForTest(['en']));
+    }
+}
+
+class TestQubitCultureHeaderFilter extends QubitCultureHeaderFilter
+{
+    public function isAllowedCultureForTest($culture)
+    {
+        if (is_string($culture)) {
+            $culture = trim($culture);
+        }
+
+        return $this->isAllowedCulture($culture);
+    }
+}


### PR DESCRIPTION
Move HTTP_X_ATOM_CULTURE handling from myUser initialization into a dedicated filter that runs after settings are loaded.

Add PHPUnit coverage for the culture allowlist logic in the new filter.