### PR TITLE
Fix worker context leak in CSV exports

### DIFF
--- a/lib/job/arAccessionExportJob.class.php
+++ b/lib/job/arAccessionExportJob.class.php
@@ -105,8 +105,7 @@ class arAccessionExportJob extends arExportJob
      */
     protected function csvActionExport($resource, $writer)
     {
-        $configuration = ProjectConfiguration::getApplicationConfiguration('qubit', 'prod', false);
-        $this->context = sfContext::createInstance($configuration);
+        $this->context = sfContext::getInstance();
 
         $cultures = array_keys(DefaultTranslationLinksComponent::getOtherCulturesAvailable(
             $resource->accessionI18ns,
@@ -115,8 +114,9 @@ class arAccessionExportJob extends arExportJob
         );
 
         foreach ($cultures as $culture) {
-            $this->context->getUser()->setCulture($culture);
-            $writer->exportResource($resource);
+            $this->withUserCulture($culture, function () use ($writer, $resource) {
+                $writer->exportResource($resource);
+            });
         }
 
         ++$this->itemsExported;

--- a/lib/job/arActorExportJob.class.php
+++ b/lib/job/arActorExportJob.class.php
@@ -79,8 +79,7 @@ class arActorExportJob extends arExportJob
 
     protected function csvActionExport($path, $resource)
     {
-        $configuration = ProjectConfiguration::getApplicationConfiguration('qubit', 'prod', false);
-        $this->context = sfContext::createInstance($configuration);
+        $this->context = sfContext::getInstance();
 
         // Prepare CSV exporter
         $writer = new csvActorExport($path);
@@ -92,9 +91,10 @@ class arActorExportJob extends arExportJob
         // Write row to file and initialize row
         foreach ($cultures as $culture) {
             $actor = QubitActor::getById($resource->id);
-            $this->context->getUser()->setCulture($culture);
 
-            $writer->exportResource($actor);
+            $this->withUserCulture($culture, function () use ($writer, $actor) {
+                $writer->exportResource($actor);
+            });
         }
 
         ++$this->itemsExported;

--- a/lib/job/arExportJob.class.php
+++ b/lib/job/arExportJob.class.php
@@ -93,6 +93,29 @@ class arExportJob extends arBaseJob
     }
 
     /**
+     * Run export code with a temporary user culture.
+     *
+     * The worker context is long-lived, so culture changes must be scoped to
+     * the row currently being exported.
+     *
+     * @param callable $callback
+     * @param mixed    $culture
+     *
+     * @return mixed
+     */
+    protected function withUserCulture($culture, $callback)
+    {
+        $previousCulture = $this->user->getCulture();
+        $this->user->setCulture($culture);
+
+        try {
+            return $callback();
+        } finally {
+            $this->user->setCulture($previousCulture);
+        }
+    }
+
+    /**
      * Copy a digital object to the temporary job directory for export.
      *
      * @param mixed  $resource the object to which the digital object is attached

--- a/lib/job/arRepositoryCsvExportJob.class.php
+++ b/lib/job/arRepositoryCsvExportJob.class.php
@@ -106,8 +106,7 @@ class arRepositoryCsvExportJob extends arExportJob
 
     protected function csvActionExport($resource, $writer)
     {
-        $configuration = ProjectConfiguration::getApplicationConfiguration('qubit', 'prod', false);
-        $this->context = sfContext::createInstance($configuration);
+        $this->context = sfContext::getInstance();
 
         // Export repositories and, optionally, related data
         $itemsExported = 0;
@@ -116,9 +115,9 @@ class arRepositoryCsvExportJob extends arExportJob
 
         // Write row to file and initialize row
         foreach ($cultures as $culture) {
-            $this->context->getUser()->setCulture($culture);
-
-            $writer->exportResource($resource);
+            $this->withUserCulture($culture, function () use ($writer, $resource) {
+                $writer->exportResource($resource);
+            });
 
             // Log progress every 1000 rows
             if ($itemsExported && (0 == $itemsExported % 1000)) {

--- a/test/phpunit/lib/job/arExportJobTest.php
+++ b/test/phpunit/lib/job/arExportJobTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+// Extend the class being tested to avoid calling
+// the base constructor and attempting to start
+// a gearman job
+class arExportTestableJob extends arExportJob
+{
+    protected $user;
+
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+
+    public function runWithUserCulture($culture, callable $callback)
+    {
+        return $this->withUserCulture($culture, $callback);
+    }
+}
+
+// Mock user class for setting and getting culture
+class TestCultureUser
+{
+    private $culture;
+
+    public function __construct($culture)
+    {
+        $this->culture = $culture;
+    }
+
+    public function getCulture()
+    {
+        return $this->culture;
+    }
+
+    public function setCulture($culture)
+    {
+        $this->culture = $culture;
+    }
+}
+
+/**
+ * @internal
+ *
+ * @covers \arExportJob
+ */
+class arExportJobTest extends TestCase
+{
+    public function testWithUserCultureWithRestoresCultureAfterRun()
+    {
+        $defaultCulture = 'fr';
+        $testCulture = 'en';
+        $testUser = new TestCultureUser($defaultCulture);
+        $testJob = new arExportTestableJob($testUser);
+        $testJob->runWithUserCulture($testCulture, function () {});
+        $this->assertSame($defaultCulture, $testUser->getCulture());
+    }
+
+    public function testWithUserCultureWithChangesCultureDuringRun()
+    {
+        $defaultCulture = 'en';
+        $testCulture = 'fr';
+        $testUser = new TestCultureUser($defaultCulture);
+        $testJob = new arExportTestableJob($testUser);
+        $testJob->runWithUserCulture($testCulture, function () use ($testCulture, $testUser) {
+            $this->assertSame($testCulture, $testUser->getCulture());
+        });
+        $this->assertSame($defaultCulture, $testUser->getCulture());
+    }
+}


### PR DESCRIPTION
CSV export jobs were creating a new qubit/prod Symfony context inside the long-running worker.

That leaked prod into later jobs and made arUpdateEsIoDocumentsJob enqueue descendant updates asynchronously instead of handling them inline.

Keep the worker context intact and scope only the export culture changes needed for translated CSV output.