### PR TITLE
Add shared redirect target validator

### DIFF
--- a/apps/qubit/modules/actor/actions/editAction.class.php
+++ b/apps/qubit/modules/actor/actions/editAction.class.php
@@ -37,7 +37,7 @@ class ActorEditAction extends DefaultEditAction
 
                 $this->resource->save();
 
-                if (isset($request->id) && (0 < strlen($next = $this->form->getValue('next')))) {
+                if (isset($request->id) && null !== $next = Qubit::filterRedirectTarget($this->form->getValue('next'))) {
                     $this->redirect($next);
                 }
 

--- a/apps/qubit/modules/clipboard/templates/exportSuccess.php
+++ b/apps/qubit/modules/clipboard/templates/exportSuccess.php
@@ -81,7 +81,8 @@
 
     <ul class="actions mb-3 nav gap-2">
       <li><input class="btn atom-btn-outline-success" type="submit" id="exportSubmit" value="<?php echo __('Export'); ?>"></li>
-      <li><?php echo link_to(__('Cancel'), !empty($sf_request->getReferer()) ? $sf_request->getReferer() : ['module' => 'clipboard', 'action' => 'view'], ['class' => 'btn atom-btn-outline-light', 'role' => 'button']); ?></li>
+      <?php $cancelTarget = Qubit::filterRedirectTarget($sf_request->getReferer()); ?>
+      <li><?php echo link_to(__('Cancel'), null !== $cancelTarget ? $cancelTarget : ['module' => 'clipboard', 'action' => 'view'], ['class' => 'btn atom-btn-outline-light', 'role' => 'button']); ?></li>
     </ul>
 
   </form>

--- a/apps/qubit/modules/jobs/actions/deleteAction.class.php
+++ b/apps/qubit/modules/jobs/actions/deleteAction.class.php
@@ -43,7 +43,11 @@ class JobsDeleteAction extends sfAction
                 $this->deleteJobsNotInProgress([$job]);
             }
 
-            $this->redirect($request->getReferer());
+            if (null !== $redirectUrl = Qubit::filterRedirectTarget($request->getReferer())) {
+                $this->redirect($redirectUrl);
+            }
+
+            $this->redirect('@homepage');
         } elseif ($this->context->user->isAuthenticated() && !$token) {
             // Handle bulk deletion of jobs associated with an authenticated user
             $jobs = QubitJob::getJobsByUser($this->context->user);

--- a/apps/qubit/modules/physicalobject/actions/deleteAction.class.php
+++ b/apps/qubit/modules/physicalobject/actions/deleteAction.class.php
@@ -44,7 +44,7 @@ class PhysicalObjectDeleteAction extends sfAction
             if ($this->form->isValid()) {
                 $this->resource->delete();
 
-                $next = $this->form->getValue('next');
+                $next = Qubit::filterRedirectTarget($this->form->getValue('next'));
                 if (isset($next)) {
                     $this->redirect($next);
                 }

--- a/apps/qubit/modules/physicalobject/actions/editAction.class.php
+++ b/apps/qubit/modules/physicalobject/actions/editAction.class.php
@@ -41,7 +41,7 @@ class PhysicalObjectEditAction extends DefaultEditAction
 
                 $this->resource->save();
 
-                if (null !== $next = $this->form->getValue('next')) {
+                if (null !== $next = Qubit::filterRedirectTarget($this->form->getValue('next'))) {
                     $this->redirect($next);
                 }
 

--- a/apps/qubit/modules/physicalobject/templates/editSuccess.php
+++ b/apps/qubit/modules/physicalobject/templates/editSuccess.php
@@ -41,7 +41,7 @@
     </div>
 
     <ul class="actions mb-3 nav gap-2">
-      <?php if (null !== $next = $form->getValue('next')) { ?>
+      <?php if (null !== $next = Qubit::filterRedirectTarget($form->getValue('next'))) { ?>
         <li><?php echo link_to(__('Cancel'), $next, ['class' => 'btn atom-btn-outline-light', 'role' => 'button']); ?></li>
       <?php } elseif (isset($sf_request->getAttribute('sf_route')->resource)) { ?>
         <li><?php echo link_to(__('Cancel'), [$resource, 'module' => 'physicalobject'], ['class' => 'btn atom-btn-outline-light', 'role' => 'button']); ?></li>

--- a/apps/qubit/modules/user/actions/loginAction.class.php
+++ b/apps/qubit/modules/user/actions/loginAction.class.php
@@ -71,7 +71,7 @@ class UserLoginAction extends sfAction
                     // Can be read by reverse proxies to allow users to bypass caching
                     setcookie('atom_authenticated', '1', ['path' => '/', 'secure' => true, 'samesite' => 'strict']);
 
-                    if (null !== $next = $this->form->getValue('next')) {
+                    if (null !== $next = Qubit::filterRedirectTarget($this->form->getValue('next'))) {
                         $this->redirect($next);
                     }
 

--- a/lib/Qubit.class.php
+++ b/lib/Qubit.class.php
@@ -19,14 +19,57 @@
 
 class Qubit
 {
-    public static function pathInfo($url)
+    public static function pathInfo($url, $request = null)
     {
+        // Allow callers and tests to supply a request explicitly; otherwise use the current one.
+        if (null === $request) {
+            $request = sfContext::getInstance()->request;
+        }
+
         // Other options to get path info from URL include parse_url() or building
         // an exact regex from the BNF in RFC 1738.  Note however that our only
         // goal is to get path info from valid URL, which the following simple
         // regex should accomplish.  Slash characters don't occur in the scheme,
         // user, password, host, or port component of valid URL
-        return preg_replace('/^(?:[^:]+:\/\/[^\/]+)?'.preg_quote(sfContext::getInstance()->request->getPathInfoPrefix(), '/').'/', null, $url);
+        return preg_replace('/^(?:[^:]+:\/\/[^\/]+)?'.preg_quote($request->getPathInfoPrefix(), '/').'/', '', $url);
+    }
+
+    /**
+     * Filter redirect targets.
+     *
+     * @param string       $target  The redirect target URL
+     * @param sfWebRequest $request The request object (optional)
+     *
+     * @return null|string The filtered redirect target, or null
+     */
+    public static function filterRedirectTarget($target)
+    {
+        if (!is_string($target)) {
+            return null;
+        }
+
+        // Reject empty values and control characters before any URL handling.
+        $target = trim($target);
+        if ('' === $target || preg_match('/[\x00-\x1F\x7F]/', $target)) {
+            return null;
+        }
+
+        // Reject protocol-relative and UNC-style targets, which browsers can treat as external locations.
+        // This is rejecting targets that start with "//" or "\\".  Note that the latter is not a valid
+        // URL but is accepted by some browsers as a UNC path.
+        if (0 === strpos($target, '//') || 0 === strpos($target, '\\\\')) {
+            return null;
+        }
+
+        // Only allow absolute URLs when they resolve to the configured site origin.
+        if (preg_match('/^[a-z][a-z0-9+\-.]*:/i', $target)) {
+            $parts = parse_url($target);
+            if (false === $parts || !self::isSameConfiguredOriginUrl($parts)) {
+                return null;
+            }
+        }
+
+        return $target;
     }
 
     // Alternative to format_date() symfony helper
@@ -417,5 +460,45 @@ class Qubit
                 return $match[2];
             }
         }, $mask);
+    }
+
+    /**
+     * Determine if a URL matches the configured site origin.
+     *
+     * @param array $urlParts Parsed URL components
+     *
+     * @return bool
+     */
+    private static function isSameConfiguredOriginUrl(array $urlParts)
+    {
+        // If the URL is missing a scheme or host, it cannot match the configured origin.
+        if (!isset($urlParts['scheme'], $urlParts['host'])) {
+            return false;
+        }
+
+        $configuredBaseUrl = sfConfig::get('app_siteBaseUrl');
+        if (!is_string($configuredBaseUrl) || '' === trim($configuredBaseUrl)) {
+            return false;
+        }
+
+        $baseUrlParts = parse_url($configuredBaseUrl);
+        if (false === $baseUrlParts || !isset($baseUrlParts['scheme'], $baseUrlParts['host'])) {
+            return false;
+        }
+
+        // Compare scheme and host case-insensitively.
+        if (0 !== strcasecmp($urlParts['scheme'], $baseUrlParts['scheme'])) {
+            return false;
+        }
+
+        if (0 !== strcasecmp($urlParts['host'], $baseUrlParts['host'])) {
+            return false;
+        }
+
+        // Compare ports numerically, defaulting to null if not present.
+        $urlPort = isset($urlParts['port']) ? (int) $urlParts['port'] : null;
+        $baseUrlPort = isset($baseUrlParts['port']) ? (int) $baseUrlParts['port'] : null;
+
+        return $urlPort === $baseUrlPort;
     }
 }

--- a/plugins/arOidcPlugin/modules/oidc/actions/loginAction.class.php
+++ b/plugins/arOidcPlugin/modules/oidc/actions/loginAction.class.php
@@ -30,8 +30,8 @@ class OidcLoginAction extends sfAction
         // Save referring page URL. The request will be oidc/login but the referrer will be @homepage, or
         // user/list (for example) if the user was attempting to access a secure resource. When redirected
         // back from the OIDC endpoint, the referrer will be empty.
-        if ($request->isMethod('post') && !empty($request->getReferer())) {
-            $this->context->user->setAttribute('atom-login-referer', $request->getReferer());
+        if ($request->isMethod('post') && null !== $redirectUrl = Qubit::filterRedirectTarget($request->getReferer())) {
+            $this->context->user->setAttribute('atom-login-referer', $redirectUrl);
         }
 
         if ($request->isMethod('post') || isset($_REQUEST['code'])) {
@@ -50,7 +50,7 @@ class OidcLoginAction extends sfAction
         // Redirect to module/action the user was trying to reach before being redirected
         // to the OIDC IAM system for authentication. We prefer a redirect to a forward so that the ticket
         // parameter is not accidentally exposed in the user's browser.
-        if (null !== $redirectUrl = $this->context->user->getAttribute('atom-login-referer', null)) {
+        if (null !== $redirectUrl = Qubit::filterRedirectTarget($this->context->user->getAttribute('atom-login-referer', null))) {
             $this->context->user->setAttribute('atom-login-referer', null);
             $this->redirect($redirectUrl);
         }

--- a/plugins/sfTranslatePlugin/modules/sfTranslatePlugin/actions/translateAction.class.php
+++ b/plugins/sfTranslatePlugin/modules/sfTranslatePlugin/actions/translateAction.class.php
@@ -49,6 +49,10 @@ class sfTranslatePluginTranslateAction extends sfAction
 
         $messageSource->getCache()->clean();
 
-        $this->redirect($request->getReferer());
+        if (null !== $redirectUrl = Qubit::filterRedirectTarget($request->getReferer())) {
+            $this->redirect($redirectUrl);
+        }
+
+        $this->redirect('@homepage');
     }
 }

--- a/test/phpunit/lib/QubitRedirectTest.php
+++ b/test/phpunit/lib/QubitRedirectTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @covers \Qubit
+ */
+class QubitRedirectTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        sfConfig::set('app_siteBaseUrl', 'https://atom.example.test');
+    }
+
+    /*
+     * Relative application targets should pass through unchanged when they are
+     * already local and do not contain any disallowed characters.
+     */
+    public function testFilterRedirectTargetAllowsInternalRoute()
+    {
+        $target = 'actor/1';
+
+        $this->assertSame($target, Qubit::filterRedirectTarget($target));
+    }
+
+    public function testFilterRedirectTargetAllowsRootRelativeUrl()
+    {
+        $target = '/index.php/actor/1?sortDir=asc&sort=lastUpdated';
+
+        $this->assertSame($target, Qubit::filterRedirectTarget($target));
+    }
+
+    /*
+     * Absolute URLs are allowed only when they match the configured site base
+     * URL. Matching values are returned unchanged; mismatches are rejected.
+     */
+    public function testFilterRedirectTargetAllowsSameOriginAbsoluteUrl()
+    {
+        $target = 'https://atom.example.test/index.php/actor/1?sortDir=asc&sort=lastUpdated';
+
+        $this->assertSame($target, Qubit::filterRedirectTarget($target));
+    }
+
+    public function testFilterRedirectTargetRejectsExternalAbsoluteUrl()
+    {
+        $target = 'https://external.example.test/index.php/actor/1';
+
+        $this->assertNull(Qubit::filterRedirectTarget($target));
+    }
+
+    public function testFilterRedirectTargetRejectsAbsoluteUrlWhenConfiguredBaseUrlIsMissing()
+    {
+        $target = 'https://atom.example.test/index.php/actor/1';
+        sfConfig::set('app_siteBaseUrl', null);
+
+        $this->assertNull(Qubit::filterRedirectTarget($target));
+    }
+
+    /*
+     * Scheme-based and protocol-relative targets are never safe redirect
+     * values because they can resolve outside the local application.
+     */
+    public function testFilterRedirectTargetRejectsUnsafeSchemesAndProtocolRelativeUrls()
+    {
+        $schemeTarget = 'javascript:alert(1)';
+        $protocolRelativeTarget = '//external.example.test/path';
+
+        $this->assertNull(Qubit::filterRedirectTarget($schemeTarget));
+        $this->assertNull(Qubit::filterRedirectTarget($protocolRelativeTarget));
+    }
+
+    /*
+     * Permissive slug characters supported by routing should remain valid when
+     * they appear inside same-site absolute URLs.
+     */
+    public function testFilterRedirectTargetAllowsSameOriginAbsoluteUrlWithPermissiveUnicodeSlug()
+    {
+        $target = 'https://atom.example.test/index.php/Tést-SLÜG';
+
+        $this->assertSame($target, Qubit::filterRedirectTarget($target));
+    }
+
+    public function testFilterRedirectTargetAllowsSameOriginAbsoluteUrlWithPermissivePunctuationSlug()
+    {
+        $target = 'https://atom.example.test/index.php/a_-~:,=*@b';
+
+        $this->assertSame($target, Qubit::filterRedirectTarget($target));
+    }
+
+    public function testFilterRedirectTargetAllowsSameOriginAbsoluteUrlWithColonInPermissiveSlug()
+    {
+        $target = 'https://atom.example.test/index.php/abc:def';
+
+        // Verify that a colon inside a same-origin slug is preserved as part of
+        // the allowed redirect target rather than being treated as an external URI scheme.
+        $this->assertSame($target, Qubit::filterRedirectTarget($target));
+    }
+
+    /*
+     * Malformed values are rejected early. Empty strings and control characters
+     * are invalid, while query-only and fragment-only values are preserved.
+     */
+    public function testFilterRedirectTargetRejectsControlCharacters()
+    {
+        $target = "actor/1\nLocation: https://external.example.test";
+
+        $this->assertNull(Qubit::filterRedirectTarget($target));
+    }
+
+    public function testFilterRedirectTargetAllowsQueryOnlyAndFragmentOnlyTargets()
+    {
+        $this->assertNull(Qubit::filterRedirectTarget(''));
+        $this->assertSame('?sortDir=asc&sort=lastUpdated', Qubit::filterRedirectTarget('?sortDir=asc&sort=lastUpdated'));
+        $this->assertSame('#content', Qubit::filterRedirectTarget('#content'));
+    }
+}


### PR DESCRIPTION
Use the configured site base URL to validate redirect targets.

Apply the filter to user login, OIDC login return, actor edit, and physical object edit/delete and cancel-link flows.