### PR TITLE
Restrict physical object API creation

### DIFF
--- a/plugins/arRestApiPlugin/modules/api/actions/physicalobjectsCreateAction.class.php
+++ b/plugins/arRestApiPlugin/modules/api/actions/physicalobjectsCreateAction.class.php
@@ -21,6 +21,10 @@ class ApiPhysicalObjectsCreateAction extends QubitApiAction
 {
     protected function post($request, $payload)
     {
+        if (!$this->context->user->hasCredential(['administrator', 'editor', 'contributor'], false)) {
+            throw new QubitApiNotAuthorizedException();
+        }
+
         // Optionally set culture
         $this->culture = 'en';
         if (!empty($payload->culture)) {


### PR DESCRIPTION
Align REST API physical object creation with existing UI permissions. Users require appropriate ACL role before creating physical objects through the API.