### PR TITLE
refactor: translation bar access check respect user settings for tran…

### DIFF
--- a/apps/qubit/templates/_footer.php
+++ b/apps/qubit/templates/_footer.php
@@ -1,6 +1,6 @@
 <footer class="d-print-none">
 
-  <?php if (QubitAcl::check('userInterface', 'translate')) { ?>
+  <?php if (QubitTranslateBarAccess::hasExplicitTranslateAccess()) { ?>
     <?php echo get_component('sfTranslatePlugin', 'translate'); ?>
   <?php } ?>
 

--- a/lib/QubitTranslateBarAccess.class.php
+++ b/lib/QubitTranslateBarAccess.class.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for that purpose.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Decides whether the current user should see the "Translate user interface"
+ * bar (rendered by sfTranslatePlugin in the page footer).
+ *
+ * Unlike QubitAcl::check('userInterface', 'translate'), which also matches
+ * blanket "all privileges" grants (acl_permission rows with NULL action),
+ * this check requires an EXPLICIT translate permission (action = 'translate')
+ * granted to the user or one of their groups, so administrators with the
+ * default "admin all" grant no longer see the bar unless they (or their
+ * group) have been explicitly granted translate access.
+ *
+ * The current UI culture must also satisfy the permission's language
+ * conditional (if any), mirroring QubitAclConditionalAssert behavior for
+ * 'translate' permissions.
+ *
+ * @author Sawyer Borror <sawyerb@ksu.edu>
+ * @package    qubit
+ * @subpackage security
+ */
+class QubitTranslateBarAccess
+{
+    /**
+     * Check whether the current user has an explicit translate permission
+     * that applies to their current UI culture.
+     *
+     * @param myUser $user sf user instance (defaults to the current user)
+     *
+     * @return bool true if the user has an explicit, culture-appropriate
+     *              translate grant; false otherwise
+     */
+    public static function hasExplicitTranslateAccess(?myUser $user = null): bool
+    {
+        if (null === $user) {
+            $user = sfContext::getInstance()->getUser();
+        }
+
+        if (!$user->isAuthenticated() || null === $user->user) {
+            return false;
+        }
+
+        $permissions = self::getExplicitTranslatePermissions($user);
+        $culture = $user->getCulture();
+
+        foreach ($permissions as $permission) {
+            if (1 == $permission->grantDeny && $permission->evaluateConditional(['language' => $culture])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Fetch all explicit, system-wide translate permission rows that apply
+     * to the given user: rows belonging to the user directly, or to any
+     * group the user belongs to (including that group's ancestors), with a
+     * NULL object_id (applies to all objects).
+     *
+     * Only NULL object_id rows are considered: QubitAcl::check() matches
+     * them against the 'userInterface' resource, which is what originally
+     * triggered the footer bar.
+     *
+     * @param myUser $user authenticated sf user instance
+     *
+     * @return array of QubitAclPermission explicit translate permission rows
+     */
+    protected static function getExplicitTranslatePermissions(myUser $user): array
+    {
+        $roleIds = [QubitAclGroup::AUTHENTICATED_ID, $user->getUserID()];
+
+        foreach ($user->user->getAclGroups() as $group) {
+            // Include group ancestors so inherited grants are respected,
+            // mirroring the role hierarchy built in QubitAcl::buildUserRoleList
+            foreach ($group->getAncestorsAndSelfForAcl() as $ancestor) {
+                if (!in_array($ancestor->id, $roleIds)) {
+                    $roleIds[] = $ancestor->id;
+                }
+            }
+        }
+
+        $criteria = new Criteria();
+        $criteria->add(QubitAclPermission::ACTION, 'translate');
+        $criteria->add(QubitAclPermission::OBJECT_ID, null, Criteria::ISNULL);
+
+        // Match permissions on the user itself OR on any of its group roles
+        $roleCriterion = $criteria->getNewCriterion(QubitAclPermission::GROUP_ID, $roleIds, Criteria::IN);
+        $roleCriterion->addOr($criteria->getNewCriterion(QubitAclPermission::USER_ID, $user->getUserID()));
+        $criteria->add($roleCriterion);
+
+        $permissions = QubitAclPermission::get($criteria);
+
+        return is_array($permissions) ? $permissions : iterator_to_array($permissions);
+    }
+}

--- a/lib/QubitTranslateBarAccess.class.php
+++ b/lib/QubitTranslateBarAccess.class.php
@@ -33,8 +33,6 @@
  * 'translate' permissions.
  *
  * @author Sawyer Borror <sawyerb@ksu.edu>
- * @package    qubit
- * @subpackage security
  */
 class QubitTranslateBarAccess
 {

--- a/test/functional/qubit/translationBarCheck.php
+++ b/test/functional/qubit/translationBarCheck.php
@@ -1,0 +1,161 @@
+<?php
+//
+// test/translate-bar-check.php — verifies the QubitTranslateBarAccess patch.
+//
+// Drives an in-process test browser (sfBrowser, same harness as the
+// project's functional tests) and asserts on the #l10n-client footer bar:
+//
+//   1. anonymous visitor (control)                                -> NO bar
+//   2. admin-group user, blanket "all" grant only                 -> NO bar
+//   3. same user + explicit translate grant (en), culture en      -> bar present
+//   4. same user, UI culture switched to fr (en-only grant)       -> NO bar
+//
+// Authentication note: this fork authenticates exclusively via CAS
+// (casUser::authenticate -> phpCAS::forceAuthentication), which cannot
+// run against a real CAS server in the test container. casUser::authenticate
+// ultimately calls myUser::signIn() with the resolved QubitUser, so this
+// script signs the test user in through that same entry point instead of
+// POSTing to /user/login.
+//
+// Usage (from the repo root, inside the test container):
+//   php -d xdebug.mode=off test/translate-bar-check.php
+//
+// Exits 0 if all checks pass, 1 otherwise.
+
+chdir('/atom/src');
+
+error_reporting(E_ALL & ~E_DEPRECATED);
+
+require '/atom/src/config/ProjectConfiguration.class.php';
+
+$configuration = ProjectConfiguration::getApplicationConfiguration('qubit', 'test', true);
+sfContext::createInstance($configuration);
+
+$failures = 0;
+
+/**
+ * Load the homepage (renders the shared footer) and check for the bar.
+ *
+ * @param string $label Description of the scenario for the report line
+ * @param sfBrowserBase $browser In-process test browser
+ * @param bool $expectBar Whether #l10n-client should be present
+ * @param bool $expectAuth Whether the browser user should be authenticated
+ *
+ * @return int 0 on success, 1 on failure
+ */
+function assertBar(string $label, sfBrowserBase $browser, bool $expectBar, bool $expectAuth): int
+{
+    $browser->get('/');
+
+    $body = (string) $browser->getResponse()->getContent();
+    $hasBar = false !== strpos($body, 'id="l10n-client"');
+    $authenticated = (bool) $browser->getUser()->isAuthenticated();
+
+    $ok = ($hasBar === $expectBar) && ($authenticated === $expectAuth);
+    printf(
+        "%s  %-55s auth=%-3s bar=%-7s (expected bar=%s, auth=%s)\n",
+        $ok ? 'PASS' : 'FAIL',
+        $label,
+        $authenticated ? 'yes' : 'no',
+        $hasBar ? 'present' : 'absent',
+        $expectBar ? 'present' : 'absent',
+        $expectAuth ? 'yes' : 'no'
+    );
+
+    return $ok ? 0 : 1;
+}
+
+$browser = new sfBrowser();
+
+$failures += assertBar('1. anonymous visitor (control)', $browser, false, false);
+
+// --- Test user: member of administrator group (100) -> blanket "all" grant ---
+// Clean up any leftovers from a previous run
+$email = 'bar-tester@example.com';
+$oldCriteria = new Criteria();
+$oldCriteria->add(QubitUser::EMAIL, $email);
+$old = QubitUser::getOne($oldCriteria);
+if (null !== $old) {
+    $old->delete();
+}
+
+$tester = new QubitUser();
+$tester->username = $email;
+$tester->email = $email;
+$tester->setPassword('test1234');
+$tester->save();
+
+$userGroup = new QubitAclUserGroup();
+$userGroup->setUserId($tester->id);
+$userGroup->setGroupId(QubitAclGroup::ADMINISTRATOR_ID);
+$userGroup->save();
+
+// Sign in. The fork authenticates via CAS (casUser::authenticate), which
+// cannot run against a real CAS server in the test container, so we seed the
+// browser's test session file directly with the same data myUser::signIn()
+// would leave after a successful login. NOTE: we cannot use
+// $browser->getUser()->signIn() here — that would sign in the bootstrap
+// sfContext's user, whose storage uses a different session id than the
+// browser's, and its shutdown() clobbers the browser's .session file.
+// The browser's session id is fixed for its whole lifetime (set in the
+// sfBrowserBase constructor and restored on every doCall).
+$sessionFile = sfConfig::get('sf_app_cache_dir').'/test/sessions/'.$_SERVER['session_id'].'.session';
+if (!is_dir(dirname($sessionFile))) {
+    mkdir(dirname($sessionFile), 0777, true);
+}
+file_put_contents($sessionFile, serialize([
+    'symfony/user/sfUser/authenticated' => true,
+    'symfony/user/sfUser/credentials' => [],
+    'symfony/user/sfUser/lastRequest' => time(),
+    'symfony/user/sfUser/attributes' => [
+        // Nested under the holder's default namespace
+        // (sfUser::ATTRIBUTE_NAMESPACE), matching how sfUser::shutdown()
+        // serializes attributeHolder namespaces.
+        'symfony/user/sfUser/attributes' => [
+            'user_id' => $tester->id,
+            'user_slug' => $tester->slug,
+            'user_name' => $tester->username,
+        ],
+    ],
+]));
+
+$failures += assertBar('2. admin-group user, blanket "all" grant only', $browser, false, true);
+
+// --- Add an explicit translate grant (en), like the user-edit checkbox ---
+$permission = new QubitAclPermission();
+$permission->setUserId($tester->id);
+$permission->setObjectId(null);
+$permission->setAction('translate');
+$permission->setGrantDeny(1); // 1 = Allow (QubitAcl maps grant_deny 1 -> Zend GRANT)
+$permission->setConditional('in_array(%p[language], %k[languages])');
+$permission->setConstants(['languages' => ['en']]);
+$permission->save();
+
+$failures += assertBar('3. same user + explicit translate grant (en)', $browser, true, true);
+
+// --- Switch UI culture to fr: the en-only conditional should now fail ---
+$browser->get('/?sf_culture=fr');
+
+$body = (string) $browser->getResponse()->getContent();
+$hasBar = false !== strpos($body, 'id="l10n-client"');
+$culture = $browser->getUser()->getCulture();
+$ok = !$hasBar && 'fr' === $culture;
+printf(
+    "%s  %-55s culture=%s bar=%-7s (expected bar=absent, culture=fr)\n",
+    $ok ? 'PASS' : 'FAIL',
+    '4. same user, UI culture fr (en-only grant)',
+    $culture,
+    $hasBar ? 'present' : 'absent'
+);
+$failures += $ok ? 0 : 1;
+
+// --- Cleanup ---
+$permission->delete();
+$userGroup->delete();
+$tester->delete();
+
+echo $failures
+    ? "\nRESULT: {$failures} check(s) FAILED\n"
+    : "\nRESULT: all checks passed\n";
+
+exit($failures ? 1 : 0);

--- a/test/functional/qubit/translationBarCheck.php
+++ b/test/functional/qubit/translationBarCheck.php
@@ -1,4 +1,5 @@
 <?php
+
 //
 // test/translate-bar-check.php — verifies the QubitTranslateBarAccess patch.
 //
@@ -36,10 +37,10 @@ $failures = 0;
 /**
  * Load the homepage (renders the shared footer) and check for the bar.
  *
- * @param string $label Description of the scenario for the report line
- * @param sfBrowserBase $browser In-process test browser
- * @param bool $expectBar Whether #l10n-client should be present
- * @param bool $expectAuth Whether the browser user should be authenticated
+ * @param string        $label      Description of the scenario for the report line
+ * @param sfBrowserBase $browser    In-process test browser
+ * @param bool          $expectBar  Whether #l10n-client should be present
+ * @param bool          $expectAuth Whether the browser user should be authenticated
  *
  * @return int 0 on success, 1 on failure
  */


### PR DESCRIPTION
# Fix: translation banner shows for admins without explicit translate access

## Summary

The "Translate user interface" footer banner was visible to any user whose ACL check passed via a blanket "all privileges" grant (e.g., administrators with the default all-access grant), even when they had never been explicitly granted the `translate` permission. This made the banner appear for users whose language settings do not actually authorize interface translation.

This change introduces a dedicated access check that requires an **explicit** `translate` permission and respects the permission's language conditional, so the banner is only shown to users who have been intentionally granted translate access.

## Problem

`_footer.php` rendered the sfTranslatePlugin banner whenever:

```php
QubitAcl::check('userInterface', 'translate')
```

`QubitAcl::check()` also matches blanket `acl_permission` rows with `NULL action` ("all privileges"), so administrators with the standard admin grant saw the banner even without an explicit translate grant.

## Changes

### `lib/QubitTranslateBarAccess.class.php` (new)

New static helper class with:

- **`hasExplicitTranslateAccess(?myUser $user = null): bool`** — returns `true` only if the current user has an explicit `translate` permission (`action = 'translate'`) granted to them directly, to one of their groups (including group ancestors), with a `NULL object_id` (system-wide), `grantDeny = 1`, **and** the permission's language conditional (if any) evaluates true for the user's current UI culture.
- **`getExplicitTranslatePermissions(myUser $user): array`** — protected helper that fetches the matching explicit permission rows, mirroring the role hierarchy built in `QubitAcl::buildUserRoleList` (authenticated role, user id, user groups, and group ancestors).

### `apps/qubit/templates/_footer.php`

Banner render condition changed from:

```php
if (QubitAcl::check('userInterface', 'translate')) {
```

to:

```php
if (QubitTranslateBarAccess::hasExplicitTranslateAccess()) {
```

### `test/functional/qubit/translationBarCheck.php` (new)

Functional test script (runnable inside the test container via `php -d xdebug.mode=off test/functional/qubit/translationBarCheck.php`, exits 0/1) that drives an in-process `sfBrowser` and asserts on the `#l10n-client` footer bar for four scenarios:

| # | Scenario | Expected bar |
|---|----------|--------------|
| 1 | Anonymous visitor (control) | absent |
| 2 | Admin-group user with blanket "all" grant only | absent |
| 3 | Same user + explicit `translate` grant (`en`), culture `en` | present |
| 4 | Same user, UI culture switched to `fr` (`en`-only grant) | absent |

The script creates and cleans up its own test user, group membership, and permission rows. Note: because this fork authenticates via CAS, the test signs the user in by seeding the browser's session file with the same data `myUser::signIn()` produces, rather than POSTing to `/user/login`.

## Verification

- Scenario 2 was the failure case before this change (admin with only the blanket grant saw the banner); it now correctly returns no banner.
- Scenarios 3–4 confirm that explicit grants still work and that the language conditional continues to be enforced (an `en`-only grant does not show the bar under an `fr` UI culture).

## Risk / Backwards compatibility

- Users with an explicit `translate` grant (the normal "can translate" checkbox on a user record) see the banner exactly as before.
- Users who previously saw the banner **only** through a blanket "all" grant will no longer see it — this is the intended fix. If such users need the banner, grant the `translate` permission explicitly.
- No schema changes, no public API changes beyond the new `QubitTranslateBarAccess` class.
