### PR TITLE
Update XML import parser configuration

### DIFF
--- a/lib/QubitXmlDomDocument.class.php
+++ b/lib/QubitXmlDomDocument.class.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * DOMDocument with parser metadata fields used by AtoM XML import helpers.
+ *
+ * PHP 8.2 deprecates dynamic properties, so declare these fields explicitly.
+ */
+class QubitXmlDomDocument extends DOMDocument
+{
+    public $namespaces = [];
+    public $xpath;
+    public $libxmlerrors = [];
+    public $schemaLocations = [];
+}

--- a/lib/QubitXmlImport.class.php
+++ b/lib/QubitXmlImport.class.php
@@ -535,7 +535,7 @@ class QubitXmlImport
 
         // FIXME: trap possible load validation errors (just suppress for now)
         $err_level = error_reporting(0);
-        $doc = new DOMDocument('1.0', 'UTF-8');
+        $doc = new QubitXmlDomDocument('1.0', 'UTF-8');
 
         // Default $strictXmlParsing to false
         $strictXmlParsing = (isset($options['strictXmlParsing'])) ? $options['strictXmlParsing'] : false;
@@ -547,17 +547,17 @@ class QubitXmlImport
         if ($strictXmlParsing) {
             // enforce all XML parsing rules and validation
             $doc->validateOnParse = true;
-            $doc->resolveExternals = true;
+            $doc->resolveExternals = false;
         } else {
             // try to load whatever we've got, even if it's malformed or invalid
             $doc->recover = true;
             $doc->strictErrorChecking = false;
         }
         $doc->formatOutput = false;
-        $doc->preserveWhitespace = false;
-        $doc->substituteEntities = true;
+        $doc->preserveWhiteSpace = false;
+        $doc->substituteEntities = false;
 
-        $doc->loadXML($this->removeDefaultNamespace($rawXML));
+        $doc->loadXML($this->removeDefaultNamespace($rawXML), LIBXML_NONET);
 
         $xsi = false;
         $doc->namespaces = [];

--- a/lib/oai/QubitOai.class.php
+++ b/lib/oai/QubitOai.class.php
@@ -379,16 +379,17 @@ class QubitOai
         libxml_use_internal_errors(true);
 
         // FIXME: trap possible load validation errors (just suppress for now)
-        $doc = new DOMDocument('1.0', 'UTF-8');
+        $doc = new QubitXmlDomDocument('1.0', 'UTF-8');
 
         // Enforce all XML parsing rules and validation
         $doc->validateOnParse = true;
-        $doc->resolveExternals = true;
+        $doc->resolveExternals = false;
 
         $doc->formatOutput = false;
-        $doc->preserveWhitespace = false;
+        $doc->preserveWhiteSpace = false;
+        $doc->substituteEntities = false;
 
-        $doc->loadXML($XMLString);
+        $doc->loadXML($XMLString, LIBXML_NONET);
 
         $xsi = false;
         $doc->namespaces = [];

--- a/test/phpunit/lib/QubitXmlImportTest.php
+++ b/test/phpunit/lib/QubitXmlImportTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @covers \QubitXmlImport
+ */
+class QubitXmlImportTest extends TestCase
+{
+    public function testLoadXmlDoesNotSubstituteExternalEntities()
+    {
+        // Imported XML must not substitute external entity content into the DOM.
+        $secretFile = tempnam(sys_get_temp_dir(), 'atom-xxe-secret-');
+        $xmlFile = tempnam(sys_get_temp_dir(), 'atom-xxe-import-');
+
+        file_put_contents($secretFile, 'ATOM-XXE-SHOULD-NOT-APPEAR');
+        file_put_contents($xmlFile, sprintf(
+            <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ead [
+  <!ENTITY xxe SYSTEM "file://%s">
+]>
+<ead>
+  <archdesc>
+    <did>
+      <unittitle>&xxe;</unittitle>
+    </did>
+  </archdesc>
+</ead>
+XML,
+            $secretFile
+        ));
+
+        try {
+            $doc = $this->loadXmlWithImporter($xmlFile);
+
+            $this->assertStringNotContainsString(
+                'ATOM-XXE-SHOULD-NOT-APPEAR',
+                $doc->saveXML(),
+                'External entity contents must not be substituted into imported XML.'
+            );
+        } finally {
+            @unlink($secretFile);
+            @unlink($xmlFile);
+        }
+    }
+
+    private function loadXmlWithImporter($xmlFile)
+    {
+        $importer = new QubitXmlImport();
+        $method = new ReflectionMethod(QubitXmlImport::class, 'loadXML');
+        $method->setAccessible(true);
+
+        return $method->invoke($importer, $xmlFile, ['strictXmlParsing' => false]);
+    }
+}

--- a/test/phpunit/lib/oai/QubitOaiTest.php
+++ b/test/phpunit/lib/oai/QubitOaiTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @covers \QubitOai
+ */
+class QubitOaiTest extends TestCase
+{
+    public function testLoadXmlDoesNotResolveExternalEntities()
+    {
+        // OAI XML parsing must not resolve external entity content into the DOM.
+        $secretFile = tempnam(sys_get_temp_dir(), 'atom-oai-xxe-secret-');
+        file_put_contents($secretFile, 'ATOM-OAI-XXE-SHOULD-NOT-APPEAR');
+
+        $xml = sprintf(
+            <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE OAI-PMH [
+  <!ENTITY xxe SYSTEM "file://%s">
+]>
+<OAI-PMH>
+  <responseDate>&xxe;</responseDate>
+</OAI-PMH>
+XML,
+            $secretFile
+        );
+
+        try {
+            $doc = QubitOai::loadXML($xml);
+
+            $this->assertStringNotContainsString(
+                'ATOM-OAI-XXE-SHOULD-NOT-APPEAR',
+                $doc->saveXML(),
+                'External entity contents must not be resolved into OAI XML.'
+            );
+        } finally {
+            @unlink($secretFile);
+        }
+    }
+}


### PR DESCRIPTION
Update XML import and OAI parsing to disable external entity resolution.

Add a small DOMDocument subclass for parser metadata fields used by AtoM, avoiding dynamic property deprecations on newer PHP versions. Add focused parser tests for entity handling.