### PR TITLE
Batch new i18n inserts

### DIFF
--- a/lib/model/QubitNote.php
+++ b/lib/model/QubitNote.php
@@ -54,6 +54,12 @@ class QubitNote extends BaseNote
 
     public function save($connection = null)
     {
+        // A deleted language note may remain in its parent's loaded notes
+        // collection. Saving the parent must not try to persist it again.
+        if ($this->deleted) {
+            return $this;
+        }
+
         // TODO: $cleanObject = $this->object->clean;
         $cleanObjectId = $this->__get('objectId', ['clean' => true]);
 

--- a/lib/model/om/BaseAccessLog.php
+++ b/lib/model/om/BaseAccessLog.php
@@ -126,7 +126,7 @@ abstract class BaseAccessLog implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {

--- a/lib/model/om/BaseActor.php
+++ b/lib/model/om/BaseActor.php
@@ -90,7 +90,7 @@ abstract class BaseActor extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array('QubitObject::__isset', $args);
+      return parent::__isset(...$args);
     }
     catch (sfException $e)
     {
@@ -149,7 +149,7 @@ abstract class BaseActor extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array('QubitObject::__get', $args);
+      return parent::__get(...$args);
     }
     catch (sfException $e)
     {
@@ -266,7 +266,7 @@ abstract class BaseActor extends QubitObject implements ArrayAccess
       $options = $args[2];
     }
 
-    call_user_func_array('QubitObject::__set', $args);
+    parent::__set(...$args);
 
     call_user_func_array(array($this->getCurrentactorI18n($options), '__set'), $args);
 
@@ -283,7 +283,7 @@ abstract class BaseActor extends QubitObject implements ArrayAccess
       $options = $args[1];
     }
 
-    call_user_func_array('QubitObject::__unset', $args);
+    parent::__unset(...$args);
 
     call_user_func_array(array($this->getCurrentactorI18n($options), '__unset'), $args);
 
@@ -304,12 +304,15 @@ abstract class BaseActor extends QubitObject implements ArrayAccess
   {
     parent::save($connection);
 
+    $actorI18ns = array();
     foreach ($this->actorI18ns as $actorI18n)
     {
       $actorI18n->id = $this->id;
 
-      $actorI18n->save($connection);
+      $actorI18ns[] = $actorI18n;
     }
+
+    QubitActorI18n::bulkSave($actorI18ns, $connection);
 
     return $this;
   }

--- a/lib/model/om/BaseActorI18n.php
+++ b/lib/model/om/BaseActorI18n.php
@@ -152,7 +152,7 @@ abstract class BaseActorI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -358,6 +358,196 @@ abstract class BaseActorI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/lib/model/om/BaseAuditLog.php
+++ b/lib/model/om/BaseAuditLog.php
@@ -132,7 +132,7 @@ abstract class BaseAuditLog implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {

--- a/lib/model/om/BaseClipboardSave.php
+++ b/lib/model/om/BaseClipboardSave.php
@@ -128,7 +128,7 @@ abstract class BaseClipboardSave implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {

--- a/lib/model/om/BaseClipboardSaveItem.php
+++ b/lib/model/om/BaseClipboardSaveItem.php
@@ -128,7 +128,7 @@ abstract class BaseClipboardSaveItem implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {

--- a/lib/model/om/BaseContactInformation.php
+++ b/lib/model/om/BaseContactInformation.php
@@ -154,7 +154,7 @@ abstract class BaseContactInformation implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -286,7 +286,7 @@ abstract class BaseContactInformation implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrentcontactInformationI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrentcontactInformationI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrentcontactInformationI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }
@@ -463,12 +463,15 @@ abstract class BaseContactInformation implements ArrayAccess
     $this->new = false;
     $this->values = array();
 
+    $contactInformationI18ns = array();
     foreach ($this->contactInformationI18ns as $contactInformationI18n)
     {
       $contactInformationI18n->id = $this->id;
 
-      $contactInformationI18n->save($connection);
+      $contactInformationI18ns[] = $contactInformationI18n;
     }
+
+    QubitContactInformationI18n::bulkSave($contactInformationI18ns, $connection);
 
     return $this;
   }

--- a/lib/model/om/BaseContactInformationI18n.php
+++ b/lib/model/om/BaseContactInformationI18n.php
@@ -134,7 +134,7 @@ abstract class BaseContactInformationI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -340,6 +340,196 @@ abstract class BaseContactInformationI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/lib/model/om/BaseDigitalObject.php
+++ b/lib/model/om/BaseDigitalObject.php
@@ -118,7 +118,7 @@ abstract class BaseDigitalObject extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array('QubitObject::__get', $args);
+      return parent::__get(...$args);
     }
     catch (sfException $e)
     {

--- a/lib/model/om/BaseEvent.php
+++ b/lib/model/om/BaseEvent.php
@@ -90,7 +90,7 @@ abstract class BaseEvent extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array('QubitObject::__isset', $args);
+      return parent::__isset(...$args);
     }
     catch (sfException $e)
     {
@@ -129,7 +129,7 @@ abstract class BaseEvent extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array('QubitObject::__get', $args);
+      return parent::__get(...$args);
     }
     catch (sfException $e)
     {
@@ -154,7 +154,7 @@ abstract class BaseEvent extends QubitObject implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrenteventI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrenteventI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrenteventI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }
@@ -178,7 +178,7 @@ abstract class BaseEvent extends QubitObject implements ArrayAccess
       $options = $args[2];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__set'), $args);
+    parent::__set(...$args);
 
     call_user_func_array(array($this->getCurrenteventI18n($options), '__set'), $args);
 
@@ -195,7 +195,7 @@ abstract class BaseEvent extends QubitObject implements ArrayAccess
       $options = $args[1];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__unset'), $args);
+    parent::__unset(...$args);
 
     call_user_func_array(array($this->getCurrenteventI18n($options), '__unset'), $args);
 
@@ -216,12 +216,15 @@ abstract class BaseEvent extends QubitObject implements ArrayAccess
   {
     parent::save($connection);
 
+    $eventI18ns = array();
     foreach ($this->eventI18ns as $eventI18n)
     {
       $eventI18n->id = $this->id;
 
-      $eventI18n->save($connection);
+      $eventI18ns[] = $eventI18n;
     }
+
+    QubitEventI18n::bulkSave($eventI18ns, $connection);
 
     return $this;
   }

--- a/lib/model/om/BaseEventI18n.php
+++ b/lib/model/om/BaseEventI18n.php
@@ -132,7 +132,7 @@ abstract class BaseEventI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -338,6 +338,196 @@ abstract class BaseEventI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/lib/model/om/BaseFunctionObject.php
+++ b/lib/model/om/BaseFunctionObject.php
@@ -86,7 +86,7 @@ abstract class BaseFunctionObject extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__isset'), $args);
+      return parent::__isset(...$args);
     }
     catch (sfException $e)
     {
@@ -125,7 +125,7 @@ abstract class BaseFunctionObject extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__get'), $args);
+      return parent::__get(...$args);
     }
     catch (sfException $e)
     {
@@ -150,7 +150,7 @@ abstract class BaseFunctionObject extends QubitObject implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrentfunctionObjectI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrentfunctionObjectI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrentfunctionObjectI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }
@@ -174,7 +174,7 @@ abstract class BaseFunctionObject extends QubitObject implements ArrayAccess
       $options = $args[2];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__set'), $args);
+    parent::__set(...$args);
 
     call_user_func_array(array($this->getCurrentfunctionObjectI18n($options), '__set'), $args);
 
@@ -191,7 +191,7 @@ abstract class BaseFunctionObject extends QubitObject implements ArrayAccess
       $options = $args[1];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__unset'), $args);
+    parent::__unset(...$args);
 
     call_user_func_array(array($this->getCurrentfunctionObjectI18n($options), '__unset'), $args);
 
@@ -212,12 +212,15 @@ abstract class BaseFunctionObject extends QubitObject implements ArrayAccess
   {
     parent::save($connection);
 
+    $functionObjectI18ns = array();
     foreach ($this->functionObjectI18ns as $functionObjectI18n)
     {
       $functionObjectI18n->id = $this->id;
 
-      $functionObjectI18n->save($connection);
+      $functionObjectI18ns[] = $functionObjectI18n;
     }
+
+    QubitFunctionObjectI18n::bulkSave($functionObjectI18ns, $connection);
 
     return $this;
   }

--- a/lib/model/om/BaseFunctionObjectI18n.php
+++ b/lib/model/om/BaseFunctionObjectI18n.php
@@ -146,7 +146,7 @@ abstract class BaseFunctionObjectI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -352,6 +352,196 @@ abstract class BaseFunctionObjectI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/lib/model/om/BaseGrantedRight.php
+++ b/lib/model/om/BaseGrantedRight.php
@@ -136,7 +136,7 @@ abstract class BaseGrantedRight implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {

--- a/lib/model/om/BaseInformationObject.php
+++ b/lib/model/om/BaseInformationObject.php
@@ -119,7 +119,7 @@ abstract class BaseInformationObject extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array('QubitObject::__isset', $args);
+      return parent::__isset(...$args);
     }
     catch (sfException $e)
     {
@@ -178,7 +178,7 @@ abstract class BaseInformationObject extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array('QubitObject::__get', $args);
+      return parent::__get(...$args);
     }
     catch (sfException $e)
     {
@@ -301,7 +301,7 @@ abstract class BaseInformationObject extends QubitObject implements ArrayAccess
       $options = $args[2];
     }
 
-    call_user_func_array('QubitObject::__set', $args);
+    parent::__set(...$args);
 
     call_user_func_array(array($this->getCurrentinformationObjectI18n($options), '__set'), $args);
 
@@ -318,7 +318,7 @@ abstract class BaseInformationObject extends QubitObject implements ArrayAccess
       $options = $args[1];
     }
 
-    call_user_func_array('QubitObject::__unset', $args);
+    parent::__unset(...$args);
 
     call_user_func_array(array($this->getCurrentinformationObjectI18n($options), '__unset'), $args);
 
@@ -339,12 +339,15 @@ abstract class BaseInformationObject extends QubitObject implements ArrayAccess
   {
     parent::save($connection);
 
+    $informationObjectI18ns = array();
     foreach ($this->informationObjectI18ns as $informationObjectI18n)
     {
       $informationObjectI18n->id = $this->id;
 
-      $informationObjectI18n->save($connection);
+      $informationObjectI18ns[] = $informationObjectI18n;
     }
+
+    QubitInformationObjectI18n::bulkSave($informationObjectI18ns, $connection);
 
     return $this;
   }

--- a/lib/model/om/BaseInformationObjectI18n.php
+++ b/lib/model/om/BaseInformationObjectI18n.php
@@ -168,7 +168,7 @@ abstract class BaseInformationObjectI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -374,6 +374,196 @@ abstract class BaseInformationObjectI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/lib/model/om/BaseKeymap.php
+++ b/lib/model/om/BaseKeymap.php
@@ -132,7 +132,7 @@ abstract class BaseKeymap implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {

--- a/lib/model/om/BaseMenu.php
+++ b/lib/model/om/BaseMenu.php
@@ -157,7 +157,7 @@ abstract class BaseMenu implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -321,7 +321,7 @@ abstract class BaseMenu implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrentmenuI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrentmenuI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrentmenuI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }
@@ -538,12 +538,15 @@ abstract class BaseMenu implements ArrayAccess
     $this->new = false;
     $this->values = array();
 
+    $menuI18ns = array();
     foreach ($this->menuI18ns as $menuI18n)
     {
       $menuI18n->id = $this->id;
 
-      $menuI18n->save($connection);
+      $menuI18ns[] = $menuI18n;
     }
+
+    QubitMenuI18n::bulkSave($menuI18ns, $connection);
 
     return $this;
   }

--- a/lib/model/om/BaseMenuI18n.php
+++ b/lib/model/om/BaseMenuI18n.php
@@ -130,7 +130,7 @@ abstract class BaseMenuI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -336,6 +336,196 @@ abstract class BaseMenuI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/lib/model/om/BaseNote.php
+++ b/lib/model/om/BaseNote.php
@@ -134,7 +134,7 @@ abstract class BaseNote implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -266,7 +266,7 @@ abstract class BaseNote implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrentnoteI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrentnoteI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrentnoteI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }
@@ -409,7 +409,7 @@ abstract class BaseNote implements ArrayAccess
   {
     if ($this->deleted)
     {
-      return $this;
+      throw new PropelException('You cannot save an object that has been deleted.');
     }
 
     if ($this->new)
@@ -443,12 +443,15 @@ abstract class BaseNote implements ArrayAccess
     $this->new = false;
     $this->values = array();
 
+    $noteI18ns = array();
     foreach ($this->noteI18ns as $noteI18n)
     {
       $noteI18n->id = $this->id;
 
-      $noteI18n->save($connection);
+      $noteI18ns[] = $noteI18n;
     }
+
+    QubitNoteI18n::bulkSave($noteI18ns, $connection);
 
     return $this;
   }

--- a/lib/model/om/BaseNoteI18n.php
+++ b/lib/model/om/BaseNoteI18n.php
@@ -128,7 +128,7 @@ abstract class BaseNoteI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -334,6 +334,196 @@ abstract class BaseNoteI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/lib/model/om/BaseOaiHarvest.php
+++ b/lib/model/om/BaseOaiHarvest.php
@@ -140,7 +140,7 @@ abstract class BaseOaiHarvest implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {

--- a/lib/model/om/BaseOaiRepository.php
+++ b/lib/model/om/BaseOaiRepository.php
@@ -136,7 +136,7 @@ abstract class BaseOaiRepository implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {

--- a/lib/model/om/BaseObject.php
+++ b/lib/model/om/BaseObject.php
@@ -263,7 +263,6 @@ abstract class BaseObject implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
-
   #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
@@ -561,7 +560,6 @@ abstract class BaseObject implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
-
   #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
@@ -616,7 +614,6 @@ abstract class BaseObject implements ArrayAccess
 
     return $this;
   }
-
 
   #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)

--- a/lib/model/om/BaseOtherName.php
+++ b/lib/model/om/BaseOtherName.php
@@ -134,7 +134,7 @@ abstract class BaseOtherName implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -266,7 +266,7 @@ abstract class BaseOtherName implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrentotherNameI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrentotherNameI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrentotherNameI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }
@@ -443,12 +443,15 @@ abstract class BaseOtherName implements ArrayAccess
     $this->new = false;
     $this->values = array();
 
+    $otherNameI18ns = array();
     foreach ($this->otherNameI18ns as $otherNameI18n)
     {
       $otherNameI18n->id = $this->id;
 
-      $otherNameI18n->save($connection);
+      $otherNameI18ns[] = $otherNameI18n;
     }
+
+    QubitOtherNameI18n::bulkSave($otherNameI18ns, $connection);
 
     return $this;
   }

--- a/lib/model/om/BaseOtherNameI18n.php
+++ b/lib/model/om/BaseOtherNameI18n.php
@@ -132,7 +132,7 @@ abstract class BaseOtherNameI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -338,6 +338,196 @@ abstract class BaseOtherNameI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/lib/model/om/BasePhysicalObject.php
+++ b/lib/model/om/BasePhysicalObject.php
@@ -78,7 +78,7 @@ abstract class BasePhysicalObject extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array('QubitObject::__isset', $args);
+      return parent::__isset(...$args);
     }
     catch (sfException $e)
     {
@@ -117,7 +117,7 @@ abstract class BasePhysicalObject extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array('QubitObject::__get', $args);
+      return parent::__get(...$args);
     }
     catch (sfException $e)
     {
@@ -142,7 +142,7 @@ abstract class BasePhysicalObject extends QubitObject implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrentphysicalObjectI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrentphysicalObjectI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrentphysicalObjectI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }
@@ -166,7 +166,7 @@ abstract class BasePhysicalObject extends QubitObject implements ArrayAccess
       $options = $args[2];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__set'), $args);
+    parent::__set(...$args);
 
     call_user_func_array(array($this->getCurrentphysicalObjectI18n($options), '__set'), $args);
 
@@ -183,7 +183,7 @@ abstract class BasePhysicalObject extends QubitObject implements ArrayAccess
       $options = $args[1];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__unset'), $args);
+    parent::__unset(...$args);
 
     call_user_func_array(array($this->getCurrentphysicalObjectI18n($options), '__unset'), $args);
 
@@ -204,12 +204,15 @@ abstract class BasePhysicalObject extends QubitObject implements ArrayAccess
   {
     parent::save($connection);
 
+    $physicalObjectI18ns = array();
     foreach ($this->physicalObjectI18ns as $physicalObjectI18n)
     {
       $physicalObjectI18n->id = $this->id;
 
-      $physicalObjectI18n->save($connection);
+      $physicalObjectI18ns[] = $physicalObjectI18n;
     }
+
+    QubitPhysicalObjectI18n::bulkSave($physicalObjectI18ns, $connection);
 
     return $this;
   }

--- a/lib/model/om/BasePhysicalObjectI18n.php
+++ b/lib/model/om/BasePhysicalObjectI18n.php
@@ -132,7 +132,7 @@ abstract class BasePhysicalObjectI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -338,6 +338,196 @@ abstract class BasePhysicalObjectI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/lib/model/om/BaseProperty.php
+++ b/lib/model/om/BaseProperty.php
@@ -132,7 +132,7 @@ abstract class BaseProperty implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -441,12 +441,15 @@ abstract class BaseProperty implements ArrayAccess
     $this->new = false;
     $this->values = array();
 
+    $propertyI18ns = array();
     foreach ($this->propertyI18ns as $propertyI18n)
     {
       $propertyI18n->id = $this->id;
 
-      $propertyI18n->save($connection);
+      $propertyI18ns[] = $propertyI18n;
     }
+
+    QubitPropertyI18n::bulkSave($propertyI18ns, $connection);
 
     return $this;
   }

--- a/lib/model/om/BasePropertyI18n.php
+++ b/lib/model/om/BasePropertyI18n.php
@@ -128,7 +128,7 @@ abstract class BasePropertyI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -334,6 +334,196 @@ abstract class BasePropertyI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/lib/model/om/BaseRelation.php
+++ b/lib/model/om/BaseRelation.php
@@ -86,7 +86,7 @@ abstract class BaseRelation extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__isset'), $args);
+      return parent::__isset(...$args);
     }
     catch (sfException $e)
     {
@@ -125,7 +125,7 @@ abstract class BaseRelation extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array('QubitObject::__get', $args);
+      return parent::__get(...$args);
     }
     catch (sfException $e)
     {
@@ -150,7 +150,7 @@ abstract class BaseRelation extends QubitObject implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrentrelationI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrentrelationI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrentrelationI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }
@@ -174,7 +174,7 @@ abstract class BaseRelation extends QubitObject implements ArrayAccess
       $options = $args[2];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__set'), $args);
+    parent::__set(...$args);
 
     call_user_func_array(array($this->getCurrentrelationI18n($options), '__set'), $args);
 
@@ -191,7 +191,7 @@ abstract class BaseRelation extends QubitObject implements ArrayAccess
       $options = $args[1];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__unset'), $args);
+    parent::__unset(...$args);
 
     call_user_func_array(array($this->getCurrentrelationI18n($options), '__unset'), $args);
 
@@ -212,12 +212,15 @@ abstract class BaseRelation extends QubitObject implements ArrayAccess
   {
     parent::save($connection);
 
+    $relationI18ns = array();
     foreach ($this->relationI18ns as $relationI18n)
     {
       $relationI18n->id = $this->id;
 
-      $relationI18n->save($connection);
+      $relationI18ns[] = $relationI18n;
     }
+
+    QubitRelationI18n::bulkSave($relationI18ns, $connection);
 
     return $this;
   }

--- a/lib/model/om/BaseRelationI18n.php
+++ b/lib/model/om/BaseRelationI18n.php
@@ -130,7 +130,7 @@ abstract class BaseRelationI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -336,6 +336,196 @@ abstract class BaseRelationI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/lib/model/om/BaseRepository.php
+++ b/lib/model/om/BaseRepository.php
@@ -86,7 +86,7 @@ abstract class BaseRepository extends QubitActor implements ArrayAccess
 
     try
     {
-      return call_user_func_array('QubitActor::__isset', $args);
+      return parent::__isset(...$args);
     }
     catch (sfException $e)
     {
@@ -130,7 +130,7 @@ abstract class BaseRepository extends QubitActor implements ArrayAccess
 
     try
     {
-      return call_user_func_array('QubitActor::__get', $args);
+      return parent::__get(...$args);
     }
     catch (sfException $e)
     {
@@ -172,7 +172,7 @@ abstract class BaseRepository extends QubitActor implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrentrepositoryI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrentrepositoryI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrentrepositoryI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }
@@ -196,7 +196,7 @@ abstract class BaseRepository extends QubitActor implements ArrayAccess
       $options = $args[2];
     }
 
-    call_user_func_array('QubitActor::__set', $args);
+    parent::__set(...$args);
 
     call_user_func_array(array($this->getCurrentrepositoryI18n($options), '__set'), $args);
 
@@ -213,7 +213,7 @@ abstract class BaseRepository extends QubitActor implements ArrayAccess
       $options = $args[1];
     }
 
-    call_user_func_array('QubitActor::__unset', $args);
+    parent::__unset(...$args);
 
     call_user_func_array(array($this->getCurrentrepositoryI18n($options), '__unset'), $args);
 
@@ -234,12 +234,15 @@ abstract class BaseRepository extends QubitActor implements ArrayAccess
   {
     parent::save($connection);
 
+    $repositoryI18ns = array();
     foreach ($this->repositoryI18ns as $repositoryI18n)
     {
       $repositoryI18n->id = $this->id;
 
-      $repositoryI18n->save($connection);
+      $repositoryI18ns[] = $repositoryI18n;
     }
+
+    QubitRepositoryI18n::bulkSave($repositoryI18ns, $connection);
 
     return $this;
   }

--- a/lib/model/om/BaseRepositoryI18n.php
+++ b/lib/model/om/BaseRepositoryI18n.php
@@ -156,7 +156,7 @@ abstract class BaseRepositoryI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -362,6 +362,196 @@ abstract class BaseRepositoryI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/lib/model/om/BaseRights.php
+++ b/lib/model/om/BaseRights.php
@@ -94,7 +94,7 @@ abstract class BaseRights extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__isset'), $args);
+      return parent::__isset(...$args);
     }
     catch (sfException $e)
     {
@@ -138,7 +138,7 @@ abstract class BaseRights extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__get'), $args);
+      return parent::__get(...$args);
     }
     catch (sfException $e)
     {
@@ -180,7 +180,7 @@ abstract class BaseRights extends QubitObject implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrentrightsI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrentrightsI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrentrightsI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }
@@ -204,7 +204,7 @@ abstract class BaseRights extends QubitObject implements ArrayAccess
       $options = $args[2];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__set'), $args);
+    parent::__set(...$args);
 
     call_user_func_array(array($this->getCurrentrightsI18n($options), '__set'), $args);
 
@@ -221,7 +221,7 @@ abstract class BaseRights extends QubitObject implements ArrayAccess
       $options = $args[1];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__unset'), $args);
+    parent::__unset(...$args);
 
     call_user_func_array(array($this->getCurrentrightsI18n($options), '__unset'), $args);
 
@@ -242,12 +242,15 @@ abstract class BaseRights extends QubitObject implements ArrayAccess
   {
     parent::save($connection);
 
+    $rightsI18ns = array();
     foreach ($this->rightsI18ns as $rightsI18n)
     {
       $rightsI18n->id = $this->id;
 
-      $rightsI18n->save($connection);
+      $rightsI18ns[] = $rightsI18n;
     }
+
+    QubitRightsI18n::bulkSave($rightsI18ns, $connection);
 
     return $this;
   }

--- a/lib/model/om/BaseRightsI18n.php
+++ b/lib/model/om/BaseRightsI18n.php
@@ -144,7 +144,7 @@ abstract class BaseRightsI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -350,6 +350,196 @@ abstract class BaseRightsI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/lib/model/om/BaseSetting.php
+++ b/lib/model/om/BaseSetting.php
@@ -134,7 +134,7 @@ abstract class BaseSetting implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -266,7 +266,7 @@ abstract class BaseSetting implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrentsettingI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrentsettingI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrentsettingI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }
@@ -443,12 +443,15 @@ abstract class BaseSetting implements ArrayAccess
     $this->new = false;
     $this->values = array();
 
+    $settingI18ns = array();
     foreach ($this->settingI18ns as $settingI18n)
     {
       $settingI18n->id = $this->id;
 
-      $settingI18n->save($connection);
+      $settingI18ns[] = $settingI18n;
     }
+
+    QubitSettingI18n::bulkSave($settingI18ns, $connection);
 
     return $this;
   }

--- a/lib/model/om/BaseSettingI18n.php
+++ b/lib/model/om/BaseSettingI18n.php
@@ -128,7 +128,7 @@ abstract class BaseSettingI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -334,6 +334,196 @@ abstract class BaseSettingI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/lib/model/om/BaseSlug.php
+++ b/lib/model/om/BaseSlug.php
@@ -128,7 +128,7 @@ abstract class BaseSlug implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {

--- a/lib/model/om/BaseStaticPage.php
+++ b/lib/model/om/BaseStaticPage.php
@@ -76,7 +76,7 @@ abstract class BaseStaticPage extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array('QubitObject::__isset', $args);
+      return parent::__isset(...$args);
     }
     catch (sfException $e)
     {
@@ -115,7 +115,7 @@ abstract class BaseStaticPage extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array('QubitObject::__get', $args);
+      return parent::__get(...$args);
     }
     catch (sfException $e)
     {
@@ -140,7 +140,7 @@ abstract class BaseStaticPage extends QubitObject implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrentstaticPageI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrentstaticPageI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrentstaticPageI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }
@@ -164,7 +164,7 @@ abstract class BaseStaticPage extends QubitObject implements ArrayAccess
       $options = $args[2];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__set'), $args);
+    parent::__set(...$args);
 
     call_user_func_array(array($this->getCurrentstaticPageI18n($options), '__set'), $args);
 
@@ -181,7 +181,7 @@ abstract class BaseStaticPage extends QubitObject implements ArrayAccess
       $options = $args[1];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__unset'), $args);
+    parent::__unset(...$args);
 
     call_user_func_array(array($this->getCurrentstaticPageI18n($options), '__unset'), $args);
 
@@ -202,12 +202,15 @@ abstract class BaseStaticPage extends QubitObject implements ArrayAccess
   {
     parent::save($connection);
 
+    $staticPageI18ns = array();
     foreach ($this->staticPageI18ns as $staticPageI18n)
     {
       $staticPageI18n->id = $this->id;
 
-      $staticPageI18n->save($connection);
+      $staticPageI18ns[] = $staticPageI18n;
     }
+
+    QubitStaticPageI18n::bulkSave($staticPageI18ns, $connection);
 
     return $this;
   }

--- a/lib/model/om/BaseStaticPageI18n.php
+++ b/lib/model/om/BaseStaticPageI18n.php
@@ -130,7 +130,7 @@ abstract class BaseStaticPageI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -336,6 +336,196 @@ abstract class BaseStaticPageI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/lib/model/om/BaseStatus.php
+++ b/lib/model/om/BaseStatus.php
@@ -130,7 +130,7 @@ abstract class BaseStatus implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {

--- a/lib/model/om/BaseTaxonomy.php
+++ b/lib/model/om/BaseTaxonomy.php
@@ -80,7 +80,7 @@ abstract class BaseTaxonomy extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array('QubitObject::__isset', $args);
+      return parent::__isset(...$args);
     }
     catch (sfException $e)
     {
@@ -129,7 +129,7 @@ abstract class BaseTaxonomy extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array( 'QubitObject::__get', $args);
+      return parent::__get(...$args);
     }
     catch (sfException $e)
     {
@@ -188,7 +188,7 @@ abstract class BaseTaxonomy extends QubitObject implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrenttaxonomyI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrenttaxonomyI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrenttaxonomyI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }
@@ -212,7 +212,7 @@ abstract class BaseTaxonomy extends QubitObject implements ArrayAccess
       $options = $args[2];
     }
 
-    call_user_func_array('QubitObject::__set', $args);
+    parent::__set(...$args);
 
     call_user_func_array(array($this->getCurrenttaxonomyI18n($options), '__set'), $args);
 
@@ -229,7 +229,7 @@ abstract class BaseTaxonomy extends QubitObject implements ArrayAccess
       $options = $args[1];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__unset'), $args);
+    parent::__unset(...$args);
 
     call_user_func_array(array($this->getCurrenttaxonomyI18n($options), '__unset'), $args);
 
@@ -250,12 +250,15 @@ abstract class BaseTaxonomy extends QubitObject implements ArrayAccess
   {
     parent::save($connection);
 
+    $taxonomyI18ns = array();
     foreach ($this->taxonomyI18ns as $taxonomyI18n)
     {
       $taxonomyI18n->id = $this->id;
 
-      $taxonomyI18n->save($connection);
+      $taxonomyI18ns[] = $taxonomyI18n;
     }
+
+    QubitTaxonomyI18n::bulkSave($taxonomyI18ns, $connection);
 
     return $this;
   }

--- a/lib/model/om/BaseTaxonomyI18n.php
+++ b/lib/model/om/BaseTaxonomyI18n.php
@@ -130,7 +130,7 @@ abstract class BaseTaxonomyI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -187,7 +187,6 @@ abstract class BaseTaxonomyI18n implements ArrayAccess
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
 
-
   #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
@@ -229,7 +228,6 @@ abstract class BaseTaxonomyI18n implements ArrayAccess
 
     throw new sfException("Unknown record property \"$name\" on \"".get_class($this).'"');
   }
-
 
   #[\ReturnTypeWillChange]
   public function offsetGet($offset)
@@ -286,7 +284,6 @@ abstract class BaseTaxonomyI18n implements ArrayAccess
     return $this;
   }
 
-
   #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
@@ -339,6 +336,196 @@ abstract class BaseTaxonomyI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/lib/model/om/BaseTerm.php
+++ b/lib/model/om/BaseTerm.php
@@ -103,7 +103,7 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array('QubitObject::__isset', $args);
+      return parent::__isset(...$args);
     }
     catch (sfException $e)
     {
@@ -337,7 +337,7 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array('QubitObject::__get', $args);
+      return parent::__get(...$args);
     }
     catch (sfException $e)
     {
@@ -991,7 +991,7 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrenttermI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrenttermI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrenttermI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }
@@ -1055,7 +1055,7 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
       $options = $args[2];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__set'), $args);
+    parent::__set(...$args);
 
     call_user_func_array(array($this->getCurrenttermI18n($options), '__set'), $args);
 
@@ -1072,7 +1072,7 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
       $options = $args[1];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__unset'), $args);
+    parent::__unset(...$args);
 
     call_user_func_array(array($this->getCurrenttermI18n($options), '__unset'), $args);
 
@@ -1093,12 +1093,15 @@ abstract class BaseTerm extends QubitObject implements ArrayAccess
   {
     parent::save($connection);
 
+    $termI18ns = array();
     foreach ($this->termI18ns as $termI18n)
     {
       $termI18n->id = $this->id;
 
-      $termI18n->save($connection);
+      $termI18ns[] = $termI18n;
     }
+
+    QubitTermI18n::bulkSave($termI18ns, $connection);
 
     return $this;
   }

--- a/lib/model/om/BaseTermI18n.php
+++ b/lib/model/om/BaseTermI18n.php
@@ -128,7 +128,7 @@ abstract class BaseTermI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -334,6 +334,196 @@ abstract class BaseTermI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/lib/model/om/BaseUser.php
+++ b/lib/model/om/BaseUser.php
@@ -78,7 +78,7 @@ abstract class BaseUser extends QubitActor implements ArrayAccess
 
     try
     {
-      return call_user_func_array('QubitActor::__isset', $args);
+      return parent::__isset(...$args);
     }
     catch (sfException $e)
     {
@@ -129,7 +129,7 @@ abstract class BaseUser extends QubitActor implements ArrayAccess
 
     try
     {
-      return call_user_func_array('QubitActor::__get', $args);
+      return parent::__get(...$args);
     }
     catch (sfException $e)
     {

--- a/lib/propel/builder/QubitObjectBuilder.php
+++ b/lib/propel/builder/QubitObjectBuilder.php
@@ -100,7 +100,7 @@ class QubitObjectBuilder extends PHP5ObjectBuilder
         return $this->getBuildProperty('basePrefix').ucfirst($this->getTable()->getPhpName());
     }
 
-    public function getColumnConstant(Column $column)
+    public function getColumnConstant($column, $classname = null)
     {
         return "{$this->getPeerClassName()}::".strtoupper($column->getName());
     }
@@ -148,7 +148,7 @@ class QubitObjectBuilder extends PHP5ObjectBuilder
             $names[] = ucfirst($column->getPhpName());
         }
 
-        return 'getBy'.implode($names, 'And');
+        return 'getBy'.implode('And', $names);
     }
 
     protected function getVarName($plural = null)
@@ -206,6 +206,10 @@ script;
         if (!isset($this->inheritanceFk)) {
             $this->addNew($script);
             $this->addDeleted($script);
+        }
+
+        if (isset($this->cultureColumn)) {
+            $this->addBulkSave($script);
         }
 
         $this->addManipulationMethods($script);
@@ -687,7 +691,7 @@ adds;
       return \$this->keys[\$name];
     }
 
-    if (!array_key_exists(\$offset, \$this->row))
+    if (is_array(\$this->row) && !array_key_exists(\$offset, \$this->row))
     {
       if (\$this->new)
       {
@@ -736,12 +740,12 @@ script;
         }
 
         if (isset($this->inheritanceFk)) {
-            $script .= <<<script
+            $script .= <<<'script'
     try
     {
-      return call_user_func_array(array(\$this, '{$this->baseClassName}::__isset'), \$args);
+      return parent::__isset(...$args);
     }
-    catch (sfException \$e)
+    catch (sfException $e)
     {
     }
 
@@ -828,6 +832,7 @@ script;
         if (!isset($this->inheritanceFk)) {
             $script .= <<<'script'
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     $args = func_get_args();
@@ -860,12 +865,12 @@ script;
         }
 
         if (isset($this->inheritanceFk)) {
-            $script .= <<<script
+            $script .= <<<'script'
     try
     {
-      return call_user_func_array(array(\$this, '{$this->baseClassName}::__get'), \$args);
+      return parent::__get(...$args);
     }
-    catch (sfException \$e)
+    catch (sfException $e)
     {
     }
 
@@ -935,7 +940,7 @@ script;
 
     try
     {
-      if (1 > strlen(\$value = call_user_func_array(array(\$this->getCurrent{$this->getRefFkPhpNameAffix($this->i18nFk)}(\$options), '__get'), \$args)) && !empty(\$options['cultureFallback']))
+      if (1 > strlen((string) \$value = call_user_func_array(array(\$this->getCurrent{$this->getRefFkPhpNameAffix($this->i18nFk)}(\$options), '__get'), \$args)) && !empty(\$options['cultureFallback']))
       {
         return call_user_func_array(array(\$this->getCurrent{$this->getRefFkPhpNameAffix($this->i18nFk)}(array('sourceCulture' => true) + \$options), '__get'), \$args);
       }
@@ -1005,6 +1010,7 @@ script;
         if (!isset($this->inheritanceFk)) {
             $script .= <<<'script'
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     $args = func_get_args();
@@ -1033,8 +1039,8 @@ script;
         }
 
         if (isset($this->inheritanceFk) && $this->getTable()->getAttribute('isI18n')) {
-            $script .= <<<script
-    call_user_func_array(array(\$this, '{$this->baseClassName}::__set'), \$args);
+            $script .= <<<'script'
+    parent::__set(...$args);
 
 script;
         }
@@ -1098,6 +1104,7 @@ script;
         if (!isset($this->inheritanceFk)) {
             $script .= <<<'script'
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $args = func_get_args();
@@ -1132,8 +1139,8 @@ script;
         }
 
         if (isset($this->inheritanceFk) && $this->getTable()->getAttribute('isI18n')) {
-            $script .= <<<script
-    call_user_func_array(array(\$this, '{$this->baseClassName}::__unset'), \$args);
+            $script .= <<<'script'
+    parent::__unset(...$args);
 
 script;
         }
@@ -1182,6 +1189,7 @@ script;
         if (!isset($this->inheritanceFk)) {
             $script .= <<<'script'
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $args = func_get_args();
@@ -1332,14 +1340,19 @@ script;
             }
             $sets = implode("\n", $sets);
 
+            $i18nObjectClassName = self::getNewObjectBuilder($this->i18nFk->getTable())->getObjectClassName();
+
             $script .= <<<script
 
+    \${$this->getRefFkCollVarName($this->i18nFk)} = array();
     foreach (\$this->{$this->getRefFkCollVarName($this->i18nFk)} as \${$foreignPeerBuilder->getVarName()})
     {
 {$sets}
 
-      \${$foreignPeerBuilder->getVarName()}->save(\$connection);
+      \${$this->getRefFkCollVarName($this->i18nFk)}[] = \${$foreignPeerBuilder->getVarName()};
     }
+
+    {$i18nObjectClassName}::bulkSave(\${$this->getRefFkCollVarName($this->i18nFk)}, \$connection);
 
 script;
         }
@@ -1475,6 +1488,203 @@ script;
         $script .= <<<'script'
 
     return $this;
+  }
+
+script;
+    }
+
+    protected function addBulkSave(&$script)
+    {
+        $script .= <<<'script'
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
   }
 
 script;

--- a/plugins/qbAclPlugin/lib/model/om/BaseAclGroup.php
+++ b/plugins/qbAclPlugin/lib/model/om/BaseAclGroup.php
@@ -132,7 +132,7 @@ abstract class BaseAclGroup implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -330,7 +330,7 @@ abstract class BaseAclGroup implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrentaclGroupI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrentaclGroupI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrentaclGroupI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }
@@ -507,12 +507,15 @@ abstract class BaseAclGroup implements ArrayAccess
     $this->new = false;
     $this->values = array();
 
+    $aclGroupI18ns = array();
     foreach ($this->aclGroupI18ns as $aclGroupI18n)
     {
       $aclGroupI18n->id = $this->id;
 
-      $aclGroupI18n->save($connection);
+      $aclGroupI18ns[] = $aclGroupI18n;
     }
+
+    QubitAclGroupI18n::bulkSave($aclGroupI18ns, $connection);
 
     return $this;
   }

--- a/plugins/qbAclPlugin/lib/model/om/BaseAclGroupI18n.php
+++ b/plugins/qbAclPlugin/lib/model/om/BaseAclGroupI18n.php
@@ -130,7 +130,7 @@ abstract class BaseAclGroupI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -336,6 +336,196 @@ abstract class BaseAclGroupI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/plugins/qbAclPlugin/lib/model/om/BaseAclPermission.php
+++ b/plugins/qbAclPlugin/lib/model/om/BaseAclPermission.php
@@ -142,7 +142,7 @@ abstract class BaseAclPermission implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {

--- a/plugins/qbAclPlugin/lib/model/om/BaseAclUserGroup.php
+++ b/plugins/qbAclPlugin/lib/model/om/BaseAclUserGroup.php
@@ -128,7 +128,7 @@ abstract class BaseAclUserGroup implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {

--- a/plugins/qtAccessionPlugin/lib/model/om/BaseAccession.php
+++ b/plugins/qtAccessionPlugin/lib/model/om/BaseAccession.php
@@ -92,7 +92,7 @@ abstract class BaseAccession extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__isset'), $args);
+      return parent::__isset(...$args);
     }
     catch (sfException $e)
     {
@@ -141,7 +141,7 @@ abstract class BaseAccession extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__get'), $args);
+      return parent::__get(...$args);
     }
     catch (sfException $e)
     {
@@ -200,7 +200,7 @@ abstract class BaseAccession extends QubitObject implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrentaccessionI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrentaccessionI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrentaccessionI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }
@@ -224,7 +224,7 @@ abstract class BaseAccession extends QubitObject implements ArrayAccess
       $options = $args[2];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__set'), $args);
+    parent::__set(...$args);
 
     call_user_func_array(array($this->getCurrentaccessionI18n($options), '__set'), $args);
 
@@ -241,7 +241,7 @@ abstract class BaseAccession extends QubitObject implements ArrayAccess
       $options = $args[1];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__unset'), $args);
+    parent::__unset(...$args);
 
     call_user_func_array(array($this->getCurrentaccessionI18n($options), '__unset'), $args);
 
@@ -262,12 +262,15 @@ abstract class BaseAccession extends QubitObject implements ArrayAccess
   {
     parent::save($connection);
 
+    $accessionI18ns = array();
     foreach ($this->accessionI18ns as $accessionI18n)
     {
       $accessionI18n->id = $this->id;
 
-      $accessionI18n->save($connection);
+      $accessionI18ns[] = $accessionI18n;
     }
+
+    QubitAccessionI18n::bulkSave($accessionI18ns, $connection);
 
     return $this;
   }

--- a/plugins/qtAccessionPlugin/lib/model/om/BaseAccessionEvent.php
+++ b/plugins/qtAccessionPlugin/lib/model/om/BaseAccessionEvent.php
@@ -82,7 +82,7 @@ abstract class BaseAccessionEvent extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__isset'), $args);
+      return parent::__isset(...$args);
     }
     catch (sfException $e)
     {
@@ -121,7 +121,7 @@ abstract class BaseAccessionEvent extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__get'), $args);
+      return parent::__get(...$args);
     }
     catch (sfException $e)
     {
@@ -146,7 +146,7 @@ abstract class BaseAccessionEvent extends QubitObject implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrentaccessionEventI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrentaccessionEventI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrentaccessionEventI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }
@@ -170,7 +170,7 @@ abstract class BaseAccessionEvent extends QubitObject implements ArrayAccess
       $options = $args[2];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__set'), $args);
+    parent::__set(...$args);
 
     call_user_func_array(array($this->getCurrentaccessionEventI18n($options), '__set'), $args);
 
@@ -187,7 +187,7 @@ abstract class BaseAccessionEvent extends QubitObject implements ArrayAccess
       $options = $args[1];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__unset'), $args);
+    parent::__unset(...$args);
 
     call_user_func_array(array($this->getCurrentaccessionEventI18n($options), '__unset'), $args);
 
@@ -208,12 +208,15 @@ abstract class BaseAccessionEvent extends QubitObject implements ArrayAccess
   {
     parent::save($connection);
 
+    $accessionEventI18ns = array();
     foreach ($this->accessionEventI18ns as $accessionEventI18n)
     {
       $accessionEventI18n->id = $this->id;
 
-      $accessionEventI18n->save($connection);
+      $accessionEventI18ns[] = $accessionEventI18n;
     }
+
+    QubitAccessionEventI18n::bulkSave($accessionEventI18ns, $connection);
 
     return $this;
   }

--- a/plugins/qtAccessionPlugin/lib/model/om/BaseAccessionEventI18n.php
+++ b/plugins/qtAccessionPlugin/lib/model/om/BaseAccessionEventI18n.php
@@ -128,7 +128,7 @@ abstract class BaseAccessionEventI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -334,6 +334,196 @@ abstract class BaseAccessionEventI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/plugins/qtAccessionPlugin/lib/model/om/BaseAccessionI18n.php
+++ b/plugins/qtAccessionPlugin/lib/model/om/BaseAccessionI18n.php
@@ -144,7 +144,7 @@ abstract class BaseAccessionI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -350,6 +350,196 @@ abstract class BaseAccessionI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/plugins/qtAccessionPlugin/lib/model/om/BaseDeaccession.php
+++ b/plugins/qtAccessionPlugin/lib/model/om/BaseDeaccession.php
@@ -88,7 +88,7 @@ abstract class BaseDeaccession extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__isset'), $args);
+      return parent::__isset(...$args);
     }
     catch (sfException $e)
     {
@@ -127,7 +127,7 @@ abstract class BaseDeaccession extends QubitObject implements ArrayAccess
 
     try
     {
-      return call_user_func_array(array($this, 'QubitObject::__get'), $args);
+      return parent::__get(...$args);
     }
     catch (sfException $e)
     {
@@ -152,7 +152,7 @@ abstract class BaseDeaccession extends QubitObject implements ArrayAccess
 
     try
     {
-      if (1 > strlen($value = call_user_func_array(array($this->getCurrentdeaccessionI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
+      if (1 > strlen((string) $value = call_user_func_array(array($this->getCurrentdeaccessionI18n($options), '__get'), $args)) && !empty($options['cultureFallback']))
       {
         return call_user_func_array(array($this->getCurrentdeaccessionI18n(array('sourceCulture' => true) + $options), '__get'), $args);
       }
@@ -176,7 +176,7 @@ abstract class BaseDeaccession extends QubitObject implements ArrayAccess
       $options = $args[2];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__set'), $args);
+    parent::__set(...$args);
 
     call_user_func_array(array($this->getCurrentdeaccessionI18n($options), '__set'), $args);
 
@@ -193,7 +193,7 @@ abstract class BaseDeaccession extends QubitObject implements ArrayAccess
       $options = $args[1];
     }
 
-    call_user_func_array(array($this, 'QubitObject::__unset'), $args);
+    parent::__unset(...$args);
 
     call_user_func_array(array($this->getCurrentdeaccessionI18n($options), '__unset'), $args);
 
@@ -214,12 +214,15 @@ abstract class BaseDeaccession extends QubitObject implements ArrayAccess
   {
     parent::save($connection);
 
+    $deaccessionI18ns = array();
     foreach ($this->deaccessionI18ns as $deaccessionI18n)
     {
       $deaccessionI18n->id = $this->id;
 
-      $deaccessionI18n->save($connection);
+      $deaccessionI18ns[] = $deaccessionI18n;
     }
+
+    QubitDeaccessionI18n::bulkSave($deaccessionI18ns, $connection);
 
     return $this;
   }

--- a/plugins/qtAccessionPlugin/lib/model/om/BaseDeaccessionI18n.php
+++ b/plugins/qtAccessionPlugin/lib/model/om/BaseDeaccessionI18n.php
@@ -132,7 +132,7 @@ abstract class BaseDeaccessionI18n implements ArrayAccess
       return $this->keys[$name];
     }
 
-    if (!array_key_exists($offset, $this->row))
+    if (is_array($this->row) && !array_key_exists($offset, $this->row))
     {
       if ($this->new)
       {
@@ -338,6 +338,196 @@ abstract class BaseDeaccessionI18n implements ArrayAccess
 
   protected
     $deleted = false;
+
+  /**
+   * Insert new translations in groups that share the same populated columns.
+   *
+   * A multi-row INSERT reduces database round trips when a new record contains
+   * several translations. If any translation already exists, use save() for
+   * every object so updates retain their existing behavior. Grouping by column
+   * set also preserves database defaults for fields omitted from sparse rows.
+   */
+  public static function bulkSave(array $objects, $connection = null)
+  {
+    if (0 == count($objects))
+    {
+      return;
+    }
+
+    if (!isset($connection))
+    {
+      $connection = Propel::getConnection();
+    }
+
+    $hasExistingObjects = false;
+    $newObjects = array();
+    foreach ($objects as $object)
+    {
+      if ($object->deleted)
+      {
+        throw new PropelException('You cannot save an object that has been deleted.');
+      }
+
+      if ($object->new)
+      {
+        $newObjects[] = $object;
+      }
+      else
+      {
+        $hasExistingObjects = true;
+      }
+    }
+
+    if ($hasExistingObjects)
+    {
+      foreach ($objects as $object)
+      {
+        $object->save($connection);
+      }
+
+      return;
+    }
+
+    if (0 == count($newObjects))
+    {
+      return;
+    }
+
+    $databaseMap = Propel::getDatabaseMap(self::DATABASE_NAME);
+    $database = Propel::getDB(self::DATABASE_NAME);
+    $table = $databaseMap->getTable(self::TABLE_NAME);
+    $columns = $table->getColumns();
+    $insertGroups = array();
+    foreach ($newObjects as $object)
+    {
+      $insertColumns = array();
+      $insertParameters = array();
+      foreach ($columns as $column)
+      {
+        if (!array_key_exists($column->getPhpName(), $object->values))
+        {
+          if ('createdAt' == $column->getPhpName() || 'updatedAt' == $column->getPhpName())
+          {
+            $object->values[$column->getPhpName()] = new DateTime;
+          }
+
+          if ('sourceCulture' == $column->getPhpName())
+          {
+            $object->values['sourceCulture'] = sfPropel::getDefaultCulture();
+          }
+        }
+
+        if (array_key_exists($column->getPhpName(), $object->values))
+        {
+          $param = $object->param($column);
+          if (null !== $param)
+          {
+            $insertColumns[$column->getPhpName()] = $column;
+            $insertParameters[$column->getPhpName()] = $param;
+          }
+        }
+      }
+
+      $groupKey = implode("\0", array_keys($insertColumns));
+      if (!isset($insertGroups[$groupKey]))
+      {
+        $insertGroups[$groupKey] = array(
+          'columns' => $insertColumns,
+          'rows' => array(),
+        );
+      }
+
+      $insertGroups[$groupKey]['rows'][] = array(
+        'object' => $object,
+        'parameters' => $insertParameters,
+      );
+    }
+
+    foreach ($insertGroups as $insertGroup)
+    {
+      if (0 == count($insertGroup['columns']))
+      {
+        foreach ($insertGroup['rows'] as $row)
+        {
+          $row['object']->save($connection);
+        }
+
+        continue;
+      }
+
+      $columnNames = array();
+      foreach ($insertGroup['columns'] as $column)
+      {
+        $columnName = $column->getName();
+        if ($database->useQuoteIdentifier())
+        {
+          $columnName = $database->quoteIdentifier($columnName);
+        }
+
+        $columnNames[] = $columnName;
+      }
+
+      $parameterIndex = 1;
+      $placeholders = array();
+      $parameters = array();
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $rowPlaceholders = array();
+        foreach ($insertGroup['columns'] as $column)
+        {
+          $rowPlaceholders[] = ':p'.$parameterIndex++;
+          $parameters[] = array(
+            'column' => $column->getName(),
+            'table' => self::TABLE_NAME,
+            'value' => $row['parameters'][$column->getPhpName()],
+          );
+        }
+
+        $placeholders[] = '('.implode(', ', $rowPlaceholders).')';
+      }
+
+      $sql = 'INSERT INTO '.self::TABLE_NAME.' ('.implode(', ', $columnNames).') VALUES '.implode(', ', $placeholders);
+
+      try
+      {
+        $statement = $connection->prepare($sql);
+        BasePeer::populateStmtValues($statement, $parameters, $databaseMap, $database);
+        $statement->execute();
+      }
+      catch (Exception $e)
+      {
+        Propel::log($e->getMessage(), Propel::LOG_ERR);
+
+        throw new PropelException('Unable to execute INSERT statement.', $e);
+      }
+
+      foreach ($insertGroup['rows'] as $row)
+      {
+        $object = $row['object'];
+        $offset = 0;
+        foreach ($object->tables as $table)
+        {
+          foreach ($table->getColumns() as $column)
+          {
+            if (array_key_exists($column->getPhpName(), $object->values))
+            {
+              $object->row[$offset] = $object->values[$column->getPhpName()];
+            }
+
+            if ($object->new && $column->isPrimaryKey())
+            {
+              $object->keys[$column->getPhpName()] = $object->values[$column->getPhpName()];
+            }
+
+            $offset++;
+          }
+        }
+
+        $object->new = false;
+        $object->values = array();
+      }
+    }
+  }
 
   public function save($connection = null)
   {

--- a/test/phpunit/QubitI18nBulkSaveTest.php
+++ b/test/phpunit/QubitI18nBulkSaveTest.php
@@ -1,0 +1,147 @@
+<?php
+
+use AccessToMemory\test\TransactionTestCase;
+
+/**
+ * @internal
+ *
+ * @covers \BaseActorI18n::bulkSave
+ * @covers \BaseSettingI18n::bulkSave
+ */
+class QubitI18nBulkSaveTest extends TransactionTestCase
+{
+    public function testNewTranslationsUseOneInsertAndRemainPersisted()
+    {
+        $setting = new QubitSetting();
+        $setting->name = 'bulk_save_'.uniqid();
+        $setting->sourceCulture = 'en';
+        $setting->setValue('English', ['culture' => 'en']);
+        $setting->setValue('Français', ['culture' => 'fr']);
+        $setting->setValue('Español', ['culture' => 'es']);
+
+        $insertsBefore = $this->getInsertCount();
+
+        $this->assertSame($setting, $setting->save($this->connection));
+
+        // One INSERT creates the setting and one creates all translations.
+        $this->assertSame(2, $this->getInsertCount() - $insertsBefore);
+        $this->assertSame(
+            [
+                'en' => 'English',
+                'es' => 'Español',
+                'fr' => 'Français',
+            ],
+            $this->getSettingTranslations($setting->id)
+        );
+
+        // Saving the now-clean objects must not insert duplicate translations.
+        $insertsBefore = $this->getInsertCount();
+        $setting->save($this->connection);
+        $this->assertSame($insertsBefore, $this->getInsertCount());
+    }
+
+    public function testMixedNewAndExistingTranslationsUseSaveSemantics()
+    {
+        $setting = new QubitSetting();
+        $setting->name = 'bulk_save_mixed_'.uniqid();
+        $setting->sourceCulture = 'en';
+        $setting->setValue('English', ['culture' => 'en']);
+        $setting->setValue('Español', ['culture' => 'es']);
+        $setting->save($this->connection);
+
+        $setting->setValue('Revised English', ['culture' => 'en']);
+        $setting->setValue('Deutsch', ['culture' => 'de']);
+
+        $insertsBefore = $this->getInsertCount();
+        $setting->save($this->connection);
+
+        $this->assertSame(1, $this->getInsertCount() - $insertsBefore);
+        $this->assertSame(
+            [
+                'de' => 'Deutsch',
+                'en' => 'Revised English',
+                'es' => 'Español',
+            ],
+            $this->getSettingTranslations($setting->id)
+        );
+    }
+
+    public function testSparseTranslationsRetainTheirPopulatedColumns()
+    {
+        $actor = new QubitActor();
+        $actor->indexOnSave = false;
+        $actor->sourceCulture = 'en';
+        $actor->setAuthorizedFormOfName('English name', ['culture' => 'en']);
+        $actor->setHistory('Histoire française', ['culture' => 'fr']);
+        $actor->save($this->connection);
+
+        $statement = $this->connection->prepare(
+            'SELECT culture, authorized_form_of_name, history
+            FROM actor_i18n
+            WHERE id = ?
+            ORDER BY culture'
+        );
+        $statement->execute([$actor->id]);
+
+        $this->assertSame(
+            [
+                [
+                    'culture' => 'en',
+                    'authorized_form_of_name' => 'English name',
+                    'history' => null,
+                ],
+                [
+                    'culture' => 'fr',
+                    'authorized_form_of_name' => null,
+                    'history' => 'Histoire française',
+                ],
+            ],
+            $statement->fetchAll(PDO::FETCH_ASSOC)
+        );
+    }
+
+    public function testFailedBulkInsertRetainsPropelExceptionContract()
+    {
+        $actor = new QubitActor();
+        $actor->indexOnSave = false;
+        $actor->sourceCulture = 'en';
+        $actor->setAuthorizedFormOfName(
+            str_repeat('x', 1025),
+            ['culture' => 'en']
+        );
+
+        try {
+            $actor->save($this->connection);
+            $this->fail('Expected an oversized translation to fail.');
+        } catch (PropelException $exception) {
+            $this->assertStringStartsWith(
+                'Unable to execute INSERT statement.',
+                $exception->getMessage()
+            );
+            $this->assertInstanceOf(PDOException::class, $exception->getCause());
+        }
+    }
+
+    private function getInsertCount()
+    {
+        $statement = $this->connection->query(
+            "SHOW SESSION STATUS LIKE 'Com_insert'"
+        );
+        $status = $statement->fetch(PDO::FETCH_NUM);
+
+        return (int) $status[1];
+    }
+
+    private function getSettingTranslations($id)
+    {
+        $statement = $this->connection->prepare(
+            'SELECT culture, value
+            FROM setting_i18n
+            WHERE id = ?
+            ORDER BY culture'
+        );
+        $statement->execute([$id]);
+
+        return $statement->fetchAll(PDO::FETCH_KEY_PAIR);
+    }
+}

--- a/test/phpunit/QubitModelSafeguardsTest.php
+++ b/test/phpunit/QubitModelSafeguardsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use AccessToMemory\test\TransactionTestCase;
+
+/**
+ * @internal
+ *
+ * @covers \BaseObject::__get
+ * @covers \QubitNote::save
+ */
+class QubitModelSafeguardsTest extends TransactionTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        QubitSearch::disable();
+    }
+
+    protected function tearDown(): void
+    {
+        QubitSearch::enable();
+        QubitObject::clearCache();
+
+        parent::tearDown();
+    }
+
+    public function testDeletedPhysicalStorageRelationToleratesStaleLazyRow()
+    {
+        $resource = $this->createInformationObject();
+
+        $storage = new QubitPhysicalObject();
+        $storage->indexOnSave = false;
+        $storage->sourceCulture = 'en';
+        $storage->typeId = QubitTerm::CONTAINER_ID;
+        $storage->name = 'Box 1';
+        $storage->save($this->connection);
+
+        $resource->addPhysicalObject($storage);
+        $relations = $resource->relationsRelatedByobjectId->transient;
+        $this->assertCount(1, $relations);
+        $relations[0]->slug = 'physical-storage-link-'.uniqid();
+
+        $resource->save($this->connection);
+
+        $relationId = $relations[0]->id;
+
+        // Reload through the object table so relation columns remain lazy.
+        QubitObject::clearCache();
+        $relation = QubitObject::getById($relationId);
+        $this->assertInstanceOf(QubitRelation::class, $relation);
+        // Production does not promote the first missing-row warning to an
+        // exception. The second lazy lookup is the PHP 8 TypeError regression.
+        @$relation->delete($this->connection);
+
+        // The first lookup records a stale row as false. Further lookups must
+        // not pass that value to array_key_exists(), which throws on PHP 8.
+        $this->assertNull(@$relation->objectId);
+        $this->assertNull(@$relation->objectId);
+    }
+
+    public function testSavingResourceIgnoresDeletedLanguageNote()
+    {
+        $resource = $this->createInformationObject();
+
+        $note = new QubitNote();
+        $note->indexOnSave = false;
+        $note->sourceCulture = 'en';
+        $note->typeId = QubitTerm::LANGUAGE_NOTE_ID;
+        $note->content = 'English';
+        $resource->notes[] = $note;
+        $resource->save($this->connection);
+
+        $note->delete($this->connection);
+
+        $this->assertSame($resource, $resource->save($this->connection));
+
+        $statement = $this->connection->prepare(
+            'SELECT COUNT(*) FROM note WHERE id = ?'
+        );
+        $statement->execute([$note->id]);
+        $this->assertSame(0, (int) $statement->fetchColumn());
+    }
+
+    private function createInformationObject()
+    {
+        $resource = new QubitInformationObject();
+        $resource->indexOnSave = false;
+        $resource->parentId = QubitInformationObject::ROOT_ID;
+        $resource->sourceCulture = 'en';
+        $resource->title = 'Safeguard test';
+        $resource->save($this->connection);
+
+        return $resource;
+    }
+}

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/builder/om/OMBuilder.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/builder/om/OMBuilder.php
@@ -348,8 +348,11 @@ abstract class OMBuilder extends DataModelBuilder {
    * @param string $modifier The name of the modifier object providing the method in the behavior
 	 * @param string &$script The script will be modified in this method.
    */
-  public function applyBehaviorModifier($hookName, $modifier, &$script, $tab = "		")
+  public function applyBehaviorModifier($hookName, &$script, $tab = "		", $modifier = null)
   {
+    if (null === $modifier) {
+      $modifier = 'ObjectBuilderModifier';
+    }
     $modifierGetter = 'get' . $modifier;
     foreach ($this->getTable()->getBehaviors() as $behavior) {
       $modifier = $behavior->$modifierGetter();

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/builder/om/ObjectBuilder.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/builder/om/ObjectBuilder.php
@@ -170,9 +170,9 @@ abstract class ObjectBuilder extends OMBuilder {
    * @param string $hookName The name of the hook as called from one of this class methods, e.g. "preSave"
    * @return boolean
    */
-  public function hasBehaviorModifier($hookName)
+  public function hasBehaviorModifier($hookName, $modifier = 'ObjectBuilderModifier')
   {
-    return parent::hasBehaviorModifier($hookName, 'ObjectBuilderModifier');
+    return parent::hasBehaviorModifier($hookName, $modifier);
   }
 
   /**
@@ -180,8 +180,8 @@ abstract class ObjectBuilder extends OMBuilder {
    * @param string $hookName The name of the hook as called from one of this class methods, e.g. "preSave"
 	 * @param string &$script The script will be modified in this method.
    */
-  public function applyBehaviorModifier($hookName, &$script, $tab = "		")
+  public function applyBehaviorModifier($hookName, &$script, $tab = "		", $modifier = 'ObjectBuilderModifier')
   {
-    return parent::applyBehaviorModifier($hookName, 'ObjectBuilderModifier', $script, $tab);
+    return parent::applyBehaviorModifier($hookName, $script, $tab, $modifier);
   }
 }

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/builder/om/PeerBuilder.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/builder/om/PeerBuilder.php
@@ -282,9 +282,9 @@ abstract class PeerBuilder extends OMBuilder {
    * @param string $hookName The name of the hook as called from one of this class methods, e.g. "preSave"
    * @return boolean
    */
-  public function hasBehaviorModifier($hookName)
+  public function hasBehaviorModifier($hookName, $modifier = 'PeerBuilderModifier')
   {
-    return parent::hasBehaviorModifier($hookName, 'PeerBuilderModifier');
+    return parent::hasBehaviorModifier($hookName, $modifier);
   }
 
   /**
@@ -292,8 +292,8 @@ abstract class PeerBuilder extends OMBuilder {
    * @param string $hookName The name of the hook as called from one of this class methods, e.g. "preSave"
 	 * @param string &$script The script will be modified in this method.
    */
-  public function applyBehaviorModifier($hookName, &$script, $tab = "		")
+  public function applyBehaviorModifier($hookName, &$script, $tab = "		", $modifier = 'PeerBuilderModifier')
   {
-    return parent::applyBehaviorModifier($hookName, 'PeerBuilderModifier', $script, $tab);
+    return parent::applyBehaviorModifier($hookName, $script, $tab, $modifier);
   }
 }

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/builder/om/php5/PHP5TableMapBuilder.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/builder/om/php5/PHP5TableMapBuilder.php
@@ -323,9 +323,9 @@ class ".$this->getClassname()." extends TableMap {
    * @param string $hookName The name of the hook as called from one of this class methods, e.g. "preSave"
    * @return boolean
    */
-  public function hasBehaviorModifier($hookName)
+  public function hasBehaviorModifier($hookName, $modifier = 'TableMapBuilderModifier')
   {
-    return parent::hasBehaviorModifier($hookName, 'TableMapBuilderModifier');
+    return parent::hasBehaviorModifier($hookName, $modifier);
   }
 
   /**
@@ -333,8 +333,8 @@ class ".$this->getClassname()." extends TableMap {
    * @param string $hookName The name of the hook as called from one of this class methods, e.g. "preSave"
 	 * @param string &$script The script will be modified in this method.
    */
-  public function applyBehaviorModifier($hookName, &$script, $tab = "		")
+  public function applyBehaviorModifier($hookName, &$script, $tab = "		", $modifier = 'TableMapBuilderModifier')
   {
-    return parent::applyBehaviorModifier($hookName, 'TableMapBuilderModifier', $script, $tab);
+    return parent::applyBehaviorModifier($hookName, $script, $tab, $modifier);
   }
 } // PHP5TableMapBuilder

--- a/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/phing/AbstractPropelDataModelTask.php
+++ b/vendor/symfony/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/phing/AbstractPropelDataModelTask.php
@@ -235,7 +235,7 @@ abstract class AbstractPropelDataModelTask extends Task {
 	 */
 	public function setPackageObjectModel($v)
 	{
-		$this->packageObjectModel = ($v === '1' ? true : false);
+		$this->packageObjectModel = filter_var($v, FILTER_VALIDATE_BOOLEAN);
 	}
 
 	/**
@@ -416,6 +416,7 @@ abstract class AbstractPropelDataModelTask extends Task {
 			$srcDir = $fs->getDir($this->project);
 
 			$dataModelFiles = $ds->getIncludedFiles();
+			usort($dataModelFiles, array($this, 'compareDataModelFiles'));
 
 			$platform = $this->getGeneratorConfig()->getConfiguredPlatform();
 
@@ -494,6 +495,24 @@ abstract class AbstractPropelDataModelTask extends Task {
 		}
 
 		$this->dataModelsLoaded = true;
+	}
+
+	/**
+	 * Sort schema files deterministically, keeping the application schema before
+	 * plugin schemas so referrer generation remains stable.
+	 */
+	protected function compareDataModelFiles($a, $b)
+	{
+		$aBase = basename($a);
+		$bBase = basename($b);
+		$aIsMain = in_array($aBase, array('schema.xml', 'generated-schema.xml'), true);
+		$bIsMain = in_array($bBase, array('schema.xml', 'generated-schema.xml'), true);
+
+		if ($aIsMain !== $bIsMain) {
+			return $aIsMain ? -1 : 1;
+		}
+
+		return strcmp($a, $b);
 	}
 
 	/**


### PR DESCRIPTION
Batch translations that share populated columns into multi-row INSERT statements when their parent record is first saved. Preserve per-record save behavior when any translation already exists.

This primarily reduces database work during fresh installation and test fixture loading, where menus, settings, terms, and static pages may contain dozens of translations. It also improves multilingual SKOS imports, EAC-CPF parallel-name imports, and duplication of multilingual rights and events.

A fixture-backed setting with 41 translations falls from 42 INSERT statements to two: one for the setting and one for all translations.