### PR TITLE
Enable npm post-install for cypress

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -48,6 +48,8 @@ jobs:
         key: npm-${{ hashFiles('package-lock.json') }}
     - name: Install NPM dependencies
       run: sudo npm install -g npm && npm ci
+    - name: Install Cypress binary
+      run: npx cypress install
     - name: Modify Gearman config
       run: |
         echo -e "all:\n  servers:\n    default: 127.0.0.1:4730" \

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -48,8 +48,6 @@ jobs:
         key: npm-${{ hashFiles('package-lock.json') }}
     - name: Install NPM dependencies
       run: sudo npm install -g npm && npm ci
-    - name: Install Cypress binary
-      run: npx cypress install
     - name: Modify Gearman config
       run: |
         echo -e "all:\n  servers:\n    default: 127.0.0.1:4730" \

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "watch": "webpack watch",
     "format": "prettier --write .",
     "check-format": "prettier --check ."
+  },
+  "allowScripts": {
+    "cypress@15.15.0": true
   }
 }


### PR DESCRIPTION
Closes #2404 

Allows cypress post-install to run. Ran: `npm approve-scripts cypress`

With [recent breaking changes to NPM](https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/), post-install scripts are no longer run by default. This was causing integration tests to fail.