### PR TITLE
Fix error in tools:unlink-creators

### DIFF
--- a/lib/task/tools/unlinkCreatorTask.class.php
+++ b/lib/task/tools/unlinkCreatorTask.class.php
@@ -22,7 +22,7 @@
  *
  * @author     Steve Breker <sbreker@artefactual.com>
  */
-class unlinkCreatorTask extends sfBaseTask
+class unlinkCreatorTask extends arBaseTask
 {
     protected $actor;
 
@@ -52,13 +52,14 @@ EOF;
 
     protected function execute($arguments = [], $options = [])
     {
+        parent::execute($arguments, $options);
+
         if ($options['creator-slug'] && $options['description-slug']) {
             throw new Exception(
                 'Creator and description filters cannot be set at the same time. Remove one and try again.'
             );
         }
 
-        sfContext::createInstance($this->configuration);
         $databaseManager = new sfDatabaseManager($this->configuration);
         $conn = $databaseManager->getDatabase('propel')->getConnection();
 


### PR DESCRIPTION
Closes #2414 

The `tools:unlink-creators` command was failing because the `app_i18n_languages` setting was not set. This is a setting that comes from the database, and must explicitly be loaded when a CLI task runs. Switching the inherited class from `sfBaseTask` to `arBaseTask` and calling that class's `execute()` function loads the settings and fixes the bug.