### PR TITLE
Convert non-BS & slick deps to @use in main.scss

### DIFF
--- a/plugins/arDominionB5Plugin/scss/main.scss
+++ b/plugins/arDominionB5Plugin/scss/main.scss
@@ -1,3 +1,14 @@
+// Font Awesome
+@use "@fortawesome/fontawesome-free/scss/fontawesome";
+@use "@fortawesome/fontawesome-free/scss/solid";
+
+// Other components (CSS files)
+@use "@uppy/core/dist/style" as *;
+@use "@uppy/dashboard/dist/style" as *;
+@use "jquery-ui-dist/jquery-ui";
+@use "jstree/dist/themes/default/style";
+@use "mediaelement/build/mediaelementplayer";
+
 // Default variable overrides
 @import "variables";
 
@@ -47,16 +58,7 @@
 @import "bootstrap/scss/helpers";
 @import "bootstrap/scss/utilities/api";
 
-// Font Awesome
-@import "@fortawesome/fontawesome-free/scss/fontawesome";
-@import "@fortawesome/fontawesome-free/scss/solid";
-
 // Other components (CSS files)
-@import "@uppy/core/dist/style";
-@import "@uppy/dashboard/dist/style";
-@import "jquery-ui-dist/jquery-ui";
-@import "jstree/dist/themes/default/style";
-@import "mediaelement/build/mediaelementplayer";
 @import "@accessible360/accessible-slick/slick/slick";
 @import "@accessible360/accessible-slick/slick/slick-theme";
 


### PR DESCRIPTION
Migrate remaining Sass dependencies in main.scss to the module system
(@use/@forward), replacing legacy @import statements.

Bootstrap and Slick are excluded because their upstream repos have not
yet migrated to the Sass module system themselves. Until they ship @use/
@forward-compatible releases, their styles will continue to be pulled in via
@import.