### PR TITLE
Fix timeouts when saving authority records

### DIFF
--- a/lib/model/QubitActor.php
+++ b/lib/model/QubitActor.php
@@ -154,6 +154,7 @@ class QubitActor extends BaseActor
             // all events from the database when no events have been touched.
             foreach ($this->refFkValues['events'] as $event) {
                 if (isset($event->new) && $event->new) {
+                    // We don't index on save because we index below in arUpdateEsIoDocumentsJob
                     $event->indexOnSave = false;
                     $event->actor = $this;
                     $event->save();
@@ -169,24 +170,18 @@ class QubitActor extends BaseActor
 
         if ($this->indexOnSave) {
             // Find creation-type events
-            $sql = sprintf('
-                SELECT DISTINCT object_id
-                FROM %s
-                WHERE actor_id = ? AND type_id = ? AND object_id IS NOT NULL;
-                ', QubitEvent::TABLE_NAME
-            );
-            $params = [$this->id, QubitTerm::CREATION_ID];
-            $creationIoIds = QubitPdo::fetchAll($sql, $params, ['fetchMode' => PDO::FETCH_COLUMN]);
+            $sql = 'SELECT DISTINCT object_id FROM '
+                .QubitEvent::TABLE_NAME
+                .' WHERE actor_id = ? AND type_id = ? AND object_id IS NOT NULL';
+
+            $creationIoIds = QubitPdo::fetchAll($sql, [$this->id, QubitTerm::CREATION_ID], ['fetchMode' => PDO::FETCH_COLUMN]);
 
             // Find other non-creation-type events
-            $sql = sprintf('
-                SELECT DISTINCT object_id
-                FROM %s
-                WHERE actor_id = ? AND (type_id != ? OR type_id IS NULL) AND object_id IS NOT NULL;
-                ', QubitEvent::TABLE_NAME
-            );
-            $params = [$this->id, QubitTerm::CREATION_ID];
-            $otherIoIds = QubitPdo::fetchAll($sql, $params, ['fetchMode' => PDO::FETCH_COLUMN]);
+            $sql = 'SELECT DISTINCT object_id FROM '
+                .QubitEvent::TABLE_NAME
+                .' WHERE actor_id = ? AND (type_id = ? OR type_id IS NULL) AND object_id IS NOT NULL';
+
+            $otherIoIds = QubitPdo::fetchAll($sql, [$this->id, QubitTerm::CREATION_ID], ['fetchMode' => PDO::FETCH_COLUMN]);
 
             // Update asynchronously the saved IOs ids, two jobs may
             // be launched in here as creation events require updating

--- a/lib/model/QubitActor.php
+++ b/lib/model/QubitActor.php
@@ -179,7 +179,7 @@ class QubitActor extends BaseActor
             // Find other non-creation-type events
             $sql = 'SELECT DISTINCT object_id FROM '
                 .QubitEvent::TABLE_NAME
-                .' WHERE actor_id = ? AND (type_id = ? OR type_id IS NULL) AND object_id IS NOT NULL';
+                .' WHERE actor_id = ? AND (type_id != ? OR type_id IS NULL) AND object_id IS NOT NULL';
 
             $otherIoIds = QubitPdo::fetchAll($sql, [$this->id, QubitTerm::CREATION_ID], ['fetchMode' => PDO::FETCH_COLUMN]);
 

--- a/lib/model/QubitActor.php
+++ b/lib/model/QubitActor.php
@@ -148,11 +148,11 @@ class QubitActor extends BaseActor
                 $event->actor = $this;
                 $event->save();
             }
-        } elseif (isset($this->refFkValues['events'])) {
-            // Only iterate the events collection if it has been initialized
-            // (i.e. events were accessed or added). This avoids a lazy-load of
-            // all events from the database when no events have been touched.
-            foreach ($this->refFkValues['events'] as $event) {
+        } else {
+            // Only iterate over newly created but not saved events (i.e., transient events). This
+            // avoids looping over all existing events, which are already saved in the event edit
+            // component
+            foreach ($this->events->transient as $event) {
                 if (isset($event->new) && $event->new) {
                     // We don't index on save because we index below in arUpdateEsIoDocumentsJob
                     $event->indexOnSave = false;

--- a/lib/model/QubitActor.php
+++ b/lib/model/QubitActor.php
@@ -136,30 +136,29 @@ class QubitActor extends BaseActor
 
         parent::save($connection);
 
-        $creationIoIds = $otherIoIds = [];
         $context = sfContext::getInstance();
         $env = $context->getConfiguration()->getEnvironment();
 
         // Save related event objects
-        foreach ($this->events as $event) {
-            $event->indexOnSave = false;
-
-            // Update search index for related info object, update them
-            // in QubitEvent synchronously in CLI tasks and jobs
-            if (in_array($env, ['cli', 'worker'])) {
+        if (in_array($env, ['cli', 'worker'])) {
+            // In CLI/worker environments, all events are saved with indexing enabled
+            // so related information objects are updated synchronously in QubitEvent.
+            foreach ($this->events as $event) {
                 $event->indexOnSave = true;
-            } elseif (isset($event->objectId)) {
-                // Otherwise, do not update in QubitEvent,
-                // but save ids to update asynchronously
-                if (isset($event->typeId) && QubitTerm::CREATION_ID == $event->typeId) {
-                    $creationIoIds[] = $event->objectId;
-                } else {
-                    $otherIoIds[] = $event->objectId;
+                $event->actor = $this;
+                $event->save();
+            }
+        } elseif (isset($this->refFkValues['events'])) {
+            // Only iterate the events collection if it has been initialized
+            // (i.e. events were accessed or added). This avoids a lazy-load of
+            // all events from the database when no events have been touched.
+            foreach ($this->refFkValues['events'] as $event) {
+                if (isset($event->new) && $event->new) {
+                    $event->indexOnSave = false;
+                    $event->actor = $this;
+                    $event->save();
                 }
             }
-
-            $event->actor = $this;
-            $event->save();
         }
 
         // Save related contact information objects
@@ -169,6 +168,26 @@ class QubitActor extends BaseActor
         }
 
         if ($this->indexOnSave) {
+            // Find creation-type events
+            $sql = sprintf('
+                SELECT DISTINCT object_id
+                FROM %s
+                WHERE actor_id = ? AND type_id = ? AND object_id IS NOT NULL;
+                ', QubitEvent::TABLE_NAME
+            );
+            $params = [$this->id, QubitTerm::CREATION_ID];
+            $creationIoIds = QubitPdo::fetchAll($sql, $params, ['fetchMode' => PDO::FETCH_COLUMN]);
+
+            // Find other non-creation-type events
+            $sql = sprintf('
+                SELECT DISTINCT object_id
+                FROM %s
+                WHERE actor_id = ? AND (type_id != ? OR type_id IS NULL) AND object_id IS NOT NULL;
+                ', QubitEvent::TABLE_NAME
+            );
+            $params = [$this->id, QubitTerm::CREATION_ID];
+            $otherIoIds = QubitPdo::fetchAll($sql, $params, ['fetchMode' => PDO::FETCH_COLUMN]);
+
             // Update asynchronously the saved IOs ids, two jobs may
             // be launched in here as creation events require updating
             // the descendants but other events don't.


### PR DESCRIPTION
Closes #2421 

All events linked to an actor were being saved in a loop any time that actor was saved. This causes a performance hit especially when many events are linked to an actor. I found that saving all the events was unnecessary because existing events are already saved by the `EventEditComponent` when they're changed. The only events that need to be saved in `QubitActor::save` are newly created events, since those are not automatically saved by the event edit component. To improve performance:

- Instead of looping through every event linked to the actor and saving them, only save the events that are newly added.
- Instead of getting related object IDs by loading all event objects, query for them directly.